### PR TITLE
Update instructions for installing webpack 2

### DIFF
--- a/content/get-started/index.md
+++ b/content/get-started/index.md
@@ -17,7 +17,7 @@ Create a demo directory to try out webpack. [Install webpack](/get-started/insta
 ```bash
 mkdir webpack-demo && cd webpack-demo
 npm init -y
-npm install --save-dev webpack
+npm install --save-dev webpack@beta
 ./node_modules/.bin/webpack --help # Shows a list of valid cli commands
 .\node_modules\.bin\webpack --help # For windows users
 npm install --save lodash

--- a/content/get-started/install-webpack.md
+++ b/content/get-started/install-webpack.md
@@ -10,10 +10,12 @@ sort: 1
 
 Before getting started, make sure you have a fresh version of [Node.js](https://nodejs.org/en/) installed. The current LTS is an ideal starting point. You may run into a variety of issues with the older versions as they may be missing functionality webpack or related packages might need.
 
+Note that this documentation is for webpack 2, for which there is not yet a stable release.  You can get the most recent beta by installing with the `beta` tag (see below).
+
 ### Global Installation
 
 ``` bash
-npm install webpack -g
+npm install webpack@beta -g
 ```
 
 The `webpack` command is now available globally.
@@ -23,7 +25,7 @@ However, this is not a recommended practice. This locks you down to a specific v
 ### Local Installation
 
 ``` bash
-npm install webpack --save-dev
+npm install webpack@beta --save-dev
 
 npm install webpack@<version> --save-dev
 ```


### PR DESCRIPTION
This makes the installation instructions work before version 2 is stable.

See #486.  Fixes #367.
