### PR TITLE
Update hot-reload example to use require()

### DIFF
--- a/content/how-to/hot-module-reload.md
+++ b/content/how-to/hot-module-reload.md
@@ -171,12 +171,10 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { AppContainer } from 'react-hot-loader';
 
-import App from './components/App';
-
 const render = () => {
   ReactDOM.render(
     <AppContainer>
-      <App/>
+      { require('./components/App').default }
     </AppContainer>,
     document.getElementById('root')
   );


### PR DESCRIPTION
This was the only way I could get it to work, migrating from webpack 1 on a fairly simple project.

Also, seems logical since you either need to render the new reference to App, or re-require it on every `render` call (see https://github.com/gaearon/react-hot-loader/issues/243#issuecomment-213796910)