### PR TITLE
normal-module-replacement-plugin: add documentation

### DIFF
--- a/content/plugins/index.md
+++ b/content/plugins/index.md
@@ -2,6 +2,7 @@
 title: Plugins
 contributors:
   - simon04
+  - gonzoyumo
 ---
 
 webpack has a rich plugin interface. Most of the features within webpack itself use this plugin interface. This makes webpack **flexible**.
@@ -14,6 +15,7 @@ webpack has a rich plugin interface. Most of the features within webpack itself 
 |[`CompressionWebpackPlugin`](/plugins/compression-webpack-plugin)|Prepare compressed versions of assets to serve them with Content-Encoding|
 |[`I18nWebpackPlugin`](/plugins/i18n-webpack-plugin)|Adds i18n support to your bundles|
 |[`HtmlWebpackPlugin`](/plugins/html-webpack-plugin)| Simplifies creation of HTML files (`index.html`) to serve your bundles|
+|[`NormalModuleReplacementPlugin`](/plugins/normal-module-replacement-plugin)|Replaces resource that matches a regexp|
 
 
 ![Awesome](../assets/awesome-badge.svg)

--- a/content/plugins/normal-module-replacement-plugin.md
+++ b/content/plugins/normal-module-replacement-plugin.md
@@ -5,7 +5,7 @@ contributors:
 ---
 ## Install
 
-The `NormalModuleReplacementPlugin` is a built-in  Webpack plugin. There is nothing to do except requiring webpack.
+The `NormalModuleReplacementPlugin` is a built-in webpack plugin.
 
 
 ## Usage
@@ -14,13 +14,13 @@ The `NormalModuleReplacementPlugin` is a built-in  Webpack plugin. There is noth
 new webpack.NormalModuleReplacementPlugin(resourceRegExp, newResource)
 ```
 
-The `NormalModuleReplacementPlugin` allows you to replace resources that match `resourceRegExp` with `newResource`. If `newResource` is relative, it is resolved relative to the previous resource. If `newResource` is a function, it is expected to overwrite the **request** attribute of the supplied object.
+The `NormalModuleReplacementPlugin` allows you to replace resources that match `resourceRegExp` with `newResource`. If `newResource` is relative, it is resolved relative to the previous resource. If `newResource` is a function, it is expected to overwrite the request attribute of the supplied resource.
 
 This can be useful for allowing different behaviour between builds.
 
 ## Basic example
 
-Replace a specific module when building for development environment.
+Replace a specific module when building for development environment ([read more](/configuration/environment)).
 
 
 Say you have a config file `some/path/config.development.module.js` and a special version for production in `some/path/config.production.module.js`
@@ -36,17 +36,16 @@ new webpack.NormalModuleReplacementPlugin(
 
 ## Advanced example
 
-Conditional build depending on an environment var.
+Conditional build depending on an environment var ([read more](/configuration/environment)).
 
 Say you want a configuration with specific values for different build targets.
 
 ``` javascript
-// Usual config omitted for brevity
-module.exports = env => {
-  const appTarget = env.APP_TARGET || 'VERSION_A';
+module.exports = function(env) {
+  var appTarget = env.APP_TARGET || 'VERSION_A';
   return {
     plugins: [
-      new webpack.NormalModuleReplacementPlugin(/(.*)-APP_TARGET(\.*)/, resource => {
+      new webpack.NormalModuleReplacementPlugin(/(.*)-APP_TARGET(\.*)/, function(resource) {
         resource.request = resource.request.replace(/-APP_TARGET/, `-${appTarget}`);
       })
     ]
@@ -57,13 +56,13 @@ module.exports = env => {
 
 Create the two config files:
 
-app/config-VERSION_A.js:
+**app/config-VERSION_A.js:**
 ``` javascript
 export default {
   title : 'I am version A'
 }
 ```
-app/config-VERSION_B.js:
+**app/config-VERSION_B.js:**
 ``` javascript
 export default {
   title : 'I am version B'

--- a/content/plugins/normal-module-replacement-plugin.md
+++ b/content/plugins/normal-module-replacement-plugin.md
@@ -1,0 +1,88 @@
+---
+title: NormalModuleReplacementPlugin
+contributors:
+  - gonzoyumo
+---
+## Install
+
+The `NormalModuleReplacementPlugin` is a built-in  Webpack plugin. There is nothing to do except requiring webpack.
+
+
+## Usage
+
+``` javascript
+new webpack.NormalModuleReplacementPlugin(resourceRegExp, newResource)
+```
+
+The `NormalModuleReplacementPlugin` allows you to replace resources that match `resourceRegExp` with `newResource`. If `newResource` is relative, it is resolved relative to the previous resource. If `newResource` is a function, it is expected to overwrite the **request** attribute of the supplied object.
+
+This can be useful for allowing different behaviour between builds.
+
+## Basic example
+
+Replace a specific module when building for development environment.
+
+
+Say you have a config file `some/path/config.development.module.js` and a special version for production in `some/path/config.production.module.js`
+
+Just add the following plugin when building for production:
+
+``` javascript
+new webpack.NormalModuleReplacementPlugin(
+  /some\/path\/config\.development\.js/,
+  './config.production.js'
+);
+```
+
+## Advanced example
+
+Conditional build depending on an environment var.
+
+Say you want a configuration with specific values for different build targets.
+
+``` javascript
+// Usual config omitted for brevity
+module.exports = env => {
+  const appTarget = env.APP_TARGET || 'VERSION_A';
+  return {
+    plugins: [
+      new webpack.NormalModuleReplacementPlugin(/(.*)-APP_TARGET(\.*)/, resource => {
+        resource.request = resource.request.replace(/-APP_TARGET/, `-${appTarget}`);
+      })
+    ]
+  }
+  
+}
+```
+
+Create the two config files:
+
+app/config-VERSION_A.js:
+``` javascript
+export default {
+  title : 'I am version A'
+}
+```
+app/config-VERSION_B.js:
+``` javascript
+export default {
+  title : 'I am version B'
+}
+```
+Then import that config using the keyword you're looking for in the regexp:
+
+``` javascript
+import config from 'app/config-APP_TARGET';
+console.log(config.title);
+```
+
+And now you just get the right config imported depending on which target you're building for:
+
+``` shell
+webpack --env.APP_TARGET VERSION_A
+=> 'I am version A'
+
+webpack --env.APP_TARGET VERSION_B
+=> 'I am version B'
+
+```


### PR DESCRIPTION
My humble contribution to that great project. Refs #814 

I tried to keep the same structure used on other plugin documentations but it doesn't look like there is a template to follow. Please advise me if changes are needed.

