### PR TITLE
Minor Fix for the Landing Page

### DIFF
--- a/components/splash-viz/splash-viz-style.scss
+++ b/components/splash-viz/splash-viz-style.scss
@@ -1,13 +1,14 @@
 @import 'functions';
+@import 'vars';
 @import 'mixins';
 
 .splash-viz {
-  position:relative;
-  display:flex;
-  height:calc(100vh - 55px);
-  min-height:320px;
-  max-height:720px;
-  background:getColor(elephant);
+  position: relative;
+  display: flex;
+  height: calc(100vh - 55px);
+  min-height: 320px;
+  max-height: 720px;
+  background: getColor(elephant);
   flex-direction: column;
 
   &__heading {
@@ -28,8 +29,9 @@
     right: 0;
     top: 0;
     bottom: 0;
-    width: 65vw;
+    width: 75vw;
     min-width: 550px;
+    max-width: map-get($screens, large);
     margin: auto;
     display: none;
 


### PR DESCRIPTION
Preventing abnormally large illustration on large screen sizes (e.g. desktops). Stretching the illustration starts to look a bit funny past a certain point.

Before:

![screen shot 2017-02-06 at 6 00 33 pm](https://cloud.githubusercontent.com/assets/8988697/22670337/b7360b3c-ec96-11e6-97bc-10dde3bb503b.png)

After:

![screen shot 2017-02-06 at 6 00 56 pm](https://cloud.githubusercontent.com/assets/8988697/22670353/c3bb6370-ec96-11e6-9a98-15c8e2316216.png)