### PR TITLE
Split why-webpack into task-runner and comparison

### DIFF
--- a/antwar.config.js
+++ b/antwar.config.js
@@ -65,6 +65,8 @@ module.exports = {
           true,
           /^\.\/.*\.md$/
         );
+      }, {
+        'why-webpack': '/guides/comparison'
       }
     ),
 
@@ -191,7 +193,7 @@ function root(contentCb) {
   };
 }
 
-function section(title, contentCb) {
+function section(title, contentCb, redirects = {}) {
   return {
     title: title,
     path: function() {
@@ -209,7 +211,7 @@ function section(title, contentCb) {
         return require('./components/page/page.jsx').default
       }
     },
-    redirects: {} // <from>: <to>
+    redirects: redirects // <from>: <to>
   };
 }
 

--- a/content/guides/comparison.md
+++ b/content/guides/comparison.md
@@ -1,25 +1,12 @@
 ---
-title: Why webpack?
+title: Comparison with other bundlers
 contributors:
   - pksjce
   - bebraw
   - chrisVillanueva
   - tashian
+  - simon04
 ---
-
-webpack is a module bundler, like Browserify or Brunch. It is not a task runner. Make, Grunt, or Gulp are task runners. But people get confused about the difference, so let's clear that up right away.
-
-Task runners handle automation of common development tasks such as linting, building, or testing your project. Compared to bundlers, task runners have a higher level focus.
-
-Bundlers help you get your JavaScript and stylesheets ready for deployment, transforming them into a format that's suitable for the browser. For example, JavaScript can be minified or split into chunks and loaded on-demand to improve performance. Bundling is one of the most important challenges in web development, and solving it well can remove a lot of pain from the process.
-
-webpack can work alongside task runners. You can still benefit from their higher level tooling while leaving the problem of bundling to webpack. [grunt-webpack](https://www.npmjs.com/package/grunt-webpack) and [gulp-webpack](https://www.npmjs.com/package/gulp-webpack) are good examples.
-
-T> Often webpack users use npm `scripts` as their task runner. This is a good starting point. Cross-platform support can become a problem, but there are several workarounds for that.
-
-T> Even though webpack core focuses on bundling, you can find a variety of extensions that allow you to use it in a task runner kind of way.
-
-## Comparison
 
 webpack is not the only module bundler out there. If you are choosing between using webpack or any of the bundlers below, here is a feature-by-feature comparison on how webpack fares against the current competition.
 

--- a/content/guides/task-test-runner.md
+++ b/content/guides/task-test-runner.md
@@ -1,6 +1,22 @@
 ---
-title: Integration with ask/test runners
+title: Integration with task/test runners
+contributors:
+  - pksjce
+  - bebraw
+  - tashian
 ---
+
+webpack is a module bundler, like Browserify or Brunch. It is not a task runner. Make, Grunt, or Gulp are task runners. But people get confused about the difference, so let's clear that up right away.
+
+Task runners handle automation of common development tasks such as linting, building, or testing your project. Compared to bundlers, task runners have a higher level focus.
+
+Bundlers help you get your JavaScript and stylesheets ready for deployment, transforming them into a format that's suitable for the browser. For example, JavaScript can be minified or split into chunks and loaded on-demand to improve performance. Bundling is one of the most important challenges in web development, and solving it well can remove a lot of pain from the process.
+
+webpack can work alongside task runners. You can still benefit from their higher level tooling while leaving the problem of bundling to webpack. [grunt-webpack](https://www.npmjs.com/package/grunt-webpack) and [gulp-webpack](https://www.npmjs.com/package/gulp-webpack) are good examples.
+
+T> Often webpack users use npm `scripts` as their task runner. This is a good starting point. Cross-platform support can become a problem, but there are several workarounds for that.
+
+T> Even though webpack core focuses on bundling, you can find a variety of extensions that allow you to use it in a task runner kind of way.
 
 ?> Grunt
 


### PR DESCRIPTION
Rationale: The title "why webpack" is a vague. The content "webpack vs. task runners" and "webpack vs. other bundlers" is not directly related.