### PR TITLE
Rework loader api documentation

### DIFF
--- a/content/concepts/loaders.md
+++ b/content/concepts/loaders.md
@@ -8,9 +8,10 @@ contributors:
   - gangachris
   - TheLarkInn
   - simon04
+  - jhnns
 ---
 
-Loaders are transformations that are applied on a resource file of your application. They are functions (running in Node.js) that take the source of a resource file as the parameter and return the new source.
+Loaders are transformations that are applied on the source code of a module. They allow you to preprocess files as you `require()` or “load” them. Thus, loaders are kind of like “tasks” in other build tools, and provide a powerful way to handle front-end build steps. Loaders can transform files from a different language (like TypeScript) to JavaScript, or inline images as data URLs. Loaders even allow you to do things like `require()` CSS files right in your JavaScript!
 
 ## Example
 


### PR DESCRIPTION
- Remove deprecated features like `this.options` and `this._compilation` that make it heard to implement a multi-process pipeline
- Add `this.callback`
- Add `this.async`
- Add some explanatory comments
- Prepend `this` to all properties to make it obvious that these properties are accessible via `this` inside the loader

@sokra do you agree with these changes?