### PR TITLE
Update migrating.md: code-splitting section typo

### DIFF
--- a/content/guides/migrating.md
+++ b/content/guides/migrating.md
@@ -282,7 +282,7 @@ webpack treats `import()` as a split-point and puts the requested module in a se
 ``` js
 function onClick() {
   import("./module").then(module => {
-    module.default;
+    return module.default;
   }).catch(err => {
     console.log("Chunk loading failed");
   });


### PR DESCRIPTION
Under "Code Splitting with ES2015," the function inside `then()` should _return_ `module.default`.

Addresses https://github.com/webpack/webpack.js.org/issues/502