### PR TITLE
Fix module-bind usage

### DIFF
--- a/content/api/cli.md
+++ b/content/api/cli.md
@@ -176,7 +176,7 @@ These options allow you to bind [modules](/configuration/module/) as allowed by 
 
 | Parameter          | Explanation                        | Usage                       |
 |--------------------|------------------------------------|-----------------------------|
-| --module-bind      | Bind an extension to a loader      | --module-bind /\.js$/=babel-loader |
+| --module-bind      | Bind an extension to a loader      | --module-bind js=babel-loader |
 | --module-bind-post | Bind an extension to a post loader |                             |
 | --module-bind-pre  | Bind an extension to a pre loader  |                             |
 


### PR DESCRIPTION
```
webpack --module-bind /\.js$/=babel-loader
```

`test` value will be `/\.\/\\\.js\$\/$/`
