### PR TITLE
Docs: Bugfix/production build

### DIFF
--- a/content/guides/production-build.md
+++ b/content/guides/production-build.md
@@ -76,6 +76,7 @@ each environment. For example:
 ** dev.js **
 ```js
 module.exports = function (env) {
+  return {
     devtool: 'cheap-module-source-map',
     output: {
         path: path.join(__dirname, '/../dist/assets'),
@@ -91,12 +92,14 @@ module.exports = function (env) {
         stats: 'minimal',
         publicPath: publicPath
     }
+  }
 }
 ```
 
 ** prod.js **
 ```js
 module.exports = function (env) {
+  return {
     output: {
         path: path.join(__dirname, '/../dist/assets'),
         filename: '[name].bundle.js',
@@ -120,6 +123,7 @@ module.exports = function (env) {
             comments: false
         })
     ]
+  }
 }
 ```
 Have the following snippet in our webpack.config.js:

--- a/content/guides/production-build.md
+++ b/content/guides/production-build.md
@@ -6,6 +6,7 @@ contributors:
   - rajagopal4890
   - markerikson
   - simon04
+  - kisnows
 ---
 
 This page explains how to generate production builds with webpack.


### PR DESCRIPTION
[The manual way: Configuring webpack for multiple environments](https://webpack.js.org/guides/production-build/#the-manual-way-configuring-webpack-for-multiple-environments) example have syntax error.
This is  what the page show:
**dev.js**
```javascript
module.exports = function (env) {
    devtool: 'cheap-module-source-map',
    output: {
        path: path.join(__dirname, '/../dist/assets'),
        filename: '[name].bundle.js',
        publicPath: publicPath,
        sourceMapFilename: '[name].map'
    },
    devServer: {
        port: 7777,
        host: 'localhost',
        historyApiFallback: true,
        noInfo: false,
        stats: 'minimal',
        publicPath: publicPath
    }
}
```

It should be like this as i think:
**dev.js**
```javascript
module.exports = function (env) {
  return {
    devtool: 'cheap-module-source-map',
    output: {
      path: path.join(__dirname, '/../dist/assets'),
      filename: '[name].bundle.js',
      publicPath: publicPath,
      sourceMapFilename: '[name].map'
    },
    devServer: {
      port: 7777,
      host: 'localhost',
      historyApiFallback: true,
      noInfo: false,
      stats: 'minimal',
      publicPath: publicPath
    }
  }
}
```