### PR TITLE
change filename to bundlje.js

### DIFF
--- a/content/guides/code-splitting-libraries.md
+++ b/content/guides/code-splitting-libraries.md
@@ -37,7 +37,7 @@ module.exports = function(env) {
     return {
         entry: './index.js',
         output: {
-            filename: '[chunkhash].[name].js',
+            filename: 'bundle.js',
             path: './dist'
         }
     }


### PR DESCRIPTION
Seems consistent with the following information:

> On running `webpack` in your application, if you inspect the resulting bundle, you will see that `moment` and `index.js` have been bundled in `bundle.js`.