### PR TITLE
Consistent use of resolve()

### DIFF
--- a/content/how-to/set-up-hmr-with-react.md
+++ b/content/how-to/set-up-hmr-with-react.md
@@ -99,7 +99,7 @@ module.exports = env => {
       hot: true,
       //activate hot reloading
 
-      contentBase: './dist',
+      contentBase: resolve(__dirname, 'dist'),
       //match the output path
 
       publicPath: '/'


### PR DESCRIPTION
Spent an hour debugging why my devserver wasn't working. Turns out /dist would try to serve from a root folder name 'dist' on my filesystem!