### PR TITLE
Update/Fix Get-Started with ES6 standard import

### DIFF
--- a/content/concepts/index.md
+++ b/content/concepts/index.md
@@ -88,7 +88,7 @@ const config = {
 };
 ```
 
-In the configuration above we have defined a rules which used our loader with its two required properties: `test`, and `use`. This tells webpack's compiler the following:
+In the configuration above we have defined a rule which used our loader with its two required properties: `test`, and `use`. This tells webpack's compiler the following:
 
 > "Hey webpack compiler, when you come across a path that resolves to a '.js' or '.jsx' file inside of a `require()`/`import` statement, **use** the `babel-loader` to transform it before you add it to the bundle".
 

--- a/content/get-started/index.md
+++ b/content/get-started/index.md
@@ -69,7 +69,7 @@ To bundle the `lodash` dependency with the `index.js`, we need to import `lodash
 __app/index.js__
 
 ```diff
-+ import _ from 'lodash';
++ import * as _ from 'lodash';
 
 function component () {
   ...


### PR DESCRIPTION
Changed 
```javascript
import _ from 'lodash';
```
to
```javascript
import * as _ from 'lodash';
```