### PR TITLE
Use html anchor tag for sidebar anchor links

### DIFF
--- a/components/sidebar-item/sidebar-item.jsx
+++ b/components/sidebar-item/sidebar-item.jsx
@@ -25,7 +25,7 @@ export default class SidebarItem extends React.Component {
           {
             anchors.map((anchor, j) => (
               <li className="sidebar-item__anchor" key={ `anchor-${index}-${j}` }>
-                <Link to={ `${url}#${anchor.id}` }>{ anchor.title }</Link>
+                <a href={ '#' + anchor.id }>{ anchor.title}</a>
               </li>
             ))
           }


### PR DESCRIPTION
This fix prevents full page refresh for anchor links in sidebar.

Closes webpack/webpack.js.org#530