### PR TITLE
Add missing require to code in hmr-react.md

### DIFF
--- a/content/guides/hmr-react.md
+++ b/content/guides/hmr-react.md
@@ -192,6 +192,7 @@ render(App);
 // Hot Module Replacement API
 if (module.hot) {
   module.hot.accept('./components/App', () => {
+    const App = require("./components/App").default;
     render(App)
   });
 }


### PR DESCRIPTION
In Hot Module Replacement API section, the code is missing a require statement.
const App = require("./components/App").default;