### PR TITLE
Fix equality check for lazy-loading example

### DIFF
--- a/content/guides/lazy-load-react.md
+++ b/content/guides/lazy-load-react.md
@@ -83,8 +83,12 @@ class LazilyLoad extends React.Component {
   }
 
   componentDidUpdate(previous) {
-    if (this.props.modules === previous.modules) return null;
-    this.load();
+    const shouldLoad = !!Object.keys(this.props.modules).filter((key)=> {
+        return this.props.modules[key] !== previous.modules[key];
+    }).length;
+    if (shouldLoad) {
+        this.load();
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Assuming the lazy-loaded component is used as:

```js
render() {
    return (
        <div>
            <LazilyLoad modules={{
              TodoHandler: () => importLazy(import('./components/TodoHandler')),
            }}>
            {({TodoHandler}) => (
              <TodoHandler />
            )}
            </LazilyLoad>
        </div>
    );
}
```

The previous equality check called `this.load` each time the parent-component re-rendered, which remounted all the lazy-loaded components. Comparing the actual promise references instead of the modules object fixes this.
