### PR TITLE
Fix output.jsonpFunction type

### DIFF
--- a/content/configuration/output.md
+++ b/content/configuration/output.md
@@ -217,7 +217,7 @@ Here is no need to change it.
 
 ## `output.jsonpFunction`
 
-`function`
+`string`
 
 Only used when [`target`](/configuration/target) is web, which uses JSONP for loading on-demand chunks.
 


### PR DESCRIPTION
`output.jsonpFunction` is string according with [old documentation](https://webpack.github.io/docs/configuration.html#output-jsonpfunction).

There are [source code](https://github.com/webpack/webpack/blob/29ed4c3d6f5f7be89fbfc29d5c42f67c1cee7ee8/lib/JsonpMainTemplatePlugin.js#L126) that profs that `output.jsonpFunction` have to be string;

Maybe we need to rename this option. Into `output.jsonpFunctionName`, for example.