### PR TITLE
Fix a few typos

### DIFF
--- a/content/guides/migrating.md
+++ b/content/guides/migrating.md
@@ -77,9 +77,9 @@ The new naming conventions are easier to understand and are a good reason to upg
 
 ## Chaining loaders
 
-Like in webpack v1, loaders can be chained to pass results from loader to loader. Using the [rule.use](/configuration/module#rule-use)
+Like in webpack 1, loaders can be chained to pass results from loader to loader. Using the [rule.use](/configuration/module#rule-use)
  configuration option, `use` can be set to an array of loaders.
-In webpack v1, loaders were commonly chained with `!`. This style is only supported using the legacy option `module.loaders`.
+In webpack 1, loaders were commonly chained with `!`. This style is only supported using the legacy option `module.loaders`.
 
 ``` diff
   module: {
@@ -148,8 +148,8 @@ file with the [`json-loader`](https://github.com/webpack/json-loader).
 
 ## Loaders in configuration resolve relative to context
 
-In webpack v1 configured loaders resolve relative to the matched file.
-Since webpack v2 configured loaders resolve relative to the `context` option.
+In webpack 1 configured loaders resolve relative to the matched file.
+Since webpack 2 configured loaders resolve relative to the `context` option.
 
 This solves some problems with duplicate modules caused by loaders when using `npm link` or referencing modules outside of the `context`.
 
@@ -219,7 +219,7 @@ This means that if you want to see uglifyjs warnings, you need to set `compress.
 
 `UglifyJsPlugin` no longer switches loaders into minimize mode. The `minimize: true` setting needs to be passed via loader options in the long-term. See loader documentation for relevant options.
 
-The minimize mode for loaders will be removed in webpack v3 or later.
+The minimize mode for loaders will be removed in webpack 3 or later.
 
 To keep compatibility with old loaders, loaders can be switched to minimize mode via plugin:
 
@@ -258,7 +258,7 @@ It's no longer necessary to specify it in the configuration.
 
 ## `ExtractTextWebpackPlugin` - breaking change
 
-[ExtractTextPlugin](https://github.com/webpack/extract-text-webpack-plugin) requires version 2 to work with webpack v2.
+[ExtractTextPlugin](https://github.com/webpack/extract-text-webpack-plugin) requires version 2 to work with webpack 2.
 
 `npm install --save-dev extract-text-webpack-plugin`
 
@@ -340,7 +340,7 @@ These functions are now always asynchronous instead of calling their callback sy
 
 ## Loader configuration is through `options`
 
-You can *no longer* configure a loader with a custom property in the `webpack.config.js`. It must be done through the `options`. The following configuration with the `ts` property is no longer valid with webpack v2:
+You can *no longer* configure a loader with a custom property in the `webpack.config.js`. It must be done through the `options`. The following configuration with the `ts` property is no longer valid with webpack 2:
 
 ```js
 module.exports = {
@@ -351,7 +351,7 @@ module.exports = {
       loader: 'ts-loader'
     }]
   },
-  // does not work with webpack v2
+  // does not work with webpack 2
   ts: { transpileOnly: false }
 }
 ```
@@ -405,9 +405,9 @@ To keep compatibility with old loaders, this information can be passed via plugi
 
 ## `debug`
 
-The `debug` option switched loaders to debug mode in webpack v1. This needs to be passed via loader options in long-term. See loader documentation for relevant options.
+The `debug` option switched loaders to debug mode in webpack 1. This needs to be passed via loader options in long-term. See loader documentation for relevant options.
 
-The debug mode for loaders will be removed in webpack v3 or later.
+The debug mode for loaders will be removed in webpack 3 or later.
 
 To keep compatibility with old loaders, loaders can be switched to debug mode via a plugin:
 
@@ -422,7 +422,7 @@ To keep compatibility with old loaders, loaders can be switched to debug mode vi
 
 ## Code Splitting with ES2015
 
-In webpack v1, you could use [`require.ensure`](/guides/code-splitting-require) as a method to lazily-load chunks for your application:
+In webpack 1, you could use [`require.ensure`](/guides/code-splitting-require) as a method to lazily-load chunks for your application:
 
 ```javascript
 require.ensure([], function(require) {
@@ -589,8 +589,8 @@ Loaders are now cacheable by default. Loaders must opt-out if they are not cache
 
 ### Complex options
 
-webpack v1 only supports `JSON.stringify`-able options for loaders.
-webpack v2 now supports any JS object as loader options.
+webpack 1 only supports `JSON.stringify`-able options for loaders.
+webpack 2 now supports any JS object as loader options.
 
 Using complex options comes with one restriction. You may need to have a `ident` for the option object to make it referenceable by other loaders.
 

--- a/content/guides/migrating.md
+++ b/content/guides/migrating.md
@@ -12,6 +12,7 @@ contributors:
   - chrisVillanueva
   - bebraw
   - howdy39
+  - selbekk
 ---
 
 ## `resolve.root`, `resolve.fallback`, `resolve.modulesDirectories`
@@ -34,7 +35,7 @@ This option no longer requires passing an empty string. This behavior was moved 
 
 ## `resolve.*`
 
-More stuff was changed here. Not listed in detail as it's not commonly used. See [resolving](/configuration/resolve) for details.
+Several APIs were changed here. Not listed in detail as it's not commonly used. See [resolving](/configuration/resolve) for details.
 
 ## `module.loaders` is now `module.rules`
 
@@ -77,7 +78,7 @@ The new naming conventions are easier to understand and are a good reason to upg
 ## Chaining loaders
 
 Like in webpack v1, loaders can be chained to pass results from loader to loader. Using the [rule.use](/configuration/module#rule-use)
- configuration option, `use` can be set to a list of loaders.
+ configuration option, `use` can be set to an array of loaders.
 In webpack v1, loaders were commonly chained with `!`. This style is only supported using the legacy option `module.loaders`.
 
 ``` diff
@@ -147,8 +148,8 @@ file with the [`json-loader`](https://github.com/webpack/json-loader).
 
 ## Loaders in configuration resolve relative to context
 
-In webpack 1 configured loaders resolve relative to the matched file.
-Since webpack 2 configured loaders resolve relative to the `context` option.
+In webpack v1 configured loaders resolve relative to the matched file.
+Since webpack v2 configured loaders resolve relative to the `context` option.
 
 This solves some problems with duplicate modules caused by loaders when using `npm link` or referencing modules outside of the `context`.
 
@@ -216,9 +217,9 @@ This means that if you want to see uglifyjs warnings, you need to set `compress.
 
 ## `UglifyJsPlugin` minimize loaders
 
-`UglifyJsPlugin` no longer switches loaders into minimize mode. The `minimize: true` setting needs to be passed via loader options in long-term. See loader documentation for relevant options.
+`UglifyJsPlugin` no longer switches loaders into minimize mode. The `minimize: true` setting needs to be passed via loader options in the long-term. See loader documentation for relevant options.
 
-The minimize mode for loaders will be removed in webpack 3 or later.
+The minimize mode for loaders will be removed in webpack v3 or later.
 
 To keep compatibility with old loaders, loaders can be switched to minimize mode via plugin:
 
@@ -236,7 +237,7 @@ To keep compatibility with old loaders, loaders can be switched to minimize mode
 
 ## `BannerPlugin` - breaking change
 
-`BannerPlugin` no longer accept two parameters but rather only a single options object.
+`BannerPlugin` no longer accepts two parameters, but a single options object.
 
 ``` diff
   plugins: [
@@ -247,7 +248,7 @@ To keep compatibility with old loaders, loaders can be switched to minimize mode
 
 ## `OccurrenceOrderPlugin` is now on by default
 
-It's no longer necessary to specify it in configuration.
+It's no longer necessary to specify it in the configuration.
 
 ``` diff
   plugins: [
@@ -257,11 +258,11 @@ It's no longer necessary to specify it in configuration.
 
 ## `ExtractTextWebpackPlugin` - breaking change
 
-[ExtractTextPlugin](https://github.com/webpack/extract-text-webpack-plugin) requires version 2 to work with webpack 2.
+[ExtractTextPlugin](https://github.com/webpack/extract-text-webpack-plugin) requires version 2 to work with webpack v2.
 
 `npm install --save-dev extract-text-webpack-plugin`
 
- The configuration changes for this plugin are mainly syntactical.
+The configuration changes for this plugin are mainly syntactical.
 
 ### `ExtractTextPlugin.extract`
 
@@ -296,9 +297,9 @@ plugins: [
 
 ## Full dynamic requires now fail by default
 
-A dependency with only an expression (i. e. `require(expr)`) will now create an empty context instead of an context of the complete directory.
+A dependency with only an expression (i. e. `require(expr)`) will now create an empty context instead of the context of the complete directory.
 
-Best refactor this code as it won't work with ES2015 Modules. If this is not possible you can use the `ContextReplacementPlugin` to hint the compiler to the correct resolving.
+Code like this should be refactored as it won't work with ES2015 modules. If this is not possible you can use the `ContextReplacementPlugin` to hint the compiler towards the correct resolving.
 
 ?> Link to an article about dynamic dependencies.
 
@@ -317,7 +318,7 @@ module.exports = config;
 
 You may notice that this is no longer allowed. The CLI is more strict now.
 
-Instead there is an interface for passing arguments to the configuration. This should be used instead. Future tool may rely on this.
+Instead there is an interface for passing arguments to the configuration. This should be used instead. Future tools may rely on this.
 
 `webpack --env.customStuff`
 
@@ -331,15 +332,15 @@ module.exports = function(env) {
 
 See [CLI](/api/cli).
 
-## `require.ensure` and AMD `require` is asynchronous
+## `require.ensure` and AMD `require` are asynchronous
 
-These functions are now always asynchronous instead of calling their callback sync if the chunk is already loaded.
+These functions are now always asynchronous instead of calling their callback synchronously if the chunk is already loaded.
 
-**nb `require.ensure` now depends upon native `Promise`s. If using `require.ensure` in an environment that lacks them then you will need a polyfill. **
+**`require.ensure` now depends upon native `Promise`s. If using `require.ensure` in an environment that lacks them then you will need a polyfill. **
 
 ## Loader configuration is through `options`
 
-You can *no longer* configure a loader with a custom property in the `webpack.config.js`. It must be done through the `options`. The following configuration with the `ts` property is no longer valid with webpack 2:
+You can *no longer* configure a loader with a custom property in the `webpack.config.js`. It must be done through the `options`. The following configuration with the `ts` property is no longer valid with webpack v2:
 
 ```js
 module.exports = {
@@ -350,7 +351,7 @@ module.exports = {
       loader: 'ts-loader'
     }]
   },
-  // does not work with webpack 2
+  // does not work with webpack v2
   ts: { transpileOnly: false }
 }
 ```
@@ -388,7 +389,7 @@ module.exports = {
 
 ## `LoaderOptionsPlugin` context
 
-Some loaders need context information and read them from the configuration. This needs to be passed via loader options in long-term. See loader documentation for relevant options.
+Some loaders need context information and read them from the configuration. This needs to be passed via loader options in the long-term. See loader documentation for relevant options.
 
 To keep compatibility with old loaders, this information can be passed via plugin:
 
@@ -404,11 +405,11 @@ To keep compatibility with old loaders, this information can be passed via plugi
 
 ## `debug`
 
-The `debug` option switched loaders to debug mode in webpack 1. This needs to be passed via loader options in long-term. See loader documentation for relevant options.
+The `debug` option switched loaders to debug mode in webpack v1. This needs to be passed via loader options in long-term. See loader documentation for relevant options.
 
-The debug mode for loaders will be removed in webpack 3 or later.
+The debug mode for loaders will be removed in webpack v3 or later.
 
-To keep compatibility with old loaders, loaders can be switched to debug mode via plugin:
+To keep compatibility with old loaders, loaders can be switched to debug mode via a plugin:
 
 ``` diff
 - debug: true,
@@ -443,7 +444,7 @@ function onClick() {
 }
 ```
 
-Good news: Failure to load a chunk can be handled now because they are `Promise` based.
+Good news: Failure to load a chunk can now be handled because they are `Promise` based.
 
 Caveat: `require.ensure` allows for easy chunk naming with the optional third argument, but `import` API doesn't offer that capability yet. If you want to keep that functionality, you can continue using `require.ensure`.
 
@@ -588,8 +589,8 @@ Loaders are now cacheable by default. Loaders must opt-out if they are not cache
 
 ### Complex options
 
-webpack 1 only support `JSON.stringify`-able options for loaders.
-webpack 2 now supports any JS object as loader options.
+webpack v1 only supports `JSON.stringify`-able options for loaders.
+webpack v2 now supports any JS object as loader options.
 
 Using complex options comes with one restriction. You may need to have a `ident` for the option object to make it referenceable by other loaders.
 

--- a/content/writers-guide.md
+++ b/content/writers-guide.md
@@ -28,7 +28,8 @@ The site will update itself as you make changes.
 * webpack should always be written in lower-case letters. Even at the beginning of a sentence. ([source](https://github.com/webpack/media#name))
 * loaders are enclosed in backticks and [kebab-cased](https://en.wikipedia.org/w/index.php?title=Kebab_case): `css-loader`, `ts-loader`, …
 * plugins are enclosed in backticks and [camel-cased](https://en.wikipedia.org/wiki/Camel_case): `BannerPlugin`, `NpmInstallWebpackPlugin`, …
-* Use ES5; ES2015, ES2016, … to refer to the ECMAScript standards
+* Use "webpack 2" to refer to a specific webpack version (~~"webpack v2"~~)
+* Use ES5; ES2015, ES2016, … to refer to the ECMAScript standards (~~ES6~~, ~~ES7~~)
 
 ## Formatting
 


### PR DESCRIPTION
Walked through this guide as I was porting a project from webpack 1 to 2 - and spotted a few typos. 
