### PR TITLE
Update docs on parser access

### DIFF
--- a/content/api/plugins.md
+++ b/content/api/plugins.md
@@ -445,10 +445,12 @@ An asset from a chunk was added to the compilation.
 The parser instance takes a String and callback and will return an expression when there's a match.
 
 ```javascript
-compiler.parser.plugin("var rewire", function (expr) {
-    //if you original module has 'var rewire'
-    //you now have a handle on the expresssion object
-    return true;
+compiler.plugin('compilation', function(compilation, data) {
+  data.normalModuleFactory.plugin('parser', function(parser, options) {
+    parser.plugin('call require', function(expr) {
+      // you now have a reference to the call expression
+    });
+  });
 });
 ```
 


### PR DESCRIPTION
Following the existing docs results in this deprecation warning:

> webpack: Using compiler.parser is deprecated.
> Use
> compiler.plugin("compilation", function(compilation, data) {
>   data.normalModuleFactory.plugin("parser", function(parser, options) { parser.plugin(/* ... */); });
> });
> instead.
