### PR TITLE
Fix #924 - Make Sidebar anchor links not reload/refresh page. 

### DIFF
--- a/components/sidebar-item/sidebar-item.jsx
+++ b/components/sidebar-item/sidebar-item.jsx
@@ -11,11 +11,12 @@ export default class SidebarItem extends React.Component {
   }
 
   render() {
-    let { index, url, title, anchors = [] } = this.props;
+    let { index, url, title, anchors = [], currentPage } = this.props;
 
     let emptyMod = !anchors.length ? 'sidebar-item--empty' : '';
     let openMod = (this.state.open) ? 'sidebar-item--open' : '';
     let anchorUrl = url + '#';
+    let isCurrentPage = `/${currentPage}` === url;
 
     return (
       <div className={ `sidebar-item ${emptyMod} ${openMod}` }>
@@ -25,7 +26,7 @@ export default class SidebarItem extends React.Component {
           {
             anchors.map((anchor, j) => (
               <li className="sidebar-item__anchor" key={ `anchor-${index}-${j}` }>
-                <a href={ anchorUrl + anchor.id }>{ anchor.title}</a>
+                <a href={ isCurrentPage ? `#${anchor.id}` : anchorUrl + anchor.id }>{ anchor.title}</a>
               </li>
             ))
           }


### PR DESCRIPTION
Based on #924, I compared the `currentPage` props to the `url` props, to determine what should be the `href` value of the Sidebar anchor links. 

It works! :dancer: :smile: 