### PR TITLE
Fix Gitter Button Overlapping Footer

### DIFF
--- a/components/gitter/gitter.jsx
+++ b/components/gitter/gitter.jsx
@@ -26,6 +26,11 @@ export default class Gitter extends React.Component {
   }
 
   componentDidMount() {
+    setTimeout(
+      this._recalculate.bind(this),
+      250
+    );
+
     document.addEventListener(
       'scroll', 
       this._recalculate.bind(this)


### PR DESCRIPTION
This prevents issues on small pages where the gitter
was overlapping the footer.

![image](https://cloud.githubusercontent.com/assets/8988697/23046490/ce9c705c-f477-11e6-98e7-5cd84d79f29f.png)
