### PR TITLE
fix(vote): changed influence icons to be better displayed on android

### DIFF
--- a/components/vote/app-style.scss
+++ b/components/vote/app-style.scss
@@ -39,7 +39,7 @@
       border-left: 2px solid getColor(elephant);
     }
   }
-  
+
   &__influence-section {
     flex: 0 0 50%;
   }
@@ -97,7 +97,7 @@
       height: 25px;
       vertical-align: middle;
       margin-right: 10px;
-    }  
+    }
   }
 
   &__self-info {
@@ -109,7 +109,7 @@
   }
 
   &__update-button {
-    
+
   }
 
   h1 {
@@ -198,14 +198,14 @@
   &__currency-influence, &__vote-influence {
     color: blue;
     &:before {
-      content: "♦\2009";
+      content: "◆\2009";
     }
   }
 
   &__currency-goldenInfluence, &__vote-golden {
     color: #bfa203;
     &:before {
-      content: "♦\2009";
+      content: "◇\2009";
     }
   }
 


### PR DESCRIPTION
Android handles \2666 as the emoji "diamonds" (:diamonds:) and displays it with a different font-size and color.
Also influence and gold-influence are now different (filled/empty).

Cheers @sokra Thanks again for your talk at #frankenjs.
