### PR TITLE
Remove Obsolete `ident` Section

### DIFF
--- a/content/guides/migrating.md
+++ b/content/guides/migrating.md
@@ -622,4 +622,17 @@ __webpack v1__ only supports `JSON.stringify`-able options for loaders.
 
 __webpack v2__ now supports any JS object as loader options.
 
-W> Before [v2.2.1](https://github.com/webpack/webpack/releases/tag/v2.2.1) (i.e. from v2.0.0 through v2.2.0), using complex options required using `ident` for the `options` object to allow its reference from other loaders. This was removed in v2.2.1 and thus current migrations do not require any use of the `ident` key.
+Before [v2.2.1](https://github.com/webpack/webpack/releases/tag/v2.2.1) (i.e. from v2.0.0 through v2.2.0), using complex options required using `ident` for the `options` object to allow its reference from other loaders. __This was removed in v2.2.1__ and thus current migrations do not require any use of the `ident` key.
+
+```diff
+{
+  test: /\.ext/
+  use: {
+    loader: '...',
+    options: {
+-     ident: 'id',
+      fn: () => require('./foo.js')
+    }
+  }
+}
+```

--- a/content/guides/migrating.md
+++ b/content/guides/migrating.md
@@ -618,35 +618,8 @@ Loaders are now cacheable by default. Loaders must opt-out if they are not cache
 
 ### Complex options
 
-webpack 1 only supports `JSON.stringify`-able options for loaders.
-webpack 2 now supports any JS object as loader options.
+__webpack v1__ only supports `JSON.stringify`-able options for loaders.
 
-Using complex options comes with one restriction. You may need to have a `ident` for the option object to make it referenceable by other loaders.
+__webpack v2__ now supports any JS object as loader options.
 
-Having an `ident` on the options object means to be able to reference this options object in inline loaders. Here is an example:
-
-`require("some-loader??by-ident!resource")`
-
-``` js
-{
-  test: /.../,
-  loader: "...",
-  options: {
-    ident: "by-ident",
-    magic: () => return Math.random()
-  }
-}
-```
-
-This inline style should not be used by regular code, but it's often used by loader generated code.
-I. e. the `style-loader` generates a module that `require`s the remaining request (which exports the CSS).
-
-``` js
-// style-loader generated code (simplified)
-var addStyle = require("./add-style");
-var css = require("-!css-loader?{"modules":true}!postcss-loader??postcss-ident");
-
-addStyle(css);
-```
-
-So if you use complex options tell your users about the `ident`.
+W> Before [v2.2.1](https://github.com/webpack/webpack/releases/tag/v2.2.1) (i.e. from v2.0.0 through v2.2.0), using complex options required using `ident` for the `options` object to allow its reference from other loaders. This was removed in v2.2.1 and thus current migrations do not require any use of the `ident` key.


### PR DESCRIPTION
Added a warning instead that points to the v2 version in which this option
became obsolete. We could also reference an older version of the docs if
necessary for people to jump back to, though that may be overkill.

Fixes #1150