### PR TITLE
Fixed red lines that not deleted.

### DIFF
--- a/content/guides/get-started.md
+++ b/content/guides/get-started.md
@@ -91,16 +91,16 @@ function component () {
 We also need to change `index.html` to expect a single bundled js file.
 
 ```diff
-<html>
-  <head>
-    <title>webpack 2 demo</title>
--   <script src="https://unpkg.com/lodash@4.16.6"></script>
-  </head>
-  <body>
--   <script src="app/index.js"></script>
-+   <script src="dist/bundle.js"></script>
-  </body>
-</html>
+ <html>
+   <head>
+     <title>webpack 2 demo</title>
+-    <script src="https://unpkg.com/lodash@4.16.6"></script>
+   </head>
+   <body>
+-    <script src="app/index.js"></script>
++    <script src="dist/bundle.js"></script>
+   </body>
+ </html>
 ```
 
 Here, `index.js` explicitly requires `lodash` to be present, and binds it as `_` (no global scope pollution).


### PR DESCRIPTION
unified diff format, starting with a +/-/` ` character at the beginning of the line.

before
<img width="751" alt="2017-03-18 17 30 59" src="https://cloud.githubusercontent.com/assets/20813980/24070425/b7bffe44-0c00-11e7-9be4-8e31f7c59b45.png">

after
<img width="745" alt="2017-03-18 17 27 52" src="https://cloud.githubusercontent.com/assets/20813980/24070423/933e1d58-0c00-11e7-9bae-1ed021283377.png">

