### PR TITLE
Loader chaining config

### DIFF
--- a/content/configuration/module.md
+++ b/content/configuration/module.md
@@ -4,6 +4,7 @@ sort: 6
 contributors:
   - sokra
   - skipjack
+  - jouni-kantola
 ---
 
 These options determine how the [different types of modules](/concepts/modules) within a project will be treated.
@@ -168,9 +169,31 @@ An array of [`Rules`](#rule) that is also used when the Rule matches.
 
 ## `Rule.use`
 
-A list of [UseEntries](#useentry) which are applied to the module. Each entry specified a loader which should be used.
+A list of [UseEntries](#useentry) which are applied to modules. Each entry specifies a loader to be used.
 
-Passing a string (i. e. `use: [ "style-loader" ]`) is a shortcut to the loader property (i. e. `use: [ { loader: "style-loader "} ]`).
+Passing a string (i.e. `use: [ "style-loader" ]`) is a shortcut to the loader property (i.e. `use: [ { loader: "style-loader "} ]`).
+
+Loaders can be chained by passing multiple loaders, which will be applied from right to left (last to first configured).
+
+```javascript
+use: [
+  {
+    loader: 'style-loader'
+  },
+  {
+    loader: 'css-loader',
+    options: {
+      importLoaders: 1
+    }
+  },
+  {
+    loader: 'less-loader',
+    options: {
+      noIeCompat: true
+    }
+  }
+]
+```
 
 See [UseEntry](#useentry) for details.
 

--- a/content/guides/migrating.md
+++ b/content/guides/migrating.md
@@ -7,6 +7,7 @@ contributors:
   - grgur
   - domfarolino
   - johnnyreilly
+  - jouni-kantola
 ---
 
 ## `resolve.root`, `resolve.fallback`, `resolve.modulesDirectories`
@@ -58,6 +59,62 @@ The new naming conventions are easier to understand and are a good reason to upg
       }
     ]
   }
+```
+
+## Chaining loaders
+
+Like in webpack v1, loaders can be chained to pass results from loader to loader. Using the [rule.use](/configuration/module#rule-use)
+configuration option, `use` can be set to a list of loaders. Loaders are evaluated from right to left (last to first configured).
+In webpack v1, loaders were commonly chained with `!`. This style is only supported using the legacy option `module.loaders`.
+
+```javascript
+// legacy loader chaining
+module: {
+  loaders: {
+    test: /\.less$/,
+    loader: "style-loader!css-loader!less-loader"
+  }
+}
+
+// v2 loader chaining with loader names
+module: {
+  rules: [
+    {
+      test: /\.less$/,
+      use: [
+        "style-loader",
+        "css-loader",
+        "less-loader"
+      ]
+    }
+  ]
+}
+
+// v2 loader chaining with configuration objects for each loader
+module: {
+  rules: [
+    {
+      test: /\.less$/,
+      use: [
+        {
+          loader: 'style-loader'
+        },
+        {
+          loader: 'css-loader',
+          options: {
+            importLoaders: 1
+          }
+        },
+        {
+          loader: 'less-loader',
+          options: {
+            noIeCompat: true
+          }
+        }
+      ]
+    }
+  ]
+}
 ```
 
 ## Automatic `-loader` module name extension removed


### PR DESCRIPTION
Clear examples of how loaders are chained, and also mention that `!` chaining is legacy.

Idea for added docs came from https://github.com/webpack/webpack.js.org/issues/569 and https://github.com/webpack/webpack/issues/3713.