### PR TITLE
Update production-build.md

### DIFF
--- a/content/guides/production-build.md
+++ b/content/guides/production-build.md
@@ -78,7 +78,6 @@ each environment. For example:
 ####config/dev.js
 ```js
 module.exports = function (env) {
-    debug: true,
     devtool: 'cheap-module-source-map',
     output: {
         path: path.join(__dirname, '/../dist/assets'),
@@ -99,7 +98,6 @@ module.exports = function (env) {
 ####config/prod.js
 ```js
 module.exports = function (env) {
-    debug: false,
     output: {
         path: path.join(__dirname, '/../dist/assets'),
         filename: '[name].bundle.js',
@@ -211,7 +209,6 @@ const commonConfig = require('./base.js');
 
 module.exports = function(env) {
     return webpackMerge(commonConfig(), {
-        debug: false,
         plugins: [
             new webpack.LoaderOptionsPlugin({
                 minimize: true,
@@ -222,7 +219,7 @@ module.exports = function(env) {
                     'NODE_ENV': JSON.stringify('prod')
                 }
             }),
-            new webpack.optimize.UglifyJsPlugin(), ({
+            new webpack.optimize.UglifyJsPlugin({
                 beautify: false,
                 mangle: {
                     screw_ie8: true,


### PR DESCRIPTION
I believe the debug flag has been removed in webpack 2 in favour of: 
```
new webpack.LoaderOptionsPlugin({
    debug: true
})
```

Also there is a mistake with the UglifyJsPlugin code in the final prod example.