### PR TITLE
Specify webpack v2.3.3

### DIFF
--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -35,7 +35,7 @@ export default class Sidebar extends Component {
           height={ availableHeight } />
 
         <div className="sidebar__inner">
-          <img src="https://img.shields.io/badge/webpack-v2.2.1-blue.svg" />
+          <img src="https://img.shields.io/badge/webpack-v2.3.3-blue.svg" />
 
           <SidebarItem
             url={ `/${sectionName}` }


### PR DESCRIPTION
Currently, we specify webpack v2.2.1 in the docs:
![2017-04-06-23-45-13-001](https://cloud.githubusercontent.com/assets/782446/24776915/45043988-1b23-11e7-81be-1ffa76aabac7.png)

Meanwhile, [v2.3.3](https://github.com/webpack/webpack/releases/tag/v2.3.3) has been released. Shall we update the documentation?