### PR TITLE
Remove incorrect apostrophe usage in "it's".

### DIFF
--- a/content/concepts/index.md
+++ b/content/concepts/index.md
@@ -84,7 +84,7 @@ const config = {
 };
 ```
 
-In the configuration above we have defined a rules which used our loader with it's two required properties: `test`, and `use`. This tells webpack's compiler the following:
+In the configuration above we have defined a rules which used our loader with its two required properties: `test`, and `use`. This tells webpack's compiler the following:
 
 > "Hey webpack compiler, when you come across a path that resolves to a '.js' or '.jsx' file inside of a `require()`/`import` statement, **use** the `babel-loader` to transform it before you add it to the bundle".
 


### PR DESCRIPTION
The word should be "its" since the intention is to convey possession, not a contraction of "it is".