### PR TITLE
remove confusing vendor entry in CommonsChunkPlugin example

### DIFF
--- a/content/guides/code-splitting-libraries.md
+++ b/content/guides/code-splitting-libraries.md
@@ -62,8 +62,7 @@ var path = require('path');
 module.exports = function(env) {
     return {
         entry: {
-            main: './index.js',
-            vendor: 'moment'
+            main: './index.js'
         },
         output: {
             filename: '[chunkhash].[name].js',


### PR DESCRIPTION
I found it pretty confusing to have the vendors chunk set to moment when using the `CommonsChunkPlugin`. Shouldn't the plugin do this for us, so there is no need to add `moment` explicitly?

> On running `webpack` now, we see that two bundles have been created. If you inspect these though, you will find that the code for `moment` is present in both the files!