### PR TITLE
Mention running the command on home page

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -46,5 +46,7 @@ module.exports = {
 </html>
 ```
 
+Then run `webpack` on the command-line to create `bundle.js`.
+
 ## It's that simple.
 ## [Get Started](/get-started)


### PR DESCRIPTION
Add one sentence to the home page, to make it clear that you need to run a webpack command to actually build the thing.