### PR TITLE
cube setInterval -> requestAnimationFrame

### DIFF
--- a/components/cube/cube.jsx
+++ b/components/cube/cube.jsx
@@ -78,12 +78,22 @@ export default class Cube extends React.Component {
       let degrees = 0;
       let axis = 'y';
 
-      this._interval = setInterval(() => {
-        let obj = {};
-        obj[axis] = degrees += 90;
+      let lastTime = performance.now();
+      let animation = () => {
+        let nowTime = performance.now();
+        let deltaTime = nowTime - lastTime;
 
-        this.setState({ ...obj, iteration: (this.state.iteration + 1) % 4 });
-      }, repeatDelay);
+        if (repeatDelay <= deltaTime) {
+          let obj = {};
+          obj[axis] = degrees += 90;
+
+          this.setState({ ...obj, iteration: (this.state.iteration + 1) % 4 });
+          lastTime = performance.now();
+        }
+
+        this._requestAnimation = requestAnimationFrame(animation);
+      };
+      animation();
     }
   }
 
@@ -95,7 +105,7 @@ export default class Cube extends React.Component {
       this.container.removeEventListener('mouseleave', this.listeners.reset);
 
     } else if (continuous) {
-      clearInterval(this._interval);
+      cancelAnimationFrame(this._requestAnimation);
     }
   }
 


### PR DESCRIPTION
`setInterval()` execute regardless of whether a page or tab is visible or the browser window has been minimized, potentially resulting in wasted drawing calls.
`requestAnimationFrame()` was designed to solve this problem.

## before
![cube1](https://cloud.githubusercontent.com/assets/7903426/22179629/f2740b6e-e09c-11e6-966a-6ded1dbc1647.gif)

## after
![cube2](https://cloud.githubusercontent.com/assets/7903426/22179628/f1628d18-e09c-11e6-8344-08a1bdfae97c.gif)

### Docs
- https://hacks.mozilla.org/2011/08/animating-with-javascript-from-setinterval-to-requestanimationframe/

- [requestanimationframe](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame)
- [Performance.now()](https://developer.mozilla.org/en/docs/Web/API/Performance/now)
