### PR TITLE
fix typo in commons-chunk-plugin.md

### DIFF
--- a/content/plugins/commons-chunk-plugin.md
+++ b/content/plugins/commons-chunk-plugin.md
@@ -161,7 +161,7 @@ new CommonsChunkPlugin({
     // If module has a path, and inside of the path exists the name "somelib", 
     // and it is used in 3 separate chunks/entries, then break it out into
     // a separate chunk with chunk keyname "my-single-lib-chunk", and filename "my-single-lib-chunk.js"
-    return module.resouce && (/somelib/).test(module.resource) && count === 3;
+    return module.resource && (/somelib/).test(module.resource) && count === 3;
   }
 });
 ```


### PR DESCRIPTION
Was reading about CommonsChunkPlugin and found a typo in code sample that would throw practitioners of copy-and-paste off.