### PR TITLE
Document code splitting using `import()`

### DIFF
--- a/content/guides/code-splitting-import.md
+++ b/content/guides/code-splitting-import.md
@@ -1,0 +1,141 @@
+---
+title: Code Splitting - import
+sort: 33
+contributors:
+  - simon04
+---
+
+## Dynamic import
+
+Currently, a "function-like" `import()` module loading [syntax proposal](https://github.com/tc39/proposal-dynamic-import) is on the way into ECMAScript.
+
+The [ES2015 Loader spec](https://whatwg.github.io/loader/) defines `import()` as method to load ES2015 modules dynamically on runtime.
+
+webpack treats `import()` as a split-point and puts the requested module in a separate chunk.
+`import()` takes the module name as argument and returns a `Promise`: `import(name) -> Promise`
+
+**index.js**
+```javascript
+function determineDate() {
+  import('moment').then(function(moment) {
+    console.log(moment().format());
+  }).catch(function(err) {
+    console.log('Failed to load moment', err);
+  });
+}
+
+determineDate();
+```
+
+## Usage with Babel
+
+If you want to use `import` with [Babel](http://babeljs.io/), you'll need to install/add the [dynamic-import](http://babeljs.io/docs/plugins/syntax-dynamic-import/) syntax plugin while it's still Stage 3 to get around the parser error. When the proposal is added to the spec this won't be necessary anymore.
+
+```bash
+npm install --save-dev babel-core babel-loader babel-plugin-syntax-dynamic-import babel-preset-es2015
+# for this example
+npm install --save moment
+```
+
+**index-es2015.js**
+```javascript
+function determineDate() {
+  import('moment')
+    .then(moment => moment().format('LLLL'))
+    .then(str => console.log(str))
+    .catch(err => console.log('Failed to load moment', err));
+}
+
+determineDate();
+```
+
+**webpack.config.js**
+```javascript
+module.exports = {
+  entry: './index-es2015.js',
+  output: {
+    filename: 'dist.js',
+  },
+  module: {
+    loaders: [{
+      test: /\.js$/,
+      exclude: /(node_modules)/,
+      loader: 'babel-loader',
+      query: {
+        presets: [['es2015', {modules: false}]],
+        plugins: ['syntax-dynamic-import']
+      }
+    }]
+  }
+};
+```
+
+Not using the `syntax-dynamic-import` plugin will fail the build with
+* `Module build failed: SyntaxError: 'import' and 'export' may only appear at the top level`, or
+* `Module build failed: SyntaxError: Unexpected token, expected {`
+
+## Usage with Babel and `async`/`await`
+
+To use ES2017 [`async`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function)/[`await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await) with `import()`:
+
+```bash
+npm install --save-dev babel-plugin-transform-async-to-generator babel-plugin-transform-regenerator babel-plugin-transform-runtime
+```
+
+**index-es2017.js**
+```javascript
+async function determineDate() {
+  const moment = await import('moment');
+  return moment().format('LLLL');
+}
+
+determineDate().then(str => console.log(str));
+```
+
+**webpack.config.js**
+```javascript
+module.exports = {
+  entry: './index-es2017.js',
+  output: {
+    filename: 'dist.js',
+  },
+  module: {
+    loaders: [{
+      test: /\.js$/,
+      exclude: /(node_modules)/,
+      loader: 'babel-loader',
+      query: {
+        presets: [['es2015', {modules: false}]],
+        plugins: [
+          'syntax-dynamic-import',
+          'transform-async-to-generator',
+          'transform-regenerator',
+          'transform-runtime'
+        ]
+      }
+    }]
+  }
+};
+```
+
+## `import` supersedes `require.ensure`?
+
+Good news: Failure to load a chunk can be handled now because they are `Promise` based.
+
+Caveat: `require.ensure` allows for easy chunk naming with the optional third argument, but `import` API doesn't offer that capability yet. If you want to keep that functionality, you can continue using `require.ensure`.
+
+```javascript
+require.ensure([], function(require) {
+  var foo = require("./module");
+}, "custom-chunk-name");
+```
+
+## `System.import` is deprecated
+
+The use of `System.import` in webpack [did not fit the proposed spec](https://github.com/webpack/webpack/issues/2163), so it was deprecated in [v2.1.0-beta.28](https://github.com/webpack/webpack/releases/tag/v2.1.0-beta.28) in favor of `import()`.
+
+## Examples
+* https://github.com/webpack/webpack/tree/master/examples/code-splitting-native-import-context
+
+## Weblinks
+* [Lazy Loading ES2015 Modules in the Browser](https://dzone.com/articles/lazy-loading-es2015-modules-in-the-browser)

--- a/content/guides/code-splitting-require.md
+++ b/content/guides/code-splitting-require.md
@@ -9,6 +9,8 @@ contributors:
 
 In this section, we will discuss how webpack splits code using `require.ensure()`.
 
+W> `require.ensure` is specific to webpack, see [`import()`](/guides/code-splitting-import) for a proposal for ECMAScript.
+
 ## `require.ensure()`
 
 webpack statically parses for `require.ensure()` in the code while building and adds the modules here into a separate chunk. This new chunk is loaded on demand by webpack through jsonp.


### PR DESCRIPTION
Closes #589.
Related: https://github.com/webpack/webpack/issues/4265