### PR TITLE
Remove minimize option

### DIFF
--- a/content/configuration/plugins.md
+++ b/content/configuration/plugins.md
@@ -36,7 +36,6 @@ plugins: [
     filename: 'vendor-[hash].min.js',
   }),
   new webpack.optimize.UglifyJsPlugin({
-    minimize: true,
     compress: {
       warnings: false,
       drop_console: false,


### PR DESCRIPTION
Remove minimize option usage here.  According to the [migration guide](https://webpack.js.org/guides/migrating/#uglifyjsplugin-minimize-loaders), it should be passed via `new webpack.LoaderOptionsPlugin`
