### PR TITLE
Add missing "work" word in watch documentation.

### DIFF
--- a/content/configuration/watch.md
+++ b/content/configuration/watch.md
@@ -7,7 +7,7 @@ contributors:
   - SpaceK33z
 ---
 
-webpack can watch files and recompile whenever they change. This page explains how to enable this and a couple of tweaks you can make if watching does not properly for you.
+webpack can watch files and recompile whenever they change. This page explains how to enable this and a couple of tweaks you can make if watching does not work properly for you.
 
 ## `watch`
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/6318057/23181607/595f3d16-f854-11e6-9313-2f66542f5282.png)

Fix typo.