### PR TITLE
Add path module to examples

### DIFF
--- a/content/concepts/index.md
+++ b/content/concepts/index.md
@@ -38,6 +38,8 @@ Once you've bundled all of your assets together, we still need to tell webpack *
 **webpack.config.js**
 
 ```javascript
+var path = require('path');
+
 module.exports = {
   entry: './path/to/my/entry/file.js',
   output: {
@@ -70,6 +72,8 @@ At a high level, they have two purposes in your webpack config.
 **webpack.config.js**
 
 ```javascript
+var path = require('path');
+
 const config = {
   entry: './path/to/my/entry/file.js',
   output: {


### PR DESCRIPTION
`path` is required for the examples to work as is.