### PR TITLE
production-build guide is not compatible with webpack 2?

### DIFF
--- a/content/guides/production-build.md
+++ b/content/guides/production-build.md
@@ -150,6 +150,9 @@ An advanced approach would be to have a base configuration file, put in all comm
 and then have environment specific files and simply use 'webpack-merge' to merge them. This would help to avoid code repetitions.
 For example, you could have all your base configurations like resolving your js, ts, png, jpeg, json and so on.. in a common base file as follows:
 
+NOTE: THIS EXAMPLE USES WEBPACK VERSION 1 NOT VERSION 2
+
+
 ** base.js **
 ```js
 module.exports = function() {


### PR DESCRIPTION
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Make sure your PR complies with [the writer's guide](https://webpack.js.org/writers-guide/).
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
4. Remove these instructions from your PR as they are for your eyes only.
