### PR TITLE
config:remove none-existent resolveToContext prop description. fix #634

### DIFF
--- a/content/configuration/resolve.md
+++ b/content/configuration/resolve.md
@@ -215,17 +215,6 @@ modules: [path.resolve(__dirname, "src"), "node_modules"]
 ```
 
 
-## `resolve.resolveToContext`
-
-`boolean`
-
-If `true`, trying to resolve a context to its absolute path ends when a directory is found. Default:
-
-```js
-resolveToContext: false
-```
-
-
 ## `resolve.unsafeCache`
 
 `regex` `array` `boolean`


### PR DESCRIPTION
Non-existent prop resolve.resolveToContext should be removed.
