### PR TITLE
Note on custom chunk names w/ System.import

### DIFF
--- a/content/how-to/upgrade-from-webpack-1.md
+++ b/content/how-to/upgrade-from-webpack-1.md
@@ -3,6 +3,7 @@ title: How to Upgrade from Webpack 1?
 contributors:
   - sokra
   - jhnns
+  - grgur
 ---
 
 ## `resolve.root`, `resolve.fallback`, `resolve.modulesDirectories`
@@ -261,6 +262,14 @@ function onClick() {
 ```
 
 Good news: Failure to load a chunk can be handled now because they are `Promise` based.
+
+Caveat: `react.ensure` allows for easy chunk naming with the optional third argument, but `System.import` API doesn't offer that capability. If you want to keep that functionality, you can continue using `react.ensure`.
+
+```javascript
+require.ensure([], function(require) {
+  var foo = require("./module");
+}, 'custom-chunk-name');
+```
 
 ### Dynamic expressions
 


### PR DESCRIPTION
Mentioned that `react.ensure` is still needed when custom chunk names are required