### PR TITLE
Correct wrong documented synchronicity of Compiler's `before-compile` event

### DIFF
--- a/content/api/plugins/compiler.md
+++ b/content/api/plugins/compiler.md
@@ -99,7 +99,7 @@ This a reference guide to all the event hooks exposed by the `Compiler`.
 | __`watch-run`__            | Before starting compilation after watch | `compiler`           | async      |
 | __`normal-module-factory`__ | After creating a `NormalModuleFactory` | `normalModuleFactory`| sync      |
 | __`context-module-factory`__ | After creating a `ContextModuleFactory` | `contextModuleFactory`| sync      |
-| __`before-compile`__       | Compilation parameters created      | `compilationParams`  | sync       |
+| __`before-compile`__       | Compilation parameters created      | `compilationParams`  | async      |
 | __`compile`__              | Before creating new compilation     | `compilationParams`  | sync       |
 | __`this-compilation`__     | Before emitting `compilation` event | `compilation`        | sync       |
 | __`compilation`__          | Compilation creation completed      | `compilation`        | sync       |


### PR DESCRIPTION
The `before-compile` event was documented as `sync`.

If I got it right, the fact that is executed with `applyPluginsAsync ` (as seen [here](https://github.com/webpack/webpack/blob/ab2270263e9af5b0dd83e454c20ab3aa1797424a/lib/Compiler.js#L476)) makes it `async`.

Is that correct? I'm just starting to dig through the documentation, learning something about the internals.
