### PR TITLE
Header fixes for tablet/mobile

### DIFF
--- a/components/navigation/navigation-style.scss
+++ b/components/navigation/navigation-style.scss
@@ -34,14 +34,17 @@
   padding: 0.6em 1em;
 
   @include break {
-    padding:0 0 0 1.5em;
+    padding: 0.6em 1em;
+  }
+
+  @include break('large') {
+    padding: 0 1em 0 1.6em;
   }
 }
 
 .navigation__mobile {
   display: flex;
   font-size: 1.5em;
-  margin-left: -1em;
   align-items: center;
   color: map-get($colors, white);
   cursor: pointer;
@@ -51,19 +54,29 @@
     color: map-get($colors, alto);
   }
 
-  @include break {
+  @include break('large') {
     display: none;
   }
 }
 
 .navigation__logo {
-  margin:auto;
+  margin: auto;
+  position: relative;
+  left: -1em;
+
+  @include break {
+    left: -1.5em;
+  }
+
+  @include break('large') {
+    left: 0;
+  }
 }
 
 .navigation__links {
   display: none;
 
-  @include break {
+  @include break('large') {
     flex: 1 1 auto;
     display: flex;
     align-items: center;

--- a/components/sidebar-mobile/sidebar-mobile-style.scss
+++ b/components/sidebar-mobile/sidebar-mobile-style.scss
@@ -15,7 +15,7 @@
   transform: translate3D(-100%, 0, 0);
   transition: all 500ms;
 
-  @include break {
+  @include break('large') {
     display: none;
   }
 

--- a/components/sidebar-mobile/sidebar-mobile.jsx
+++ b/components/sidebar-mobile/sidebar-mobile.jsx
@@ -69,7 +69,9 @@ export default class SidebarMobile extends React.Component {
         <Link
           key={ url } 
           className={ `sidebar-mobile__page ${active ? 'sidebar-mobile__page--active' : ''}` } 
-          to={ url }>
+          to={ url }
+          onClick={ this._close.bind(this) }
+        >
           { page.title }
         </Link>
       );


### PR DESCRIPTION
- [x] Switch to mobile menu on tablet (two new items were added to menu, so menu needs to hide faster)
- [x] Fix padding for header when transitioning between breakpoints 
- [x] Hide side menu mobile when clicking on link in menu
