### PR TITLE
link from get started to concepts

### DIFF
--- a/content/get-started.md
+++ b/content/get-started.md
@@ -136,3 +136,6 @@ If you run `npm run build` now, you should get the same result. Even though this
 ## Conclusion
 
 Now that you have a basic build together, you should dig into the [basic concepts](/concepts) and [configuration](/configuration) of webpack to understand its design better. Check out also the [how to section](/how-to) in order to see how to resolve common problems. The [API](/api) section digs into lower level.
+
+**[Next, concepts >](/concepts)**
+


### PR DESCRIPTION
**Context/problem:**
I like the content on the 'get started' page, it's a nice quick overview. However, there's a few options in the conclusion for what to do/read next. This could create some 'choice paralysis' for the user. It also means the learning journey doesn't have a linear flow which may mean users don't know what they *should* read next. 

**Solution:**
Linking to the next logical section (concepts) with a main call-to-action link at the bottom should solve this. I've added the link as part of this PR. If you think this is a good idea we can change wording/styling to suit.