### PR TITLE
Consistent typesetting for loaders and plugins

### DIFF
--- a/content/api/loaders.md
+++ b/content/api/loaders.md
@@ -5,7 +5,7 @@ contributors:
     - TheLarkInn
 ---
 
-Loaders allow you to preprocess files as you `require()` or “load” them. Loaders are kind of like “tasks” in other build tools, 
+Loaders allow you to preprocess files as you `require()` or “load” them. Loaders are kind of like “tasks” in other build tools,
 and provide a powerful way to handle front-end build steps. Loaders can transform files from a different language (like CoffeeScript to JavaScript), or inline images as data URLs. Loaders even allow you to do things like `require()` css files right in your JavaScript!
 
 To tell webpack to transform a module with a loader, you can specify the loader in the webpack [configuration](/configuration) file (preferred) or in the module request, such as in a `require()` call.
@@ -30,7 +30,7 @@ module.exports = function(content) {
 };
 ```
 
-### Async Loader 
+### Async Loader
 
 **async-loader.js**
 
@@ -61,11 +61,11 @@ module.exports = function(content) {
 	// This is also allowed if loader is not "raw"
 };
 module.exports.raw = true;
-``` 
+```
 
 ### Pitching Loader
 
-The order of chained loaders are **always** called from right to left. But, in some cases, loaders do not care about the results of the previous loader or the resource. They only care for **metadata**. The `pitch` method on the loaders is called from **left to right** before the loaders are called (from right to left). 
+The order of chained loaders are **always** called from right to left. But, in some cases, loaders do not care about the results of the previous loader or the resource. They only care for **metadata**. The `pitch` method on the loaders is called from **left to right** before the loaders are called (from right to left).
 
 If a loader delivers a result in the `pitch` method the process turns around and skips the remaining loaders, continuing with the calls to the more left loaders. `data` can be passed between pitch and normal call.
 
@@ -82,9 +82,9 @@ module.exports.pitch = function(remainingRequest, precedingRequest, data) {
 };
 ```
 
-## The loader context 
+## The loader context
 
-The loader context represents the properties that are available inside of a loader assigned to the `this` property. 
+The loader context represents the properties that are available inside of a loader assigned to the `this` property.
 
 Given the following example this require call is used:
 In `/abc/file.js`:
@@ -93,7 +93,7 @@ In `/abc/file.js`:
 require("./loader1?xyz!loader2!./resource?rrr");
 ```
 
-### `version` 
+### `version`
 
 **Loader API version.** Currently `2`. This is useful for providing backwards compatibility. Using the version you can specify custom logic or fallbacks for breaking changes.  
 
@@ -227,7 +227,7 @@ addDependency(file: string)
 dependency(file: string) // shortcut
 ```
 
