### PR TITLE
Fetch only webpack-contrib repositories

### DIFF
--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -7,11 +7,8 @@ cp -rf ./content/loaders/ ./generated/loaders
 mkdir -p ./generated/plugins
 cp -rf ./content/plugins/ ./generated/plugins
 
-# Fetches github.com/webpack/*-loader repositories
-./scripts/fetch_package_names.js "webpack" "-loader" | ./scripts/fetch_package_files.js "README.md" "./generated/loaders"
-
-# Fetches github.com/webpack/*-webpack-plugin repositories
-./scripts/fetch_package_names.js "webpack" "-webpack-plugin" | ./scripts/fetch_package_files.js "README.md" "./generated/plugins"
+# Fetches github.com/webpack-contrib/*-loader repositories
+./scripts/fetch_package_names.js "webpack-contrib" "-loader" | ./scripts/fetch_package_files.js "README.md" "./generated/loaders"
 
 # Fetches github.com/webpack-contrib/*-webpack-plugin repositories
 ./scripts/fetch_package_names.js "webpack-contrib" "-webpack-plugin" | ./scripts/fetch_package_files.js "README.md" "./generated/plugins"


### PR DESCRIPTION
The loader/plugin repository locations have changed again: Now all relevant repositories are in the webpack-contrib project.

At the moment, https://webpack.js.org/loaders/ does not list any loader.