### PR TITLE
production-build: enhance documentation

### DIFF
--- a/content/guides/production-build.md
+++ b/content/guides/production-build.md
@@ -52,21 +52,7 @@ Running `webpack -p` (or `--define process.env.NODE_ENV="production"`) defines t
 
 Technically, `NODE_ENV` is a system environment variable that Node exposes into running scripts. It is used by convention to determine development-vs-production behavior, by both server tools, build scripts, and client-side libraries.
 
-On one side, this allows you to conditionally modify the build configuration, for instance change the [output filename](/configuration/output/#output-filename):
-
-```js
-// webpack.config.js
-const webpack = require('webpack');
-
-module.exports = {
-  /*...*/
-  output: {
-    filename: process.env.NODE_ENV === 'production' ? '[name].[hash].bundle.js' : '[name].bundle.js'
-  }
-};
-```
-
-Secondly, this invokes the [`DefinePlugin`](/plugins/define-plugin), which perform search-and-replace operations on the original source code. Any occurrence of `process.env.NODE_ENV` in the imported code is replaced by by `"production"`. Thus, checks like `if (process.env.NODE_ENV !== 'production') console.log('...')` are evaluated to `if (false) console.log('...')` and finally minified away using `UglifyJS`.
+This invokes the [`DefinePlugin`](/plugins/define-plugin), which perform search-and-replace operations on the original source code. Any occurrence of `process.env.NODE_ENV` in the imported code is replaced by by `"production"`. Thus, checks like `if (process.env.NODE_ENV !== 'production') console.log('...')` are evaluated to `if (false) console.log('...')` and finally minified away using `UglifyJS`.
 
 ## The manual way: Configuring webpack for multiple environments
 

--- a/content/guides/production-build.md
+++ b/content/guides/production-build.md
@@ -48,11 +48,25 @@ One of the good options to go is using `cheap-module-source-map` which simplifie
 
 ### Node environment variable
 
-Running `webpack -p` (or `--define process.env.NODE_ENV="production"`) defines the `NODE_ENV` environment variable as `"production"`.
+Running `webpack -p` (or `--define process.env.NODE_ENV="production"`) invokes the [`DefinePlugin`](/plugins/define-plugin) in the following way:
 
-Technically, `NODE_ENV` is a system environment variable that Node exposes into running scripts. It is used by convention to determine development-vs-production behavior, by both server tools, build scripts, and client-side libraries.
+```js
+// webpack.config.js
+const webpack = require('webpack');
 
-This invokes the [`DefinePlugin`](/plugins/define-plugin), which perform search-and-replace operations on the original source code. Any occurrence of `process.env.NODE_ENV` in the imported code is replaced by by `"production"`. Thus, checks like `if (process.env.NODE_ENV !== 'production') console.log('...')` are evaluated to `if (false) console.log('...')` and finally minified away using `UglifyJS`.
+module.exports = {
+  /*...*/
+  plugins:[
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify('production')
+    })
+  ]
+};
+```
+
+The `DefinePlugin` performs search-and-replace operations on the original source code. Any occurrence of `process.env.NODE_ENV` in the imported code is replaced by by `"production"`. Thus, checks like `if (process.env.NODE_ENV !== 'production') console.log('...')` are evaluated to `if (false) console.log('...')` and finally minified away using `UglifyJS`.
+
+T> Technically, `NODE_ENV` is a system environment variable that Node.js exposes into running scripts. It is used by convention to determine development-vs-production behavior, by both server tools, build scripts, and client-side libraries. Contrary to expectations, `process.env.NODE_ENV` is not set to `"production"` __within__ the build script `webpack.config.js`, see [#2537](https://github.com/webpack/webpack/issues/2537). Thus, conditionals like `process.env.NODE_ENV === 'production' ? '[name].[hash].bundle.js' : '[name].bundle.js'` do not work as expected.
 
 ## The manual way: Configuring webpack for multiple environments
 

--- a/content/plugins/define-plugin.md
+++ b/content/plugins/define-plugin.md
@@ -1,0 +1,58 @@
+---
+title: DefinePlugin
+---
+
+``` javascript
+new webpack.DefinePlugin(definitions)
+```
+
+The `DefinePlugin` allows you to create global constants which can be configured at **compile** time. This can be very useful for allowing different behaviour between development builds and release builds.  For example, you might use a global constant to determine whether logging takes place; perhaps you perform logging in your development build but not in the release build.  That's the sort of scenario the `DefinePlugin` facilitates.
+
+Example:
+
+``` javascript
+new webpack.DefinePlugin({
+	PRODUCTION: JSON.stringify(true),
+	VERSION: JSON.stringify("5fa3b9"),
+	BROWSER_SUPPORTS_HTML5: true,
+	TWO: "1+1",
+	"typeof window": JSON.stringify("object")
+})
+```
+
+``` javascript
+console.log("Running App version " + VERSION);
+if(!BROWSER_SUPPORTS_HTML5) require("html5shiv");
+```
+
+Each key passed into `DefinePlugin` is an identifier or multiple identifiers joined with `.`.
+
+* If the value is a string it will be used as a code fragment.
+* If the value isn't a string, it will be stringified (including functions).
+* If the value is an object all keys are defined the same way.
+* If you prefix `typeof` to the key, it's only defined for typeof calls.
+
+The values will be inlined into the code which allows a minification pass to remove the redundant conditional.
+
+Example:
+
+``` javascript
+if (!PRODUCTION)
+	console.log('Debug info')
+if (PRODUCTION)
+	console.log('Production log')
+`````
+After passing through webpack with no minification results in:
+
+``` javascript
+if (!true)
+	console.log('Debug info')
+if (true)
+	console.log('Production log')
+```
+
+and then after a minification pass results in:
+
+``` javascript
+console.log('Production log')
+```

--- a/content/plugins/define-plugin.md
+++ b/content/plugins/define-plugin.md
@@ -25,6 +25,8 @@ console.log("Running App version " + VERSION);
 if(!BROWSER_SUPPORTS_HTML5) require("html5shiv");
 ```
 
+T> Note that because the plugin does a direct text replacement, the value given to it must include actual quotes inside of the string itself. Typically, this is done either with alternate quotes, such as `'"production"'`, or by using `JSON.stringify('production')`.
+
 Each key passed into `DefinePlugin` is an identifier or multiple identifiers joined with `.`.
 
 * If the value is a string it will be used as a code fragment.

--- a/content/plugins/define-plugin.md
+++ b/content/plugins/define-plugin.md
@@ -6,17 +6,17 @@ title: DefinePlugin
 new webpack.DefinePlugin(definitions)
 ```
 
-The `DefinePlugin` allows you to create global constants which can be configured at **compile** time. This can be very useful for allowing different behaviour between development builds and release builds.  For example, you might use a global constant to determine whether logging takes place; perhaps you perform logging in your development build but not in the release build.  That's the sort of scenario the `DefinePlugin` facilitates.
+The `DefinePlugin` allows you to create global constants which can be configured at **compile** time. This can be very useful for allowing different behaviour between development builds and release builds. For example, you might use a global constant to determine whether logging takes place; perhaps you perform logging in your development build but not in the release build. That's the sort of scenario the `DefinePlugin` facilitates.
 
-Example:
+**Example:**
 
 ``` javascript
 new webpack.DefinePlugin({
-	PRODUCTION: JSON.stringify(true),
-	VERSION: JSON.stringify("5fa3b9"),
-	BROWSER_SUPPORTS_HTML5: true,
-	TWO: "1+1",
-	"typeof window": JSON.stringify("object")
+  PRODUCTION: JSON.stringify(true),
+  VERSION: JSON.stringify("5fa3b9"),
+  BROWSER_SUPPORTS_HTML5: true,
+  TWO: "1+1",
+  "typeof window": JSON.stringify("object")
 })
 ```
 
@@ -36,21 +36,25 @@ Each key passed into `DefinePlugin` is an identifier or multiple identifiers joi
 
 The values will be inlined into the code which allows a minification pass to remove the redundant conditional.
 
-Example:
+**Example:**
 
 ``` javascript
-if (!PRODUCTION)
-	console.log('Debug info')
-if (PRODUCTION)
-	console.log('Production log')
+if (!PRODUCTION) {
+  console.log('Debug info')
+}
+if (PRODUCTION) {
+  console.log('Production log')
+}
 `````
 After passing through webpack with no minification results in:
 
 ``` javascript
-if (!true)
-	console.log('Debug info')
-if (true)
-	console.log('Production log')
+if (!true) {
+  console.log('Debug info')
+}
+if (true) {
+  console.log('Production log')
+}
 ```
 
 and then after a minification pass results in:


### PR DESCRIPTION
- Copy over docs of DefinePlugin from webpack 1
- Add `webpack -p`
- Clarify `NODE_ENV` and the role of DefinePlugin

Addresses #353.
Incorporates parts of @markerikson's blog post https://www.packtpub.com/books/content/building-better-bundles-why-processenvnodeenv-matters-optimized-builds