### PR TITLE
Fix issue with sidebar-item with duplicate key attributes

### DIFF
--- a/components/sidebar-item/sidebar-item.jsx
+++ b/components/sidebar-item/sidebar-item.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { uniqueId } from 'lodash';
 import Link from '../link/link';
 
 const block = 'sidebar-item';
@@ -36,7 +37,7 @@ export default class SidebarItem extends React.Component {
               anchors.map(anchor => (
                 <li 
                   className={ `${block}__anchor` } 
-                  key={ `anchor-${title}-${anchor.id}` }>
+                  key={ `anchor-${title}-${uniqueId()}` }>
                   <a href={ this._generateAnchorURL(anchor) }>
                     { anchor.title }
                   </a>


### PR DESCRIPTION
I discovered an issue on this [page](https://webpack.js.org/plugins/commons-chunk-plugin/#components/sidebar/sidebar.jsx) on the production site where the Example link in the sidebar would continually duplicate itself as you scrolled down the page.

This [tweet](https://twitter.com/ryandrewjohnson/status/847083931094659078) has a screen cap of the issue.

When running the site locally I could see that there was a React error complaining that there were duplicate `key` attributes being used on elements in the sidebar. I have updated the sidebar-item component to use lodash uniqueId to generate key which prevented the error.
