### PR TITLE
docs(loaders): Clarify how to include CSS modules and fix grammar. 

### DIFF
--- a/content/concepts/loaders.md
+++ b/content/concepts/loaders.md
@@ -60,17 +60,17 @@ There are three ways to use loaders in your application:
 ### Via `webpack.config.js`
 
 [`module.rules`](https://webpack.js.org/configuration/module/#module-rules) allows you to specify several loaders within your webpack configuration.
-This is a concise way to display loaders, and helps to maintain clean code. It also offers you a full overview of each respective loader. You can find documentation for `css-loader` [here](/loaders/css-loader), and documentation for `style-loader` [here](/loaders/style-loader)  
+This is a concise way to display loaders, and helps to maintain clean code. It also offers you a full overview of each respective loader.
 
-```js
+```js-with-links-with-details
   module: {
     rules: [
       {
         test: /\.css$/,
         use: [
-          { loader: 'style-loader'},
+          { loader: ['style-loader'](/loaders/style-loader)},
           {
-            loader: 'css-loader',
+            loader: ['css-loader'](/loaders/css-loader)},
             options: {
               modules: true
             }

--- a/content/concepts/loaders.md
+++ b/content/concepts/loaders.md
@@ -60,7 +60,7 @@ There are three ways to use loaders in your application:
 ### Via `webpack.config.js`
 
 [`module.rules`](https://webpack.js.org/configuration/module/#module-rules) allows you to specify several loaders within your webpack configuration.
-This is a concise way to display loaders, and helps to maintain clean code. It also offers you a full overview of each respective loader. If you would like to enable css modules, set `modules: true.` Otherwise, be sure to set `modules: false`.  
+This is a concise way to display loaders, and helps to maintain clean code. It also offers you a full overview of each respective loader. You can find documentation for `css-loader` [here](/loaders/css-loader), and documentation for `style-loader` [here](/loaders/style-loader)  
 
 ```js
   module: {

--- a/content/concepts/loaders.md
+++ b/content/concepts/loaders.md
@@ -60,8 +60,7 @@ There are three ways to use loaders in your application:
 ### Via `webpack.config.js`
 
 [`module.rules`](https://webpack.js.org/configuration/module/#module-rules) allows you to specify several loaders within your webpack configuration.
-This is a concise way to display loaders, and helps to have clean code as
-well as you have a full overview of each respective loader.
+This is a concise way to display loaders, and helps to maintain clean code. It also offers you a full overview of each respective loader. If you would like to enable css modules, set `modules: true.` Otherwise, be sure to set `modules: false`.  
 
 ```js
   module: {


### PR DESCRIPTION
This clarification is necessary because users might try to copy and paste the below code, and will run into bugs that do not have an obvious solution. If users set `modules: true` without meaning to, they will run into an issue where the classes will be replaced with generated ones, but this isn't made clear by the documentation. 

This PR also fixes some grammar mistakes for clarity.