### PR TITLE
Fixing code snippet and typo for production build guide

### DIFF
--- a/content/guides/production-build.md
+++ b/content/guides/production-build.md
@@ -8,6 +8,7 @@ contributors:
   - simon04
   - kisnows
   - chrisVillanueva
+  - swapnilmishra
 ---
 
 This page explains how to generate production builds with webpack.
@@ -134,7 +135,7 @@ function buildConfig(env) {
   return require('./config/' + env + '.js')({ env: env })
 }
 
-module.exports = buildConfig(env);
+module.exports = buildConfig;
 ```
 And from our package.json, where we build our application using webpack, the command goes like this:
 ```js

--- a/content/guides/production-build.md
+++ b/content/guides/production-build.md
@@ -129,7 +129,7 @@ module.exports = function (env) {
   }
 }
 ```
-Have the following snippet in our webpack.config.js:
+Have the following snippet in your webpack.config.js:
 ```js
 function buildConfig(env) {
   return require('./config/' + env + '.js')({ env: env })


### PR DESCRIPTION
1. Fixing the code snippet on [building for production](https://webpack.js.org/guides/production-build/) page.

In given below code snippet only function reference should be returned.

```
module.exports = buildConfig(env);
```
should be
```
module.exports = buildConfig;
```

2. Fixing typo from 'you' to 'your'.