### PR TITLE
Document extract-loader.

### DIFF
--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -22,3 +22,4 @@ cp -rf ./content/plugins/ ./generated/plugins
 ./scripts/fetch_package_names.js "webpack-contrib" "-webpack-plugin" | ./scripts/fetch_package_files.js "README.md" "./generated/plugins"
 
 ./scripts/fetch_package_names.js "babel" "babel-loader" | ./scripts/fetch_package_files.js "README.md" "./generated/loaders"
+./scripts/fetch_package_names.js "peerigon" "extract-loader" | ./scripts/fetch_package_files.js "README.md" "./generated/loaders"


### PR DESCRIPTION
Recently I needed this and I think it's generic enough to deserve a spot in the official docs. 

This loader basically takes an output from css/html/other loader that return the output as a JS module and execute it to return it as a raw string during the compile step.