### PR TITLE
doc: fix typo in upgrade guide

### DIFF
--- a/content/how-to/upgrade-from-webpack-1.md
+++ b/content/how-to/upgrade-from-webpack-1.md
@@ -195,7 +195,7 @@ require.ensure([], function(require) {
 
 The ES6 Loader spec defines `System.import` as method to load ES6 Modules dynamically on runtime.
 
-webpack threads `System.import` as a split-point and puts the requested module in a separate chunk.
+webpack treats `System.import` as a split-point and puts the requested module in a separate chunk.
 
 `System.import` takes the module name as argument and returns a Promise.
 


### PR DESCRIPTION
This fixes a little typo in the upgrade guide, no biggie :)

Thanks for writing this doc, helped me to understand some of the differences of Webpack 2 to Webpack 1. Will definitely give it a try in a project now. Thank you all for your hard work!

