### PR TITLE
update(guides/lazy-load-react): fiber friendly side-effects

### DIFF
--- a/content/guides/lazy-load-react.md
+++ b/content/guides/lazy-load-react.md
@@ -77,29 +77,26 @@ class LazilyLoad extends React.Component {
     };
   }
 
-  componentWillMount() {
-    this.load(this.props);
-  }
-
   componentDidMount() {
     this._isMounted = true;
+    this.load();
   }
 
-  componentWillReceiveProps(next) {
-    if (next.modules === this.props.modules) return null;
-    this.load(next);
+  componentDidUpdate(previous) {
+    if (this.props.modules === previous.modules) return null;
+    this.load();
   }
 
   componentWillUnmount() {
     this._isMounted = false;
   }
 
-  load(props) {
+  load() {
     this.setState({
       isLoaded: false,
     });
 
-    const { modules } = props;
+    const { modules } = this.props;
     const keys = Object.keys(modules);
 
     Promise.all(keys.map((key) => modules[key]()))


### PR DESCRIPTION
Refactor LazilyLoad.js example to use latest React recommendations to be more defensive for Fiber rendering. This moves side effects into different lifecycle hooks. 

I actually jumped on to update the documentation to `import()` away from `System.import` but open source is awesome and others have already done that! So instead I made it more React-future friendly.

cc @TheLarkInn 