-Adds a file as dependency of the loader result in order to make them watchable. For example, [html-loader](https://github.com/webpack/html-loader) uses this technique as it finds `src` and `src-set` attributes. Then, it sets the url's for those attributes as dependencies of the html file that is parsed.  
+Adds a file as dependency of the loader result in order to make them watchable. For example, [`html-loader`](https://github.com/webpack/html-loader) uses this technique as it finds `src` and `src-set` attributes. Then, it sets the url's for those attributes as dependencies of the html file that is parsed.  
 
 ### `addContextDependency`
 
@@ -279,7 +279,7 @@ Example values: `"web"`, `"node"`
 
 This boolean is set to true when this is compiled by webpack.
 
-T> Loaders were originally designed to also work as Babel transforms. Therefore if you write a loader that works for both, you can use this property to know if there is access to additional loaderContext and webpack features. 
+T> Loaders were originally designed to also work as Babel transforms. Therefore if you write a loader that works for both, you can use this property to know if there is access to additional loaderContext and webpack features.
 
 ### `emitFile`
 
@@ -307,4 +307,4 @@ Hacky access to the Module object being loaded.
 
 ### Custom `loaderContext` Properties
 
-Custom properties can be added to the `loaderContext` by either specifying values on the `loader` proprty on your webpack [configuration](/configuration), or by creating a [custom plugin](/api/plugins) that hooks into the `normal-module-loader` event which gives you access to the `loaderContext` to modify or extend. 
+Custom properties can be added to the `loaderContext` by either specifying values on the `loader` proprty on your webpack [configuration](/configuration), or by creating a [custom plugin](/api/plugins) that hooks into the `normal-module-loader` event which gives you access to the `loaderContext` to modify or extend.

--- a/content/concepts/hot-module-replacement.md
+++ b/content/concepts/hot-module-replacement.md
@@ -48,8 +48,8 @@ store them in a JSON file.
 ### From The Module View
 
 HMR is an opt-in feature that only affects modules containing HMR code. One example
-would be patching styling through the [style-loader](https://github.com/webpack/style-loader).
-In order for patching to work, style-loader implements the HMR interface; when it
+would be patching styling through the [`style-loader`](https://github.com/webpack/style-loader).
+In order for patching to work, `style-loader` implements the HMR interface; when it
 receives an update through HMR, it replaces the old styles with the new ones.
 
 Similarly, when implementing the HMR interface in a module, you can describe what should

--- a/content/development/how-to-write-a-loader.md
+++ b/content/development/how-to-write-a-loader.md
@@ -48,9 +48,9 @@ I could write a loader that compiles the template from source, execute it and re
 
 Instead I should write loaders for every task in this use case and apply them all (pipeline):
 
-* jade-loader: Convert template to a module that exports a function.
-* apply-loader: Takes a function exporting module and returns raw result by applying query parameters.
-* html-loader: Takes HTML and exports a string exporting module.
+* `jade-loader`: Convert template to a module that exports a function.
+* `apply-loader`: Takes a function exporting module and returns raw result by applying query parameters.
+* `html-loader`: Takes HTML and exports a string exporting module.
 
 ### Generate modules that are modular
 
@@ -112,9 +112,9 @@ There are two options to do this:
 * Transform them to `require`s.
 * Use the `this.resolve` function to resolve the path
 
-Example 1 css-loader: The css-loader transform dependencies to `require`s, by replacing `@import`s with a require to the other stylesheet (processed with the css-loader too) and `url(...)` with a `require` to the referenced file.
+Example 1 `css-loader`: The `css-loader` transform dependencies to `require`s, by replacing `@import`s with a require to the other stylesheet (processed with the `css-loader` too) and `url(...)` with a `require` to the referenced file.
 
-Example 2 less-loader: The less-loader cannot transform `@import`s to `require`s, because all less files need to be compiled in one pass to track variables and mixins. Therefore the less-loader extends the less compiler with a custom path resolving logic. This custom logic uses `this.resolve` to resolve the file with the configuration of the module system (aliasing, custom module directories, etc.).
+Example 2 `less-loader`: The `less-loader` cannot transform `@import`s to `require`s, because all less files need to be compiled in one pass to track variables and mixins. Therefore the `less-loader` extends the less compiler with a custom path resolving logic. This custom logic uses `this.resolve` to resolve the file with the configuration of the module system (aliasing, custom module directories, etc.).
 
 If the language only accept relative urls (like css: `url(file)` always means `./file`), there is the `~`-convention to specify references to modules:
 
@@ -153,7 +153,7 @@ using a peerDependency allows the application developer to specify the exact ver
 
 ### Programmable objects as `query`-option
 
-there are situations where your loader requires programmable objects with functions which cannot stringified as `query`-string. The less-loader, for example, provides the possibility to specify [LESS-plugins](https://github.com/webpack/less-loader#less-plugins). In these cases, a loader is allowed to extend webpack's `options`-object to retrieve that specific option. In order to avoid name collisions, however, it is important that the option is namespaced under the loader's camelCased npm-name.
+there are situations where your loader requires programmable objects with functions which cannot stringified as `query`-string. The `less-loader`, for example, provides the possibility to specify [LESS-plugins](https://github.com/webpack/less-loader#less-plugins). In these cases, a loader is allowed to extend webpack's `options`-object to retrieve that specific option. In order to avoid name collisions, however, it is important that the option is namespaced under the loader's camelCased npm-name.
 
 **Example:**
 

--- a/content/guides/code-splitting-css.md
+++ b/content/guides/code-splitting-css.md
@@ -7,13 +7,13 @@ contributors:
   - johnstew
 ---
 
-In webpack, when you use the css-loader and import CSS into your JavaScript files, the CSS is bundled along with your JavaScript.
+In webpack, when you use the `css-loader` and import CSS into your JavaScript files, the CSS is bundled along with your JavaScript.
 This has the disadvantage that, you will not be able to utilize the browser's ability to load CSS asynchronously and parallel. Instead, your page will have to wait until your whole JavaScript bundle is loaded, to style itself.
-webpack can help with this problem by bundling the CSS separately using [extract-text-webpack-plugin](https://github.com/webpack/extract-text-webpack-plugin) and the [css-loader](https://github.com/webpack/css-loader).
+webpack can help with this problem by bundling the CSS separately using [extract-text-webpack-plugin](https://github.com/webpack/extract-text-webpack-plugin) and the [`css-loader`](https://github.com/webpack/css-loader).
 
 ## Using `css-loader`
 
-To import css into your JavaScript code like [any other module](/concepts/modules), you will have to use the [css-loader](https://github.com/webpack/css-loader).
+To import css into your JavaScript code like [any other module](/concepts/modules), you will have to use the [`css-loader`](https://github.com/webpack/css-loader).
 The webpack config with `css-loader` will look like
 
 ```javascript

--- a/content/guides/migrating.md
+++ b/content/guides/migrating.md
@@ -127,7 +127,7 @@ See [#2986](https://github.com/webpack/webpack/issues/2986) for the reason behin
 ## `json-loader` is not required anymore
 
 When no loader has been configured for a JSON file, webpack will automatically try to load the JSON
-file with the [json-loader](https://github.com/webpack/json-loader).
+file with the [`json-loader`](https://github.com/webpack/json-loader).
 
 ``` diff
   module: {
@@ -491,7 +491,7 @@ typeof fs.readFileSync === "function";
 typeof readFileSync === "function";
 ```
 
-It is important to note that you will want to tell Babel to not parse these module symbols so webpack can use them. You can do this by setting the following in your `.babelrc` or babel-loader options.
+It is important to note that you will want to tell Babel to not parse these module symbols so webpack can use them. You can do this by setting the following in your `.babelrc` or `babel-loader` options.
 
 **.babelrc**
 
@@ -611,7 +611,7 @@ Having an `ident` on the options object means to be able to reference this optio
 ```
 
 This inline style should not be used by regular code, but it's often used by loader generated code.
-I. e. the style-loader generates a module that `require`s the remaining request (which exports the CSS).
+I. e. the `style-loader` generates a module that `require`s the remaining request (which exports the CSS).
 
 ``` js
 // style-loader generated code (simplified)

--- a/content/guides/shimming.md
+++ b/content/guides/shimming.md
@@ -26,8 +26,8 @@ module.exports = {
 };
 ```
 
-## `provide-plugin`
-The [`provide-plugin`](/plugins/provide-plugin) makes a module available as a variable in every other module required by `webpack`. The module is required only if you use the variable.
+## `ProvidePlugin`
+The [`ProvidePlugin`](/plugins/provide-plugin) makes a module available as a variable in every other module required by `webpack`. The module is required only if you use the variable.
 Most legacy modules rely on the presence of specific globals, like jQuery plugins do on `$` or `jQuery`. In this scenario, you can configure webpack to prepend `var $ = require(“jquery”)` every time it encounters the global `$` identifier.
 
 ```javascript
@@ -51,7 +51,7 @@ For example, Some legacy modules rely on `this` being the `window` object. This 
 module.exports = {
   module: {
     rules: [{
-      test: require.resolve("some-module"), 
+      test: require.resolve("some-module"),
       use: 'imports-loader?this=>window'
     }]
   }
@@ -65,7 +65,7 @@ There are modules that support different [module styles](/concepts/modules), lik
 module.exports = {
   module: {
     rules: [{
-      test: require.resolve("some-module"), 
+      test: require.resolve("some-module"),
       use: 'imports-loader?define=>false'
     }]
   }
@@ -81,7 +81,7 @@ Let's say a library creates a global variable that it expects its consumers to u
 module.exports = {
   module: {
     rules: [{
-      test: require.resolve("some-module"), 
+      test: require.resolve("some-module"),
       use: 'exports-loader?file,parse=helpers.parse'
       // adds below code the file's source:
       //  exports["file"] = file;
@@ -93,7 +93,7 @@ module.exports = {
 
 ## `script-loader`
 
-The [script-loader](/loaders/script-loader/) evaluates code in the global context, just like you would add the code into a `script` tag. In this mode, every normal library should work. `require`, `module`, etc. are undefined.
+The [`script-loader`](/loaders/script-loader/) evaluates code in the global context, just like you would add the code into a `script` tag. In this mode, every normal library should work. `require`, `module`, etc. are undefined.
 
 W> The file is added as string to the bundle. It is not minimized by `webpack`, so use a minimized version. There is also no dev tool support for libraries added by this loader.
 
@@ -106,7 +106,7 @@ GLOBAL_CONFIG = {};
 
 ```javascript
 require('script-loader!legacy.js');
-``` 
+```
 
 … basically yields:
 
@@ -116,7 +116,7 @@ eval("GLOBAL_CONFIG = {};");
 
 ## `noParse` option
 
-When there is no AMD/CommonJS version of the module and you want to include the `dist`, you can flag this module as [`noParse`](/configuration/module/#module-noparse). Then `webpack` will just include the module without parsing it, which can be used to improve the build time. 
+When there is no AMD/CommonJS version of the module and you want to include the `dist`, you can flag this module as [`noParse`](/configuration/module/#module-noparse). Then `webpack` will just include the module without parsing it, which can be used to improve the build time.
 
 W> Any feature requiring the AST, like the `ProvidePlugin`, will not work.
 

--- a/content/guides/webpack-and-typescript.md
+++ b/content/guides/webpack-and-typescript.md
@@ -20,8 +20,8 @@ To start using webpack with Typescript you need a couple of things:
 
 You can install the TypeScript compiler and the TypeScript loader from npm by running:
  `npm install --save-dev typescript ts-loader`
- 
-__tsconfig.json__ 
+
+__tsconfig.json__
 
 The tsconfig file can start as an empty configuration file, here you can see an example of a basic configuration for TypeScript to compile to es5 as well as providing support for JSX.
 
@@ -59,35 +59,35 @@ module.exports = {
        exclude: /node_modules/,
      },
    ]
- }, 
+ },
  resolve: {
    extensions: [".tsx", ".ts", ".js"]
  },
 };
 ```
- 
-Here we specify our entry point to be __index.ts__ in our current directory, 
-an output file called __bundle.js__ 
+
+Here we specify our entry point to be __index.ts__ in our current directory,
+an output file called __bundle.js__
 and our TypeScript loader that is in charge of compiling our TypeScript file to JavaScript. We also add `resolve.extensions` to instruct webpack what file extensions to use when resolving Typescript modules.
 
 ## Typescript loaders
 
 Currently there are 2 loaders for TypeScript available:
-* [awesome-typescript-loader](https://github.com/s-panferov/awesome-typescript-loader)
-* [ts-loader](https://github.com/TypeStrong/ts-loader)
+* [`awesome-typescript-loader`](https://github.com/s-panferov/awesome-typescript-loader)
+* [`ts-loader`](https://github.com/TypeStrong/ts-loader)
 
-Awesome TypeScript loader has created a wonderful explanation of the 
-difference between awesome-typescript-loader and ts-loader. 
+Awesome TypeScript loader has created a wonderful explanation of the
+difference between `awesome-typescript-loader` and `ts-loader`.
 
 You can read more about it [here](https://github.com/s-panferov/awesome-typescript-loader#differences-between-ts-loader).
 
-In this guide we will be using ts-loader as currently it is easier enabling additional webpack features such as importing non code assets into your project.
+In this guide we will be using `ts-loader` as currently it is easier enabling additional webpack features such as importing non code assets into your project.
 
 ## Enabling source maps
 
 In order to enable source maps we first must configure TypeScript to output inline source maps to our compiled JavaScript files.
 This is done by setting the sourceMap property to true.
- 
+
 __tsconfig.json__
 ```json
 {
@@ -95,7 +95,7 @@ __tsconfig.json__
 }
 ```
 
-Once TypeScript is configured to output source maps we need to tell webpack 
+Once TypeScript is configured to output source maps we need to tell webpack
 to extract these source maps and pass them to the browser, this way we will get the source file
 exactly as we see it in our code editor.
 
@@ -127,10 +127,10 @@ module.exports = {
  devtool: 'inline-source-map',
 };
 ```
- 
-First we add a new loader called source-map-loader. 
 
-To install it run: 
+First we add a new loader called `source-map-loader`.
+
+To install it run:
 
 `npm install --save-dev source-map-loader`.
 
@@ -138,9 +138,9 @@ Once the loader is installed we need to tell webpack we want to run this loader 
 Finally we need to enable source maps in webpack by specifying the `devtool` property.
 Currently we use the 'inline-source-map' setting, to read more about this setting and see other options check out the [devtool documentation](https://webpack.js.org/configuration/devtool/).
 
- 
- 
- 
+
+
+
 
 ## Using 3rd Party Libraries
 
@@ -174,4 +174,3 @@ Here we declare a new module for svg by specifying any import that ends in __.sv
 If we wanted to be more explicit about this being a url we could define the type as string.
 
 This applies not only to svg but any custom loader you may want to use which includes css, scss, json or any other file you may wish to load in your project.
- 

--- a/content/plugins/banner-plugin.md
+++ b/content/plugins/banner-plugin.md
@@ -1,5 +1,5 @@
 ---
-title: banner-plugin
+title: BannerPlugin
 contributors:
   - simon04
 ---

--- a/content/plugins/commons-chunk-plugin.md
+++ b/content/plugins/commons-chunk-plugin.md
@@ -1,5 +1,5 @@
 ---
-title: commons-chunk-plugin
+title: CommonsChunkPlugin
 contributors:
   - bebraw
   - simon04
@@ -106,7 +106,7 @@ new CommonsChunkPlugin({
 <script src="app.js" charset="utf-8"></script>
 ```
 
-Hint: In combination with long term caching you may need to use [this plugin](https://github.com/diurnalist/chunk-manifest-webpack-plugin) to avoid that the vendor chunk changes. You should also use records to ensure stable module ids.
+Hint: In combination with long term caching you may need to use the [`ChunkManifestWebpackPlugin`](https://github.com/diurnalist/chunk-manifest-webpack-plugin) to avoid that the vendor chunk changes. You should also use records to ensure stable module ids.
 
 ###  Move common modules into the parent chunk
 
@@ -147,11 +147,11 @@ new CommonsChunkPlugin({
 
 ### Passing the `minChunks` property a function
 
-You also have the ability to pass the `minChunks` property a function. This function is called by the `CommonsChunkPlugin` and calls the function with `module` and `count` arguments. 
+You also have the ability to pass the `minChunks` property a function. This function is called by the `CommonsChunkPlugin` and calls the function with `module` and `count` arguments.
 
-The `module` property represents each module in the chunks you have provided via the `names` property. 
+The `module` property represents each module in the chunks you have provided via the `names` property.
 
-The `count` property represents how many chunks the `module` is used in. 
+The `count` property represents how many chunks the `module` is used in.
 
 This option is useful when you want to have fine-grained control over how the CommonsChunk algorithm determins where modules should be moved to.
 
@@ -160,7 +160,7 @@ new CommonsChunkPlugin({
   name: "my-single-lib-chunk",
   filename: "my-single-lib-chunk.js",
   minChunks: function(module, countOfHowManyTimesThisModuleIsUsedAcrossAllChunks) {
-    // If module has a path, and inside of the path exists the name "somelib", 
+    // If module has a path, and inside of the path exists the name "somelib",
     // and it is used in 3 separate chunks/entries, then break it out into
     // a separate chunk with chunk keyname "my-single-lib-chunk", and filename "my-single-lib-chunk.js"
     return module.resource && (/somelib/).test(module.resource) && count === 3;
@@ -168,4 +168,4 @@ new CommonsChunkPlugin({
 });
 ```
 
-As seen above, this example allows you to move only one lib to a separate file if and only if all conditions are met inside the function. 
+As seen above, this example allows you to move only one lib to a separate file if and only if all conditions are met inside the function.

--- a/content/plugins/define-plugin.md
+++ b/content/plugins/define-plugin.md
@@ -1,5 +1,5 @@
 ---
-title: define-plugin
+title: DefinePlugin
 ---
 
 ``` javascript

--- a/content/plugins/environment-plugin.md
+++ b/content/plugins/environment-plugin.md
@@ -1,21 +1,21 @@
 ---
-title: environment-plugin
+title: EnvironmentPlugin
 contributors:
   - simon04
   - einarlove
 ---
 
-The EnvironmentPlugin is a shorthand for using the [DefinePlugin](/plugins/define-plugin) on [`process.env`](https://nodejs.org/api/process.html#process_process_env) keys.
+The `EnvironmentPlugin` is a shorthand for using the [`DefinePlugin`](/plugins/define-plugin) on [`process.env`](https://nodejs.org/api/process.html#process_process_env) keys.
 
 ## Usage
 
-The EnvironmentPlugin accepts either an array of keys.
+The `EnvironmentPlugin` accepts either an array of keys.
 
 ```javascript
 new webpack.EnvironmentPlugin(['NODE_ENV', 'DEBUG'])
 ```
 
-This is equivalent to the following DefinePlugin application:
+This is equivalent to the following `DefinePlugin` application:
 
 ```javascript
 new webpack.DefinePlugin({
@@ -24,11 +24,11 @@ new webpack.DefinePlugin({
 })
 ```
 
-T> Not specifying the environment variable raises an "EnvironmentPlugin - `${key}` environment variable is undefined" error.
+T> Not specifying the environment variable raises an "`EnvironmentPlugin` - `${key}` environment variable is undefined" error.
 
 ## Usage with default values
 
-Alternatively, the EnvironmentPlugin supports an object, which maps keys to their default values. The default value for a key is taken if the key is undefined in `process.env`.
+Alternatively, the `EnvironmentPlugin` supports an object, which maps keys to their default values. The default value for a key is taken if the key is undefined in `process.env`.
 
 ```js
 new webpack.EnvironmentPlugin({
@@ -39,13 +39,13 @@ new webpack.EnvironmentPlugin({
 
 W> Variables coming from `process.env` are always strings.
 
-T> Unlike [DefinePlugin](/plugins/define-plugin), default values are applied to `JSON.stringify` by the EnvironmentPlugin.
+T> Unlike [`DefinePlugin`](/plugins/define-plugin), default values are applied to `JSON.stringify` by the `EnvironmentPlugin`.
 
 T> To specify an unset default value, use `null` instead of `undefined`.
 
 **Example:**
 
-Let's investigate the result when running the previous EnvironmentPlugin configuration on a test file `entry.js`: 
+Let's investigate the result when running the previous `EnvironmentPlugin` configuration on a test file `entry.js`:
 
 ```js
 if (process.env.NODE_ENV === 'production') {

--- a/content/plugins/html-webpack-plugin.md
+++ b/content/plugins/html-webpack-plugin.md
@@ -1,11 +1,11 @@
 ---
-title: html-webpack-plugin
+title: HtmlWebpackPlugin
 contributors:
   - ampedandwired
   - simon04
 ---
 
-The [html-webpack-plugin](https://github.com/ampedandwired/html-webpack-plugin) simplifies creation of HTML files to serve your
+The [`HtmlWebpackPlugin`](https://github.com/ampedandwired/html-webpack-plugin) simplifies creation of HTML files to serve your
 webpack bundles. This is especially useful for webpack bundles that include
 a hash in the filename which changes every compilation. You can either let the plugin generate an HTML file for you, supply
 your own template using [lodash templates](https://lodash.com/docs#template), or use your own [loader](/loaders).

--- a/content/plugins/index.md
+++ b/content/plugins/index.md
@@ -8,12 +8,12 @@ webpack has a rich plugin interface. Most of the features within webpack itself 
 
 |Name|Description|
 |:--:|:----------|
-|[commons-chunk-plugin](/plugins/commons-chunk-plugin)|Generates chunks of common modules shared between entry points and splits them into separate  bundles, e.g., `1vendor.bundle.js` && `app.bundle.js`|
-|[extract-text-webpack-plugin](/plugins/extract-text-webpack-plugin)|Extracts Text (CSS) from your bundles into a separate file (app.bundle.css)|
-|[component-webpack-plugin](/plugins/component-webpack-plugin)|Use components with webpack|
-|[compression-webpack-plugin](/plugins/compression-webpack-plugin)|Prepare compressed versions of assets to serve them with Content-Encoding|
-|[i18n-webpack-plugin](/plugins/i18n-webpack-plugin)|Adds i18n support to your bundles|
-|[html-webpack-plugin](/plugins/html-webpack-plugin)| Simplifies creation of HTML files (`index.html`) to serve your bundles|
+|[`CommonsChunkPlugin`](/plugins/commons-chunk-plugin)|Generates chunks of common modules shared between entry points and splits them into separate  bundles, e.g., `1vendor.bundle.js` && `app.bundle.js`|
+|[`ExtractTextWebpackPlugin`](/plugins/extract-text-webpack-plugin)|Extracts Text (CSS) from your bundles into a separate file (app.bundle.css)|
+|[`ComponentWebpackPlugin`](/plugins/component-webpack-plugin)|Use components with webpack|
+|[`CompressionWebpackPlugin`](/plugins/compression-webpack-plugin)|Prepare compressed versions of assets to serve them with Content-Encoding|
+|[`I18nWebpackPlugin`](/plugins/i18n-webpack-plugin)|Adds i18n support to your bundles|
+|[`HtmlWebpackPlugin`](/plugins/html-webpack-plugin)| Simplifies creation of HTML files (`index.html`) to serve your bundles|
 
 
 ![Awesome](../assets/awesome-badge.svg)

--- a/content/plugins/loader-options-plugin.md
+++ b/content/plugins/loader-options-plugin.md
@@ -1,14 +1,14 @@
 ---
-title: loader-options-plugin
+title: LoaderOptionsPlugin
 contributors:
     - johnnyreilly
 ---
 
 ?> Review this content
 
-The `loader-options-plugin` is unlike other plugins.  It exists to help people move from webpack 1 to webpack 2.  With webpack 2 the schema for a `webpack.config.js` became stricter; no longer open for extension by other loaders / plugins.  With webpack 2 the intention is that you pass `options` directly to loaders / plugins. i.e. options are **not** global / shared.
+The `LoaderOptionsPlugin` is unlike other plugins.  It exists to help people move from webpack 1 to webpack 2.  With webpack 2 the schema for a `webpack.config.js` became stricter; no longer open for extension by other loaders / plugins.  With webpack 2 the intention is that you pass `options` directly to loaders / plugins. i.e. options are **not** global / shared.
 
-However, until a loader has been updated to depend upon options being passed directly to them, the `loader-options-plugin` exists to bridge the gap.  You can configure global / shared loader options with this plugin and all loaders will receive these options.
+However, until a loader has been updated to depend upon options being passed directly to them, the `LoaderOptionsPlugin` exists to bridge the gap.  You can configure global / shared loader options with this plugin and all loaders will receive these options.
 
 In the future this plugin may be removed.
 
@@ -34,4 +34,3 @@ new webpack.LoaderOptionsPlugin({
   }
 })
 ```
-

--- a/content/plugins/provide-plugin.md
+++ b/content/plugins/provide-plugin.md
@@ -1,5 +1,5 @@
 ---
-title: provide-plugin
+title: ProvidePlugin
 contributors:
   - sokra
   - simon04

--- a/content/plugins/source-map-dev-tool-plugin.md
+++ b/content/plugins/source-map-dev-tool-plugin.md
@@ -1,5 +1,5 @@
 ---
-title: source-map-dev-tool-plugin
+title: SourceMapDevToolPlugin
 contributors:
     - johnnyreilly
 ---
@@ -23,4 +23,3 @@ new webpack.SourceMapDevToolPlugin(options)
 ## Examples
 
 ?> TODO
-

--- a/content/writers-guide.md
+++ b/content/writers-guide.md
@@ -23,6 +23,12 @@ title: Writer's Guide
 
 The site will update itself as you make changes.
 
+## Typesetting
+
+* webpack should always be written in lower-case letters. Even at the beginning of a sentence. ([source](https://github.com/webpack/media#name))
+* loaders are enclosed in backticks and [kebab-cased](https://en.wikipedia.org/w/index.php?title=Kebab_case): `css-loader`, `ts-loader`, …
+* plugins are enclosed in backticks and [camel-cased](https://en.wikipedia.org/wiki/Camel_case): `BannerPlugin`, `NpmInstallWebpackPlugin`, …
+
 ## Formatting
 
 ### Code
@@ -84,4 +90,3 @@ W> This is a warning.
 **Syntax: ?\>**
 
 ?> This is a todo.
-

--- a/scripts/fetch_package_files.js
+++ b/scripts/fetch_package_files.js
@@ -78,9 +78,16 @@ function fetchPackageFiles(options, finalCb) {
             .replace(/<\/h2>/g, ''); // drop </h2>
         }
 
+        var title = pkg.name;
+        if (title.match(/-plugin$/)) {
+          title = _.camelCase(title);
+          title = _.upperFirst(title);
+          title = title.replace(/I18N/, 'I18n');
+        }
+
         // TODO: push this type of to a script of its own to keep this generic
         let headmatter = yamlHeadmatter({
-          title: pkg.name,
+          title: title,
           source: url,
           edit: [pkg.html_url, 'edit', branch, file].join('/'),
         });


### PR DESCRIPTION
* loaders are enclosed in backticks and kebab-cased
* plugins are enclosed in backticks and CamelCased

#794 is meant to be merged first. I'll rebase afterwards.