### PR TITLE
chore(travis): update the node_js version on travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 6
-
+  - "6"
 script:
   - bash ./scripts/deploy.sh


### PR DESCRIPTION
I was noticing that all recent travis builds were still running against node 4 as the config. Am curious if this is related to the invariant issues. Going to try this out. 