### PR TITLE
Corrects bundle filepath in index.html

### DIFF
--- a/content/get-started/index.md
+++ b/content/get-started/index.md
@@ -97,7 +97,7 @@ We also need to change `index.html` to expect a single bundled js file.
   </head>
   <body>
 -   <script src="app/index.js"></script>
-+   <script src="dist/bundle.js"></script>
++   <script src="../dist/bundle.js"></script>
   </body>
 </html>
 ```


### PR DESCRIPTION
Bundle filepath wasn't relative to location of index.html. Changes to "../dist/bundle.js" to correct this

1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Make sure your PR complies with [the writer's guide](https://webpack.js.org/writers-guide/).
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
4. Remove these instructions from your PR as they are for your eyes only.
