### PR TITLE
Update Production Build Guide

### DIFF
--- a/components/contributors/contributors-style.scss
+++ b/components/contributors/contributors-style.scss
@@ -1,15 +1,17 @@
 @import 'functions';
+@import 'mixins';
 
 .contributors__list {
-  padding: 6px;
+  font-size: 14px;
+  margin-left: -0.5em;
+  padding-right: 75px;
 }
 
 .contributor {
   display: inline-flex;
   flex-direction: column;
   align-items: center;
-  margin-right: 1em;
-  font-size: 14px;
+  margin: 0.5em;
 
   img {
     height: 45px;
@@ -19,14 +21,18 @@
   }
 
   .contributor__name {
-    color: getColor(fiord);
+    width: 110px;
     margin-top: -6px;
-    box-shadow: 0 0 2px rgba(0,0,0,0.3);
-    line-height: 1.4;
-    transition: color 0.1s;
     padding: 0 6px;
+    line-height: 1.4;
     border-radius: 2px;
+    text-align: center;
+    overflow-wrap: break-word;
+    hyphens: auto;
+    color: getColor(fiord);
+    box-shadow: 0 0 2px rgba(0,0,0,0.3);
     background: transparentize(getColor(white), 0.05);
+    transition: color 0.1s;
   }
 
   &:hover {

--- a/content/guides/production-build.md
+++ b/content/guides/production-build.md
@@ -11,23 +11,24 @@ contributors:
   - swapnilmishra
   - bring2dip
   - redian
+  - skipjack
 ---
 
-This page explains how to generate production builds with webpack.
+The following article describes the best practices and tools to use when using webpack to build a production version of a site or application.
 
 
-## The automatic way
+## The Automatic Way
 
 Running `webpack -p` (or equivalently `webpack --optimize-minimize --define process.env.NODE_ENV="'production'"`). This performs the following steps:
 
 - Minification using `UglifyJsPlugin`
-- Runs the `LoaderOptionsPlugin`, see its [documentation](/plugins/loader-options-plugin)
-- Sets the Node environment variable
+- Runs the `LoaderOptionsPlugin` (see its [documentation](/plugins/loader-options-plugin))
+- Sets the NodeJS environment variable triggering certain packages to compile differently
 
 
 ### Minification
 
-webpack comes with `UglifyJsPlugin`, which runs [UglifyJS](http://lisperator.net/uglifyjs/) in order to minimize the output. The plugin supports all of [UglifyJS options](https://github.com/mishoo/UglifyJS2#usage). Specifying `--optimize-minimize` on the command line, the following plugin configuration is added:
+webpack comes with `UglifyJsPlugin`, which runs [UglifyJS](http://lisperator.net/uglifyjs/) in order to minimize the output. The plugin supports all of the [UglifyJS options](https://github.com/mishoo/UglifyJS2#usage). Specifying `--optimize-minimize` on the command line, the following plugin configuration is added:
 
 ```js
 // webpack.config.js
@@ -48,14 +49,12 @@ Thus, depending on the [devtool options](/configuration/devtool), Source Maps ar
 
 ### Source Maps
 
-We encourage you to have Source Maps enabled in production. They are useful for debugging and to run benchmark tests. webpack can generate inline Source Maps included in the bundles or separated files.
+We encourage you to have source maps enabled in production, as they are useful for debugging as well as running benchmark tests. webpack can generate inline source maps within bundles or as separate files.
 
-In your configuration, use the `devtool` object to set the Source Map type. We currently support seven types of Source Maps. You can find more information about them in our [configuration](/configuration/devtool) documentation page.
-
-One of the good options to go is using `cheap-module-source-map` which simplifies the Source Maps to a single mapping per line.
+In your configuration, use the `devtool` object to set the Source Map type. We currently support seven types of source maps. You can find more information about them in our [configuration](/configuration/devtool) documentation page (`cheap-module-source-map` is one of the simpler options, using a single mapping per line).
 
 
-### Node environment variable
+### Node Environment Variable
 
 Running `webpack -p` (or `--define process.env.NODE_ENV="'production'"`) invokes the [`DefinePlugin`](/plugins/define-plugin) in the following way:
 
@@ -78,193 +77,210 @@ The `DefinePlugin` performs search-and-replace operations on the original source
 T> Technically, `NODE_ENV` is a system environment variable that Node.js exposes into running scripts. It is used by convention to determine development-vs-production behavior by server tools, build scripts, and client-side libraries. Contrary to expectations, `process.env.NODE_ENV` is not set to `"production"` __within__ the build script `webpack.config.js`, see [#2537](https://github.com/webpack/webpack/issues/2537). Thus, conditionals like `process.env.NODE_ENV === 'production' ? '[name].[hash].bundle.js' : '[name].bundle.js'` do not work as expected. See how to use [environment variables](/guides/environment-variables).
 
 
-## The manual way: Configuring webpack for multiple environments
+## The Manual Way
 
-When we do have multiple configurations in mind for different environments, the easiest way is to write separate js files for
-each environment. For example:
+When we do have multiple configurations in mind for different environments, the easiest approach is to write separate webpack configurations for each environment.
 
-__dev.js__
+
+### Simple Approach
+
+The simplest way to do this is just to define two fully independent configuration files, like so:
+
+__webpack.dev.js__
 
 ```js
-module.exports = function (env) {
-  return {
-    devtool: 'cheap-module-source-map',
-    output: {
-        path: path.join(__dirname, '/../dist/assets'),
-        filename: '[name].bundle.js',
-        publicPath: publicPath,
-        sourceMapFilename: '[name].map'
-    },
-    devServer: {
-        port: 7777,
-        host: 'localhost',
-        historyApiFallback: true,
-        noInfo: false,
-        stats: 'minimal',
-        publicPath: publicPath
-    }
+module.exports = {
+  devtool: 'cheap-module-source-map',
+
+  output: {
+    path: path.join(__dirname, '/../dist/assets'),
+    filename: '[name].bundle.js',
+    publicPath: publicPath,
+    sourceMapFilename: '[name].map'
+  },
+
+  devServer: {
+    port: 7777,
+    host: 'localhost',
+    historyApiFallback: true,
+    noInfo: false,
+    stats: 'minimal',
+    publicPath: publicPath
   }
 }
 ```
 
-__prod.js__
+__webpack.prod.js__
 
 ```js
-module.exports = function (env) {
-  return {
-    output: {
-        path: path.join(__dirname, '/../dist/assets'),
-        filename: '[name].bundle.js',
-        publicPath: publicPath,
-        sourceMapFilename: '[name].map'
-    },
-    plugins: [
-        new webpack.LoaderOptionsPlugin({
-            minimize: true,
-            debug: false
-        }),
-        new webpack.optimize.UglifyJsPlugin({
-            beautify: false,
-            mangle: {
-                screw_ie8: true,
-                keep_fnames: true
-            },
-            compress: {
-                screw_ie8: true
-            },
-            comments: false
-        })
-    ]
-  }
-}
-```
+module.exports = {
+  output: {
+    path: path.join(__dirname, '/../dist/assets'),
+    filename: '[name].bundle.js',
+    publicPath: publicPath,
+    sourceMapFilename: '[name].map'
+  },
 
-Have the following snippet in your webpack.config.js:
-
-```js
-function buildConfig(env) {
-  return require('./config/' + env + '.js')(env)
-}
-
-module.exports = buildConfig;
-```
-
-And from our package.json, where we build our application using webpack, the command goes like this:
-
-```js
- "build:dev": "webpack --env=dev --progress --profile --colors",
- "build:dist": "webpack --env=prod --progress --profile --colors",
-```
-
-You can see that we passed the environment variable to our webpack.config.js file. 
-The environment variable is then passed to `buildConfig` method which simply loads the right js file for the build.
-
-An advanced approach would be to have a base configuration file, put in all common functionalities, and then have environment specific files and simply use 'webpack-merge' to merge them. This would help to avoid code repetitions.
-
-For example, you could have all your base configurations like resolving your js, ts, png, jpeg, json and so on.. in a common base file as follows:
-
-__base.js__
-
-```js
-module.exports = function() {
-    return {
-        entry: {
-            'polyfills': './src/polyfills.ts',
-            'vendor': './src/vendor.ts',
-            'main': './src/main.ts'
-
-        },
-        output: {
-            path: path.join(__dirname, '/../dist/assets'),
-            filename: '[name].bundle.js',
-            publicPath: publicPath,
-            sourceMapFilename: '[name].map'
-        },
-        resolve: {
-            extensions: ['.ts', '.js', '.json'],
-            modules: [path.join(__dirname, 'src'), 'node_modules']
-
-        },
-        module: {
-            rules: [{
-                test: /\.ts$/,
-                use: [
-                    'awesome-typescript-loader',
-                    'angular2-template-loader'
-                ],
-                exclude: [/\.(spec|e2e)\.ts$/]
-            }, {
-                test: /\.css$/,
-                use: ['to-string-loader', 'css-loader']
-            }, {
-                test: /\.(jpg|png|gif)$/,
-                use: 'file-loader'
-            }, {
-                test: /\.(woff|woff2|eot|ttf|svg)$/,
-                use: {
-                  loader: 'url-loader',
-                  options: {
-                    limit: 100000
-                  }
-                }
-            }],
-        },
-        plugins: [
-            new ForkCheckerPlugin(),
-
-            new webpack.optimize.CommonsChunkPlugin({
-                name: ['polyfills', 'vendor'].reverse()
-            }),
-            new HtmlWebpackPlugin({
-                template: 'src/index.html',
-                chunksSortMode: 'dependency'
-            })
-        ],
-    };
-}
-```
-
-And then merge this base config with an environment specific configuration file using 'webpack-merge'. Let's look at an example where we merge our prod file, mentioned above, with this base config file using 'webpack-merge':
-
-** prod.js (updated) **
-
-```js
-const webpackMerge = require('webpack-merge');
-
-const commonConfig = require('./base.js');
-
-module.exports = function() {
-    return webpackMerge(commonConfig(), {
-        plugins: [
-            new webpack.LoaderOptionsPlugin({
-                minimize: true,
-                debug: false
-            }),
-            new webpack.DefinePlugin({
-                'process.env': {
-                    'NODE_ENV': JSON.stringify('production')
-                }
-            }),
-            new webpack.optimize.UglifyJsPlugin({
-                beautify: false,
-                mangle: {
-                    screw_ie8: true,
-                    keep_fnames: true
-                },
-                compress: {
-                    screw_ie8: true
-                },
-                comments: false
-            })
-        ]
+  plugins: [
+    new webpack.LoaderOptionsPlugin({
+      minimize: true,
+      debug: false
+    }),
+    new webpack.optimize.UglifyJsPlugin({
+      beautify: false,
+      mangle: {
+        screw_ie8: true,
+        keep_fnames: true
+      },
+      compress: {
+        screw_ie8: true
+      },
+      comments: false
     })
+  ]
 }
 ```
 
-You will notice three major updates to our 'prod.js' file:
+Then, by tweaking the `scripts` in your `package.json`, like so:
 
-- 'webpack-merge' with the 'base.js'.
-- We have move 'output' property to 'base.js'. Just to stress on that point that our output property, here, is common across all our environments and that we refactored our 'prod.js' and moved it to our 'base.js', the common configuration file.
-- We have defined the 'process.env.NODE_ENV' to be 'production' using the 'DefinePlugin'. Now across the application 'process.env.NODE_ENV' would have the value, 'production', when we build our application for production environment. Likewise we can manage various variables of our choice, specific to environments this way.
+__package.json__
 
-The choice of what is going to be common across all your environments is up to you, however. We have just demonstrated a few that could typically be common across environments when we build our application.
+```js
+"scripts": {
+  ...
+  "build:dev": "webpack --env=dev --progress --profile --colors",
+  "build:dist": "webpack --env=prod --progress --profile --colors"
+}
+```
+
+you can now toggle between the two configurations by turning our base configuration into a function and accepting the `env` parameter (set via `--env`):
+
+__webpack.config.js__
+
+```js
+module.exports = function(env) {
+  return require('./webpack.${env}.js')
+}
+```
+
+See the CLI's [common options section](/api/cli#common-options) for more details on how to use the `env` flag.
+
+
+### Advanced Approach
+
+A more complex approach would be to have a base configuration file, containing the configuration common to both environments, and then merge that with environment specific configurations. This would yield the full configuration for each environment and prevent repetition for the common bits.
+
+The tool used to perform this "merge" is simply called [webpack-merge](https://github.com/survivejs/webpack-merge) and provides a variety of merging options, though we are only going to use the simplest version of it below.
+
+We'll start by adding our base configuration:
+
+__webpack.common.js__
+
+```js
+module.exports = {
+  entry: {
+    'polyfills': './src/polyfills.ts',
+    'vendor': './src/vendor.ts',
+    'main': './src/main.ts'
+  },
+
+  output: {
+    path: path.join(__dirname, '/../dist/assets'),
+    filename: '[name].bundle.js',
+    publicPath: publicPath,
+    sourceMapFilename: '[name].map'
+  },
+
+  resolve: {
+    extensions: ['.ts', '.js', '.json'],
+    modules: [path.join(__dirname, 'src'), 'node_modules']
+  },
+
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        exclude: [/\.(spec|e2e)\.ts$/],
+        use: [
+          'awesome-typescript-loader',
+          'angular2-template-loader'
+        ]
+      },
+      {
+        test: /\.css$/,
+        use: ['to-string-loader', 'css-loader']
+      },
+      {
+        test: /\.(jpg|png|gif)$/,
+        use: 'file-loader'
+      },
+      {
+        test: /\.(woff|woff2|eot|ttf|svg)$/,
+        use: {
+          loader: 'url-loader',
+          options: {
+            limit: 100000
+          }
+        }
+      }
+    ]
+  },
+
+  plugins: [
+    new ForkCheckerPlugin(),
+
+    new webpack.optimize.CommonsChunkPlugin({
+      name: ['polyfills', 'vendor'].reverse()
+    }),
+
+    new HtmlWebpackPlugin({
+      template: 'src/index.html',
+      chunksSortMode: 'dependency'
+    })
+  ]
+}
+```
+
+And then merge this common configuration with an environment specific configuration file using `webpack-merge`. Let's look at an example where we merge our production file:
+
+__webpack.prod.js__
+
+```js
+const Merge = require('webpack-merge');
+const CommonConfig = require('./base.js');
+
+module.exports = function(env) {
+  return Merge(CommonConfig, {
+    plugins: [
+      new webpack.LoaderOptionsPlugin({
+        minimize: true,
+        debug: false
+      }),
+      new webpack.DefinePlugin({
+        'process.env': {
+          'NODE_ENV': JSON.stringify('production')
+        }
+      }),
+      new webpack.optimize.UglifyJsPlugin({
+        beautify: false,
+        mangle: {
+          screw_ie8: true,
+          keep_fnames: true
+        },
+        compress: {
+          screw_ie8: true
+        },
+        comments: false
+      })
+    ]
+  })
+}
+```
+
+You will notice three major updates to our 'webpack.prod.js' file:
+
+- Use `webpack-merge` to combine it with the 'webpack.common.js'.
+- We moved the `output` property to `webpack.common.js` as it is common to all environments.
+- We defined `'process.env.NODE_ENV'` as `'production'` using the `DefinePlugin` only in `webpack.prod.js`.
+
+The example above only demonstrates a few typical configuration options used in each (or both) environments. Now that you know how to split up configurations, the choice of what options go where is up to you.


### PR DESCRIPTION
Rework and simplify the production build guide to address some of the issues discussed in #1100 as well as just doing some general cleanup of titles and whatnot.

Also sneaking a UI/UX fix for the contributors section in here...

![image](https://cloud.githubusercontent.com/assets/8988697/25371089/d5220ecc-295c-11e7-824f-d7057c455a6b.png)

to...

![image](https://cloud.githubusercontent.com/assets/8988697/25371111/ea6f4a74-295c-11e7-9662-234b5ea56da5.png)

This puts some space between rows and prevents them from being overlapped by the gitter button.