### PR TITLE
Document missing stats options

### DIFF
--- a/content/configuration/stats.md
+++ b/content/configuration/stats.md
@@ -4,6 +4,7 @@ sort: 15
 contributors:
   - SpaceK33z
   - sallar
+  - jungomi
 ---
 
 The `stats` option lets you precisely control what bundle information gets displayed. This can be a nice middle ground if you don't want to use `quiet` or `noInfo` because you want some bundle information, but not all of it.
@@ -40,6 +41,8 @@ stats: {
   assetsSort: "field",
   // Add information about cached (not built) modules
   cached: true,
+  // Show cached assets (setting this to `false` only shows emitted files)
+  cachedAssets: true,
   // Add children information
   children: true,
   // Add chunk information (setting this to `false` allows for a less verbose output)
@@ -54,16 +57,28 @@ stats: {
   context: "../src/",
   // `webpack --colors` equivalent
   colors: true,
+  // Display the distance from the entry point for each module
+  depth: false,
+  // Display the entry points with the corresponding bundles
+  entrypoints: false,
   // Add errors
   errors: true,
   // Add details to errors (like resolving log)
   errorDetails: true,
+  // Exclude modules which match one of the given strings or regular expressions
+  exclude: [],
   // Add the hash of the compilation
   hash: true,
+  // Set the maximum number of modules to be shown
+  maxModules: 15,
   // Add built modules information
   modules: true,
   // Sort the modules by a field
   modulesSort: "field",
+  // Show performance hint when file size exceeds `performance.maxAssetSize`
+  performance: true,
+  // Show the exports of the modules
+  providedExports: false,
   // Add public path information
   publicPath: true,
   // Add information about the reasons why modules are included
@@ -72,6 +87,8 @@ stats: {
   source: true,
   // Add timing information
   timings: true,
+  // Show which exports of a module are used
+  usedExports: false,
   // Add webpack version information
   version: true,
   // Add warnings


### PR DESCRIPTION
Add the stats options which are used in [webpack/lib/Stats.js](https://github.com/webpack/webpack/blob/4b9b660e8c4fe8ab6425014cb24dcec2d5df194b/lib/Stats.js#L51-L81) but were missing from the stats documentation.

- cachedAssets
- depth
- entrypoints
- exclude
- maxModules
- performance
- providedExports
- usedExports

Fixes #899 