### PR TITLE
Remove -v shorthand

### DIFF
--- a/content/api/cli.md
+++ b/content/api/cli.md
@@ -233,7 +233,7 @@ These options allow webpack to display various [stats](/configuration/stats/) an
 | --sort-assets-by        | Sorts the assets list by property in asset                         | string  |
 | --sort-chunks-by        | Sorts the chunks list by property in chunk                         | string  |
 | --sort-modules-by       | Sorts the modules list by property in module                       | string  |
-| --verbose, -v           | Show more details                                                  | boolean |
+| --verbose               | Show more details                                                  | boolean |
 
 ### Advanced Options
 


### PR DESCRIPTION
There is a typo in the CLI documentation.

`-v` displays webpack's version. 
It is not a shorthand for `--verbose`.
