### PR TITLE
Fixed sidecar overflowing content

### DIFF
--- a/components/sidecar/sidecar-style.scss
+++ b/components/sidecar/sidecar-style.scss
@@ -4,7 +4,7 @@
 .sidecar {
   display: none;
 
-  @include break(large) {
+  @media (min-width: 1085px) {
     display: block;
     position: fixed;
     top: 100px;


### PR DESCRIPTION
Resolves #382

@skipjack What do you think?

I see two fixes for this problem:

1. Increase break point (implemented in this PR)
2. Add padding to the content so that we can still display sidecar to the 1024px break point

I think that first option is better, that's why it's also part of this PR :smiley: 