### PR TITLE
Fix in webpack-and-typescript.md code example

### DIFF
--- a/content/guides/webpack-and-typescript.md
+++ b/content/guides/webpack-and-typescript.md
@@ -116,7 +116,7 @@ module.exports = {
      },
      {
        enforce: 'pre',
-       test: /\.js$/,
+       test: /\.tsx?$/,
        use: "source-map-loader"
      }
    ]


### PR DESCRIPTION
Hi, 
This fixes duplicate module rules.
The intention I suppose was to have a rule for `.js` and one for `.ts(x)`
Cheers!