### PR TITLE
remove useless env param

### DIFF
--- a/content/guides/production-build.md
+++ b/content/guides/production-build.md
@@ -233,7 +233,7 @@ const webpackMerge = require('webpack-merge');
 
 const commonConfig = require('./base.js');
 
-module.exports = function(env) {
+module.exports = function() {
     return webpackMerge(commonConfig(), {
         plugins: [
             new webpack.LoaderOptionsPlugin({


### PR DESCRIPTION
no need to pass here since we have commonConfig(), useless params

1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Make sure your PR complies with [the writer's guide](https://webpack.js.org/writers-guide/).
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
4. Remove these instructions from your PR as they are for your eyes only.
