### PR TITLE
Adding resolve.extentions to configuration sample

### DIFF
--- a/content/guides/webpack-and-typescript.md
+++ b/content/guides/webpack-and-typescript.md
@@ -61,14 +61,14 @@ module.exports = {
    ]
  }, 
  resolve: {
-   extensions: ["*", ".tsx", ".ts", ".js"]
+   extensions: [".tsx", ".ts", ".js"]
  },
 };
 ```
  
 Here we specify our entry point to be __index.ts__ in our current directory, 
 an output file called __bundle.js__ 
-and our TypeScript loader that is in charge of compiling our TypeScript file to JavaScript. We also add `resolve.extensions` to insruct webpack what file extensions to use when resolving Typescript modules.
+and our TypeScript loader that is in charge of compiling our TypeScript file to JavaScript. We also add `resolve.extensions` to instruct webpack what file extensions to use when resolving Typescript modules.
 
 ## Typescript loaders
 
@@ -122,7 +122,7 @@ module.exports = {
    ]
  },
  resolve: {
-   extensions: ["*", ".tsx", ".ts", ".js"]
+   extensions: [".tsx", ".ts", ".js"]
  },
  devtool: 'inline-source-map',
 };

--- a/content/guides/webpack-and-typescript.md
+++ b/content/guides/webpack-and-typescript.md
@@ -57,15 +57,18 @@ module.exports = {
        test: /\.tsx?$/,
        loader: 'ts-loader',
        exclude: /node_modules/,
-     }
+     },
    ]
- }
+ }, 
+ resolve: {
+   extensions: ["*", ".tsx", ".ts", ".js"]
+ },
 };
 ```
  
 Here we specify our entry point to be __index.ts__ in our current directory, 
 an output file called __bundle.js__ 
-and our TypeScript loader that is in charge of compiling our TypeScript file to JavaScript.
+and our TypeScript loader that is in charge of compiling our TypeScript file to JavaScript. We also add `resolve.extensions` to insruct webpack what file extensions to use when resolving Typescript modules.
 
 ## Typescript loaders
 
@@ -111,7 +114,15 @@ module.exports = {
        test: /\.js$/,
        loader: "source-map-loader"
      },
+     {
+       enforce: 'pre',
+       test: /\.js$/,
+       use: "source-map-loader"
+     }
    ]
+ },
+ resolve: {
+   extensions: ["*", ".tsx", ".ts", ".js"]
  },
  devtool: 'inline-source-map',
 };


### PR DESCRIPTION
I think it makes sense to have it there, because people will pretty quickly run into `Module not found: Error: Can't resolve` and it is not easy to figure out the cause of this error by searching since it is very generic.
Besides, I've extended second configuration example with additional rule; it is easier to copy paste it that ways, which people will likely do.