### PR TITLE
DOCS: Expand content/loaders 

### DIFF
--- a/content/concepts/loaders.md
+++ b/content/concepts/loaders.md
@@ -66,49 +66,8 @@ $ npm install --save-dev babel-loader css-loader style-loader sass-loader
 ```
 ## Options
 
-The following is a list of values you can pass to the `module.rules` array.  Each element shall contain an object defining the desired loader.
-
-### `test (required)`
-
-The `test` property contains a regex of the files you wish to transform
-
-`eg /\.js$/` will transform all files which end with `.js`
-
-### `loader (either loader or loaders required)`
-
-The `loader` property contains the name of the desired loader (eg `babel-loader`). If you wish to apply more than one transformation, use `loaders` property.
-
-`eg. loader: 'babel-loader'` will apply babel transformation to all `.js` files
-
-### `loaders (either loader or loaders required)`
-
-The `loaders` property shall contain an array of loaders (reads right to left) which you wish to apply.
-
-`eg. ['style-loader','css-loader']` will apply `css` then `style` tranformation
-
-### `use`
-
-The `use` property can be used instead of the `loaders` -or- `loaders` properties, where each array element contains a `loader` object
-
-```javascript
-  module: {
-    rules: [
-      ...
-      {test: /\.js$/, use: [{loader: 'babel-loader'},{loader: 'eslint-loader'}]}
-      ...
-    ]
-  },
-```
-
-### `include`
-
-The `include` property will contain a regex of path patterns you wish to use during transformation.  If property is not supplied, the default webpack `context` pathname will be used.
-
-### `exclude`
-
-The `execlude` property will contain a regex path patterns you wish to ignore during transformation.
-
-`eg. exclude: /bower_components|node_modules` will ignore supplied paths
+The above example demonstrates the different approaches which can be used when defining the `module.rules` section of your `webpack.config.js` file.
+For complete details, refer to [loaders section](/loaders).
 
 #### Omitting Loader Error
 

--- a/content/concepts/loaders.md
+++ b/content/concepts/loaders.md
@@ -6,6 +6,7 @@ contributors:
   - ev1stensberg
   - SpaceK33z
   - gangachris
+  - mikeerickson
 ---
 
 Loaders are transformations that are applied on a resource file of your application. They are functions (running in Node.js) that take the source of a resource file as the parameter and return the new source.
@@ -32,6 +33,105 @@ Loaders are [resolved similar to modules](/concepts/module-resolution/). A loade
 
 ### Referencing Loaders
 
-By convention, loaders are usually named as `XXX-loader`, where `XXX` is the context name. For example, `json-loader`.
+By convention, loaders are usually named as `xxx-loader`, where `xxx` is the context name. For example, `babel-loader`.
 
+In the following example, we will configure webpack to run all files which end with `.js` through the `babel-loader`.
+
+All webpack loaders are standard npm modules and installed via npm from command line as follows:
+
+
+## Usage
+
+To set the `loader` property, you define the `module.rules` array value in your webpack config:
+
+**webpack.config.js**
+
+```javascript
+const config = {
+  ...
+  module: {
+    rules: [
+      {test: /\.js$/, loader: 'babel-loader', exclude: /node_modules/}, // transform js files
+      {test: /\s[a|c]ss$/, loader: 'sass-loader'}                       // transform sass files
+      {test: /\.css$/, loaders: ['style-loader','css-loader']}          // transform css files
+    ]
+  }
+  ...
+};
+```
+#### Install Webpack Loader modules
+Each of the specified rules requires one or more loaders.  In the `webpack.config.js` we referenced the following loaders
+```
+$ npm install --save-dev babel-loader css-loader style-loader sass-loader
+```
+## Options
+
+The following is a list of values you can pass to the `module.rules` array.  Each element shall contain an object defining the desired loader.
+
+### `test (required)`
+
+The `test` property contains a regex of the files you wish to transform
+
+`eg /\.js$/` will transform all files which end with `.js`
+
+### `loader (either loader or loaders required)`
+
+The `loader` property contains the name of the desired loader (eg `babel-loader`). If you wish to apply more than one transformation, use `loaders` property.
+
+`eg. loader: 'babel-loader'` will apply babel transformation to all `.js` files
+
+### `loaders (either loader or loaders required)`
+
+The `loaders` property shall contain an array of loaders (reads right to left) which you wish to apply.
+
+`eg. ['style-loader','css-loader']` will apply `css` then `style` tranformation
+
+### `use`
+
+The `use` property can be used instead of the `loaders` -or- `loaders` properties, where each array element contains a `loader` object
+
+```javascript
+  module: {
+    rules: [
+      ...
+      {test: /\.js$/, use: [{loader: 'babel-loader'},{loader: 'eslint-loader'}]}
+      ...
+    ]
+  },
+```
+
+### `include`
+
+The `include` property will contain a regex of path patterns you wish to use during transformation.  If property is not supplied, the default webpack `context` pathname will be used.
+
+### `exclude`
+
+The `execlude` property will contain a regex path patterns you wish to ignore during transformation.
+
+`eg. exclude: /bower_components|node_modules` will ignore supplied paths
+
+#### Omitting Loader Error
+
+If you fail to define a loader for the desired files within your project, you will receive an error similar to the following:
+
+`Module not found: Error: Can't resolve 'json-loader' in ...`
+
+This can be cured by installing `json-loader`
+
+`$ npm install --save-dev json-loader`
+
+And referencing the loader within your `webpack.config.js`
+
+```
+...
+module: {
+  rules: [
+    ...
+    {test: /\.json$/, loader: 'json-loader'},
+    ...
+  ]
+}
+...
+```
+#### Loader Convention and Precedence
 The loader name convention and precedence search order is defined by [`resolveLoader.moduleTemplates`](/configuration/resolve#resolveloader) within the webpack configuration API.

--- a/content/concepts/loaders.md
+++ b/content/concepts/loaders.md
@@ -59,7 +59,7 @@ const config = {
   ...
 };
 ```
-#### Install Webpack Loader modules
+### Install Webpack Loader modules
 Each of the specified rules requires one or more loaders.  In the `webpack.config.js` we referenced the following loaders
 ```
 $ npm install --save-dev babel-loader css-loader style-loader sass-loader
@@ -69,7 +69,7 @@ $ npm install --save-dev babel-loader css-loader style-loader sass-loader
 The above example demonstrates the different approaches which can be used when defining the `module.rules` section of your `webpack.config.js` file.
 For complete details, refer to [loaders section](/loaders).
 
-#### Omitting Loader Error
+### Omitting Loader Error
 
 If you fail to define a loader for the desired files within your project, you will receive an error similar to the following:
 
@@ -92,5 +92,5 @@ module: {
 }
 ...
 ```
-#### Loader Convention and Precedence
+### Loader Convention and Precedence
 The loader name convention and precedence search order is defined by [`resolveLoader.moduleTemplates`](/configuration/resolve#resolveloader) within the webpack configuration API.

--- a/content/concepts/loaders.md
+++ b/content/concepts/loaders.md
@@ -73,11 +73,11 @@ For complete details, refer to [loaders section](/loaders).
 
 If you fail to define a loader for the desired files within your project, you will receive an error similar to the following:
 
-`Module not found: Error: Can't resolve 'json-loader' in ...`
+`Module not found: Error: Can't resolve 'sass-loader' in ...`
 
-This can be cured by installing `json-loader`
+This can be cured by installing `sass-loader`
 
-`$ npm install --save-dev json-loader`
+`$ npm install --save-dev sass-loader`
 
 And referencing the loader within your `webpack.config.js`
 
@@ -86,7 +86,7 @@ And referencing the loader within your `webpack.config.js`
 module: {
   rules: [
     ...
-    {test: /\.json$/, loader: 'json-loader'},
+    {test: /\s[a|c]ss$/, loader: 'sass-loader'}
     ...
   ]
 }

--- a/content/concepts/output.md
+++ b/content/concepts/output.md
@@ -3,6 +3,7 @@ title: Output
 sort: 3
 contributors:
 - TheLarkInn
+- mikeerickson
 ---
 
 Options affecting the output of the compilation. `output` options tell Webpack how to write the compiled files to disk. Note, that while there can be multiple `entry` points, only one `output` configuration is specified.

--- a/content/loaders/index.md
+++ b/content/loaders/index.md
@@ -6,9 +6,10 @@ contributors:
   - TheLarkInn
   - manekinekko
   - SpaceK33z
+  - mikeerickson
 ---
 
-As explained in detail on the [concepts page](/concepts/loaders), loaders are transformations that are applied on a resource file of your application. Loaders allow you to, for example, configure how webpack should handle a CSS file.
+As explained on the [concepts page](/concepts/loaders), loaders are transformations that are applied on a resource file of your application. Loaders allow you to, for example, configure how webpack should handle a CSS file.
 
 A loader is typically a npm package, which you can install as a development dependency:
 
@@ -25,8 +26,22 @@ There are three ways to use loaders in your application:
 ## Via Configuration
 
 [`module.rules`](https://webpack.js.org/configuration/module/#module-rules) allows you to specify several loaders within your webpack configuration.
-This is a concise way to display loaders, and helps to have clean code as 
+This is a concise way to display loaders, and helps to have clean code as
 well as you have a full overview of each respective loader.
+
+#### Webpack Rules Shorthand Syntax
+The following example demonstrates how to use the [`module.rules`](https://webpack.js.org/configuration/module/#module-rules) shorthand sytnax for defining loaders
+
+```javascript
+  module: {
+    rules: [
+      {test: /\.css$/, loaders: ['style-loader','css-loader']}          // transform css files
+    ]
+  }
+  ...
+```
+#### Webpack Rules Use Syntax
+If you need more configuration options, you can also use the [`use`](https://webpack.js.org/configuration/module/#rule-use) syntax
 
 ```js
   module: {

--- a/content/loaders/index.md
+++ b/content/loaders/index.md
@@ -29,7 +29,7 @@ There are three ways to use loaders in your application:
 This is a concise way to display loaders, and helps to have clean code as
 well as you have a full overview of each respective loader.
 
-#### Webpack Rules Shorthand Syntax
+### Webpack Rules Shorthand Syntax
 The following example demonstrates how to use the [`module.rules`](https://webpack.js.org/configuration/module/#module-rules) shorthand sytnax for defining loaders
 
 ```javascript
@@ -40,7 +40,7 @@ The following example demonstrates how to use the [`module.rules`](https://webpa
   }
   ...
 ```
-#### Webpack Rules Use Syntax
+### Webpack Rules Use Syntax
 If you need more configuration options, you can also use the [`use`](https://webpack.js.org/configuration/module/#rule-use) syntax
 
 ```js


### PR DESCRIPTION
Extended `content/concepts/loaders` section

- [x] Expand documentation, providing additional instructions
- [x] Added examples to accompany expanded points
- [x] Added `mikeerickson` to list of contributors (also updated output section)

@TheLarkInn Please review and let me know if you like the format used for the `loaders` section.  I basically expanded on what you have done elsewhere so it should flow the same.  