### PR TITLE
Fixed small typo in get started guide

### DIFF
--- a/content/get-started/index.md
+++ b/content/get-started/index.md
@@ -119,7 +119,7 @@ The above CLI command would be represented in config as follows -
 __webpack.config.js__
 ```javascript
 module.exports = {
-  entry: './app/index.js'
+  entry: './app/index.js',
   output: {
     filename: 'bundle.js',
     path: './dist'


### PR DESCRIPTION
Added a missing comma in `module.exports`