### PR TITLE
Compare sidebar height with window height

### DIFF
--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -77,14 +77,14 @@ export default class Sidebar extends Component {
     let { scrollY, innerHeight } = window;
     let { scrollHeight } = document.body;
     let { offsetHeight: sidebarHeight } = this._container;
-    let { offsetWidth: parentWidth, offsetHeight: parentHeight } = this._container.parentNode;
+    let { offsetWidth: parentWidth } = this._container.parentNode;
     let headerHeight = document.querySelector('header').offsetHeight;
     let footerHeight = document.querySelector('footer').offsetHeight;
     let distToBottom = scrollHeight - scrollY - innerHeight;
     let availableSpace = innerHeight + distToBottom - footerHeight;
     
     this.setState({ 
-      fixed: scrollY >= headerHeight && sidebarHeight < parentHeight,
+      fixed: scrollY >= headerHeight && sidebarHeight < innerHeight,
       extraHeight: sidebarHeight > availableSpace ? sidebarHeight - availableSpace : 0,
       maxWidth: parentWidth
     });


### PR DESCRIPTION
This PR is fixing the issue about the following sidebar when there aren't enough space.

We need to compare the height of sidebar with window inner height instead of parent element.
With innerHeight we check if the sidebar has enough space to follow, the check for the offsetHeight of the parent sidebar element is irrelevant.

Example:
![follower](https://cloud.githubusercontent.com/assets/839767/22946954/dc11b57a-f301-11e6-9ae5-8b95dcf947bf.png)

innerHeight: 719px
parent node of sidebar (`<div class='interactive'>`): 3994px
