### PR TITLE
Empty extension isn't valid anymore

### DIFF
--- a/content/configuration/resolve.md
+++ b/content/configuration/resolve.md
@@ -243,7 +243,7 @@ This set of options is identical to the `resolve` property set above, but is use
 ```js
 {
     modules: ["web_loaders", "web_modules", "node_loaders", "node_modules"],
-    extensions: ["", ".webpack-loader.js", ".web-loader.js", ".loader.js", ".js"],
+    extensions: [".webpack-loader.js", ".web-loader.js", ".loader.js", ".js"],
     packageMains: ["webpackLoader", "webLoader", "loader", "main"]
 }
 ```


### PR DESCRIPTION
In Webpack 2+ this would throw an invalid configuration object error.