### PR TITLE
Call webpack using relative path

### DIFF
--- a/content/guides/get-started.md
+++ b/content/guides/get-started.md
@@ -8,6 +8,7 @@ contributors:
   - chrisVillanueva
   - johnstew
   - simon04
+  - aaronang
 ---
 
 webpack is a tool to build JavaScript modules in your application. To start using `webpack` from its [cli](/api/cli) or [api](/api/node), follow the [Installation instructions](/guides/installation).
@@ -154,7 +155,7 @@ module.exports = {
 This file can be run by webpack as follows.
 
 ```bash
-webpack --config webpack.config.js
+./node_modules/.bin/webpack --config webpack.config.js
 
 Hash: ff6c1d39b26f89b3b7bb
 Version: webpack 2.2.0


### PR DESCRIPTION
In this patch, the webpack command is called using the relative path because it wouldn't work otherwise (unless the user installed webpack globally, which was not suggested in this guide).