### PR TITLE
feat(lint): implement markdownlint

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,0 +1,10 @@
+{
+  "default": true,
+  "MD003": { "style": "atx" },
+  "MD007": { "indent": 4 },
+  "MD013": { "line_length": 200 },
+  "MD033": false,
+  "MD034": false,
+  "no-hard-tabs": false,
+  "whitespace": false
+}

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
     "start": "antwar -d",
     "build": "antwar -b && npm run sitemap && echo webpack.js.org > build/CNAME",
     "deploy": "antwar -D",
+    "markdownlint": "markdownlint --config ./.markdownlintrc *.md",
     "lint": "eslint . --ext .js --ext .jsx --ext .md",
-    "test": "npm run lint",
+    "test": "npm run lint && npm run markdownlint",
     "sitemap": "cd build && sitemap-static --prefix=https://webpack.js.org/ > sitemap.xml"
   },
   "devDependencies": {
@@ -47,6 +48,8 @@
     "file-loader": "^0.9.0",
     "json-loader": "^0.5.4",
     "markdown-loader": "^0.1.7",
+    "markdownlint": "^0.2.0",
+    "markdownlint-cli": "^0.2.0",
     "marked": "^0.3.5",
     "modularscale-sass": "^2.1.1",
     "moment": "^2.14.1",


### PR DESCRIPTION
* Markdown lint added. There are a variety of rules we can choose from. I selected some defaults.

* Tests should fail on this commit. I will cleanup all documents afterwards.

