### PR TITLE
Getting Started Clarifications

### DIFF
--- a/content/get-started/index.md
+++ b/content/get-started/index.md
@@ -84,7 +84,7 @@ Also we will need to change the `index.html` to expect a single bundled js file.
   <head>
     <title>Webpack demo</title>
 -   <script src='https://unpkg.com/lodash@4.16.6' type='text/javascript'></script>
--   <script src='index.js' type='text/javascript'></script>
+-   <script src='app/index.js' type='text/javascript'></script>
 +   <script src='dist/bundle.js' type='text/javascript'></script>
   </head>
   <body>

--- a/content/get-started/index.md
+++ b/content/get-started/index.md
@@ -44,7 +44,7 @@ document.body.appendChild(component());
 
 To run this piece of code, one usually has the below html
 
-__index.html__
+__app/index.html__
 
 ```html
 <html>

--- a/content/get-started/index.md
+++ b/content/get-started/index.md
@@ -2,6 +2,7 @@
 title: Get Started with Webpack
 contributors:
   - bebraw
+  - varunjayaraman
 sort: 3
 ---
 

--- a/content/get-started/index.md
+++ b/content/get-started/index.md
@@ -50,9 +50,9 @@ __index.html__
   <head>
     <title>Webpack demo</title>
     <script src='https://unpkg.com/lodash@4.16.6' type='text/javascript'></script>
-    <script src='index.js' type='text/javascript'></script>
   </head>
   <body>
+    <script src='index.js' type='text/javascript'></script>
   </body>
 </html>
 ```

--- a/content/get-started/index.md
+++ b/content/get-started/index.md
@@ -44,7 +44,7 @@ document.body.appendChild(component());
 
 To run this piece of code, one usually has the below html
 
-__app/index.html__
+__index.html__
 
 ```html
 <html>
@@ -53,7 +53,7 @@ __app/index.html__
     <script src='https://unpkg.com/lodash@4.16.6' type='text/javascript'></script>
   </head>
   <body>
-    <script src='index.js' type='text/javascript'></script>
+    <script src='app/index.js' type='text/javascript'></script>
   </body>
 </html>
 ```


### PR DESCRIPTION
The script tag in `get-started/index.md` is incorrectly placed. If someone tries to execute the code to demonstrate how browsers load global variables, they're going to get an error that the browser can't read `appendChild` of undefined because `document.body` won't exist yet. 

The script tag should be placed at the bottom of the body so that they don't get confused (although this is a pretty inconsequential thing and the whole point of this part of the tutorial is to tell people not to code this way lol).