### PR TITLE
Move module.exports to syntactically valid positions

### DIFF
--- a/content/concepts/entry-points.md
+++ b/content/concepts/entry-points.md
@@ -12,25 +12,21 @@ Usage: `entry: string|Array<string>`
 **webpack.config.js**
 
 ```javascript
-  module.exports = config;
+const config = {
+  entry: './path/to/my/entry/file.js'
+};
 
-  const config = {
-    entry: './path/to/my/entry/file.js'
-  };
-
+module.exports = config;
 ```
 
 The single entry syntax for the `entry` property is a short hand for:
 
 ```javascript
-  module.exports = config;
-
-  const config = {
-    entry: {
-      main: './path/to/my/entry/file.js'
-    }
-  };
-
+const config = {
+  entry: {
+    main: './path/to/my/entry/file.js'
+  }
+};
 ```
 
 T> **What happens when you pass an array to `entry`?** Passing an array of file paths to the `entry` property creates what is known as a **"multi-main entry"**. This is useful when you would like to inject multiple dependent files together and graph their dependencies into one "chunk".
@@ -44,14 +40,12 @@ Usage: `entry: {[entryChunkName: string]: string|Array<string>}`
 **webpack.config.js**
 
 ```javascript
-  module.exports = config;
-
-  const config = {
-    entry: {
-      app: './src/app.js',
-      vendors: './src/vendors.js'
-    }
-  };
+const config = {
+  entry: {
+    app: './src/app.js',
+    vendors: './src/vendors.js'
+  }
+};
 ```
 
 The object syntax is a more verbose, however scalable way of defining entry/entries in your application.
@@ -67,8 +61,6 @@ Below is a list of entry configurations and their real-world use cases:
 **webpack.config.js**
 
 ```javascript
-module.exports = config;
-
 const config = {
   entry: {
     app: './src/app.js',
@@ -86,8 +78,6 @@ const config = {
 **webpack.config.js**
 
 ```javascript
