### PR TITLE
Remove unclear qoutes in configuration/target/ around "node"

### DIFF
--- a/content/configuration/target.md
+++ b/content/configuration/target.md
@@ -22,7 +22,7 @@ Tells webpack which environment the application is targeting. The following valu
 | `async-node`| Compile for usage in a Node.js-like environment (uses `fs` and `vm` to load chunks asynchronously)    |
 | `electron`      | Compile for [Electron](http://electron.atom.io/) renderer process, provide a target using `JsonpTemplatePlugin`, `FunctionModulePlugin` for browser environments and `NodeTargetPlugin` and `ExternalsPlugin` for CommonJs and Electron built-in modules. |
 | `electron-renderer` | Compile for [Electron](http://electron.atom.io/) for `renderer-process` |
-| `"node"` | Compile for usage in a Node.js-like environment (uses Node.js `require` to load chunks) |
+| `node` | Compile for usage in a Node.js-like environment (uses Node.js `require` to load chunks) |
 |`node-webkit`|  Compile for usage in WebKit and uses JSONP for chunk loading. Allows importing of built-in Node.js modules and [`nw.gui`](http://docs.nwjs.io/en/latest/) (experimental) |
 |`web`| Compile for usage in a browser-like environment **(default)** |
 |`webworker`| Compile as WebWorker |


### PR DESCRIPTION
They seem unnecessary to me and might cause confusion.