### PR TITLE
Add documentation for `overlay` in devServer

### DIFF
--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -259,6 +259,24 @@ With `noInfo` enabled, messages like the webpack bundle information that is show
 noInfo: true
 ```
 
+## `devServer.overlay`
+
+`boolean` `object`
+
+Shows a full-screen overlay in the browser when there are compiler errors or warnings. Disabled by default. If you want to show only compiler errors:
+
+```js
+overlay: true
+```
+
+If you want to show warnings as well as errors: 
+
+```js
+overlay: {
+  warnings: true,
+  errors: true
+}
+```
 
 ## `devServer.port` - CLI only
 


### PR DESCRIPTION
In webpack-dev-server 2.3.0, `overlay` was introduced. I forgot to document this, but better late than never.