### PR TITLE
Update links entry point page 

### DIFF
--- a/content/concepts/entry-points.md
+++ b/content/concepts/entry-points.md
@@ -3,7 +3,7 @@ title: Entry Points
 sort: 0
 ---
 
-Like we mentioned in the [introduction]('./'), there are multiple ways to define the `entry` property in your webpack configuration. We will show you the ways you **can** configure the property, in addition to explaining why it may be useful to you.
+Like we mentioned in the [introduction](./), there are multiple ways to define the `entry` property in your webpack configuration. We will show you the ways you **can** configure the property, in addition to explaining why it may be useful to you.
 
 ## Single Entry (Shorthand) Syntax
 
@@ -79,7 +79,7 @@ const config = {
 
 **What does this do?** At face value this tells webpack to create dependency graphs starting at both `app.js` and `vendors.js`. These graphs are completely separate and independant of eachother. (AKA there will be a webpack bootstrap in each bundle). This is commonly seen with single page applications which have only one entry point (excluding vendors).
 
-**Why?** This setup allows you to leverage [`CommonsChunkPlugin`](../api/plugins/commonschunkplugin) and extract any vendor references from your app bundle into your vendor bundle, replacing them with `__webpack_require__()` calls. If there is no vendor code in your application bundle, then you can achieve a common pattern in webpack known as [long-term vendor-caching.](../how-to/cache).
+**Why?** This setup allows you to leverage [`CommonsChunkPlugin`](../../api/plugins/commonschunkplugin) and extract any vendor references from your app bundle into your vendor bundle, replacing them with `__webpack_require__()` calls. If there is no vendor code in your application bundle, then you can achieve a common pattern in webpack known as [long-term vendor-caching.](../../how-to/cache).
 
 #### Multi Page Application
 
@@ -102,9 +102,9 @@ const config = {
 
 **Why?** In a multi-page application, the server is going to fetch a new html document for you, and the page reloads this new document and assets are redownloaded. However this gives us the unique opportunity to do multiple things:
 
-- Use [`CommonsChunkPlugin`](../api/plugins/commonschunkplugin) to create bundles of shared application code between each page. Multi-page applications that reuse a lot of code/modules between entry points can greatly benefit from these techniques, as the amount of entry points increase.
+- Use [`CommonsChunkPlugin`](../../api/plugins/commonschunkplugin) to create bundles of shared application code between each page. Multi-page applications that reuse a lot of code/modules between entry points can greatly benefit from these techniques, as the amount of entry points increase.
 
-- Set up [long-term vendor-caching.](../how-to/cache) with the same plugin and techniques seen in the first example.
+- Set up [long-term vendor-caching.](../../how-to/cache) with the same plugin and techniques seen in the first example.
 
 
 


### PR DESCRIPTION
The links on entry page were pointing to wrong place and now they are fixed.