### PR TITLE
Fix stats.toJson() naming

### DIFF
--- a/content/api/node.md
+++ b/content/api/node.md
@@ -150,15 +150,15 @@ Can be used to check if there were errors while compiling. Returns `true` or `fa
 
 Can be used to check if there were warnings while compiling. Returns `true` or `false`.
 
-### `stats.toJSON(options)`
+### `stats.toJson(options)`
 
 Returns compilation information as a JSON object. `options` can be either a string (a preset) or an object for more granular control:
 
 ``` js-with-links
-stats.toJSON("minimal"); // [more options: "verbose", etc](/configuration/stats).
+stats.toJson("minimal"); // [more options: "verbose", etc](/configuration/stats).
 ```
 ``` js
-stats.toJSON({
+stats.toJson({
   assets: false,
   hash: true
 });
@@ -172,7 +172,7 @@ All available options and presets are described in [Stats documentation](/config
 
 Returns a formatted string of the compilation information (similar to [CLI](/api/cli) output).
 
-Options are the same as [`stats.toJSON(options)`](/api/node#stats-tojson-options-) with one addition:
+Options are the same as [`stats.toJson(options)`](/api/node#stats-tojson-options-) with one addition:
 
 ``` js
 stats.toString({
@@ -226,7 +226,7 @@ webpack({
     return;
   }
 
-  const info = stats.toJSON();
+  const info = stats.toJson();
 
   if (stats.hasErrors()) {
     console.error(info.errors);


### PR DESCRIPTION
Fixes `stats.toJSON()` -> `stats.toJson()`.

I'm pretty sure the correct method is `toJson()`: https://github.com/webpack/webpack/blob/ac340bce1d7239c0e6c0d0cf93dbb6c26dddde1f/lib/Stats.js#L21. However, I'm definitely not an expert on webpack core, so I could be wrong. Certainly in webpack@2.1.0-beta.25 it is.