### PR TITLE
add meta tag description to website

### DIFF
--- a/antwar.config.js
+++ b/antwar.config.js
@@ -7,6 +7,7 @@ var highlight = require('./utilities/highlight');
 module.exports = {
   template: {
     title: 'webpack',
+    description: 'webpack is a module bundler. Its main purpose is to bundle JavaScript files for usage in a browser, yet it is also capable of transforming, bundling, or packaging just about any resource or asset.',
     file: path.join(__dirname, 'template.ejs')
   },
   output: 'build',

--- a/template.ejs
+++ b/template.ejs
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8">
     <title><%= webpackConfig.template.title %></title>
+    <meta name="description" content="webpack is a module bundler. It packs CommonJs/AMD modules i. e. for the browser. Allows to split your codebase into multiple bundles, which can be loaded on demand.">
+
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#2B3A42">
     <link rel="shortcut icon" href="/assets/favicon.ico">

--- a/template.ejs
+++ b/template.ejs
@@ -3,8 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <title><%= webpackConfig.template.title %></title>
-    <meta name="description" content="webpack is a module bundler. It packs CommonJs/AMD modules i. e. for the browser. Allows to split your codebase into multiple bundles, which can be loaded on demand.">
-
+    <meta name="description" content="<%= webpackConfig.template.description %>">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#2B3A42">
     <link rel="shortcut icon" href="/assets/favicon.ico">


### PR DESCRIPTION
Added the description meta tag to the `<head>` section.
The content is taken from the old webpack website ([webpack.github.io](webpack.github.io)), feel free to suggest edits.

When googling "webpack" I currently get this:
<img width="696" alt="screen shot 2017-03-06 at 11 08 47 am" src="https://cloud.githubusercontent.com/assets/927264/23626521/0cd27554-0262-11e7-8982-32ef6a5cc086.png">
This change should hopefully fix that problem.

