### PR TITLE
navigation: flatten menu hierarchy

### DIFF
--- a/components/navigation/navigation.jsx
+++ b/components/navigation/navigation.jsx
@@ -8,22 +8,22 @@ let Sections = [
   {
     title: 'Concepts',
     url: 'concepts'
-  },
-  {
+  }, {
     title: 'Guides',
     url: 'guides'
-  },
-  {
-    title: 'Documentation',
-    url: 'configuration',
-    children: [
-      { title: 'API', url: 'api' },
-      { title: 'Configuration', url: 'configuration' },
-      { title: 'Loaders', url: 'loaders' },
-      { title: 'Plugins', url: 'plugins' }
-    ]
-  },
-  {
+  }, {
+    title: 'API',
+    url: 'api'
+  }, {
+    title: 'Configuration',
+    url: 'configuration'
+  }, {
+    title: 'Loaders',
+    url: 'loaders'
+  }, {
+    title: 'Plugins',
+    url: 'plugins'
+  }, {
     title: 'Donate',
     url: '//opencollective.com/webpack'
   }


### PR DESCRIPTION
One says (e.g. [here](https://www.orbitmedia.com/blog/website-navigation/)) that it's okay to have up to 7 menu entries. I find the current splitting rather confusing (why is "guides" not part of "documentation"?)