### PR TITLE
Improve WatchOptions docs

### DIFF
--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -122,22 +122,6 @@ T> This option has no effect when used with `quiet` or `noInfo`.
 
 Control options related to watching the files.
 
-You can control how many milliseconds webpack will wait before re-compiling if no additional change was detected. If you want to wait one second, set it like this:
-
-```js
-watchOptions: {
-  aggregateTimeout: 1000
-}
-```
-
-For some systems, watching many file systems can result in a lot of CPU or memory usage. If this is the case, it is possible to exclude a huge folder like `node_modules`:
-
-```js
-watchOptions: {
-  ignored: /node_modules/
-}
-```
-
 webpack uses the file system to get notified of file changes. In some cases this does not work. For example, when using Network File System (NFS). [Vagrant](https://www.vagrantup.com/) also has a lot of problems with this. In these cases, use polling:
 
 ```js
@@ -147,6 +131,8 @@ watchOptions: {
 ```
 
 If this is too heavy on the file system, you can change this to an integer to set the interval in milliseconds.
+
+See [WatchOptions](./watch) for more options.
 
 
 ### `devServer.headers` 🔑
@@ -198,7 +184,7 @@ T> `filename` has no effect when used without **lazy mode**.
 
 ### `devServer.contentBase`
 
-`string` `array`
+`boolean` `string` `array`
 
 Tell the server where to serve content from. This is only necessary if you want to serve static files. [`output.publicPath`](#output-publicpath) will be used to determine where the bundles should be served from, and takes precedence.
 
@@ -214,6 +200,12 @@ It is also possible to serve from multiple directories:
 
 ```js
 contentBase: [path.join(__dirname, "public"), path.join(__dirname, "assets")]
+```
+
+To disable `contentBase`:
+
+```js
+contentBase: false
 ```
 
 ### `devServer.staticOptions`

--- a/content/configuration/watch.md
+++ b/content/configuration/watch.md
@@ -3,9 +3,10 @@ title: Watch and WatchOptions
 contributors:
   - sokra
   - gregvenech
+  - SpaceK33z
 ---
 
-?> Description...
+Webpack can watch files and recompile whenever they change. This page explains how to enable this and a couple of tweaks you can make if watching does not properly for you.
 
 ### `watch`
 
@@ -17,6 +18,7 @@ Turn on watch mode. This means that after the initial build, webpack will contin
 watch: false
 ```
 
+T> In webpack-dev-server and webpack-dev-middleware watch mode is enabled by default.
 
 ### `watchOptions`
 
@@ -51,4 +53,21 @@ Turn on [polling](http://whatis.techtarget.com/definition/polling) by passing `t
 
 ```js
 poll: 1000 // Check for changes every second
+```
+
+T> If watching does not work for you, try out this option. Watching does not work with NFS and machines in VirtualBox.
+
+
+### `watchOptions.ignored`
+
+For some systems, watching many file systems can result in a lot of CPU or memory usage. It is possible to exclude a huge folder like `node_modules`:
+
+```js
+ignored: /node_modules/
+```
+
+It is also possible to use [anymatch](https://github.com/es128/anymatch) patterns:
+
+```js
+ignored: "files/**/*.js"
 ```


### PR DESCRIPTION
Added some more docs to WatchOptions.
Moved duplicate documentation from DevServer about WatchOptions to there. Added link back to WatchOptions.

Also added how to disable `contentBase` while I was at it :).

PS: Still working on the "how to develop" page.