### PR TITLE
Fix CLI sample mistake.

### DIFF
--- a/content/api/cli.md
+++ b/content/api/cli.md
@@ -176,7 +176,7 @@ These options allow you to bind [modules](/configuration/module/) as allowed by 
 
 | Parameter          | Explanation                        | Usage                       |
 |--------------------|------------------------------------|-----------------------------|
-| --module-bind      | Bind an extension to a loader      | --module-bind /\.js$/=babel |
+| --module-bind      | Bind an extension to a loader      | --module-bind /\.js$/=babel-loader |
 | --module-bind-post | Bind an extension to a post loader |                             |
 | --module-bind-pre  | Bind an extension to a pre loader  |                             |
 

--- a/content/concepts/loaders.md
+++ b/content/concepts/loaders.md
@@ -100,7 +100,7 @@ T> Use `module.rules` whenever possible, as this will reduce boilerplate in your
 Optionally, you could also use loaders through the CLI:
 
 ```sh
-webpack --module-bind jade --module-bind 'css=style!css'
+webpack --module-bind jade-loader --module-bind 'css=style-loader!css-loader'
 ```
 
 This uses the `jade-loader` for `.jade` files, and the [`style-loader`](/loaders/style-loader) and [`css-loader`](/loaders/css-loader) for `.css` files.


### PR DESCRIPTION
I found probrem in the loader sample.
This sample was allowed in webpack 1.x, but there was a sample that was not allowed in 2.x.
