### PR TITLE
Devtool: add links to plugin, loader, examples

### DIFF
--- a/content/configuration/devtool.md
+++ b/content/configuration/devtool.md
@@ -8,7 +8,9 @@ contributors:
   - lricoy
 ---
 
-This option controls if and how Source Maps are generated.
+This option controls if and how source maps are generated.
+
+Use the [`SourceMapDevToolPlugin`](/plugins/source-map-dev-tool-plugin.md) for a more fine grained configuration. See the [`source-map-loader`](/loaders/source-map-loader/) how to deal with existing source maps.
 
 ## `devtool`
 

--- a/content/configuration/devtool.md
+++ b/content/configuration/devtool.md
@@ -10,7 +10,7 @@ contributors:
 
 This option controls if and how source maps are generated.
 
-Use the [`SourceMapDevToolPlugin`](/plugins/source-map-dev-tool-plugin.md) for a more fine grained configuration. See the [`source-map-loader`](/loaders/source-map-loader/) how to deal with existing source maps.
+Use the [`SourceMapDevToolPlugin`](/plugins/source-map-dev-tool-plugin.md) for a more fine grained configuration. See the [`source-map-loader`](/loaders/source-map-loader/) to deal with existing source maps.
 
 ## `devtool`
 

--- a/content/configuration/devtool.md
+++ b/content/configuration/devtool.md
@@ -18,6 +18,8 @@ Use the [`SourceMapDevToolPlugin`](/plugins/source-map-dev-tool-plugin.md) for a
 
 Choose a style of [source mapping](http://blog.teamtreehouse.com/introduction-source-maps) to enhance the debugging process. These values can affect build and rebuild speed dramatically.
 
+T> The webpack repository contains an [example showing the effect of all `devtool` variants](https://github.com/webpack/webpack/tree/master/examples/source-map). Those examples will likely help you to understand the differences.
+
  devtool                      | build | rebuild | production | quality
 ------------------------------|-------|---------|------------|--------------------------
  eval                         | +++   | +++     | no         | generated code


### PR DESCRIPTION
This adds links to the source map plugin and loader as well as the examples from the webpack repository (via https://github.com/webpack/webpack/issues/4698).

Relates to #971