### PR TITLE
DOCS: Fix output example to use object.filename

### DIFF
--- a/content/concepts/output.md
+++ b/content/concepts/output.md
@@ -17,7 +17,9 @@ To set the `output` property, you simply set the output value in your webpack co
 
 ```javascript
 const config = {
-  output: 'bundle.js'
+  output: {
+    filename: 'bundle.js'
+  }
 };
 
 module.exports = config;


### PR DESCRIPTION
Fix output example to use output.filename instead of assigning file to output object.