### PR TITLE
Extended last example in code-splitting-libraries.md

### DIFF
--- a/content/guides/code-splitting-libraries.md
+++ b/content/guides/code-splitting-libraries.md
@@ -178,6 +178,40 @@ module.exports = function(env) {
 };
 ```
 
-With the above webpack config, we see three bundles being generated. `vendor`, `main` and `manifest` bundles.
+With the above webpack config, we see three bundles being generated. `vendor`, `main` and `manifest` bundles. 
+
+Using what we have learned so far, we could also achieve the same result with an implicit common vendor chunk.
+
+ __webpack.config.js__
+ 
+```javascript
+var webpack = require('webpack');
+var path = require('path');
+
+module.exports = function() {
+    return {
+        entry: {
+            main: './index.js' //Notice that we do not have an explicit vendor entry here
+        },
+        output: {
+            filename: '[name].[chunkhash].js',
+            path: path.resolve(__dirname, 'dist')
+        },
+        plugins: [
+            new webpack.optimize.CommonsChunkPlugin({
+                name: 'vendor',
+                minChunks: function (module) {
+                   // this assumes your vendor imports exist in the node_modules directory
+                   return module.context && module.context.indexOf('node_modules') !== -1;
+                }
+            }),
+            //CommonChunksPlugin will now extract all the common modules from vendor and main bundles
+            new webpack.optimize.CommonsChunkPlugin({ 
+                name: 'manifest' //But since there are no more common modules between them we end up with just the runtime code included in the manifest file
+            })
+        ]
+    };
+}
+```
 
 T> Note that long-term bundle caching is achieved with content-based hashing policy `chunkhash`. Learn more about [caching](/guides/caching/).


### PR DESCRIPTION
Added a case which combines an implicit vendor bundle and a separate manifest bundle.
