### PR TITLE
Font anti aliasing

### DIFF
--- a/components/footer/footer-style.scss
+++ b/components/footer/footer-style.scss
@@ -68,6 +68,7 @@
   font-size: getFontSize(-2);
   text-transform: uppercase;
   color: getColor(dusty-grey);
+  @include fontantialias(false);
 
   &:not(:last-child) {
     margin-right: 1.5em;

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -23,6 +23,7 @@ html {
 body {
   font: 400 getFontSize(0) $font-stack-body;
   color: getColor(elephant);
+  @include fontantialias(true);
 }
 
 a {

--- a/styles/partials/_mixins.scss
+++ b/styles/partials/_mixins.scss
@@ -3,3 +3,14 @@
     @content;
   }
 }
+
+@mixin fontantialias ($on) {
+  @if $on == true {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+  @else {
+    -webkit-font-smoothing: subpixel-antialiased;
+    -moz-osx-font-smoothing: auto;
+  }
+}

--- a/styles/prism-theme.scss
+++ b/styles/prism-theme.scss
@@ -1,4 +1,5 @@
 @import 'functions';
+@import 'mixins';
 
 code[class*="lang-"],
 pre[class*="lang-"] {
@@ -12,6 +13,7 @@ pre[class*="lang-"] {
   hyphens: none;
   //color: getColor(fiord);
   color: desaturate(getColor(malibu), 40%);
+  @include fontantialias(false);
 
   a {
     color: inherit;


### PR DESCRIPTION
This (semi-opinionated) commit adds CSS font anti aliasing on devices that support it.

I added a mixin `fontantialias` that will add anti aliasing properties or not. The mixin is applied to the body element and disabled on code and the footer (the text becomes too small/thin). 

# Comparison
*Open in fullscreen!*

## Before

![before](https://cloud.githubusercontent.com/assets/12237065/22789215/96235532-eee2-11e6-8f9e-7c506b1d9231.png)

## After

![after](https://cloud.githubusercontent.com/assets/12237065/22789232/a30c855c-eee2-11e6-88b1-01895839948a.png)
