### PR TITLE
Deduplicate target options and improve descriptions

### DIFF
--- a/content/concepts/targets.md
+++ b/content/concepts/targets.md
@@ -16,27 +16,12 @@ To set the `target` property, you simply set the target value in your webpack co
 **webpack.config.js**
 
 ```javascript
-const config = {
+module.exports = {
   target: 'node'
 };
-
-module.exports = config;
 ```
 
-## Options
-
-The following is a list of values you can pass to the `target` property.
-
-* `"async-node"` Compile for usage in a Node.js-like environment (use `fs` and `vm` to load chunks async)
-* `"electron-main"` Compile for electron renderer process, provide a target using `JsonpTemplatePlugin`, `FunctionModulePlugin` for browser environment and `NodeTargetPlugin` and `ExternalsPlugin` for commonjs and electron bulit-in modules. *Note: need `webpack` >= 1.12.15.
-* `"node"` Compile for usage in a Node.js-like environment (uses Node.js `require` to load chunks)
-* `"node-webkit"` Compile for usage in webkit, uses jsonp chunk loading but also supports build in Node.js modules plus require("nw.gui") (experimental)
-* `"web"` Compile for usage in a browser-like environment (default)
-* `"webworker"` Compile as WebWorker
-
-Each _target_ has a variety of deployment/environment specific additions, support to fit its needs.
-
-For example, when you use the `electron-main` _target_, *webpack* includes multiple `electron-main` specific variables. For more information on which templates and _externals_ are used, you can refer [directly to the webpack source code](https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsApply.js#L70-L185).
+Each _target_ has a variety of deployment/environment specific additions, support to fit its needs. See what [targets are available](/configuration/target).
 
 ?> We should expand on this further. What specifically is included.
 

--- a/content/configuration/target.md
+++ b/content/configuration/target.md
@@ -5,38 +5,28 @@ contributors:
   - juangl
   - sokra
   - skipjack
+  - SpaceK33z
 ---
 
-?> Compare with [the concept page](/concepts/targets) and determine what goes where.
+webpack can compile to multiple environments. We call this _targets_. This page shows what targets are supported. [The concept page](/concepts/targets) explains in greater detail what a target is.
 
 ## `target`
 
 `string`
 
-Tell webpack what environment the application is targeting. The following options are supported:
+Tell webpack what environment the application is targeting. The following values are supported:
 
-`target: "node"` - Compile for [NodeJS](https://nodejs.org/en/), using `require` to load chunks
+* `"async-node"` Compile for usage in a Node.js-like environment (use `fs` and `vm` to load chunks async)
+* `"electron"` Compile for [Electron](http://electron.atom.io/) renderer process, provide a target using `JsonpTemplatePlugin`, `FunctionModulePlugin` for browser environment and `NodeTargetPlugin` and `ExternalsPlugin` for CommonJs and Electron built-in modules.
+* `"electron-renderer"` - Compile for [Electron](http://electron.atom.io/) for `renderer-process`
+* `"node"` Compile for usage in a Node.js-like environment (uses Node.js `require` to load chunks)
+* `"node-webkit"` Compile for usage in WebKit and uses jsonp chunk loading. Allows importing of built-in Node.js modules and [`nw.gui`](http://docs.nwjs.io/en/latest/) (experimental)
+* `"web"` Compile for usage in a browser-like environment (default)
+* `"webworker"` Compile as WebWorker
 
-`target: "node-webkit"` - Compile for [Webkit](https://webkit.org/), using [JSONP](https://sacha.me/articles/jsonp-demystified/) to load chunks
+For example, when you use the `"electron"` _target_, *webpack* includes multiple Electron specific variables. For more information on which templates and _externals_ are used, you can refer [directly to the webpack source code](https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsApply.js#L70-L185).
 
-`target: "web"` - Compile for usage in a browser
-
-`target: "webworker"` - Compile as a [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API)
-
-
-T> Allows importing of built-in Node.js modules and [`nw.gui`](http://docs.nwjs.io/en/latest/) (experimental).
-
-`target: "async-node"` - Use `fs` and `vm` to load chunks asynchronously
-
-`target: "electron"` - Compile for [Electron](http://electron.atom.io/) for `main-process`
-
-`target: "electron-main"` - Alias for `target: "electron"`
-
-`target: "electron-renderer"` - Compile for [Electron](http://electron.atom.io/) for `renderer-process`
-
-T> Allows importing of Electron-specific modules.
-
-It defaults to:
+The target option defaults to:
 
 ```js
 target: "web"


### PR DESCRIPTION
This PR removes the duplicate target options (see #373), fixes various typo's and adds an intro text.

Fixes #373.