### PR TITLE
Fix syntax error in per-env configuration example

### DIFF
--- a/content/guides/production-build.md
+++ b/content/guides/production-build.md
@@ -159,7 +159,7 @@ __webpack.config.js__
 
 ```js
 module.exports = function(env) {
-  return require('./webpack.${env}.js')
+  return require(`./webpack.${env}.js`)
 }
 ```
 


### PR DESCRIPTION
Template literals must be enclosed by backticks