### PR TITLE
Only let Travis build on the master and develop branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+    - master
+    - develop
 language: node_js
 node_js:
   - "6"


### PR DESCRIPTION
If you're making a PR from a branch on the same repo (only possible if you're a collaborator / admin), Travis CI does a build twice. This can take a looong time. This PR fixes that.