### PR TITLE
Removed --optimize-dedupe option as it was removed from webpack

### DIFF
--- a/content/api/cli.md
+++ b/content/api/cli.md
@@ -173,7 +173,6 @@ These options allow you to manipulate optimisations for a production build using
 
 | Parameter                 | Explanation                                            | Plugin used                          |
 |---------------------------|--------------------------------------------------------|--------------------------------------|
-| --optimize-dedupe         | Optimize duplicate module sources in the bundle        | DedupePlugin                         |
 | --optimize-max-chunks     | Try to keep the chunk count below a limit              | LimitChunkCountPlugin                |
 | --optimize-min-chunk-size | Try to keep the chunk size above a limit               | MinChunkSizePlugin                   |
 | --optimize-minimize       | Minimize javascript and switches loaders to minimizing | UglifyJsPlugin & LoaderOptionsPlugin |


### PR DESCRIPTION
Running `webpack --optimize-dedupe` with latest release doesn't work either.