### PR TITLE
correct a typo

### DIFF
--- a/content/configuration/output.md
+++ b/content/configuration/output.md
@@ -295,7 +295,7 @@ But, `require([ _what?_ ])`?
 
 ```javascript
 output: {
-	name: "MyLibrary",
+	library: "MyLibrary",
 	libraryTarget: "amd"
 }
 ```


### PR DESCRIPTION
The following snippet in https://github.com/webpack/webpack.js.org/blob/master/content/configuration/output.md#outputlibrarytarget makes use of "output.name" where it should be "output.library":

```
But, require([ _what?_ ])?

output.library!

output: {
    name: "MyLibrary",
    libraryTarget: "amd"
}
```