### PR TITLE
Fix broken sublinks in sidebar

### DIFF
--- a/components/sidebar-item/sidebar-item.jsx
+++ b/components/sidebar-item/sidebar-item.jsx
@@ -25,7 +25,7 @@ export default class SidebarItem extends React.Component {
           {
             anchors.map((anchor, j) => (
               <li className="sidebar-item__anchor" key={ `anchor-${index}-${j}` }>
-                <a href={ '#' + anchor.id }>{ anchor.title}</a>
+                <Link to={ `${url}#${anchor.id}` }>{ anchor.title }</Link>
               </li>
             ))
           }


### PR DESCRIPTION
There is a bug in the sidebar links. Only the top level links (eg. `Module`) will link to another page. The sublinks (eg. `module.noParse`) only append the fragment to the url instead of linking to the correct page. 
For example, if you are at `/configuration`, open the `Module` category in the sidebar, and click the `module.noparse` anchor, it'll navigate to 
`/configuration/#module-noparse`
instead of 
`/configuration/module#module-noparse`.
I fixed it to include the entire link using react-router. 