### PR TITLE
Add a section on naming

### DIFF
--- a/content/configuration/entry-context.md
+++ b/content/configuration/entry-context.md
@@ -41,7 +41,10 @@ entry: {
 }
 ```
 
-Dynamically entry.
+### Naming
+If a string or array of strings is passed, the chunk is named `main`. If an object is passed, each key is the name of a chunk, and the value describes the entrypoint for the chunk.
+
+### Dynamic entry
 
 ```js
 entry: () => './demo'


### PR DESCRIPTION
This tripped me up when I was working on making a project use vendor chunking when it previously used an array of strings as the value for the `entry` key. It wasn't clear which key that array should move to in the object syntax.
