### PR TITLE
Fix typo in migration guide

### DIFF
--- a/content/guides/migrating.md
+++ b/content/guides/migrating.md
@@ -549,7 +549,7 @@ Changes only relevant for loader authors.
 
 ### Cacheable
 
-Loaders are not cacheable by default. Loaders must opt-out if they are not cacheable.
+Loaders are now cacheable by default. Loaders must opt-out if they are not cacheable.
 
 ``` diff
   // Cacheable loader


### PR DESCRIPTION
I _think_ it currently says the opposite of what it means because of a one letter typo - figured it would quicker to just submit a PR than an issue 🚀 