### PR TITLE
fix: Use consistent quotation marks

### DIFF
--- a/content/guides/get-started.md
+++ b/content/guides/get-started.md
@@ -141,7 +141,7 @@ with the following config settings.
 __webpack.config.js__
 ```javascript
 var path = require('path');
-var webpack = require("webpack");
+var webpack = require('webpack');
 
 module.exports = {
   entry: './app/index.js',


### PR DESCRIPTION
All statements in the code snippet are using single quote to denote strings. Assuming this is the default style, the quotes around the webpack module name were also converted from double to single.