### PR TITLE
feat(migration-guide): added System.import

### DIFF
--- a/content/how-to/upgrade-from-webpack-1.md
+++ b/content/how-to/upgrade-from-webpack-1.md
@@ -183,12 +183,19 @@ To keep compatiblity with old loaders, this information can be passed via plugin
   ]
 ```
 
-
 #### Code Splitting with ES6
+
+In webpack v1, you could use `require.ensure` as a method to lazily-load chunks for your application: 
+
+```javascript
+require.ensure([], function(require) {
+  var foo = require("./module");
+});
+```
 
 The ES6 Loader spec defines `System.import` as method to load ES6 Modules dynamically on runtime.
 
-Webpack threads `System.import` as splitpoint and puts the requested module in a separate chunk.
+webpack threads `System.import` as a split-point and puts the requested module in a separate chunk.
 
 `System.import` takes the module name as argument and returns a Promise.
 

--- a/content/how-to/upgrade-from-webpack-1.md
+++ b/content/how-to/upgrade-from-webpack-1.md
@@ -239,3 +239,13 @@ import { readFileSync } from "fs"; // named exports are read from returned objec
 typeof fs.readFileSync === "function";
 typeof readFileSync === "function";
 ```
+
+It is important to note that you will want to tell babel to not parse these module symbols so webpack can use them. You can do this by setting the following in your .babelrc or babel-loader options. 
+
+```
+{
+  presets: [
+    ["es2015", { "modules": false }]
+  ]
+}
+```

--- a/content/how-to/upgrade-from-webpack-1.md
+++ b/content/how-to/upgrade-from-webpack-1.md
@@ -202,10 +202,9 @@ function onClick() {
 }
 ```
 
-
+Good news: Failure to load a chunk can be handled now because they are Promise based.
 
 #### Dynamic expressions
-Good news: Failure to load a chunk can be handled now.
 
 It's possible to pass an partial expression to `System.import`. This is handled similar to expressions in CommonJS (webpack creates a context with all possible files).
 

--- a/content/how-to/upgrade-from-webpack-1.md
+++ b/content/how-to/upgrade-from-webpack-1.md
@@ -242,9 +242,11 @@ typeof readFileSync === "function";
 
 It is important to note that you will want to tell babel to not parse these module symbols so webpack can use them. You can do this by setting the following in your .babelrc or babel-loader options. 
 
-```
+**.babelrc**
+
+```json
 {
-  presets: [
+  "presets": [
     ["es2015", { "modules": false }]
   ]
 }

--- a/content/how-to/upgrade-from-webpack-1.md
+++ b/content/how-to/upgrade-from-webpack-1.md
@@ -182,3 +182,61 @@ To keep compatiblity with old loaders, this information can be passed via plugin
 +   })
   ]
 ```
+
+
+#### Code Splitting with ES6
+
+The ES6 Loader spec defines `System.import` as method to load ES6 Modules dynamically on runtime.
+
+Webpack threads `System.import` as splitpoint and puts the requested module in a separate chunk.
+
+`System.import` takes the module name as argument and returns a Promise.
+
+``` js
+function onClick() {
+	System.import("./module").then(module => {
+		module.default;
+	}).catch(err => {
+		console.log("Chunk loading failed");
+	});
+}
+```
+
+
+
+#### Dynamic expressions
+Good news: Failure to load a chunk can be handled now.
+
+It's possible to pass an partial expression to `System.import`. This is handled similar to expressions in CommonJS (webpack creates a context with all possible files).
+
+`System.import` creates a separate chunk for each possible module.
+
+``` js
+function route(path, query) {
+	return System.import("./routes/" + path + "/route")
+		.then(route => new route.Route(query));
+}
+// This creates a separate chunk for each possible route
+```
+
+#### Mixing ES6 with AMD and CommonJS
+
+As for AMD and CommonJS you can freely mix all three module types (even within the same file). Webpack behaves similar to babel in this case:
+
+``` js
+// CommonJS consuming ES6 Module
+var book = require("./book");
+
+book.currentPage;
+book.readPage();
+book.default === "This is a book";
+```
+
+``` js
+// ES6 Module consuming CommonJS
+import fs from "fs"; // module.exports map to default
+import { readFileSync } from "fs"; // named exports are read from returned object+
+
+typeof fs.readFileSync === "function";
+typeof readFileSync === "function";
+```

--- a/content/how-to/upgrade-from-webpack-1.md
+++ b/content/how-to/upgrade-from-webpack-1.md
@@ -209,11 +209,11 @@ function onClick() {
 }
 ```
 
-Good news: Failure to load a chunk can be handled now because they are Promise based.
+Good news: Failure to load a chunk can be handled now because they are `Promise` based.
 
 #### Dynamic expressions
 
-It's possible to pass an partial expression to `System.import`. This is handled similar to expressions in CommonJS (webpack creates a context with all possible files).
+It's possible to pass an partial expression to `System.import`. This is handled similar to expressions in CommonJS (webpack creates a [context](https://webpack.github.io/docs/context.html) with all possible files).
 
 `System.import` creates a separate chunk for each possible module.
 
@@ -247,7 +247,7 @@ typeof fs.readFileSync === "function";
 typeof readFileSync === "function";
 ```
 
-It is important to note that you will want to tell babel to not parse these module symbols so webpack can use them. You can do this by setting the following in your .babelrc or babel-loader options. 
+It is important to note that you will want to tell Babel to not parse these module symbols so webpack can use them. You can do this by setting the following in your .babelrc or babel-loader options. 
 
 **.babelrc**
 


### PR DESCRIPTION
Added code-splitting guide from "Whats new in webpack 2 old doc" into new one.

I noticed that @addyosmani was linking https://gist.github.com/sokra/27b24881210b56bbaff7 in his newest Medium publications, its probably best we just add this content to the new page which is more comprehensive and detailed for webpack 2.x. 

cc// @bebraw 