### PR TITLE
Suggesting `webpack-isomorphic-tools` for server-side rendering.

### DIFF
--- a/content/how-to/cache.md
+++ b/content/how-to/cache.md
@@ -135,7 +135,7 @@ A sample output of webpack-manifest-plugin for our config looks like:
 }
 ```
 
-The rest depends on your server setup. There is a nice [walk through for Rails-based projects](http://clarkdave.net/2015/01/how-to-use-webpack-with-rails/#including-precompiled-assets-in-views). Or, if your application doesn’t rely on any server-side rendering, it’s often enough to generate a single `index.html` file for your application. To do so, just use these 2 amazing plugins:
+The rest depends on your server setup. There is a nice [walk through for Rails-based projects](http://clarkdave.net/2015/01/how-to-use-webpack-with-rails/#including-precompiled-assets-in-views). For serverside rendering in node you can use [webpack-isomorphic-tools](https://github.com/halt-hammerzeit/webpack-isomorphic-tools). Or, if your application doesn’t rely on any server-side rendering, it’s often enough to generate a single `index.html` file for your application. To do so, just use these 2 amazing plugins:
 
 * https://github.com/ampedandwired/html-webpack-plugin
 * https://github.com/szrenwei/inline-manifest-webpack-plugin


### PR DESCRIPTION
This dependency helped me to retrieve my chunk unique hashes while rendering my views on the server side. My view wasn't an html file so I couldn't simply use `html-webpack-plugin`. I thought this worth mentioning and save people's time.