### PR TITLE
added (CLI) to CLI page title following discussion in #557

### DIFF
--- a/content/api/cli.md
+++ b/content/api/cli.md
@@ -1,5 +1,5 @@
 ---
-title: Command Line Interface
+title: Command Line Interface (CLI)
 sort: 2
 ---
 


### PR DESCRIPTION
To access the page when searching for "cli"
> Adding (CLI) to the header tag on that page should make it a top match for the short CLI
https://github.com/webpack/webpack.js.org/issues/557