### PR TITLE
fix typo 

### DIFF
--- a/content/concepts/index.md
+++ b/content/concepts/index.md
@@ -91,11 +91,11 @@ const config = {
 module.exports = config;
 ```
 
-The configuration above has defined a `rules` property for a single module with two required properties: `test`, and `use`. This tells webpack's compiler the following:
+The configuration above has defined a `rules` property for a single module with two required properties: `test` and `use`. This tells webpack's compiler the following:
 
 > "Hey webpack compiler, when you come across a path that resolves to a '.js' or '.jsx' file inside of a `require()`/`import` statement, **use** the `babel-loader` to transform it before you add it to the bundle".
 
-W> It is important to remember when defining rules in your webpack config, you are defining them under `module.rules`, and not `rules`. However webpack will yell at you when doing this incorrectly.
+W> It is important to remember when defining rules in your webpack config, you are defining them under `module.rules` and not `rules`. However webpack will yell at you when doing this incorrectly.
 
 There are more specific properties to define on loaders that we haven't yet covered.
 


### PR DESCRIPTION
To my understanding of grammar there shouldn't be ',' before an 'and' conjunction. As here we have only two sentences to be combined. 