### PR TITLE
Add Rule.resourceQuery property to module.md

### DIFF
--- a/content/configuration/module.md
+++ b/content/configuration/module.md
@@ -5,6 +5,7 @@ contributors:
   - sokra
   - skipjack
   - jouni-kantola
+  - jhnns
 ---
 
 These options determine how the [different types of modules](/concepts/modules) within a project will be treated.
@@ -158,11 +159,13 @@ parser: {
 
 A [`Condition`](#condition) matched with the resource. See details in [`Rule` conditions](#rule-conditions).
 
+## `Rule.resourceQuery`
+
+A [`Condition`](#condition) matched with the resource query. The condition matches against a string that starts with a question mark (`"?exampleQuery"`). See details in [`Rule` conditions](#rule-conditions).
 
 ## `Rule.rules`
 
 An array of [`Rules`](#rule) that is also used when the Rule matches.
-
 
 ## `Rule.test`
 


### PR DESCRIPTION
The `Rule.resourceQuery` property can be used to match different loader pipelines depending on the query string, like this: https://github.com/webpack/loader-utils/issues/69#issuecomment-284725071

---

@sokra @bebraw Was this omitted intentionally? Is it ok to document it as a public API?