### PR TITLE
quick fix to make votes more readable

### DIFF
--- a/components/vote/app-style.scss
+++ b/components/vote/app-style.scss
@@ -136,6 +136,8 @@
   &__item-card {
     display: flex;
     flex-direction: column;
+    margin-top: 30px;
+    margin-bottom: 30px;
 
     @include break(medium){
       flex-direction: row;


### PR DESCRIPTION
I think the votes were very hard to read especially on mobile. It was hard to figure out, if some points are for the feature above or below the points. I added some margins as a a quick fix.

**Old**

![image](https://cloud.githubusercontent.com/assets/1152805/22081708/e4eaacee-ddc4-11e6-8bda-bc2b887bc319.png)

![image](https://cloud.githubusercontent.com/assets/1152805/22081679/cc369fd2-ddc4-11e6-9d2d-e0f371841493.png)

**New**

![image](https://cloud.githubusercontent.com/assets/1152805/22081653/ad3e01ba-ddc4-11e6-9213-bbdb12e7af77.png)

![image](https://cloud.githubusercontent.com/assets/1152805/22081666/ba933b14-ddc4-11e6-9bc6-087e9e50470a.png)
