### PR TITLE
Fixed 404 fail resource in plugins page

### DIFF
--- a/utilities/markdown.js
+++ b/utilities/markdown.js
@@ -9,7 +9,7 @@ module.exports = function(section) {
   var renderer = new marked.Renderer();
 
   renderer.image = function(href, title, text) {
-    return '<img src="' + section + href + '" alt="' + text + '">';
+    return '<img src="' + href + '" alt="' + text + '">';
   };
 
   // patch ids (this.options.headerPrefix can be undefined!)


### PR DESCRIPTION
Removed `section` variable from `renderer.image` in file markdown.js because it will fail to load resource ( jpg, gif, svg, mp4 )

url with failed resources can be found here.
https://webpack.js.org/plugins/npm-install-webpack-plugin
https://webpack.js.org/plugins/uglifyjs-webpack-plugin/


### Actual Behavior in pages
![screen shot 2017-02-07 at 4 24 09 pm](https://cloud.githubusercontent.com/assets/5017156/22697504/e41bd422-ed51-11e6-9389-b30bd2e70110.png)

![screen shot 2017-02-07 at 4 24 38 pm](https://cloud.githubusercontent.com/assets/5017156/22697522/f37fddd2-ed51-11e6-8093-c5e37ad077b4.png)

![screen shot 2017-02-07 at 5 13 01 pm](https://cloud.githubusercontent.com/assets/5017156/22699780/ce33b542-ed58-11e6-9a76-1c8ab04fb815.png)
