### PR TITLE
Fix link text on module resolution page

### DIFF
--- a/content/concepts/module-resolution.md
+++ b/content/concepts/module-resolution.md
@@ -57,7 +57,7 @@ Once the path is resolved based on the above rule, the resolver checks to see if
 * Otherwise, the file extension is resolved using the [`resolve.extensions`](/configuration/resolve/#resolve-extensions) option, which tells the resolver which extensions (eg - `.js`, `.jsx`) are acceptable for resolution.
 
 If the path points to a folder, then the following steps are taken to find the right file with the right extension:
-* If the folder contains a `package.json` file, then fields specified in [`resolve.mainFiles`](/configuration/resolve/#resolve-mainfields) configuration option are looked up in order, and the first such field in `package.json` determines the file path. 
+* If the folder contains a `package.json` file, then fields specified in [`resolve.mainFields`](/configuration/resolve/#resolve-mainfields) configuration option are looked up in order, and the first such field in `package.json` determines the file path. 
 * If there is no `package.json` or if the main fields do not return a valid path, file names specified in the [`resolve.mainFiles`](/configuration/resolve/#resolve-mainfiles) configuration option are looked for in order, to see if a matching filename exists in the imported/required directory .
 * The file extension is then resolved in a similar way using the `resolve.extensions` option.
 


### PR DESCRIPTION
Just a fix for small typo, the link text says `mainFiles` but the link URL points to `mainFields`.

The fix is obvious: `s/mainFiles/mainFields/`