### PR TITLE
Explanation of module argument in CommonsChunkPlugin & add advanced implicit common vendor chunk example

### DIFF
--- a/content/plugins/commons-chunk-plugin.md
+++ b/content/plugins/commons-chunk-plugin.md
@@ -187,7 +187,7 @@ new webpack.optimize.CommonsChunkPlugin({
 })
 ```
 
-In order to obtain a single CSS file containing your application and vendor CSS, use the following `minChunks` function together with [`ExtractTextPlugin`](plugins/extract-text-webpack-plugin/):
+In order to obtain a single CSS file containing your application and vendor CSS, use the following `minChunks` function together with [`ExtractTextPlugin`](/plugins/extract-text-webpack-plugin/):
 
 ```javascript
 new webpack.optimize.CommonsChunkPlugin({

--- a/content/plugins/commons-chunk-plugin.md
+++ b/content/plugins/commons-chunk-plugin.md
@@ -194,9 +194,9 @@ specific modules from being included in the vendor chunk (such as stylesheets yo
 new webpack.optimize.CommonsChunkPlugin({
   name: "vendor",
   minChunks: function (module) {
+    // This prevents stylesheet resources with the .css or .scss extension
+    // from being moved from their original chunk to the vendor chunk
     if(module.resource && (/^.*\.(css|scss)$/).test(module.resource)) {
-      // This prevents stylesheet resources with the .css or .scss extension
-      // from being moved from their original chunk to the vendor chunk
       return false;
     }
     return module.context && module.context.indexOf("node_modules") !== -1;

--- a/content/plugins/commons-chunk-plugin.md
+++ b/content/plugins/commons-chunk-plugin.md
@@ -153,8 +153,8 @@ You also have the ability to pass the `minChunks` property a function. This func
 The `module` argument represents each module in the chunks you have provided via the `name`/`names` property.
 `module` has the shape of a [NormalModule](https://github.com/webpack/webpack/blob/master/lib/NormalModule.js#L57), which has two particularly useful properties for this use case:
 
-- `resource`: The name of the file being processed. For example: `'/my_project/node_modules/example-dependency/index.js'`
-- `context`: The directory that stores the file. For example: `'/my_project/node_modules/example-dependency'`
+- `module.context`: The directory that stores the file. For example: `'/my_project/node_modules/example-dependency'`
+- `module.resource`: The name of the file being processed. For example: `'/my_project/node_modules/example-dependency/index.js'`
 
 The `count` argument represents how many chunks the `module` is used in.
 

--- a/content/plugins/commons-chunk-plugin.md
+++ b/content/plugins/commons-chunk-plugin.md
@@ -187,8 +187,7 @@ new webpack.optimize.CommonsChunkPlugin({
 })
 ```
 
-To add further control to an implicit common vendor chunk, you can additional logic before the `node_modules` context check to prevent
-specific modules from being included in the vendor chunk (such as stylesheets you want to keep in the original chunk):
+In order to obtain a single CSS file containing your application and vendor CSS, use the following `minChunks` function together with [`ExtractTextPlugin`](plugins/extract-text-webpack-plugin/):
 
 ```javascript
 new webpack.optimize.CommonsChunkPlugin({

--- a/content/plugins/commons-chunk-plugin.md
+++ b/content/plugins/commons-chunk-plugin.md
@@ -4,6 +4,7 @@ contributors:
   - bebraw
   - simon04
   - christopher4lis
+  - kevinzwhuang
 ---
 
 ```javascript
@@ -149,9 +150,13 @@ new webpack.optimize.CommonsChunkPlugin({
 
 You also have the ability to pass the `minChunks` property a function. This function is called by the `CommonsChunkPlugin` and calls the function with `module` and `count` arguments.
 
-The `module` property represents each module in the chunks you have provided via the `names` property.
+The `module` argument represents each module in the chunks you have provided via the `name`/`names` property.
+`module` has the shape of a [NormalModule](https://github.com/webpack/webpack/blob/master/lib/NormalModule.js#L57), which has two particularly useful properties for this use case:
 
-The `count` property represents how many chunks the `module` is used in.
+- `resource`: The name of the file being processed.
+- `context`: The directory that stores the file.
+
+The `count` argument represents how many chunks the `module` is used in.
 
 This option is useful when you want to have fine-grained control over how the CommonsChunk algorithm determines where modules should be moved to.
 

--- a/content/plugins/commons-chunk-plugin.md
+++ b/content/plugins/commons-chunk-plugin.md
@@ -187,6 +187,23 @@ new webpack.optimize.CommonsChunkPlugin({
 })
 ```
 
+To add further control to an implicit common vendor chunk, you can additional logic before the `node_modules` context check to prevent
+specific modules from being included in the vendor chunk (such as stylesheets you want to keep in a separate file):
+
+```javascript
+new webpack.optimize.CommonsChunkPlugin({
+  name: "vendor",
+  minChunks: function (module) {
+    if(module.resource && (/^.*\.(css|scss)$/).test(module.resource)) {
+      // This prevents stylesheet resources with the .css or .scss extension
+      // from being moved from their original chunk to the vendor chunk
+      return false;
+    }
+    return module.context && module.context.indexOf("node_modules") !== -1;
+  }
+})
+```
+
 ## Manifest file
 
 To extract the webpack bootstrap logic into a separate file, use the `CommonsChunkPlugin` on a `name` which is not defined as `entry`. Commonly the name `manifest` is used. See the [code splitting libraries guide](/guides/code-splitting-libraries/#manifest-file) for details.

--- a/content/plugins/commons-chunk-plugin.md
+++ b/content/plugins/commons-chunk-plugin.md
@@ -153,8 +153,8 @@ You also have the ability to pass the `minChunks` property a function. This func
 The `module` argument represents each module in the chunks you have provided via the `name`/`names` property.
 `module` has the shape of a [NormalModule](https://github.com/webpack/webpack/blob/master/lib/NormalModule.js#L57), which has two particularly useful properties for this use case:
 
-- `resource`: The name of the file being processed.
-- `context`: The directory that stores the file.
+- `resource`: The name of the file being processed. For example: `'/my_project/node_modules/example-dependency/index.js'`
+- `context`: The directory that stores the file. For example: `'/my_project/node_modules/example-dependency'`
 
 The `count` argument represents how many chunks the `module` is used in.
 

--- a/content/plugins/commons-chunk-plugin.md
+++ b/content/plugins/commons-chunk-plugin.md
@@ -188,7 +188,7 @@ new webpack.optimize.CommonsChunkPlugin({
 ```
 
 To add further control to an implicit common vendor chunk, you can additional logic before the `node_modules` context check to prevent
-specific modules from being included in the vendor chunk (such as stylesheets you want to keep in a separate file):
+specific modules from being included in the vendor chunk (such as stylesheets you want to keep in the original chunk):
 
 ```javascript
 new webpack.optimize.CommonsChunkPlugin({

--- a/content/plugins/commons-chunk-plugin.md
+++ b/content/plugins/commons-chunk-plugin.md
@@ -151,7 +151,7 @@ new webpack.optimize.CommonsChunkPlugin({
 You also have the ability to pass the `minChunks` property a function. This function is called by the `CommonsChunkPlugin` and calls the function with `module` and `count` arguments.
 
 The `module` argument represents each module in the chunks you have provided via the `name`/`names` property.
-`module` has the shape of a [NormalModule](https://github.com/webpack/webpack/blob/master/lib/NormalModule.js#L57), which has two particularly useful properties for this use case:
+`module` has the shape of a [NormalModule](https://github.com/webpack/webpack/blob/master/lib/NormalModule.js), which has two particularly useful properties for this use case:
 
 - `module.context`: The directory that stores the file. For example: `'/my_project/node_modules/example-dependency'`
 - `module.resource`: The name of the file being processed. For example: `'/my_project/node_modules/example-dependency/index.js'`


### PR DESCRIPTION
This PR focuses on improvements to `CommonsChunkPlugin`.

### Summary:
There currently is no description of what shape the `module` argument provided by `minChunks` takes - which makes it hard for new users to understand how to use it for custom common chunks. (This is mentioned in #902)

### Changes
This PR adds a description of two particularly important properties for this use case (`context` and `resource`), and links to the `NormalModule` class definition that the `module` argument takes the shape of. 

It also adds an additional advanced implicit common chunks example that shows how to use the `resource` property to prevent specific files (such as stylesheets needed in a separate file with `ExtractTextWebpackPlugin`) from being moved to the common chunk.

---

Fixes #902 