### PR TITLE
fix(migrating): An array of loaders as string

### DIFF
--- a/content/guides/migrating.md
+++ b/content/guides/migrating.md
@@ -11,6 +11,7 @@ contributors:
   - frederikprijck
   - chrisVillanueva
   - bebraw
+  - howdy39
 ---
 
 ## `resolve.root`, `resolve.fallback`, `resolve.modulesDirectories`
@@ -48,17 +49,18 @@ The new naming conventions are easier to understand and are a good reason to upg
       {
         test: /\.css$/,
 -       loaders: [
+-         "style-loader",
+-         "css-loader?modules=true"
 +       use: [
-          {
-            loader: "style-loader"
-          },
-          {
-            loader: "css-loader",
--           query: {
++         {
++           loader: "style-loader"
++         },
++         {
++           loader: "css-loader",
 +           options: {
-              modules: true
-            }
-          }
++             modules: true
++           }
++         }
         ]
       },
       {


### PR DESCRIPTION
"loaders" is string of Array.
https://webpack.github.io/docs/configuration.html#module-loaders

Example
The following code will cause an error.
`Module not found: Error: Cannot resolve 'file' or 'directory'`

```javascript
  module: {
    loaders: [
      {
        test: /\.css$/,
        loaders: [
          {
            loader: 'style-loader',
          },
          {
            loader: 'css-loader',
            query: {
              module: true
            }
          }
        ]
      }
    ]
  }
```