### PR TITLE
Support Cleanup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,7 @@
     "react"
   ],
   "plugins": [
-    "transform-object-rest-spread"
+    "transform-object-rest-spread",
+    "transform-class-properties"
   ]
 }

--- a/components/splash/splash.jsx
+++ b/components/splash/splash.jsx
@@ -32,10 +32,10 @@ export default props => {
           <p>Through contributions, donations, and sponsorship, you allow webpack to thrive. Your donations directly support office hours, continued enhancements, and most importantly, great documentation and learning material!</p>
 
           <h2>Sponsors</h2>
-          <Support number={ 40 } type="sponsor" />
+          <Support number={ 50 } type="sponsors" />
 
           <h2>Backers</h2>
-          <Support number={ 130 } type="backer" />
+          <Support number={ 130 } type="backers" />
         </Container>
       </div>
     </div>

--- a/components/support/support-additional.json
+++ b/components/support/support-additional.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": 20000,
+    "name": "MoonMail",
+    "username": "moonmail",
+    "tier": "sponsor",
+    "avatar": "https://static.moonmail.io/moonmail-logo.svg",
+    "website": "https://moonmail.io/?utm_source=webpack.js.org"
+  },
+  {
+    "index": 20001,
+    "name": "MONEI",
+    "username": "monei",
+    "tier": "sponsor",
+    "avatar": "https://static.monei.net/monei-logo.svg",
+    "website": "https://monei.net/?utm_source=webpack.js.org"
+  }
+]

--- a/components/support/support-style.scss
+++ b/components/support/support-style.scss
@@ -4,32 +4,52 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  padding:10px 5px;
+  padding: 1em 0.5em;
 
   &__item {
-    margin:0 5px;
+    position: relative;
+    margin: 0 5px 5px 5px;
+  }
+
+  &__sponsors-avatar {
+    height: 64px;
+  }
+
+  &__backers-avatar {
+    width: 62px;
+    height: 62px;
+    border-radius: 50%;
+    border: 2px solid white;
+    overflow: hidden;
+  }
+
+  &__outline {
+    position: absolute;
+    top: 0;
+    margin: -2px;
+    width: calc(100% + 4px);
+    height: calc(100% - 2px);
+    border-radius: 50%;
+    border: 2px solid rgb(112, 202, 10);
   }
 
   &__bottom {
-    flex:0 0 100%;
-    margin-top:10px;
+    flex: 0 0 100%;
+    margin-top: 1em;
   }
 
   &__button {
-    display:inline-block;
-    padding:0.4em 1em;
-    border:2px solid getColor(denim);
-    color:getColor(denim);
-    border-radius:1.25em;
-    transition:all 250ms;
+    display: inline-block;
+    padding: 0.4em 1em;
+    text-transform: uppercase;
+    color: getColor(denim);
+    border: 1px solid getColor(denim);
+    border-radius: 1.25em;
+    transition: all 250ms;
 
     &:hover {
-      background:getColor(denim);
-      color:getColor(white);
+      background: getColor(denim);
+      color: getColor(white);
     }
-  }
-  &__missing {
-    display: flex;
-    align-items: center;
   }
 }

--- a/components/support/support.jsx
+++ b/components/support/support.jsx
@@ -1,56 +1,59 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import Additional from './support-additional.json';
+import 'whatwg-fetch';
 import './support-style';
 
-const MISSING_SPONSORS = [
-  {
-    index: 33,
-    name: 'MoonMail',
-    title: 'Email Marketing Software',
-    logo: 'https://static.moonmail.io/moonmail-logo.svg',
-    url: 'https://moonmail.io/?utm_source=webpack.js.org'
-  },
-  {
-    index: 34,
-    name: 'MONEI',
-    title: 'Best payment gateway rates',
-    logo: 'https://static.monei.net/monei-logo.svg',
-    url: 'https://monei.net/?utm_source=webpack.js.org'
-  }
-];
+export default class Support extends React.Component {
+  static propTypes = {
+    number: PropTypes.number.isRequired,
+    type: PropTypes.oneOf([
+      'sponsors',
+      'backers'
+    ]).isRequired
+  };
 
-export default ({number, type}) => {
-  const supportItems = [...Array(number)].map((x, i) =>
-    <a key={ i }
-       className="support__item"
-       href={ `https://opencollective.com/webpack/${type}/${i}/website?requireActive=false` }
-       target="_blank">
-      <img
-        src={ `//opencollective.com/webpack/${type}/${i}/avatar?requireActive=false` }
-        alt={ `${type} avatar` } />
-    </a>
-  );
-
-  // add missing sponsors
-  if (type === 'sponsor') {
-    MISSING_SPONSORS.forEach(sponsor => {
-      supportItems.splice(sponsor.index, 0, (
-        <a key={ sponsor.name }
-           className="support__item support__missing"
-           href={ sponsor.url }
-           target="_blank"
-           title={ sponsor.title }>
-          <img
-            src={ sponsor.logo }
-            height={ 45 }
-            alt={ sponsor.name } />
-        </a>
-      ));
-    });
+  state = {
+    supporters: [],
+    error: false
   }
 
-  return (
-    <div className="support">
-      {supportItems}
-    </div>
-  );
-};
+  render() {
+    let { number, type } = this.props;
+    let { supporters } = this.state;
+
+    return (
+      <div className="support">
+        {
+          supporters.slice(0, number).map((supporter, i) => (
+            <a key={ supporter.id }
+               className="support__item"
+               target="_blank"
+               href={ supporter.website }>
+              <img
+                className={ `support__${type}-avatar` }
+                src={ supporter.avatar }
+                alt={ `${supporter.username}'s avatar` } />
+              { type === 'backers' ? <figure className="support__outline" /> : null }
+            </a>
+          ))
+        }
+
+        <div className="support__bottom">
+          <a className="support__button" href="https://opencollective.com/webpack#support">
+            Become a { type.replace(/s$/, '') }
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  componentDidMount() {
+    let { type } = this.props;
+
+    fetch(`https://opencollective.com/webpack/${type}.json`)
+      .then(response => response.json())
+      .then(json => this.setState({ supporters: json.concat(Additional) }))
+      .catch(error => this.setState({ error: true }));
+  }
+}

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "babel-core": "^6.10.4",
     "babel-eslint": "^6.1.2",
     "babel-loader": "^6.2.5",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.16.0",
     "babel-preset-env": "^0.0.8",
     "babel-preset-react": "^6.11.1",
@@ -99,6 +100,7 @@
   "dependencies": {
     "preact": "^6.2.1",
     "preact-compat": "3.11.0",
+    "prop-types": "^15.5.8",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-router": "^2.8.1",


### PR DESCRIPTION
Cleaning up the support component by... 

- updating the way sponsors are retrieved using the method mentioned in #411 
- abstracting the additional sponsors into a separate json sheet that follows the same model
- concatenating the additional sponsors on to those fetched from open collective

This gives us full control over styling and allows us to...

- easily add new additional sponsors, not from open collective, without bloating the component file
- refactor how we display sponsors, e.g. using one of the methods discussed in #411 

I think this should resolve #411 as it has been inactive for a while __and__ with this in place changing the display algorithm should be a piece of cake as we have more data to key off.

Thanks to @rafaelrinaldi for pinging opencollective to find out about the json feature!