### PR TITLE
Compiler event hook is `failed`, not `fail`.

### DIFF
--- a/content/api/plugins/compiler.md
+++ b/content/api/plugins/compiler.md
@@ -110,7 +110,7 @@ This a reference guide to all the event hooks exposed by the `Compiler`.
 | __`emit`__                 | Before writing emitted assets to output dir | `compilation` | async      |
 | __`after-emit`__           | After writing emitted assets to output dir | `compilation` | async      |
 | __`done`__                 | Completion of compile               | `stats`              | sync       |
-| __`fail`__                 | Failure of compile                  | `error`              | sync       |
+| __`failed`__               | Failure of compile                  | `error`              | sync       |
 | __`invalid`__              | After invalidating a watch compile  | `fileName`, `changeTime` | sync       |
 
 ## Examples


### PR DESCRIPTION
https://github.com/webpack/webpack/blob/ab2270263e9af5b0dd83e454c20ab3aa1797424a/lib/Compiler.js#L94
```js
	if(this.stats)
		this.compiler.applyPlugins("done", this.stats);
	else
		this.compiler.applyPlugins("failed", this.error);
```
