### PR TITLE
[Vote Style] fix issue in Safari mobile

### DIFF
--- a/components/vote/app-style.scss
+++ b/components/vote/app-style.scss
@@ -28,10 +28,10 @@
   }
 
   &__user-section {
-    flex: 0 0 25%;
     padding: 0 0 30px;
 
     @include break(medium) {
+      flex: 0 0 25%;
       padding: 0 0 0 20px;
     }
 
@@ -144,12 +144,12 @@
 
   &__score-section {
     display: flex;
-    flex: 0 0 40%;
     border: 1px solid lightgray;
     user-select: none;
     flex-wrap: wrap;
 
     @include break(medium){
+      flex: 0 0 40%;
       margin-right: 30px;
       padding: 0 0 0 20px;
     }
@@ -168,8 +168,8 @@
   }
 
   &__item-button {
+    align-self: center;
     flex: 0 0 50%;
-      align-self: center;
 
     @include break(medium){
       flex: 0 0 40%;


### PR DESCRIPTION
In smaller screen sizes of Safari (e.g. Mobile) the user and score sections were overlapping the content. Which made the it harder to read the copy. Move the position to be medium on up. 

This wasn't an issue in Chrome or Firefox. Confirmed this still looks as expected in Safari medium on up, Chrome medium on up and Firefox medium on up.

**Before**
<img width="502" alt="screen shot 2017-01-17 at 8 04 12 pm" src="https://cloud.githubusercontent.com/assets/1427854/22050528/82a49ec0-dcf0-11e6-9a35-77e6f5a2d6d4.png">

**After**
<img width="504" alt="screen shot 2017-01-17 at 8 03 02 pm" src="https://cloud.githubusercontent.com/assets/1427854/22050526/7c9c00cc-dcf0-11e6-8d5b-4e1f41d3df8b.png">