### PR TITLE
Improvements to code-splitting-import

### DIFF
--- a/content/guides/code-splitting-import.md
+++ b/content/guides/code-splitting-import.md
@@ -1,5 +1,5 @@
 ---
-title: Code Splitting - import
+title: Code Splitting - Using import()
 sort: 33
 contributors:
   - simon04

--- a/content/guides/code-splitting-import.md
+++ b/content/guides/code-splitting-import.md
@@ -29,7 +29,7 @@ determineDate();
 
 ## Usage with Babel
 
-If you want to use `import` with [Babel](http://babeljs.io/), you'll need to install/add the [dynamic-import](http://babeljs.io/docs/plugins/syntax-dynamic-import/) syntax plugin while it's still Stage 3 to get around the parser error. When the proposal is added to the spec this won't be necessary anymore.
+If you want to use `import` with [Babel](http://babeljs.io/), you'll need to install/add the [`syntax-dynamic-import`](http://babeljs.io/docs/plugins/syntax-dynamic-import/) plugin while it's still Stage 3 to get around the parser error. When the proposal is added to the spec this won't be necessary anymore.
 
 ```bash
 npm install --save-dev babel-core babel-loader babel-plugin-syntax-dynamic-import babel-preset-es2015

--- a/content/guides/code-splitting-import.md
+++ b/content/guides/code-splitting-import.md
@@ -135,6 +135,8 @@ require.ensure([], function(require) {
 The use of `System.import` in webpack [did not fit the proposed spec](https://github.com/webpack/webpack/issues/2163), so it was deprecated in [v2.1.0-beta.28](https://github.com/webpack/webpack/releases/tag/v2.1.0-beta.28) in favor of `import()`.
 
 ## Examples
+* https://github.com/webpack/webpack/tree/master/examples/harmony
+* https://github.com/webpack/webpack/tree/master/examples/code-splitting-harmony
 * https://github.com/webpack/webpack/tree/master/examples/code-splitting-native-import-context
 
 ## Weblinks

--- a/content/guides/migrating.md
+++ b/content/guides/migrating.md
@@ -421,7 +421,7 @@ To keep compatibility with old loaders, loaders can be switched to debug mode vi
 
 ## Code Splitting with ES2015
 
-In webpack v1, you could use `require.ensure` as a method to lazily-load chunks for your application:
+In webpack v1, you could use [`require.ensure`](/guides/code-splitting-require) as a method to lazily-load chunks for your application:
 
 ```javascript
 require.ensure([], function(require) {
@@ -429,10 +429,8 @@ require.ensure([], function(require) {
 });
 ```
 
-The ES2015 Loader spec defines `import()` as method to load ES2015 Modules dynamically on runtime.
-
+The ES2015 Loader spec defines [`import()`](/guides/code-splitting-import) as method to load ES2015 Modules dynamically on runtime.
 webpack treats `import()` as a split-point and puts the requested module in a separate chunk.
-
 `import()` takes the module name as argument and returns a Promise.
 
 ``` js
@@ -454,10 +452,6 @@ require.ensure([], function(require) {
   var foo = require("./module");
 }, "custom-chunk-name");
 ```
-
-(Note on the deprecated `System.import`: webpack's use of `System.import` didn't fit the proposed spec, so it was deprecated in [v2.1.0-beta.28](https://github.com/webpack/webpack/releases/tag/v2.1.0-beta.28) in favor of `import()`)
-
-If you want to use `import` with [Babel](http://babeljs.io/), you'll need to install/add the [dynamic-import](http://babeljs.io/docs/plugins/syntax-dynamic-import/) syntax plugin while it's still Stage 3 to get around the parser error. When the proposal is added to the spec this won't be necessary anymore.
 
 ## Dynamic expressions
 


### PR DESCRIPTION
* Add more example links
* Link from migrating to code-splitting-import
* Change title to "Code Splitting - Using import()"
* Consistent typesetting "syntax-dynamic-import"