### PR TITLE
Added scroll table for desktop

### DIFF
--- a/content/guides/comparison.md
+++ b/content/guides/comparison.md
@@ -10,8 +10,6 @@ contributors:
 
 webpack is not the only module bundler out there. If you are choosing between using webpack or any of the bundlers below, here is a feature-by-feature comparison on how webpack fares against the current competition.
 
-<div class="scroll-table">
-
 | Feature | webpack/webpack | jrburke/requirejs | substack/node-browserify | jspm/jspm-cli | rollup/rollup | brunch/brunch |
 |---------|-----------------|-------------------|--------------------------|---------------|---------------|---------------|
 | Additional chunks are loaded on demand | **yes** | **yes** | no | [System.import](https://github.com/systemjs/systemjs/blob/master/docs/system-api.md#systemimportmodulename--normalizedparentname---promisemodule) | no | no |
@@ -43,7 +41,6 @@ webpack is not the only module bundler out there. If you are choosing between us
 | Runtime overhead | **243B + 20B per module + 4B per dependency** | 14.7kB + 0B per module + (3B + X) per dependency | 415B + 25B per module + (6B + 2X) per dependency | 5.5kB for self-executing bundles, 38kB for full loader and polyfill, 0 plain modules, 293B CJS, 139B ES2015 System.register before gzip | **none for ES2015 modules** (other formats may have) | |
 | Watch mode | yes | not required | yes | not needed in dev | no | yes |
 
-</div>
 
 ♦ in production mode (opposite in development mode)
 

--- a/content/guides/comparison.md
+++ b/content/guides/comparison.md
@@ -10,6 +10,8 @@ contributors:
 
 webpack is not the only module bundler out there. If you are choosing between using webpack or any of the bundlers below, here is a feature-by-feature comparison on how webpack fares against the current competition.
 
+<div class="scroll-table">
+
 | Feature | webpack/webpack | jrburke/requirejs | substack/node-browserify | jspm/jspm-cli | rollup/rollup | brunch/brunch |
 |---------|-----------------|-------------------|--------------------------|---------------|---------------|---------------|
 | Additional chunks are loaded on demand | **yes** | **yes** | no | [System.import](https://github.com/systemjs/systemjs/blob/master/docs/system-api.md#systemimportmodulename--normalizedparentname---promisemodule) | no | no |
@@ -40,6 +42,8 @@ webpack is not the only module bundler out there. If you are choosing between us
 | Requirable files | file system | **web** | file system | through plugins | file system or through plugins | file system |
 | Runtime overhead | **243B + 20B per module + 4B per dependency** | 14.7kB + 0B per module + (3B + X) per dependency | 415B + 25B per module + (6B + 2X) per dependency | 5.5kB for self-executing bundles, 38kB for full loader and polyfill, 0 plain modules, 293B CJS, 139B ES2015 System.register before gzip | **none for ES2015 modules** (other formats may have) | |
 | Watch mode | yes | not required | yes | not needed in dev | no | yes |
+
+</div>
 
 ♦ in production mode (opposite in development mode)
 

--- a/styles/markdown.scss
+++ b/styles/markdown.scss
@@ -121,14 +121,12 @@
     }
   }
 
-  .scroll-table {
+  .table {
     @include break {
       overflow-x: auto;
       overflow-y: hidden;
     }
-  }
 
-  .table {
     &-wrap {
       display: block;
       width: 100%;

--- a/styles/markdown.scss
+++ b/styles/markdown.scss
@@ -121,11 +121,23 @@
     }
   }
 
+  .scroll-table {
+    @include break {
+      overflow-x: auto;
+      overflow-y: hidden;
+    }
+  }
+
   .table {
     &-wrap {
-      display:block;
-      width:100%;
-      overflow:auto;
+      display: block;
+      width: 100%;
+
+      @include break {
+        display: table;
+        border-left: 1px solid #cccccc;
+        border-bottom: 1px solid #cccccc;
+      }
     }
 
     &-tr {
@@ -138,8 +150,7 @@
 
       @include break {
         border: none;
-        border-left: 1px solid #cccccc;
-        display: flex;
+        display: table-row;
       }
 
       &:nth-child(2n) {
@@ -182,9 +193,20 @@
       &-content {
         display: block;
         width: 60%;
+        padding-left: 10px;
+
+        code {
+          white-space: normal;
+          word-break: break-word;
+        }
 
         @include break {
           width: auto;
+
+          code {
+            word-break: normal;
+            white-space: nowrap;
+          }
         }
       }
     }
@@ -198,7 +220,7 @@
       @include break {
         border-top: 1px solid #cccccc;
         border-right: 1px solid #cccccc;
-        flex-grow: 1;
+        display: table-cell;
       }
     }
 
@@ -210,7 +232,13 @@
       }
 
       @include break {
-        display: block;
+        display: table-header-group;
+      }
+    }
+
+    &-body {
+      @include break {
+        display: table-row-group;
       }
     }
   }

--- a/utilities/markdown.js
+++ b/utilities/markdown.js
@@ -236,13 +236,15 @@ function handleTable(t) {
   }
 
   return `
-    <div class="table-wrap">
-      <div class="table-header">
-          ${header}
-      </div>
-      <div class="table-body">
-          ${body}
-      </div>
+    <div class="table">
+        <div class="table-wrap">
+          <div class="table-header">
+              ${header}
+          </div>
+          <div class="table-body">
+              ${body}
+          </div>
+        </div>
     </div>`;
 }
 

--- a/utilities/markdown.js
+++ b/utilities/markdown.js
@@ -183,7 +183,11 @@ function handleHTML(t) {
 
     // if only one item in codeArray, then it's already parsed
     if(codeArray.length == 1) {
-      return t;
+      const htmlArray = codeArray[0].split(/\s*(<[^>]*>)/g).filter(v => (v !== '' && v !== '\n'));
+
+      if (htmlArray.length == 1) {
+        return t;
+      }
     }
 
     codeArray.forEach(item => {


### PR DESCRIPTION
Based on #911 I added basic table css for desktop version. 

Because the comparison table is just to big I added option to display scroll for table on desktop and then mobile version for mobile devices. 