### PR TITLE
Define the ESLint config as root

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,6 @@
 {
+    "root": true,
+    
     "extends": "eslint:recommended",
 
     "parser": "babel-eslint",


### PR DESCRIPTION
This tells ESLint not to extend any config up the directory tree, which (for example) makes it easier to be used as a submodule.

Let's say that I'm building a Dash docset from new Webpack docs, _hipothetically_, 😜 and I'm including this repo as a submodule, this repo's ESLint config will inherit my docset's config.