### PR TITLE
Fix scrolling marquee text overlapping on safari

### DIFF
--- a/components/splash-viz/splash-viz.jsx
+++ b/components/splash-viz/splash-viz.jsx
@@ -11,7 +11,7 @@ export default class SplashViz extends React.Component {
       <section className="splash-viz">
         <h1 className="splash-viz__heading">
           <span> bundle your</span>
-          <TextRotator repeatDelay={ 5000 } maxWidth={ 110 }>
+          <TextRotator delay={ 5000 } repeatDelay={ 5000 } maxWidth={ 110 }>
             <span> assets </span>
             <span> scripts </span>
             <span> images </span>

--- a/components/text-rotater/text-rotater-style.scss
+++ b/components/text-rotater/text-rotater-style.scss
@@ -39,4 +39,8 @@
   display: inline-flex;
   flex-direction: column;
   text-align: left;
+
+  > * {
+    flex-shrink: 0;
+  }
 }


### PR DESCRIPTION
Setting `flex-shrink: 0;` fixes the text overlapping problem on safari. Used `* >` in case someone uses the component with something else than `<span>` as children.

Also set an initial delay on the text rotator, because the first transition did not work on safari if none was set.