### PR TITLE
Adding documentation for implicit common vendor chunk

### DIFF
--- a/content/guides/code-splitting-libraries.md
+++ b/content/guides/code-splitting-libraries.md
@@ -5,6 +5,7 @@ contributors:
   - pksjce
   - chrisVillanueva
   - johnstew
+  - rafde
 ---
 
 A typical application uses third party libraries for framework/functionality needs. Particular versions of these libraries are used and code here does not change often. However, the application code changes frequently.
@@ -108,6 +109,38 @@ module.exports = function(env) {
 }
 ```
 Now run `webpack` on your application. Bundle inspection shows that `moment` code is present only in the vendor bundle.
+
+## Implicit Common Vendor Chunk
+
+You can configure a `CommonsChunkPlugin` instance to only accept vendor libraries.
+ 
+ __webpack.config.js__
+ 
+```javascript
+var webpack = require('webpack');
+var path = require('path');
+
+module.exports = function() {
+    return {
+        entry: {
+            main: './index.js'
+        },
+        output: {
+            filename: '[chunkhash].[name].js',
+            path: path.resolve(__dirname, 'dist')
+        },
+        plugins: [
+            new webpack.optimize.CommonsChunkPlugin({
+                name: 'vendor',
+                minChunks: function (module) {
+                   // this assumes your vendor imports exist in the node_modules directory
+                   return module.context && module.context.indexOf('node_modules') !== -1;
+                }
+            })
+        ]
+    };
+}
+```
 
 ## Manifest File
 


### PR DESCRIPTION
From the [Stack Overflow answer](http://stackoverflow.com/questions/30329337/how-to-bundle-vendor-scripts-separately-and-require-them-as-needed-with-webpack/38733864#38733864
) I gave a while back.

I updated the example to use `module.context` since it's more reliable than `module.userRequest`.

@bebraw you might want to [update](http://survivejs.com/webpack/building-with-webpack/splitting-bundles/#loading-dependencies-to-a-vendor-bundle-automatically)

Where I have this example and then seeing
https://webpack.js.org/plugins/commons-chunk-plugin/#explicit-vendor-chunk

I am starting to think that maybe this and all examples in this area should migrate to the plugin example section to have one area for all related common chunk info.