### PR TITLE
Added instructions to disable safe write in the WebStorm IDE

### DIFF
--- a/content/guides/development.md
+++ b/content/guides/development.md
@@ -18,6 +18,7 @@ Each editor has a different way of disabling this. For the most common ones:
 * **Sublime Text 3** - Add `"atomic_save": false` to your user preferences.
 * **IntelliJ** - use search in the preferences to find "safe write" and disable it.
 * **Vim** - add `:set backupcopy=yes` in your settings.
+* **WebStorm** - uncheck `Use "safe write"` in Preferences > Appearance & Behavior > System Settings
 
 ## Source Maps
 


### PR DESCRIPTION
Just a simple addition to the list of instructions on how to disable safe write in WebStorm