### PR TITLE
Remove Double Title in Get-Started

### DIFF
--- a/content/get-started/index.md
+++ b/content/get-started/index.md
@@ -1,12 +1,10 @@
 ---
-title: Get Started with Webpack
+title: Getting Started
+sort: 3
 contributors:
   - bebraw
   - varunjayaraman
-sort: 3
 ---
-
-## Getting Started
 
 webpack is a tool to build JavaScript modules in your application. To start using `webpack` from its [cli](/api/cli) or [api](/api/node), follow the [Installation instructions](/get-started/install-webpack).
 webpack simplifies your workflow by quickly constructing a dependency graph of your application and bundling them in the right order. webpack can be configured to customise optimisations to your code, to split vendor/css/js code for production, run a development server that hot-reloads your code without page refresh and many such cool features. Learn more about [why you should use webpack](/get-started/why-webpack).


### PR DESCRIPTION
Removing the double title in the get-started index page.