### PR TITLE
Rename example import file to match import name

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -6,12 +6,12 @@ title: webpack
 **app.js**
 
 ```js
-import bar from './foo';
+import bar from './bar';
 
 bar();
 ```
 
-**foo.js**
+**bar.js**
 
 ```js
 export default function bar() {


### PR DESCRIPTION
I find it confusing (as I'm sure others will) that the import is `bar` but the file is `foo.js`. This goes against standard practices ASFAIK so I propose keeping names consistent.