### PR TITLE
Update shimming.md

### DIFF
--- a/content/guides/shimming.md
+++ b/content/guides/shimming.md
@@ -41,6 +41,20 @@ module.exports = {
 };
 ```
 
+This plugin is also capable of providing only a certain export of a module by configuring it with an array path using this format:  `[module, child, ...children?]`
+The following configuration will correctly import function `__assign` from TypeScript's `tslib` package, and provide it whereever it's invoked.
+
+```javascript
+module.exports = {
+  plugins: [
+    new webpack.ProvidePlugin({
+      __assign: ['tslib', '__assign'],
+      __extends: ['tslib', '__extends'],
+    })
+  ]
+};
+```
+
 ## `imports-loader`
 
 [`imports-loader`](/loaders/imports-loader/) inserts necessary globals into the required legacy module.

--- a/content/guides/shimming.md
+++ b/content/guides/shimming.md
@@ -42,7 +42,7 @@ module.exports = {
 ```
 
 This plugin is also capable of providing only a certain export of a module by configuring it with an array path using this format:  `[module, child, ...children?]`
-The following configuration will correctly import function `__assign` from TypeScript's `tslib` package, and provide it whereever it's invoked.
+The following configuration will correctly import function `__assign` from TypeScript's `tslib` package, and provide it wherever it's invoked.
 
 ```javascript
 module.exports = {


### PR DESCRIPTION
Add example of ProvidePlugin's capability of providing certain children of a module by configuring it with an array instead of a string.
