### PR TITLE
require() for components is no longer needed after hot-update.

### DIFF
--- a/content/guides/hmr-react.md
+++ b/content/guides/hmr-react.md
@@ -192,8 +192,7 @@ render(App);
 // Hot Module Replacement API
 if (module.hot) {
   module.hot.accept('./components/App', () => {
-    const NewApp = require('./components/App').default
-    render(NewApp)
+    render(App)
   });
 }
 ```


### PR DESCRIPTION
As mentioned at [here](https://github.com/gaearon/react-hot-boilerplate/blob/9609a8e567b940ff341176638fb1169f70efd461/src/index.js) and  [here](http://localhost:3000/guides/hmr-react#code), just re-render the component works properly and re-require() then use a new component doesn't work as long as I tried.