### PR TITLE
Added docs for loader options plugin (and placeholder for sourcemap)

### DIFF
--- a/content/plugins/loader-options-plugin.md
+++ b/content/plugins/loader-options-plugin.md
@@ -1,5 +1,7 @@
 ---
 title: loader-options-plugin
+contributors:
+    - johnnyreilly
 ---
 
 ?> Review this content
@@ -33,5 +35,3 @@ new webpack.LoaderOptionsPlugin({
 })
 ```
 
-contributors:
-    - johnnyreilly

--- a/content/plugins/loader-options-plugin.md
+++ b/content/plugins/loader-options-plugin.md
@@ -1,0 +1,33 @@
+---
+title: loader-options-plugin
+---
+
+?> Review this content
+
+The `loader-options-plugin` is unlike other plugins.  It exists to help people move from webpack 1 to webpack 2.  With webpack 2 the schema for a `webpack.config.js` became stricter; no longer open for extension by other loaders / plugins.  With webpack 2 the intention is that you pass `options` directly to loaders / plugins. i.e. options are **not** global / shared.
+
+However, until a loader has been updated to depend upon options being passed directly to them, the `loader-options-plugin` exists to bridge the gap.  You can configure global / shared loader options with this plugin and all loaders will receive these options.
+
+In the future this plugin may be removed.
+
+```javascript
+new webpack.LoaderOptionsPlugin(options)
+```
+
+* `options.debug` (`boolean`): Whether loaders should be in `debug` mode or not.
+* `options.minimize` (`boolean`): Where loaders can be switched to minimize mode.
+* `options.options` (`object`): A configuration object that can be used to configure older loaders - this will take the same schema a `webpack.config.js`
+
+* `options.options.context` (`string`): The context that can be used to configure older loaders
+
+## Examples
+
+```javascript
+new webpack.LoaderOptionsPlugin({
+  minimize: true,
+  debug: false,
+  options {
+    context: __dirname
+  }
+})
+```

--- a/content/plugins/loader-options-plugin.md
+++ b/content/plugins/loader-options-plugin.md
@@ -32,3 +32,6 @@ new webpack.LoaderOptionsPlugin({
   }
 })
 ```
+
+contributors:
+    - johnnyreilly

--- a/content/plugins/loader-options-plugin.md
+++ b/content/plugins/loader-options-plugin.md
@@ -19,6 +19,7 @@ new webpack.LoaderOptionsPlugin(options)
 * `options.options` (`object`): A configuration object that can be used to configure older loaders - this will take the same schema a `webpack.config.js`
 
 * `options.options.context` (`string`): The context that can be used to configure older loaders
+* other options as in a `webpack.config.js`....
 
 ## Examples
 

--- a/content/plugins/loader-options-plugin.md
+++ b/content/plugins/loader-options-plugin.md
@@ -16,7 +16,7 @@ In the future this plugin may be removed.
 new webpack.LoaderOptionsPlugin(options)
 ```
 
-* `options.debug` (`boolean`): Whether loaders should be in `debug` mode or not.
+* `options.debug` (`boolean`): Whether loaders should be in `debug` mode or not. `debug` will be removed as of webpack 3.
 * `options.minimize` (`boolean`): Where loaders can be switched to minimize mode.
 * `options.options` (`object`): A configuration object that can be used to configure older loaders - this will take the same schema a `webpack.config.js`
 

--- a/content/plugins/source-map-dev-tool-plugin.md
+++ b/content/plugins/source-map-dev-tool-plugin.md
@@ -1,0 +1,5 @@
+---
+title: source-map-dev-tool-plugin.md
+---
+
+?> TODO

--- a/content/plugins/source-map-dev-tool-plugin.md
+++ b/content/plugins/source-map-dev-tool-plugin.md
@@ -1,5 +1,26 @@
 ---
 title: source-map-dev-tool-plugin.md
+contributors:
+    - johnnyreilly
 ---
 
+?> Review this content
+
+Adds SourceMaps for assets.
+
+```javascript
+new webpack.SourceMapDevToolPlugin(options)
+```
+
+* `options.test` / `options.include` / `options.exclude` (`string|RegExp|Array`): Used to determine which assets should be processed. Each one can be a `RegExp` (asset filename is matched), a `string` (asset filename need to start with this string) or an `Array` of those (any of them need to be matched). `test` defaults to `.js` files if omitted.
+* `options.filename` (`string`): defines the output filename of the SourceMap. If no value is provided the SourceMap is inlined.
+* `options.append` (`string`): is appended to the original asset. Usually the `#sourceMappingURL` comment. `[url]` is replaced with a URL to the SourceMap file. `false` disables the appending.
+* `options.moduleFilenameTemplate` / `options.fallbackModuleFilenameTemplate` (`string`): see `output.devtoolModuleFilenameTemplate`.
+* `options.module` (`boolean`):  (defaults to `true`) When `false` loaders do not generate SourceMaps and the transformed code is used as source instead.
+* `options.columns` (`boolean`):  (defaults to `true`) When `false` column mappings in SourceMaps are ignored and a faster SourceMap implementation is used.
+* `options.lineToLine` (`{test: string|RegExp|Array, include: string|RegExp|Array, exclude: string|RegExp|Array}` matched modules uses simple (faster) line to line source mappings.
+
+## Examples
+
 ?> TODO
+


### PR DESCRIPTION
This PR adds docs for the loader options plugin (as well as a placeholder for SourceMapDevToolPlugin https://github.com/webpack/webpack.js.org/issues/494  ).

The docs may well be inaccurate - that's fine; set me straight!