### PR TITLE
Include path library in sample configuration

### DIFF
--- a/content/configuration/index.md
+++ b/content/configuration/index.md
@@ -19,6 +19,8 @@ T> Notice that throughout the configuration we use Node's built-in [path module]
 ## Options
 
 ``` js-with-links-with-details
+var path = require('path');
+
 {
   // click on the name of the option to get to the detailed documentation
   // click on the items with arrows to show more examples / advanced options


### PR DESCRIPTION
If you're going to use the path library in the configuration sample, it ought to be included. Otherwise newb readers (points to self) will get confusing errors.