### PR TITLE
fix bundle path

### DIFF
--- a/content/guides/webpack-and-typescript.md
+++ b/content/guides/webpack-and-typescript.md
@@ -48,7 +48,7 @@ module.exports = {
  entry: './index.ts',
  output: {
    filename: 'bundle.js',
-   path: '.'
+   path: __dirname
  },
  module: {
    rules: [
@@ -104,7 +104,7 @@ module.exports = {
  entry: './index.ts',
  output: {
    filename: 'bundle.js',
-   path: '.'
+   path: __dirname
  },
  module: {
    rules: [

--- a/content/guides/webpack-and-typescript.md
+++ b/content/guides/webpack-and-typescript.md
@@ -47,8 +47,8 @@ A basic webpack with TypeScript config should look along these lines:
 module.exports = {
  entry: './index.ts',
  output: {
-   filename: '/bundle.js',
-   path: '/'
+   filename: 'bundle.js',
+   path: '.'
  },
  module: {
    rules: [
@@ -103,8 +103,8 @@ __webpack.config.js__
 module.exports = {
  entry: './index.ts',
  output: {
-   filename: '/bundle.js',
-   path: '/'
+   filename: 'bundle.js',
+   path: '.'
  },
  module: {
    rules: [


### PR DESCRIPTION
fixes issue with 'bundle.js' put to the root of the file system (and causing error) rather than project folder.

1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Make sure your PR complies with [the writer's guide](https://webpack.js.org/writers-guide/).
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
4. Remove these instructions from your PR as they are for your eyes only.
