### PR TITLE
Move stats documentation to separate page

### DIFF
--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -96,22 +96,13 @@ noInfo: true
 
 This option lets you precisely control what bundle information gets displayed. This can be a nice middle ground if you want some bundle information, but not all of it.
 
-There are some presets: `none`, `errors-only`, `minimal` and `verbose`. Use them like this:
+To show only errors in your bundle:
 
 ```js
 stats: "errors-only"
 ```
 
-You can control this even more granularly:
-
-```js
-stats: {
-  chunks: false,
-  hash: false
-}
-```
-
-The available options are: `hash`, `version`, `timings`, `assets`, `chunks`, `modules`, `reasons`, `children`, `source`, `errors`, `errorDetails`, `warnings`and `publicPath`.
+For more information, see the [**stats documentation**](./stats).
 
 T> This option has no effect when used with `quiet` or `noInfo`.
 

--- a/content/configuration/stats.md
+++ b/content/configuration/stats.md
@@ -1,0 +1,44 @@
+---
+title: Stats
+contributors:
+  - SpaceK33z
+---
+
+The `stats` option lets you precisely control what bundle information gets displayed. This can be a nice middle ground if you don't want to use `quiet` or `noInfo` because you want some bundle information, but not all of it.
+
+T> For webpack-dev-server, this property needs to be in the `devServer` object.
+
+### `stats`
+
+`object` `string`
+
+There are some presets: `none`, `errors-only`, `minimal` and `verbose`. Use them like this:
+
+```js
+stats: "errors-only"
+```
+
+For more granular control, it is possible to specify exactly what information you want:
+
+```js
+stats: {
+  chunks: false,
+  hash: false
+}
+```
+
+The available options are:
+
+* `hash`
+* `version`
+* `timings`
+* `assets`
+* `chunks`
+* `modules`
+* `reasons`
+* `children`
+* `source`
+* `errors`
+* `errorDetails`
+* `warnings`
+* `publicPath`

--- a/content/configuration/stats.md
+++ b/content/configuration/stats.md
@@ -8,7 +8,7 @@ The `stats` option lets you precisely control what bundle information gets displ
 
 T> For webpack-dev-server, this property needs to be in the `devServer` object.
 
-### `stats`
+## `stats`
 
 `object` `string`
 
@@ -27,7 +27,7 @@ stats: {
 }
 ```
 
-The available options are:
+The available properties in this object are:
 
 * `hash`
 * `version`


### PR DESCRIPTION
As described in #226, this moves the documentation I wrote about `devServer.stats` to a separate page, because it also applies when using webpack itself.

Fixes #226