### PR TITLE
update Complex Options `ident` block per #1150

### DIFF
--- a/content/guides/migrating.md
+++ b/content/guides/migrating.md
@@ -14,6 +14,8 @@ contributors:
   - howdy39
   - selbekk
   - ndelangen
+  - michael-ciniawsky
+  - rouzbeh84
 ---
 
 ## `resolve.root`, `resolve.fallback`, `resolve.modulesDirectories`

--- a/content/guides/migrating.md
+++ b/content/guides/migrating.md
@@ -621,32 +621,4 @@ Loaders are now cacheable by default. Loaders must opt-out if they are not cache
 webpack 1 only supports `JSON.stringify`-able options for loaders.
 webpack 2 now supports any JS object as loader options.
 
-Using complex options comes with one restriction. You may need to have a `ident` for the option object to make it referenceable by other loaders.
-
-Having an `ident` on the options object means to be able to reference this options object in inline loaders. Here is an example:
-
-`require("some-loader??by-ident!resource")`
-
-``` js
-{
-  test: /.../,
-  loader: "...",
-  options: {
-    ident: "by-ident",
-    magic: () => return Math.random()
-  }
-}
-```
-
-This inline style should not be used by regular code, but it's often used by loader generated code.
-I. e. the `style-loader` generates a module that `require`s the remaining request (which exports the CSS).
-
-``` js
-// style-loader generated code (simplified)
-var addStyle = require("./add-style");
-var css = require("-!css-loader?{"modules":true}!postcss-loader??postcss-ident");
-
-addStyle(css);
-```
-
-So if you use complex options tell your users about the `ident`.
+T> The `ident` (Complex Options) is obsolete since webpack >= v2.2.1 and gets automatically added internally by webpack


### PR DESCRIPTION
per #1150 removing info past new `T>...` about `ident` as anyone looking to migrate from this point on should be on webpack >= v2.2.1 but leaving the tip just to clarify for any curious during migration.

thoughts @michael-ciniawsky & @skipjack?

1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Make sure your PR complies with [the writer's guide](https://webpack.js.org/writers-guide/).
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
4. Remove these instructions from your PR as they are for your eyes only.
