### PR TITLE
use webpack2.0 config for code-splitting-import

### DIFF
--- a/content/guides/code-splitting-import.md
+++ b/content/guides/code-splitting-import.md
@@ -57,14 +57,16 @@ module.exports = {
     filename: 'dist.js',
   },
   module: {
-    loaders: [{
+    rules: [{
       test: /\.js$/,
       exclude: /(node_modules)/,
-      loader: 'babel-loader',
-      query: {
-        presets: [['es2015', {modules: false}]],
-        plugins: ['syntax-dynamic-import']
-      }
+      use: [{
+        loader: 'babel-loader',
+        options: {
+          presets: [['es2015', {modules: false}]],
+          plugins: ['syntax-dynamic-import']
+        }
+      }]
     }]
   }
 };
@@ -100,19 +102,21 @@ module.exports = {
     filename: 'dist.js',
   },
   module: {
-    loaders: [{
+    rules: [{
       test: /\.js$/,
       exclude: /(node_modules)/,
-      loader: 'babel-loader',
-      query: {
-        presets: [['es2015', {modules: false}]],
-        plugins: [
-          'syntax-dynamic-import',
-          'transform-async-to-generator',
-          'transform-regenerator',
-          'transform-runtime'
-        ]
-      }
+      use: [{
+        loader: 'babel-loader',
+        options: {
+          presets: [['es2015', {modules: false}]],
+          plugins: [
+            'syntax-dynamic-import',
+            'transform-async-to-generator',
+            'transform-regenerator',
+            'transform-runtime'
+          ]
+        }
+      }]
     }]
   }
 };


### PR DESCRIPTION
use the original config in this doc, I got :

```
throw new Error(RuleSet.buildErrorMessage(rule, new Error("options/query provided without loader (use loader + options)")));
```