### PR TITLE
feat(splash): bump sponsor and backer counts

### DIFF
--- a/components/splash/splash.jsx
+++ b/components/splash/splash.jsx
@@ -30,10 +30,10 @@ export default props => {
         <p>Through contributions, donations, and sponsorship, you allow webpack to thrive. Your donations directly support office hours, continued enhancements, and most importantly, great documentation and learning material!</p>
 
         <h2>Sponsors</h2>
-        <Support number={ 20 } type="sponsor" />
+        <Support number={ 40 } type="sponsor" />
 
         <h2>Backers</h2>
-        <Support number={ 100 } type="backer" />
+        <Support number={ 130 } type="backer" />
       </Container>
     </div>
   );


### PR DESCRIPTION
😅 Although its manual work its satisfying to need to bump our sponsorship counts and backer counts on the homepage. I profiled load speed and everything looks alright still. 😅 