### PR TITLE
Multiple configurations in dev-server.md

### DIFF
--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -40,7 +40,7 @@ that will give some background on where the server is located and what it's serv
 
 If you're using dev-server through the Node.js API, the options in `devServer` will be ignored. Pass the options as a second parameter instead: `new WebpackDevServer(compiler, {...})`. [See here](https://github.com/webpack/webpack-dev-server/blob/master/examples/node-api-simple/server.js) for an example of how to use webpack-dev-server through the Node.js API.
 
-W> Be aware that when [exporting multiple configurations](https://webpack.js.org/configuration/configuration-types/#exporting-multiple-configurations) only the `devServer` options for the first configuration will be taken into account and used for all the configurations in the array.
+W> Be aware that when [exporting multiple configurations](/configuration/configuration-types/#exporting-multiple-configurations) only the `devServer` options for the first configuration will be taken into account and used for all the configurations in the array.
 
 ## `devServer.clientLogLevel`
 

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -40,6 +40,7 @@ that will give some background on where the server is located and what it's serv
 
 If you're using dev-server through the Node.js API, the options in `devServer` will be ignored. Pass the options as a second parameter instead: `new WebpackDevServer(compiler, {...})`. [See here](https://github.com/webpack/webpack-dev-server/blob/master/examples/node-api-simple/server.js) for an example of how to use webpack-dev-server through the Node.js API.
 
+W> Be aware that when [exporting multiple configurations](https://webpack.js.org/configuration/configuration-types/#exporting-multiple-configurations) only the `devServer` options for the first configuration will be taken into account and used for all the configurations in the array.
 
 ## `devServer.clientLogLevel`
 


### PR DESCRIPTION
Add a warning in `dev-server.md` regarding exporting multiple configurations, since only the first is passed to the `webpack-dev-server` CLI.