### PR TITLE
Clarify that dynamic entries can return array and object

### DIFF
--- a/content/configuration/entry-context.md
+++ b/content/configuration/entry-context.md
@@ -25,7 +25,7 @@ By default the current directory is used, but it's recommended to pass a value i
 
 ## `entry`
 
-`string | [string] | object { <key>: string | [string] } | function: () => string`
+`string | [string] | object { <key>: string | [string] } | (function: () => string | [string] | object { <key>: string | [string] })`
 
 The point or points to enter the application. At this point the application starts executing. If an array is passed all items will be executed.
 
@@ -53,7 +53,7 @@ entry: () => './demo'
 or
 
 ```js
-entry: () => new Promise((resolve) => resolve('./demo'))
+entry: () => new Promise((resolve) => resolve(['./demo', './demo2']))
 ```
 
 When combining with the [`output.library`](/configuration/output#output-library) option: If an array is passed only the last item is exported.


### PR DESCRIPTION
I looked at the code and it seems that if entry is a function it can return an array or an object too.

https://github.com/webpack/webpack/blob/028c51301733836abbedc88be7483af2623f5943/lib/DynamicEntryPlugin.js#L40..L46

https://github.com/webpack/webpack-dev-server/blob/master/lib/util/addDevServerEntrypoints.js#L20

As simply adding more return types made the type ambiguous I added parens around the function type, but can also remove it again if desired.