### PR TITLE
feat(donate/open_collective): add open collective content

### DIFF
--- a/components/site/site.jsx
+++ b/components/site/site.jsx
@@ -6,6 +6,7 @@ import Footer from '../footer/footer';
 import './site-style';
 
 const pages = [
+  { title: 'Donate', url: '//opencollective.com/webpack'},
   { title: 'Concepts', url: 'concepts' },
   { title: 'Configuration', url: 'configuration' },
   { title: 'How to', url: 'how-to' },

--- a/components/splash/splash-style.scss
+++ b/components/splash/splash-style.scss
@@ -50,6 +50,15 @@
     color:map-get($colors, dove-grey);
   }
 
+  &__sponsorheadline {
+    font-style:italic;
+  }
+
+  &__sponsor { 
+    padding-top: 1.5em;
+    text-align: center;
+  }
+
   &__section {
     background:map-get($colors, white);
   }

--- a/components/splash/splash.jsx
+++ b/components/splash/splash.jsx
@@ -9,6 +9,16 @@ export default props => {
 
   return (
     <div className="splash">
+      <section className="splash__section splash__sponsor">
+        <Container className="splash__content splash_sponsorheadline">
+          <h1 id="opencollective-banner" className="splash__sponsorheadline">Help support webpack!</h1>
+          <p>By your contributions, donations, and sponsorship, you allow webpack to thrive.</p>
+          <p>Your donations go directly towards supporting office hours, continued enhancements, and most importantly, great documenation and learning material!</p>
+          
+          <object type="image/svg+xml" data="https://opencollective.com/webpack/sponsors.svg"></object>
+          <object type="image/svg+xml" data="https://opencollective.com/webpack/backers.svg"></object>
+        </Container>
+      </section>
       <section className="splash__viz">
         <div className="splash__modules">
 
@@ -38,7 +48,9 @@ export default props => {
             __html: page.content 
           }} />
         </Container>
-      </section>
+      </section>        
+
+
     </div>
   );
 };

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -46,4 +46,9 @@ a {
   }
 }
 
+#opencollective-banner h1 {
+  color: map-get($colors, emperor);
+  font: 300 getFontSize(3) 'Open Sans', 'Century Gothic', sans-serif;
+}
+
 @import './markdown';


### PR DESCRIPTION
This adds an open collective banner (minimalist) and navigation link to "DONATE". We are now apart of the open collective organization. Am open to additional styling but wanted to get the base content in ASAP. 

![screen shot 2016-10-14 at 11 46 22 pm](https://cloud.githubusercontent.com/assets/3408176/19407413/3a722b28-9267-11e6-9d72-d7b27899efcc.png)
