### PR TITLE
Bad `.jsx` test may load the JSON file

### DIFF
--- a/content/guides/migrating.md
+++ b/content/guides/migrating.md
@@ -135,7 +135,7 @@ file with the [`json-loader`](https://github.com/webpack/json-loader).
   module: {
     rules: [
 -     {
--       test: /\.json/,
+-       test: /\.json$/,
 -       loader: "json-loader"
 -     }
     ]
@@ -144,6 +144,25 @@ file with the [`json-loader`](https://github.com/webpack/json-loader).
 
 [We decided to do this](https://github.com/webpack/webpack/issues/3363) in order to iron out environment differences
   between webpack, node.js and browserify.
+
+### Bad `.jsx` test may load the JSON file
+
+When `json-loader` has not been configured, bad `.jsx` test may load the JSON file as a javascript module. The JSON file must be filtered out by the test rule for `.jsx`.
+
+``` diff
+  module: {
+    rules: [
+       {
+-         test: /\.jsx?/, // This passes .jsx, .js, and .json!
++         test: /\.jsx$/, // This only passes .jsx.
+          loader: "babel-loader",
+          options: {
+            // ...
+          }
+       }
+    ]
+  }
+```
 
 ## Loaders in configuration resolve relative to context
 


### PR DESCRIPTION
When `json-loader` has not been configured, bad `.jsx` test may load the JSON file as a javascript module.
JSON files must be filtered out by the test rule for `.jsx`.

```
test: /\.jsx?/,  // Bad

test: /\.jsx$/,  // Good

test: /\.jsx?$/, // Good
```

1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Make sure your PR complies with [the writer's guide](https://webpack.js.org/writers-guide/).
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
4. Remove these instructions from your PR as they are for your eyes only.
