### PR TITLE
Fixed resolveLoader defaults

### DIFF
--- a/content/configuration/resolve.md
+++ b/content/configuration/resolve.md
@@ -242,9 +242,9 @@ This set of options is identical to the `resolve` property set above, but is use
 
 ```js
 {
-    modules: ["web_loaders", "web_modules", "node_loaders", "node_modules"],
-    extensions: [".webpack-loader.js", ".web-loader.js", ".loader.js", ".js"],
-    packageMains: ["webpackLoader", "webLoader", "loader", "main"]
+    modules: ["node_modules"],
+    extensions: [".js", ".json"],
+    mainFields: ["loader", "main"]
 }
 ```
 


### PR DESCRIPTION
This part is outdated, c.f.
- https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsDefaulter.js#L98
- https://github.com/webpack/enhanced-resolve/blob/master/lib/ResolverFactory.js#L38
- https://github.com/webpack/webpack/issues/2532
