### PR TITLE
Specify NodeJS version for contributing to documentation.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ From adding an issue for a documentation suggestion to creating a pull request: 
 ## Setup
 
 * Install [Node.js](https://nodejs.org/) if you have not already.
-  *Note: Node 4-6 is required for "best results".*. Node 7 may have issues!
+  *Note: Node 6.9.* is required for "best results".*. Node 7 may have issues!
 * Fork the **webpack.js.org** repo at [https://github.com/webpack/webpack.js.org](https://github.com/webpack/webpack.js.org).
 * `git clone <your-clone-url> && cd webpack.js.org`
 * `npm install`

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "bugs": {
     "url": "https://github.com/webpack/webpack.js.org/issues"
   },
+  "engines": {
+    "node": ">=6.9"
+  },
   "scripts": {
     "start": "npm run init:generated && node ./bootstrap.js",
     "build": "npm run init:generated && rm -rf build/ && node ./bootstrap.js && npm run sitemap && echo webpack.js.org > build/CNAME",


### PR DESCRIPTION
This is a _required_ change based on the usage of `let` without `use strict` [here](https://github.com/webpack/webpack.js.org/pull/607/files#diff-454cc7d35544d042a685f267fef1f668R234).

Obviously this is not the only way to resolve this issue (add `use strict` or avoid `let`), but either way I would suggest adding the node engine version requirement to the `package.json` – let me know how you would like to proceed and I can provide a follow-up PR if necessary. 


**edit** 

I just noticed the Travis configuration uses `node` at `6` so this might, in fact, be the desired change set. 