### PR TITLE
Fix landscape size of logo on front page

### DIFF
--- a/components/splash-viz/splash-viz-style.scss
+++ b/components/splash-viz/splash-viz-style.scss
@@ -10,7 +10,7 @@
   background:getColor(elephant);
 
   &__modules,
-  &__output { 
+  &__output {
     flex:0 0 45%;
   }
 
@@ -36,8 +36,8 @@
     align-items:center;
     justify-content: center;
 
-    img { 
-      width:50%; 
+    img {
+      width:45%; 
 
       @include break {
         width:100%;


### PR DESCRIPTION
Hey, i found while browsing front-page in landscape mode there is glitch with logo:
![localhost-3000- iphone 6 1](https://cloud.githubusercontent.com/assets/5691926/20869052/a98fa82a-ba6a-11e6-9886-b568e299974d.png)
And after fix:
![localhost-3000- iphone 6 2](https://cloud.githubusercontent.com/assets/5691926/20869054/b4462366-ba6a-11e6-9df1-6c7dfea7413d.png)
It's little bit smaller but it works on every tested device in chrome simulator 
