### PR TITLE
add note about use with Babel [skip ci]

### DIFF
--- a/content/guides/migrating.md
+++ b/content/guides/migrating.md
@@ -301,6 +301,8 @@ require.ensure([], function(require) {
 
 (Note on the deprecated `System.import`: Webpack's use of `System.import` didn't fit the proposed spec, so it was deprecated in [v2.1.0-beta.28](https://github.com/webpack/webpack/releases/tag/v2.1.0-beta.28) in favor of `import()`)
 
+If you want to use `import` with [Babel](http://babeljs.io/), you'll need to install/add the [dynamic-import](http://babeljs.io/docs/plugins/syntax-dynamic-import/) syntax plugin while it's still Stage-3. When the proposal is added to the spec this won't be necessary anymore.
+
 ### Dynamic expressions
 
 It's possible to pass a partial expression to `import()`. This is handled similar to expressions in CommonJS (webpack creates a [context](https://webpack.github.io/docs/context.html) with all possible files).

--- a/content/guides/migrating.md
+++ b/content/guides/migrating.md
@@ -301,7 +301,7 @@ require.ensure([], function(require) {
 
 (Note on the deprecated `System.import`: Webpack's use of `System.import` didn't fit the proposed spec, so it was deprecated in [v2.1.0-beta.28](https://github.com/webpack/webpack/releases/tag/v2.1.0-beta.28) in favor of `import()`)
 
-If you want to use `import` with [Babel](http://babeljs.io/), you'll need to install/add the [dynamic-import](http://babeljs.io/docs/plugins/syntax-dynamic-import/) syntax plugin while it's still Stage-3. When the proposal is added to the spec this won't be necessary anymore.
+If you want to use `import` with [Babel](http://babeljs.io/), you'll need to install/add the [dynamic-import](http://babeljs.io/docs/plugins/syntax-dynamic-import/) syntax plugin while it's still Stage 3 to get around the parser error. When the proposal is added to the spec this won't be necessary anymore.
 
 ### Dynamic expressions
 


### PR DESCRIPTION
Should we be mentioning https://github.com/airbnb/babel-plugin-dynamic-import-webpack separately as well?