-module.exports = config;
-
 const config = {
   entry: {
     pageOne: './src/pageOne/index.js',
@@ -105,6 +95,3 @@ const config = {
 - Use [`CommonsChunkPlugin`](../../api/plugins/commonschunkplugin) to create bundles of shared application code between each page. Multi-page applications that reuse a lot of code/modules between entry points can greatly benefit from these techniques, as the amount of entry points increase.
 
 - Set up [long-term vendor-caching.](../../how-to/cache) with the same plugin and techniques seen in the first example.
-
-
-

--- a/content/concepts/index.md
+++ b/content/concepts/index.md
@@ -19,12 +19,11 @@ The simplest example is seen below:
 **webpack.config.js**
 
 ```javascript
-  module.exports = config;
+const config = {
+  entry: './path/to/my/entry/file.js'
+};
 
-  const config = {
-    entry: './path/to/my/entry/file.js'
-  };
-
+module.exports = config;
 ```
 
 There are multiple ways to declare your `entry` property that are specific to your applications needs.
@@ -38,15 +37,13 @@ Once you've bundled all of your assets together, we still need to tell webpack *
 **webpack.config.js**
 
 ```javascript
-  module.exports = config;
-
-  const config = {
-    entry: './path/to/my/entry/file.js',
-    output: {
-      filename: 'my-first-webpack.bundle.js',
-      path: './dist'
-    }
-  };
+const config = {
+  entry: './path/to/my/entry/file.js',
+  output: {
+    filename: 'my-first-webpack.bundle.js',
+    path: './dist'
+  }
+};
 ```
 
 In the example above, through the `output.filename` and `output.path` properties we are describing to webpack the name of our bundle, and where we want it to be emitted to.
@@ -72,20 +69,18 @@ At a high level, they have two purposes in your webpack config.
 **webpack.config.js**
 
 ```javascript
-  module.exports = config;
-
-  const config = {
-    entry: './path/to/my/entry/file.js',
-    output: {
-      filename: 'my-first-webpack.bundle.js',
-      path: './dist'
-    },
-    module: {
-      loaders: [
-        {test: /\.(js|jsx)$/, loader: 'babel-loader'}
-      ]
-    }
-  };
+const config = {
+  entry: './path/to/my/entry/file.js',
+  output: {
+    filename: 'my-first-webpack.bundle.js',
+    path: './dist'
+  },
+  module: {
+    loaders: [
+      {test: /\.(js|jsx)$/, loader: 'babel-loader'}
+    ]
+  }
+};
 ```
 
 In the configuration above we have defined our loader with its two required properties: `test`, and `loader`. It tells webpack's compiler the following:
@@ -107,27 +102,27 @@ In order to use a plugin, you just need to `require()` it and add it to the `plu
 **webpack.config.js**
 
 ```javascript
-  const HtmlWebpackPlugin = require('html-webpack-plugin'); //installed via npm
-  const webpack = require('webpack'); //to access built-in plugins
+const HtmlWebpackPlugin = require('html-webpack-plugin'); //installed via npm
+const webpack = require('webpack'); //to access built-in plugins
 
-  module.exports = config;
-
-  const config = {
-    entry: './path/to/my/entry/file.js',
-    output: {
-      filename: 'my-first-webpack.bundle.js',
-      path: './dist'
-    },
-    module: {
-      loaders: [
-        {test: /\.(js|jsx)$/, loader: 'babel-loader'}
-      ]
-    },
-    plugins: [
-      new webpack.optimize.UglifyJsPlugin(),
-      new HtmlWebpackPlugin({template: './src/index.html'})
+const config = {
+  entry: './path/to/my/entry/file.js',
+  output: {
+    filename: 'my-first-webpack.bundle.js',
+    path: './dist'
+  },
+  module: {
+    loaders: [
+      {test: /\.(js|jsx)$/, loader: 'babel-loader'}
     ]
-  };
+  },
+  plugins: [
+    new webpack.optimize.UglifyJsPlugin(),
+    new HtmlWebpackPlugin({template: './src/index.html'})
+  ]
+};
+
+module.exports = config;
 ```
 
 There are many plugins that webpack provides out of the box! Check out our [list of plugins](https://webpack.github.io/docs/list-of-plugins.html) for more information.

--- a/content/concepts/output.md
+++ b/content/concepts/output.md
@@ -14,11 +14,11 @@ To set the `output` property, you simply set the output value in your webpack co
 **webpack.config.js**
 
 ```javascript
-module.exports = config;
-
-config = {
+const config = {
   output: 'blah'
-}
+};
+
+module.exports = config;
 ```
 
 ## Options
@@ -81,7 +81,6 @@ output: {
 	path: "/home/proj/public/assets",
 	publicPath: "/assets/"
 }
-
 ```
 
 **index.html**

--- a/content/concepts/plugins.md
+++ b/content/concepts/plugins.md
@@ -5,20 +5,20 @@ contributors:
   - TheLarkInn
 ---
 
-**Plugins** are the [backbone]('https://github.com/webpack/tapable') of webpack. webpack itself is built on the **same plugin system** that you use in your webpack configuration!! 
+**Plugins** are the [backbone]('https://github.com/webpack/tapable') of webpack. webpack itself is built on the **same plugin system** that you use in your webpack configuration!!
 
 They also serve the purpose of doing **anything else** that a [loader]('./loaders') cannot do.
 
 ## Anatomy
 
-A webpack **plugin** is a JavaScript object that has an `apply` property. This `apply` property is called by the webpack compiler, giving access to the **entire** compilation lifecycle. 
+A webpack **plugin** is a JavaScript object that has an `apply` property. This `apply` property is called by the webpack compiler, giving access to the **entire** compilation lifecycle.
 
 
 **ConsoleLogOnBuildWebpackPlugin.js**
 
 ```javascript
 function ConsoleLogOnBuildWebpackPlugin() {
-  
+
 };
 
 ConsoleLogOnBuildWebpackPlugin.prototype.apply = function(compiler) {
@@ -41,30 +41,30 @@ Depending on how you are using webpack, there are multiple ways to use plugins.
 **webpack.config.js**
 
 ```javascript
-  const HtmlWebpackPlugin = require('html-webpack-plugin'); //installed via npm
-  const webpack = require('webpack'); //to access built-in plugins
+const HtmlWebpackPlugin = require('html-webpack-plugin'); //installed via npm
+const webpack = require('webpack'); //to access built-in plugins
 
-  module.exports = config;
-
-  const config = {
-    entry: './path/to/my/entry/file.js',
-    output: {
-      filename: 'my-first-webpack.bundle.js',
-      path: './dist'
-    },
-    module: {
-      loaders: [
-        {
-          test: /\.(js|jsx)$/, 
-          loader: 'babel-loader'
-        }
-      ]
-    },
-    plugins: [
-      new webpack.optimize.UglifyJsPlugin(),
-      new HtmlWebpackPlugin({template: './src/index.html'})
+const config = {
+  entry: './path/to/my/entry/file.js',
+  output: {
+    filename: 'my-first-webpack.bundle.js',
+    path: './dist'
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.(js|jsx)$/,
+        loader: 'babel-loader'
+      }
     ]
-  };
+  },
+  plugins: [
+    new webpack.optimize.UglifyJsPlugin(),
+    new HtmlWebpackPlugin({template: './src/index.html'})
+  ]
+};
+
+module.exports = config;
 ```
 
 ### Node API
@@ -84,4 +84,3 @@ Depending on how you are using webpack, there are multiple ways to use plugins.
 ```
 
 T> Did you know: The example seen above is extremely similar to the [webpack runtime itself!](https://github.com/webpack/webpack/blob/master/bin/webpack.js#L290-L292) There are lots of great usage examples hiding in the [webpack source code](https://github.com/webpack/webpack) that you can apply to your own configurations and scripts!
-

--- a/content/concepts/targets.md
+++ b/content/concepts/targets.md
@@ -12,22 +12,22 @@ W> The webpack `target` property is not to be confused with the `output.libraryT
 
 ### Usage
 
-To set the `target` property, you simply set the target value in your webpack config: 
+To set the `target` property, you simply set the target value in your webpack config:
 
 
 **webpack.config.js**
 
 ```javascript
-module.exports = config;
-
 const config = {
-  target: 'node' 
+  target: 'node'
 };
+
+module.exports = config;
 ```
 
 ### Options
 
-The following is a list of values you can pass to the `target` property. 
+The following is a list of values you can pass to the `target` property.
 
 * `"web"` Compile for usage in a browser-like environment (default)
 * `"webworker"` Compile as WebWorker
@@ -36,7 +36,7 @@ The following is a list of values you can pass to the `target` property.
 * `"node-webkit"` Compile for usage in webkit, uses jsonp chunk loading but also supports build in node.js modules plus require("nw.gui") (experimental)
 * `"electron-main"` Compile for electron renderer process, provide a target using `JsonpTemplatePlugin`, `FunctionModulePlugin` for browser environment and `NodeTargetPlugin` and `ExternalsPlugin` for commonjs and electron bulit-in modules. *Note: need `webpack` >= 1.12.15.
 
-Each _target_ has a variety of deployment/environment specific additions, support to fit its needs. 
+Each _target_ has a variety of deployment/environment specific additions, support to fit its needs.
 
 For example, when you use the `electron-main` _target_, *webpack* includes multiple `electron-main` specific variables. For more information on which templates and _externals_ are used, you can refer [directly to the webpack source code](https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsApply.js#L70-L185).
 
@@ -44,21 +44,18 @@ For example, when you use the `electron-main` _target_, *webpack* includes multi
 
 ### Multiple Targets
 
-Although webpack does **not** support multiple strings being passed into the `target` property, you can create an isomorphic library by bundling two separate configurations: 
+Although webpack does **not** support multiple strings being passed into the `target` property, you can create an isomorphic library by bundling two separate configurations:
 
 **webpack.config.js**
 
 ```javascript
-
-module.exports = [ serverConfig, clientConfig ];
-
 var serverConfig = {
   target: 'node',
   output: {
     path: 'dist',
     filename: 'lib.node.js'
   }
-  //… 
+  //…
 };
 
 var clientConfig = {
@@ -70,17 +67,17 @@ var clientConfig = {
   //…
 };
 
+module.exports = [ serverConfig, clientConfig ];
 ```
 
 The example above will create a `lib.js` and `lib.node.js` file in your `dist` folder.
 
 ### Resources
 
-As seen from the options above there are multiple different deployment _targets_ that you can choose from. Below is a list of examples, and resources that you can refer to. 
+As seen from the options above there are multiple different deployment _targets_ that you can choose from. Below is a list of examples, and resources that you can refer to.
 
 #### Bundle Output Comparison
 
-  **[compare-webpack-target-bundles](https://github.com/TheLarkInn/compare-webpack-target-bundles)**: A great resource for testing and viewing different webpack _targets_. Also great for bug reporting. 
+  **[compare-webpack-target-bundles](https://github.com/TheLarkInn/compare-webpack-target-bundles)**: A great resource for testing and viewing different webpack _targets_. Also great for bug reporting.
 
 ?> Need to find up to date examples of these webpack targets being used in live code or boilerplates.
-

--- a/content/how-to/cache.md
+++ b/content/how-to/cache.md
@@ -216,7 +216,6 @@ module.exports = {
     new webpack.optimize.OccurenceOrderPlugin()
   ]
 };
-
 ```
 
 T> If you're using [webpack-html-plugin](https://github.com/ampedandwired/html-webpack-plugin), you can use [inline-manifest-webpack-plugin](https://github.com/szrenwei/inline-manifest-webpack-plugin) to do this.


### PR DESCRIPTION
Fixes #228 

- Moves `module.exports` to syntactically valid positions (e.g. after `const config = {...}` is defined).
- In some cases, removes `module.exports` line entirely when it has already been written at least once in the doc (as per @timdorr 's suggestion)