### PR TITLE
Update code-splitting-css.md

### DIFF
--- a/content/guides/code-splitting-css.md
+++ b/content/guides/code-splitting-css.md
@@ -47,9 +47,10 @@ Install the [`ExtractTextWebpackPlugin`](/plugins/extract-text-webpack-plugin) p
 npm i --save-dev extract-text-webpack-plugin
 ```
 
-To use this plugin, it needs to be added to the `webpack.config.js` file in two steps.
+To use this plugin, it needs to be added to the `webpack.config.js` file in three steps.
 
 ```diff
++var ExtractTextPlugin = require('extract-text-webpack-plugin');
 module.exports = {
     module: {
          rules: [{


### PR DESCRIPTION
A step is missing for how to actually import the plugin into the webpack configuration.
