### PR TITLE
Update sidebar-item-style.scss

### DIFF
--- a/components/sidebar-item/sidebar-item-style.scss
+++ b/components/sidebar-item/sidebar-item-style.scss
@@ -2,10 +2,12 @@
 @import 'functions';
 
 .sidebar-item {
+  position: relative;
   font-size: getFontSize(-1);
   margin-bottom: 0.75em;
 
   &__title {
+    padding-right: 15px;
     font-weight: 400;
     text-decoration: none;
     color: inherit;
@@ -16,7 +18,8 @@
   }
 
   &__toggle {
-    float: right;
+    position: absolute;
+    right: 0;
     line-height: 1.5;
     cursor: pointer;
     color: getColor(dusty-grey);


### PR DESCRIPTION
Fix icon location for long titles in sidebar
![image](https://cloud.githubusercontent.com/assets/3078595/22404557/c8d1bca8-e63b-11e6-9a46-2792f5f4c8c1.png)