### PR TITLE
Update hot-module-replacement.md

### DIFF
--- a/content/concepts/hot-module-replacement.md
+++ b/content/concepts/hot-module-replacement.md
@@ -24,19 +24,19 @@ In addition to the normal assets the compiler need to emit the "Update" to allow
 
 The manifest contains the new compilation hash and a list of all update chunks (2.).
 
-The update chunks contains code for all updated modules in this chunk (or a flag if a module was removed).
+The update chunks contain code for all updated modules in this chunk (or a flag if a module was removed).
 
-The compiler addtionally makes sure that module and chunk ids as consistent between these builds. It uses a "records" json file to store them between builds (on it store them in memory).
+The compiler addtionally makes sure that module and chunk ids are consistent between these builds. It uses a "records" json file to store them between builds (or it stores them in memory).
 
 ### From The Module View
 
 HMR is an opt-in feature, so it only affects modules that contains HMR code. The documentation describes the API that is available in modules. In general the module developer writes handlers that are called when a dependency of this module is updated. The developer can also write a handler that is called when this module is updated.
 
-In most cases it's not mandatory to write HMR code in every module. If a module has no HMR handlers the update bubbles up. This means a single handler can handle a update to a complete module tree. If a single module in this tree is updated, the complete module tree is reloaded (only reloaded not transferred).
+In most cases it's not mandatory to write HMR code in every module. If a module has no HMR handlers the update bubbles up. This means a single handler can handle an update to a complete module tree. If a single module in this tree is updated, the complete module tree is reloaded (only reloaded not transferred).
 
 ### From The HMR Runtime View (Technical)
 
-For the module system runtime is additional code emitted to track module `parents` and `children`.
+For the module system runtime additional code is emitted to track module `parents` and `children`.
 
 On the management side the runtime supports two methods: `check` and `apply`.
 
@@ -44,13 +44,13 @@ A `check` does a HTTP request to the update manifest. When this request fails, t
 
 For each new chunk request in the ready state the update chunk is also downloaded.
 
-The `apply` method flags all updated modules as invalid. For each invalid module there need to be a update handler in the module or update handlers in every parent. Else the invalid buddles up and mark all parents as invalid too. This process continues until no more "bubble up" occurs. If it bubbles up from an entry point the process fails.
+The `apply` method flags all updated modules as invalid. For each invalid module there need to be a update handler in the module or update handlers in every parent. Else the invalid buddles up and marks all parents as invalid too. This process continues until no more "bubble up" occurs. If it bubbles up from an entry point the process fails.
 
 Now all invalid modules are disposed (dispose handler) and unloaded. Then the current hash is updated and all "accept" handlers are called. The runtime switches back to the `idle` state and everything continues as normal.
 
 ## What can I do with it?
 
-You can use it in development as LiveReload replacement. webpack-dev-server supports a hot mode which tries to update with HMR before trying to reload the whole page. See how to implement [HMR with React](/guides/hmr-react) for example.
+You can use it in development as a LiveReload replacement. webpack-dev-server supports a hot mode which tries to update with HMR before trying to reload the whole page. See how to implement [HMR with React](/guides/hmr-react) for example.
 
 Some loaders already generate modules that are hot-updateable. i.e. the `style-loader` can exchange the stylesheet. You don't need to do anything special.
 


### PR DESCRIPTION
Added several suggested corrections to typos. Also, I'm not sure what the intended meaning in this sentence (line 33) is: In general the module developer writes handlers that are called when a dependency of this module is updated.