### PR TITLE
Desktop Sidebar

### DIFF
--- a/components/page/page.jsx
+++ b/components/page/page.jsx
@@ -20,7 +20,7 @@ export default ({ section, page }) => {
           title: page.title,
           anchors: page.anchors
         }))}
-        currentPage={ page.url }
+        currentPage={ page.url.replace("/index", "") }
       />
 
       <section className="page__content">

--- a/components/page/page.jsx
+++ b/components/page/page.jsx
@@ -20,6 +20,7 @@ export default ({ section, page }) => {
           title: page.title,
           anchors: page.anchors
         }))}
+        currentPage={ page.url }
       />
 
       <section className="page__content">

--- a/components/sidebar-item/sidebar-item-style.scss
+++ b/components/sidebar-item/sidebar-item-style.scss
@@ -52,12 +52,6 @@
     }
   }
 
-  &--empty {
-    .sidebar-item__toggle {
-      display:none;
-    }
-  }
-
   &--open {
     .sidebar-item__anchors {
       display:block;
@@ -70,6 +64,13 @@
     .sidebar-item__toggle {
       margin-left:-2px;
       transform:rotate(180deg) translateX(1px);
+    }
+  }
+
+  &--empty {
+    .sidebar-item__toggle,
+    .sidebar-item__anchors {
+      display: none;
     }
   }
 }

--- a/components/sidebar-item/sidebar-item-style.scss
+++ b/components/sidebar-item/sidebar-item-style.scss
@@ -63,6 +63,10 @@
       display:block;
     }
 
+    .sidebar-item__title {
+      color: #c0903f;
+    }
+
     .sidebar-item__toggle {
       margin-left:-2px;
       transform:rotate(180deg) translateX(1px);

--- a/components/sidebar-item/sidebar-item.js
+++ b/components/sidebar-item/sidebar-item.js
@@ -14,7 +14,7 @@ export default class SidebarItem extends React.Component {
   render() {
     let { index, url, title, anchors = [], currentPage } = this.props;
     let emptyMod = !anchors.length ? 'sidebar-item--empty' : '';
-    let active = `/${currentPage}`.includes(url);
+    let active = `/${currentPage}` === url;
     let openMod = (active || this.state.open) ? 'sidebar-item--open' : '';
 
     return (

--- a/components/sidebar-item/sidebar-item.js
+++ b/components/sidebar-item/sidebar-item.js
@@ -12,9 +12,10 @@ export default class SidebarItem extends React.Component {
   }
 
   render() {
-    let { index, url, title, anchors = [] } = this.props;
+    let { index, url, title, anchors = [], currentPage } = this.props;
     let emptyMod = !anchors.length ? 'sidebar-item--empty' : '';
-    let openMod = this.state.open ? 'sidebar-item--open' : '';
+    let active = `/${currentPage}`.includes(url);
+    let openMod = (active || this.state.open) ? 'sidebar-item--open' : '';
 
     return (
       <div className={ `sidebar-item ${emptyMod} ${openMod}` }>

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -3,14 +3,16 @@ import SidebarItem from '../sidebar-item/sidebar-item';
 import './sidebar-style';
 
 export default props => {
-  let { sectionName, pages } = props;
+  let { sectionName, pages, currentPage } = props;
 
   return (
     <nav className="sidebar">
       <div className="sidebar__inner">
         <SidebarItem 
           url={ `/${sectionName}` } 
-          title="Introduction" />
+          title="Introduction"
+          currentPage= { currentPage }
+        />
 
         {
           pages.map(({ url, title, anchors }, i) =>
@@ -20,6 +22,7 @@ export default props => {
               url={ `/${url}` }
               title={ title }
               anchors={ anchors }
+              currentPage= { currentPage }
             />
           )
         }


### PR DESCRIPTION
This PR is based on #256 . The only thing that I found out that is was not yet implemented is

> When you click on menu with sub-menu, sub-menu should open

Some more things that I found:

- [x] Highlight active link
- [x] Hide empty sub-menu (empty `ul `creates space between items)