### PR TITLE
Fixed mobile menu alignment

### DIFF
--- a/components/navigation/navigation-style.scss
+++ b/components/navigation/navigation-style.scss
@@ -35,6 +35,7 @@
 .navigation__inner {
   display: flex;
   align-items: center;
+  position: relative;
   padding: 0.6em 1em;
 
   @include break {
@@ -45,7 +46,7 @@
 .navigation__mobile {
   display: flex;
   font-size: 1.5em;
-  margin-left: -1em;
+  position: absolute;
   align-items: center;
   color: map-get($colors, white);
   cursor: pointer;


### PR DESCRIPTION
The mobile menu button appears in a place it shoulnd't on Chrome (at least using the Desktop version with a small viewport).

That margin is the cause. Also, to let the logo be center aligned the best way is to absolute positioning the menu button and take it out of flow.