### PR TITLE
update(guides/lazy-load-react): refactor LazilyLoad.js example to use fiber friendly side-effects

### DIFF
--- a/content/guides/lazy-load-react.md
+++ b/content/guides/lazy-load-react.md
@@ -77,29 +77,26 @@ class LazilyLoad extends React.Component {
     };
   }
 
-  componentWillMount() {
-    this.load(this.props);
-  }
-
   componentDidMount() {
     this._isMounted = true;
+    this.load();
   }
 
-  componentWillReceiveProps(next) {
-    if (next.modules === this.props.modules) return null;
-    this.load(next);
+  componentDidUpdate(previous) {
+    if (this.props.modules === previous.modules) return null;
+    this.load();
   }
 
   componentWillUnmount() {
     this._isMounted = false;
   }
 
-  load(props) {
+  load() {
     this.setState({
       isLoaded: false,
     });
 
-    const { modules } = props;
+    const { modules } = this.props;
     const keys = Object.keys(modules);
 
     Promise.all(keys.map((key) => modules[key]()))


### PR DESCRIPTION
Redoing the merge against master.