### PR TITLE
Improve CLI reference

### DIFF
--- a/components/navigation/navigation.jsx
+++ b/components/navigation/navigation.jsx
@@ -17,6 +17,7 @@ let Sections = [
     title: 'Documentation',
     url: 'configuration',
     children: [
+      { title: 'CLI', url: 'api/cli' },
       { title: 'API', url: 'api' },
       { title: 'Configuration', url: 'configuration' },
       { title: 'Loaders', url: 'loaders' },

--- a/content/api/cli.md
+++ b/content/api/cli.md
@@ -94,7 +94,8 @@ Send [environment](/configuration/environment) variable to be used in webpack co
 
 
 ```bash
-webpack --env=DEVELOPMENT
+webpack --env.production    # sets production to true
+webpack --env.platform=web  # sets platform to "web"
 ```
 
 **Print result of webpack as a JSON**
@@ -104,10 +105,12 @@ webpack --json
 webpack --json > stats.json
 ```
 
-In every other case, webpack prints out a set of stats showing bundle, chunk and timing details. Using this option the output can be a JSON object.This response is accepted by webpack's [analyse tool](https://webpack.github.com/analyse), or chrisbateman's [webpack-visualizer](https://chrisbateman.github.io/webpack-visualizer/), or th0r's [webpack-bundle-analyzer](https://github.com/th0r/webpack-bundle-analyzer).
+In every other case, webpack prints out a set of stats showing bundle, chunk and timing details. Using this option the output can be a JSON object.
+This response is accepted by webpack's [analyse tool](https://webpack.github.com/analyse), or chrisbateman's [webpack-visualizer](https://chrisbateman.github.io/webpack-visualizer/), or th0r's [webpack-bundle-analyzer](https://github.com/th0r/webpack-bundle-analyzer).
 The analyse tool will take in the JSON and provide all the details of the build in graphical form.
 
 *Further reads:*
+* [Analyzing Build Statistics](https://survivejs.com/webpack/optimizing-build/analyzing-build-statistics/)
 * [Three simple ways to inspect a Webpack bundle](https://medium.com/@joeclever/three-simple-ways-to-inspect-a-webpack-bundle-7f6a8fe7195d#.7d2i06mjx)
 * [Optimising your application bundle size with webpack](https://hackernoon.com/optimising-your-application-bundle-size-with-webpack-e85b00bab579#.5w5ko08pq)
 * [Analyzing & optimizing your Webpack bundle](https://medium.com/@ahmedelgabri/analyzing-optimizing-your-webpack-bundle-8590818af4df#.hce4vdjs9)
@@ -195,8 +198,8 @@ These options allow you to manipulate optimisations for a production build using
 
 | Parameter                 | Explanation                                            | Plugin used                          |
 |---------------------------|--------------------------------------------------------|--------------------------------------|
-| --optimize-max-chunks     | Try to keep the chunk count below a limit              | LimitChunkCountPlugin                |
-| --optimize-min-chunk-size | Try to keep the chunk size above a limit               | MinChunkSizePlugin                   |
+| --optimize-max-chunks     | Try to keep the chunk count below a limit              | [LimitChunkCountPlugin](/plugins/limit-chunk-count-plugin) |
+| --optimize-min-chunk-size | Try to keep the chunk size above a limit               | [MinChunkSizePlugin](/plugins/min-chunk-size-plugin) |
 | --optimize-minimize       | Minimize javascript and switches loaders to minimizing | [UglifyJsPlugin](/plugins/uglifyjs-webpack-plugin/) & [LoaderOptionsPlugin](/plugins/loader-options-plugin/) |
 
 ### Resolve Options

--- a/content/api/cli.md
+++ b/content/api/cli.md
@@ -3,30 +3,38 @@ title: Command Line Interface (CLI)
 sort: 2
 contributors:
     - ev1stensberg
+    - simon04
 ---
 
 webpack provides a Command Line Interface (CLI) to configure and interact with your build. This is mostly useful in case of early prototyping, profiling, writing npm scripts or personal customization of the build.
 
 For proper usage and easy distribution of this configuration, webpack can be configured with `webpack.config.js`. Any parameters sent to the CLI will map to a corresponding parameter in the config file.
 
-## Installation
+Have a look at the [installation guide](/guides/installation) unless you have webpack already running.
 
-Have a look at [this page](/guides/installation)
+T> The new CLI for webpack is under development. New features are being added such as the `--init` flag. [Check it out!](https://github.com/webpack/webpack-cli)
 
-?> The new CLI for webpack is under development. New features are being added such as the `--init` flag. [Check it out!](https://github.com/webpack/webpack-cli)
+## Usage with config file
+```sh
+webpack [--config webpack.config.js]
+```
 
-### Common Usage
+See [configuration](/configuration) for the options in the configuration file.
 
-```bash
+## Usage without config file
+```sh
 webpack <entry> [<entry>] <output>
 ```
 
-| Parameter | Configuration Mapping         | Explanation                                                                                                                                                             |
-|-----------|-------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| entry     | entry                         | A filename or a set of named filenames which act as the entry point to build your project. If you pass a pair in the form of `=` you can create an additional entry point. |
-| output    | output.path + output.filename | A path and filename for the bundled file to be saved in. |
+**`<entry>`**
 
-#### Examples
+A filename or a set of named filenames which act as the entry point to build your project. You can pass multiple entries (every entry is loaded on startup). If you pass a pair in the form `<name>=<request>` you can create an additional entry point. It will be mapped to the configuration option `entry`.
+
+**`<output>`**
+
+A path and filename for the bundled file to be saved in. It will be mapped to the configuration options `output.path` and `output.filename`.
+
+**Example**
 
 If your project structure is as follows -
 
@@ -68,18 +76,22 @@ webpack index=./src/index.js entry2=./src/index2.js dist/bundle.js
 **List all of the options available on the cli**
 
 ```bash
-webpack --help , webpack -h
+webpack --help
+webpack -h
 ```
 
 **Build source using a config file**
 
-Specifies a different configuration file to pick up. Use this if you want to specify something different than `webpack.config.js`, which is the default.
+Specifies a different [configuration](/configuration) file to pick up. Use this if you want to specify something different than `webpack.config.js`, which is the default.
 
 ```bash
 webpack --config example.config.js
 ```
 
-**Send environment variable to be used in webpack config file**
+**Specify build environment**
+
+Send [environment](/configuration/environment) variable to be used in webpack config file.
+
 
 ```bash
 webpack --env=DEVELOPMENT
@@ -87,18 +99,23 @@ webpack --env=DEVELOPMENT
 
 **Print result of webpack as a JSON**
 
-In every other case, webpack prints out a set of stats showing bundle, chunk and timing details. Using this option the output can be a JSON object.This response is accepted by webpack's [analyse tool](https://webpack.github.com/analyse).
+```bash
+webpack --json
+webpack --json > stats.json
+```
+
+In every other case, webpack prints out a set of stats showing bundle, chunk and timing details. Using this option the output can be a JSON object.This response is accepted by webpack's [analyse tool](https://webpack.github.com/analyse), or chrisbateman's [webpack-visualizer](https://chrisbateman.github.io/webpack-visualizer/), or th0r's [webpack-bundle-analyzer](https://github.com/th0r/webpack-bundle-analyzer).
 The analyse tool will take in the JSON and provide all the details of the build in graphical form.
 
-?> (TODO: Link to webpack analyse article)
-
-```bash
-webpack --json , webpack -j, webpack -j > stats.json
-```
+*Further reads:*
+* [Three simple ways to inspect a Webpack bundle](https://medium.com/@joeclever/three-simple-ways-to-inspect-a-webpack-bundle-7f6a8fe7195d#.7d2i06mjx)
+* [Optimising your application bundle size with webpack](https://hackernoon.com/optimising-your-application-bundle-size-with-webpack-e85b00bab579#.5w5ko08pq)
+* [Analyzing & optimizing your Webpack bundle](https://medium.com/@ahmedelgabri/analyzing-optimizing-your-webpack-bundle-8590818af4df#.hce4vdjs9)
+* [Analysing and minimising the size of client side bundle with webpack and source-map-explorer](https://medium.com/@nimgrg/analysing-and-minimising-the-size-of-client-side-bundle-with-webpack-and-source-map-explorer-41096559beca#.c3t2srr8x)
 
 ### Output Options
 
-This set of options allows you to manipulate certain output parameters of your build.
+This set of options allows you to manipulate certain [output](/configuration/output) parameters of your build.
 
 | Parameter                    | Explanation                                                     | Input type | Default value                                         |
 |------------------------------|-----------------------------------------------------------------|------------|-------------------------------------------------------|
@@ -147,12 +164,12 @@ This set of options allows you to better debug the application containing assets
 | Parameter  | Explanation                                      | Input type | Default value |
 |------------|--------------------------------------------------|------------|---------------|
 | --debug    | Switch loaders to debug mode                     | boolean    | false         |
-| --devtool  | Define source map type for the bundled resources | string     | -             |
+| --devtool  | Define [source map type](/configuration/devtool/) for the bundled resources | string     | -             |
 | --progress | Print compilation progress in percentage         | boolean    | false         |
 
 ### Module Options
 
-These options allow you to bind modules as allowed by webpack
+These options allow you to bind [modules](/configuration/module/) as allowed by webpack
 
 | Parameter          | Explanation                        | Usage                       |
 |--------------------|------------------------------------|-----------------------------|
@@ -162,7 +179,7 @@ These options allow you to bind modules as allowed by webpack
 
 ### Watch Options
 
-These options makes the build watch for changes in files of the dependency graph and perform the build again.
+These options makes the build [watch](/configuration/watch/) for changes in files of the dependency graph and perform the build again.
 
 | Parameter                 | Explanation                                             |
 |---------------------------|---------------------------------------------------------|
@@ -180,11 +197,11 @@ These options allow you to manipulate optimisations for a production build using
 |---------------------------|--------------------------------------------------------|--------------------------------------|
 | --optimize-max-chunks     | Try to keep the chunk count below a limit              | LimitChunkCountPlugin                |
 | --optimize-min-chunk-size | Try to keep the chunk size above a limit               | MinChunkSizePlugin                   |
-| --optimize-minimize       | Minimize javascript and switches loaders to minimizing | UglifyJsPlugin & LoaderOptionsPlugin |
+| --optimize-minimize       | Minimize javascript and switches loaders to minimizing | [UglifyJsPlugin](/plugins/uglifyjs-webpack-plugin/) & [LoaderOptionsPlugin](/plugins/loader-options-plugin/) |
 
 ### Resolve Options
 
-These allow you to configure the webpack resolver with aliases and extensions.
+These allow you to configure the webpack [resolver](/configuration/resolve/) with aliases and extensions.
 
 | Parameter              | Explanation                                             | Example                                     |
 |------------------------|---------------------------------------------------------|---------------------------------------------|
@@ -194,7 +211,7 @@ These allow you to configure the webpack resolver with aliases and extensions.
 
 ### Stats Options
 
-These options allow webpack to display various stats and style them differently in the console output.
+These options allow webpack to display various [stats](/configuration/stats/) and style them differently in the console output.
 
 | Parameter               | Explanation                                                        | Type    |
 |-------------------------|--------------------------------------------------------------------|---------|
@@ -221,23 +238,23 @@ These options allow webpack to display various stats and style them differently 
 |-----------------------|------------------------------------------------------------------|---------------------------------------------|
 | --bail                | Abort the compilation on first error                             |                                             |
 | --cache               | Enable in memory caching [Enabled by default for watch]          | --cache=false                               |
-| --define              | Define any free var in the bundle                                | --define process.env.NODE_ENV='development' |
-| --hot                 | Enables Hot Module Replacement [Uses HotModuleReplacementPlugin] | --hot=true                                  |
+| --define              | Define any free var in the bundle, see [shimming](/guides/shimming) | --define process.env.NODE_ENV='development' |
+| --hot                 | Enables [Hot Module Replacement](/concepts/hot-module-replacement) [Uses HotModuleReplacementPlugin] | --hot=true                                  |
 | --labeled-modules     | Enables labeled modules [Uses LabeledModulesPlugin]              |                                             |
-| --plugin              | Load this plugin                                                 |                                             |
+| --plugin              | Load this [plugin](/configuration/plugins/)                      |                                             |
 | --prefetch            | Prefetch the particular file                                     | --prefetch=./files.js                       |
-| --provide             | Provide these modules as free vars in all modules                | --provide jQuery=jquery                     |
+| --provide             | Provide these modules as free vars in all modules, see [shimming](/guides/shimming) | --provide jQuery=jquery                     |
 | --records-input-path  | Path to the records file (reading)                               |                                             |
 | --records-output-path | Path to the records file (writing)                               |                                             |
 | --records-path        | Path to the records file                                         |                                             |
-| --target              | The targeted execution environment                                | --target='node'                             |
+| --target              | The [targeted](/configuration/target/) execution environment     | --target='node'                             |
 
 ### Shortcuts
 
 | Shortcut | Replaces                                                         |
 |----------|------------------------------------------------------------------|
 | -d       | --debug --devtool eval-cheap-module-source-map --output-pathinfo |
-| -p       | --optimize-minimize --define process.env.NODE_ENV="production"   |
+| -p       | --optimize-minimize --define process.env.NODE_ENV="production", see [building for production](/guides/production-build)   |
 
 ### Profiling
 

--- a/content/plugins/limit-chunk-count-plugin.md
+++ b/content/plugins/limit-chunk-count-plugin.md
@@ -1,0 +1,6 @@
+---
+title: LimitChunkCountPlugin
+contributors:
+---
+
+Try to keep the chunk count below a limit.

--- a/content/plugins/min-chunk-size-plugin.md
+++ b/content/plugins/min-chunk-size-plugin.md
@@ -1,0 +1,6 @@
+---
+title: MinChunkSizePlugin
+contributors:
+---
+
+Try to keep the chunk size above a limit.


### PR DESCRIPTION
- Add many links
- Clarify usage patterns with/without config file
- Add CLI link to sub-navigation (adding `/cli` causes the sidepanel to not contain any headers. This is the default for any `index.md`)

Closes #826. Supersedes #820.