### PR TITLE
Fix HMR module.hot.accept example code

### DIFF
--- a/content/guides/hmr-react.md
+++ b/content/guides/hmr-react.md
@@ -190,7 +190,8 @@ render(App);
 // Hot Module Replacement API
 if (module.hot) {
   module.hot.accept('./components/App', () => {
-    render(App)
+    const updatedApp = require('./components/App').default;
+    render(updatedApp)
   });
 }
 ```


### PR DESCRIPTION
The example shows the `module.hot.accept` callback re-rendering the original component, instead of re-requiring the component in order to render the updated component.
