### PR TITLE
Update output.md

### DIFF
--- a/content/concepts/output.md
+++ b/content/concepts/output.md
@@ -9,8 +9,6 @@ contributors:
 
 Options affecting the output of the compilation. `output` options tell webpack how to write the compiled files to disk. Note, that while there can be multiple `entry` points, only one `output` configuration is specified.
 
-If you use any hashing (`[hash]` or `[chunkhash]`), make sure to have a consistent ordering of modules. Use the `OccurrenceOrderPlugin` or `recordsPath`.
-
 ## Usage
 
 The minimum requirements for the `output` property in your webpack config is to set its value to an object including the following two things :


### PR DESCRIPTION
occurrenceOrder plugin is no longer needed and occurrence order is on by default. So we could remove those sentences.
https://gist.github.com/sokra/27b24881210b56bbaff7#occurrence-order

1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Make sure your PR complies with [the writer's guide](https://webpack.js.org/writers-guide/).
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
4. Remove these instructions from your PR as they are for your eyes only.
