### PR TITLE
Add prefix to info/warning/todo tips via CSS

### DIFF
--- a/styles/markdown.scss
+++ b/styles/markdown.scss
@@ -98,14 +98,26 @@
     &.tip {
       background-color: #DCF2FD;
       color: #618ca0;
+      .tip-content::before {
+        content: 'ℹ';
+        font-style: normal;
+      }
     }
     &.warning {
       background-color: #fbedb7;
       color: #8c8466;
+      .tip-content::before {
+        content: '⚠';
+        font-style: normal;
+      }
     }
     &.todo {
       background-color: #fbddcd;
       color: #907a6e;
+      .tip-content::before {
+        content: '[TODO]';
+        font-style: normal;
+      }
     }
   }
 


### PR DESCRIPTION
![2017-02-02-08-47-02-001](https://cloud.githubusercontent.com/assets/782446/22541042/3292471c-e924-11e6-85ef-c9d292789e94.png)

Closes #729.