### PR TITLE
Mobile enhancements

### DIFF
--- a/components/sidebar-mobile/sidebar-mobile-style.scss
+++ b/components/sidebar-mobile/sidebar-mobile-style.scss
@@ -3,7 +3,7 @@
 
 .sidebar-mobile {
   position: fixed;
-  width: 295px;
+  width: 300px;
   height: 100vh;
   z-index: 100;
   top: 0;
@@ -11,6 +11,7 @@
   overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
   transform: translate3D(-100%, 0, 0);
+  transform: translate3D(calc(-100% + 5px), 0, 0);
   transition: all 500ms cubic-bezier(0.23, 1, 0.32, 1);
 
   @include break {
@@ -48,7 +49,7 @@
   position:absolute;
   cursor:pointer;
   right: 22px;
-  top: 28px;
+  top: 22px;
   font-size: 1.3em;
   background: getColor(denim);
   color: getColor(white);

--- a/components/sidebar-mobile/sidebar-mobile-style.scss
+++ b/components/sidebar-mobile/sidebar-mobile-style.scss
@@ -11,13 +11,12 @@
   overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
   transform: translate3D(-100%, 0, 0);
-  transform: translate3D(calc(-100% + 5px), 0, 0);
-  transition: all 500ms;
+  transition: all 500ms cubic-bezier(0.23, 1, 0.32, 1);
 
   @include break {
     display: none;
   }
-  
+
   &--visible {
     transform: translate3D(0, 0, 0);
   }
@@ -40,37 +39,55 @@
   width: 285px;
   height: 100vh;
   overflow-x: hidden;
+  padding: 12px 0;
   background: getColor(white);
-  box-shadow: 0 0 5px getColor(emperor);
+  box-shadow: 0 0 15px rgba(0, 0, 0, 0.2);
 }
 
 .sidebar-mobile__close {
   position:absolute;
-  right:16px;
-  top:19px;
-  font-size:1.5em;
   cursor:pointer;
-  color:getColor(dusty-grey);
-  transition:color 250ms;
+  right: 22px;
+  top: 28px;
+  font-size: 1.3em;
+  background: getColor(denim);
+  color: getColor(white);
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: background 150ms;
+  -webkit-tap-highlight-color: transparent;
 
   &:hover {
-    color:getColor(mine-shaft);
+    background: darken(getColor(denim), 20%);
   }
 }
 
 .sidebar-mobile__section {
-  font-size: getFontSize(1);
-  text-transform: uppercase;
-  color: getColor(mine-shaft);
-  margin: 1em 16px 0.25em;
+  border-left: 2px solid transparent;
+  padding-bottom:0.5em;
 
-  &--block {
-    display: block;
-  }
-
-  &:active,
   &--active {
-    color: getColor(malibu);
+    border-left: 2px solid getColor(malibu);
+
+    .sidebar-mobile__section-header {
+      color: lighten(getColor(fiord), 15%)
+    }
+  }
+}
+
+.sidebar-mobile__section-header {
+  text-transform: uppercase;
+  color: getColor(elephant);
+  padding: 0.75em 16px 0.25em;
+  font-weight: 600;
+  display: block;
+
+  .sidebar-mobile__content div:not(:first-of-type) & {
+    border-top: 1px solid getColor(alto);
   }
 }
 
@@ -78,12 +95,17 @@
   display: block;
   padding: 0.5em 17px;
   text-transform: capitalize;
-  color: getColor(dusty-grey);
+  color: getColor(dove-grey);
   -webkit-tap-highlight-color: rgba(0,0,0,0);
 
   &:active,
   &--active {
     color: getColor(mine-shaft);
-    background: getColor(alto);
+    font-weight: 600;
+    background: #F1F4F4;
+  }
+
+  &:hover {
+    color: inherit;
   }
 }

--- a/components/sidebar-mobile/sidebar-mobile.jsx
+++ b/components/sidebar-mobile/sidebar-mobile.jsx
@@ -68,9 +68,11 @@ export default class SidebarMobile extends React.Component {
       let active = pathname === section.url || pathname.includes(`/${section.url}`),
           absoluteUrl = `/${section.url}`;
       return (
-        <div key={ absoluteUrl }>
-          <Link 
-            className={ `sidebar-mobile__section sidebar-mobile__section--block ${active ? 'sidebar-mobile__section--active' : ''}` } 
+        <div
+          className={ `sidebar-mobile__section ${active ? 'sidebar-mobile__section--active' : ''}` }
+          key={ absoluteUrl }>
+          <Link
+            className="sidebar-mobile__section-header"
             key={ absoluteUrl }
             to={ absoluteUrl }
             onClick={ this._close.bind(this) }>  

--- a/template.ejs
+++ b/template.ejs
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title><%= webpackConfig.template.title %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#2B3A42">
     <link rel="shortcut icon" href="/assets/favicon.ico">
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />


### PR DESCRIPTION
# Changes
- Sidebar open is a _pull_ transition rather than a linear one.
- New styles for sidebar to indicate active state, use colors from scheme.
- Added a theme color meta tag for chrome.

|  Before | After  |
|---|---|
| <img src="https://cloud.githubusercontent.com/assets/8946207/20642265/99eea528-b430-11e6-9c1e-dd032a9772f4.png" width="300"> |  <img src="https://cloud.githubusercontent.com/assets/8946207/20642260/83641298-b430-11e6-81cc-b3d55926c17b.png" width="300"> |




