### PR TITLE
Feature/add version to sidebar

### DIFF
--- a/components/sidebar-item/sidebar-item-style.scss
+++ b/components/sidebar-item/sidebar-item-style.scss
@@ -34,6 +34,10 @@
     margin: 0.5em 0 1em;
   }
 
+  &__version {
+    margin-bottom: 10px;
+  }
+
   &__anchor {
     margin:0.25em 0;
 

--- a/components/sidebar-mobile/sidebar-mobile-style.scss
+++ b/components/sidebar-mobile/sidebar-mobile-style.scss
@@ -63,6 +63,15 @@
   text-transform: uppercase;
   color: getColor(mine-shaft);
   margin: 1em 16px 0.25em;
+
+  &--block {
+    display: block;
+  }
+
+  &:active,
+  &--active {
+    color: getColor(malibu);
+  }
 }
 
 .sidebar-mobile__page {

--- a/components/sidebar-mobile/sidebar-mobile.jsx
+++ b/components/sidebar-mobile/sidebar-mobile.jsx
@@ -58,12 +58,29 @@ export default class SidebarMobile extends React.Component {
    * @return {array} - Markup containing sections and links
    */
   _getSections() {
-    return this.props.sections.map(section => (
-      <div key={ section.url }>
-        <h3 className='sidebar-mobile__section'>{ section.title }</h3>
-        { this._getPages(section.pages) }
-      </div>
-    ));
+    let pathname = '';
+
+    if (typeof window !== 'undefined') {
+      pathname = window.location.pathname;
+    }
+
+    return this.props.sections.map(section => {
+      let active = pathname === section.url || pathname.includes(`/${section.url}`),
+          absoluteUrl = `/${section.url}`;
+      return (
+        <div key={ absoluteUrl }>
+          <Link 
+            className={ `sidebar-mobile__section sidebar-mobile__section--block ${active ? 'sidebar-mobile__section--active' : ''}` } 
+            key={ absoluteUrl }
+            to={ absoluteUrl }
+            onClick={ this._close.bind(this) }>  
+            <h3>{ section.title }</h3>
+          </Link>
+          
+          { this._getPages(section.pages) }
+        </div>
+      );
+    });
   }
 
   /**

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -8,7 +8,7 @@ export default props => {
   return (
     <nav className="sidebar">
       <div className="sidebar__inner">
-        <h3 className="sidebar--item">Version 2.1</h3>
+        <h3 className="sidebar-item__version">Version 2.1</h3>
         <SidebarItem 
           url={ `/${sectionName}` } 
           title="Introduction"

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -3,17 +3,17 @@ import SidebarItem from '../sidebar-item/sidebar-item';
 import './sidebar-style';
 
 export default props => {
-  let { sectionName, pages, currentPage } = props;
+  let { sectionName, pages, currentPage, version } = props;
 
   return (
     <nav className="sidebar">
       <div className="sidebar__inner">
+        <h3 className="sidebar--item">Version 2.1</h3>
         <SidebarItem 
           url={ `/${sectionName}` } 
           title="Introduction"
           currentPage= { currentPage }
         />
-
         {
           pages.map(({ url, title, anchors }, i) =>
             <SidebarItem


### PR DESCRIPTION
<img width="872" alt="screen shot 2016-11-21 at 2 27 41 pm" src="https://cloud.githubusercontent.com/assets/3408176/20499575/a25634d4-aff7-11e6-87ff-82c775388e89.png">

Adds a version to the non-mobile sidebar. We should have a mobile version as well for the _next_ milestone. 

Fixes #327, fixes #354