### PR TITLE
The 'debug' property was removed in webpack 2.

### DIFF
--- a/content/configuration/other-options.md
+++ b/content/configuration/other-options.md
@@ -61,19 +61,6 @@ W> Don't share the cache between calls with different options.
 
 ?> Elaborate on the warning and example - calls with different configuration options?
 
-
-## `debug`
-
-`boolean`
-
-Switch all loaders into debug mode to get more verbose feedback. This defaults to `false` to prevent unnecessary logging but can be easily turned on:
-
-```js
-debug: true
-```
-
-?> Consider adding an example of a certain loader emitting more details.
-
 ## `loader`
 
 `object`


### PR DESCRIPTION
I tried using the debug option and got an Invalid configuration object error message so it seems strange to keep this Webpack 1 config in the v2.1 documentation.  I see there are some details about how to properly specify debug here: https://webpack.js.org/guides/migrating/#debug so I figured that's sufficient.