### PR TITLE
Update description for -p parameter

### DIFF
--- a/content/api/cli.md
+++ b/content/api/cli.md
@@ -234,10 +234,10 @@ These options allow webpack to display various stats and style them differently 
 
 ### Shortcuts
 
-| Shortcut | Replaces                                                                                  |
-|----------|-------------------------------------------------------------------------------------------|
-| -d       | --debug --devtool eval-cheap-module-source-map --output-pathinfo                          |
-| -p       | --optimize-minimize --define,process.env.NODE_ENV="production" --optimize-occurence-order |
+| Shortcut | Replaces                                                         |
+|----------|------------------------------------------------------------------|
+| -d       | --debug --devtool eval-cheap-module-source-map --output-pathinfo |
+| -p       | --optimize-minimize --define process.env.NODE_ENV="production"   |
 
 ### Profiling
 


### PR DESCRIPTION
Remove `--optimize-occurence-order` as `OccurrenceOrderPlugin` is now enabled by default. Remove the comma after `--define`.