### PR TITLE
fix mobile sidebar from getting stuck on iOS safari.

### DIFF
--- a/components/sidebar-mobile/sidebar-mobile.jsx
+++ b/components/sidebar-mobile/sidebar-mobile.jsx
@@ -181,7 +181,7 @@ export default class SidebarMobile extends React.Component {
   _handleTouchEnd(e){
     // Free up all the inline styling
     this.container.classList.remove('no-delay');
-    this.container.style = '';
+    this.container.style.transform = '';
 
     if (initialTouchPosition.x - lastTouchPosition.x > 100) {
       this._close();


### PR DESCRIPTION
`element.style = '';`

does _NOT_ clear up inline styles on safari.

Need to target specific property we are trying to remove.

`element.style.transform = '';`

in our case.

Closes #412 