### PR TITLE
Get started: do not rely on global installation

### DIFF
--- a/content/get-started/index.md
+++ b/content/get-started/index.md
@@ -7,6 +7,7 @@ contributors:
   - cntanglijun
   - chrisVillanueva
   - johnstew
+  - simon04
 ---
 
 webpack is a tool to build JavaScript modules in your application. To start using `webpack` from its [cli](/api/cli) or [api](/api/node), follow the [Installation instructions](/get-started/install-webpack).
@@ -104,7 +105,7 @@ By stating what dependencies a module needs, webpack can use this information to
 Now run `webpack` on this folder with `index.js` as the entry file and `bundle.js` as the output file in which all code required for the page is bundled.
 
 ```bash
-webpack app/index.js dist/bundle.js
+./node_modules/.bin/webpack app/index.js dist/bundle.js
 
 Hash: a3c861a7d42fc8944524
 Version: webpack 2.2.0
@@ -116,7 +117,7 @@ index.js  1.56 kB       0  [emitted]  main
 ```
 T> Output may vary. If the build is successful then you are good to go.
 
-T> If you created a local `webpack@beta` build, be sure to reference `webpack` with `./node_modules/.bin/webpack` on the command line.
+T> If you [installed webpack globally](/get-started/install-webpack#global-installation), you have to invoke webpack using `webpack`.
 
 Open `index.html` in your browser to see the result of a successful bundle.
 You should see a page with the following text: 'Hello webpack'.

--- a/content/get-started/install-webpack.md
+++ b/content/get-started/install-webpack.md
@@ -12,15 +12,7 @@ Before getting started, make sure you have a fresh version of [Node.js](https://
 
 Note that this documentation is for webpack 2, for which there is not yet a stable release. You can get the most recent beta by installing with the `beta` tag (see below).
 
-### Global Installation
-
-``` bash
-npm install webpack@beta -g
-```
-
-The `webpack` command is now available globally.
-
-However, this is not a recommended practice. This locks you down to a specific version of webpack and might fail in projects that use a different version. The next section tells you how to install webpack locally in a project.
+The next section tells you how to install webpack locally in a project.
 
 ### Local Installation
 
@@ -41,6 +33,17 @@ If you are using npm scripts in your project, npm will try to look for webpack i
 This is standard and recommended practice.
 
 T> To run the local installation of webpack you can access its bin version as `node_modules/.bin/webpack`
+
+
+### Global Installation
+
+W> Note that a global webpack installation is not a recommended practice. This locks you down to a specific version of webpack and might fail in projects that use a different version.
+
+``` bash
+npm install webpack@beta -g
+```
+
+The `webpack` command is now available globally.
 
 
 ### Bleeding Edge


### PR DESCRIPTION
Since we do not recommend a global webpack installation, do not rely on
it in the getting started guide

Relates to item 2 from #486.