### PR TITLE
`RequireJS` in the title is misleading.

### DIFF
--- a/content/guides/code-splitting-require.md
+++ b/content/guides/code-splitting-require.md
@@ -1,5 +1,5 @@
 ---
-title: Code Splitting - Using RequireJS
+title: Code Splitting - Using require.ensure
 sort: 5
 contributors:
   - pksjce


### PR DESCRIPTION
`RequireJS` in the title is misleading ( confused with [RequireJS](http://requirejs.org/) ). It should be just `require.ensure`