### PR TITLE
Clarify use of `import()` with ES2015 modules.

### DIFF
--- a/content/guides/code-splitting-async.md
+++ b/content/guides/code-splitting-async.md
@@ -11,7 +11,7 @@ contributors:
 
 This guide documents how to split your bundle into chunks which can be downloaded asynchronously at a later time. For instance, this allows to serve a minimal bootstrap bundle first and to asynchronously additional features later.
 
-webpack supports two similar techniques to achieve this goal: using `import()` (preferred, ECMAScript proposal) and `require.ensure()` (legacy, webpack specific). 
+webpack supports two similar techniques to achieve this goal: using `import()` (preferred, ECMAScript proposal) and `require.ensure()` (legacy, webpack specific).
 
 
 ## Dynamic import: `import()`
@@ -174,9 +174,10 @@ module.exports = {
 };
 ```
 
-## `import` imports the entire module namespace
 
-Consider the following two examples:
+### `import()` imports the entire module namespace
+
+Note that the promise is [resolved with the module namespace](https://github.com/tc39/proposal-dynamic-import#proposed-solution). Consider the following two examples:
 
 ```js
 // Example 1: top-level import
@@ -185,7 +186,7 @@ import * as Component from './component';
 import('./component').then(Component => /* ... */);
 ```
 
-`Component` in both of those cases resolves to the same thing, meaning in the case of using `import()` with ES2015 modules you have to explicity access default and named exports:
+`Component` in both of those cases resolves to the same thing, meaning in the case of using `import()` with ES2015 modules you have to explicitly access default and named exports:
 
 ```js
 async function main() {

--- a/content/guides/code-splitting-async.md
+++ b/content/guides/code-splitting-async.md
@@ -174,6 +174,28 @@ module.exports = {
 };
 ```
 
+## `import` imports the entire module namespace
+
+Consider the following two examples:
+
+```js
+// Example 1: top-level import
+import * as Component from './component';
+// Example 2: Code-splitting with import()
+import('./component').then(Component => /* ... */);
+```
+
+`Component` in both of those cases resolves to the same thing, meaning in the case of using `import()` with ES2015 modules you have to explicity access default and named exports:
+
+```js
+async function main() {
+  // Destructuring example
+  const { default: Component } = await import('./component');
+  // Inline example
+  render((await import('./component')).default);
+}
+```
+
 
 ### `System.import` is deprecated
 


### PR DESCRIPTION
The examples on the page show usage with commonjs modules but not ES2015 modules, which was confusing for me when I tried to import ES2015 modules.

See https://github.com/webpack/webpack/issues/3829. My provided examples could probably use some work, though I was trying to come up with something generic that doesn't introduce too many concepts at once. My personal use case is for HMR with a React component and Redux reducers:

```js
if (module.hot) {
  module.hot.accept('./root', async () => {
    mount((await import('./root')).default);
  });
  module.hot.accept('./reducers', async () => {
    store.replaceReducer((await import('./reducers')).default);
  });
}
```
