### PR TITLE
Active arrow toggles the list

### DIFF
--- a/components/sidebar-item/sidebar-item.jsx
+++ b/components/sidebar-item/sidebar-item.jsx
@@ -6,17 +6,16 @@ export default class SidebarItem extends React.Component {
     super(props);
 
     this.state = {
-      open: false
+      open: this.isOpen(props)
     };
   }
 
   render() {
-    let { index, url, title, anchors = [], currentPage } = this.props;
+    let { index, url, title, anchors = [] } = this.props;
 
     let emptyMod = !anchors.length ? 'sidebar-item--empty' : '';
-    let active = `/${currentPage}` === url;
-    let openMod = (active || this.state.open) ? 'sidebar-item--open' : '';
-    let anchorUrl = (active) ? '#' : url + '#';
+    let openMod = (this.state.open) ? 'sidebar-item--open' : '';
+    let anchorUrl = url + '#';
 
     return (
       <div className={ `sidebar-item ${emptyMod} ${openMod}` }>
@@ -33,6 +32,16 @@ export default class SidebarItem extends React.Component {
         </ul>
       </div>
     );
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.currentPage == this.props.currentPage) return;
+
+    this.setState({ open: this.isOpen(nextProps) });
+  }
+
+  isOpen(props) {
+    return `/${props.currentPage}` === props.url;
   }
 
   toggle(e) {


### PR DESCRIPTION
When we have active sidebar, the arrow toggler it does't work, this PR is fixing this issue.
![click1](https://cloud.githubusercontent.com/assets/839767/22908495/6e66be6c-f257-11e6-988e-32e1402366eb.gif)
