### PR TITLE
Updated Title to include "2"

### DIFF
--- a/content/get-started/index.md
+++ b/content/get-started/index.md
@@ -1,5 +1,5 @@
 ---
-title: Getting Started
+title: Getting Started with Webpack 2
 sort: 3
 contributors:
   - bebraw


### PR DESCRIPTION
Added "2" to the title.  The reason for this is that I found this page via a deep link (google search) and I thought it was talking about Webpack 1.  So the import statement did not work.  So I finally went on Stackoverflow where it was pointed out to me that it would work with Webpack 2.  So this simple update will help future travelers who do not realize the code will not work in V1.