### PR TITLE
Extend stub for "how to develop"

### DIFF
--- a/content/how-to/develop.md
+++ b/content/how-to/develop.md
@@ -1,12 +1,44 @@
 ---
 title: How to Develop?
+contributors:
+  - SpaceK33z
 ---
-> devtool
-> output.pathinfo
-> hot module replacement
 
-> watch
-> caching
-> dev middleware
-> in memory compilation
-> dev server
+Introduction:
+
+- Show the three ways to develop: webpack --watch, webpack-dev-server, webpack-dev-middleware and explain the differences (keep it short!). dev-server is the easiest one to get started.
+- dev-server and dev-middleware use in-memory compilation
+- Explain that IT SHOULD NOT BE USED IN PRODUCTION, NEVER.
+
+Adjusting your text editor
+
+- Explain that some editors use "atomic save"; this needs to be disabled in order to see all file changes.
+
+Choose a devtool
+
+- Explain shortly what source maps are and why they come in handy when devving
+- Link to devtool page for more info about source maps
+
+webpack-dev-server
+
+- show one use case
+- how to install
+- show how to use in CLI
+- show how to use API
+- refer to `devServer` configuration page
+- explain `inline` and `iframe` mode, and explain `inline` requires more config in API
+- make clear that there are some differences in CLI and API
+- after explaining live reload, link to HMR article
+
+webpack-dev-middleware
+
+- show one use case
+- how to install
+- show how to use API
+- refer to `devServer` configuration page
+
+webpack watch mode
+
+- show one use case
+- show how to use in CLI
+- show how to use API

--- a/content/how-to/develop.md
+++ b/content/how-to/develop.md
@@ -4,11 +4,10 @@ contributors:
   - SpaceK33z
 ---
 
-Introduction:
-
 - Show the three ways to develop: webpack --watch, webpack-dev-server, webpack-dev-middleware and explain the differences (keep it short!). dev-server is the easiest one to get started.
 - dev-server and dev-middleware use in-memory compilation
-- Explain that IT SHOULD NOT BE USED IN PRODUCTION, NEVER.
+
+W> Explain that IT SHOULD NOT BE USED IN PRODUCTION, NEVER.
 
 Adjusting your text editor
 
@@ -18,6 +17,13 @@ Choose a devtool
 
 - Explain shortly what source maps are and why they come in handy when devving
 - Link to devtool page for more info about source maps
+
+webpack watch mode
+
+- show one use case
+- show how to use in CLI
+- show how to use API
+- explain that you need to use your own server (maybe show the python server)
 
 webpack-dev-server
 
@@ -37,8 +43,3 @@ webpack-dev-middleware
 - show how to use API
 - refer to `devServer` configuration page
 
-webpack watch mode
-
-- show one use case
-- show how to use in CLI
-- show how to use API


### PR DESCRIPTION
I'm planning to write the whole "how to develop" page soon, but I would like to see first what you guys think of the structure.

I'm not even sure if explaining the three ways to develop (dev-server, dev-middleware, webpack watch) is the best way to go here. We could also explain the most common and easy use case with dev-server here, and explain the other two ways in a subpage.

I really would like some feedback on this.