### PR TITLE
Add hotOnly option for devServer

### DIFF
--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -185,6 +185,17 @@ hot: true
 ?> Add various other steps needed for this to work. (From my experience, and the current docs it looks like other steps are needed here - not like in the cmd line where it's just a flag)
 
 
+## `devServer.hotOnly`
+
+`boolean`
+
+Enables Hot Module Replacement (see [`devServer.hot`](#devserver-hot-)) without page refresh as fallback in case of build failures.
+
+```js
+hotOnly: true
+```
+
+
 ## `devServer.https`
 
 `boolean` `object`

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -172,7 +172,7 @@ host: "0.0.0.0"
 ```
 
 
-## `devServer.hot` - CLI only
+## `devServer.hot`
 
 `boolean`
 
@@ -185,7 +185,7 @@ hot: true
 ?> Add various other steps needed for this to work. (From my experience, and the current docs it looks like other steps are needed here - not like in the cmd line where it's just a flag)
 
 
-## `devServer.hotOnly`
+## `devServer.hotOnly` - CLI only
 
 `boolean`
 

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -172,7 +172,7 @@ host: "0.0.0.0"
 ```
 
 
-## `devServer.hot`
+## `devServer.hot` - CLI only
 
 `boolean`
 
@@ -189,7 +189,7 @@ hot: true
 
 `boolean`
 
-Enables Hot Module Replacement (see [`devServer.hot`](#devserver-hot-)) without page refresh as fallback in case of build failures.
+Enables Hot Module Replacement (see [`devServer.hot`](#devserver-hot)) without page refresh as fallback in case of build failures.
 
 ```js
 hotOnly: true


### PR DESCRIPTION
Noticed that this option was missing in the docs while writing docs for grunt-webpack.