### PR TITLE
Sidebar overflow fix

### DIFF
--- a/components/sidebar-item/sidebar-item-style.scss
+++ b/components/sidebar-item/sidebar-item-style.scss
@@ -25,6 +25,8 @@
     flex: 1 1 auto;
     font-weight: 600;
     color: getColor(dove-grey);
+    max-width: 90%;
+    @include control-overflow;
   }
 
   &__anchors {

--- a/content/plugins/min-chunk-size-plugin.md
+++ b/content/plugins/min-chunk-size-plugin.md
@@ -1,6 +1,7 @@
 ---
 title: MinChunkSizePlugin
 contributors:
+sort: 1
 ---
 
 Try to keep the chunk size above a limit.


### PR DESCRIPTION
Minor fix for the sidebar item titles wrapping to the next line.

From:

![image](https://cloud.githubusercontent.com/assets/8988697/24587403/d3f0e9be-1783-11e7-803a-b5f08a4e134e.png)

to this:

![image](https://cloud.githubusercontent.com/assets/8988697/24587410/f1b522bc-1783-11e7-901c-dbb19bdae183.png)