### PR TITLE
Fix mixed quotation marks and backticks

### DIFF
--- a/content/guides/code-splitting-libraries.md
+++ b/content/guides/code-splitting-libraries.md
@@ -37,7 +37,7 @@ module.exports = function(env) {
     return {
         entry: './index.js',
         output: {
-            filename: '[chunkhash].[name].js`,
+            filename: '[chunkhash].[name].js',
             path: './dist'
         }
     }
@@ -63,7 +63,7 @@ module.exports = function(env) {
             vendor: 'moment'
         },
         output: {
-            filename: '[chunkhash].[name].js`,
+            filename: '[chunkhash].[name].js',
             path: './dist'
         }
     }
@@ -92,7 +92,7 @@ module.exports = function(env) {
             vendor: 'moment'
         },
         output: {
-            filename: '[chunkhash].[name].js`,
+            filename: '[chunkhash].[name].js',
             path: './dist'
         },
         plugins: [
@@ -126,7 +126,7 @@ module.exports = function(env) {
             vendor: 'moment'
         },
         output: {
-            filename: '[chunkhash].[name].js`,
+            filename: '[chunkhash].[name].js',
             path: './dist'
         },
         plugins: [


### PR DESCRIPTION
All `filename` properties in `code-splitting-libraries.md` are using quotation marks for open their filename string and «closing» them with backticks. Yeah, is a silly edit, but I'm just reading the documentation and it disturbes me ^_^U.