### PR TITLE
Output Management

### DIFF
--- a/content/guides/output-management.md
+++ b/content/guides/output-management.md
@@ -1,0 +1,73 @@
+---
+title: Output Management
+contributors:
+  - skipjack
+---
+
+Managing webpack's [output]() and including it in your HTML files may not seem tough at first, but once you start [using hashes in filenames]() and outputting [multiple bundles](), things can start to get a bit hairy. However, there's no need to fear as a few plugins exist that will make this process much easier to manage.
+
+First let's take a look at where you might stand without these plugins:
+
+__index.html__
+
+``` html
+<!doctype html>
+
+<html>
+  <head>
+    <title>Output Management</title>
+    <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="stylesheet" href="/styles.min.css" />
+    <script src="/vendor.bundle.js"></script>
+  </head>
+  <body>
+    <script src="/app.bundle.js"></script>
+  </body>
+</html>
+```
+
+Here we've loaded a favicon, our stylesheet (extracted with the [extract-text-webpack-plugin](/plugins/extract-text-webpack-plugin)), any libraries (split into [a separate bundle](/guides/code-splitting-libraries)), and finally our main bundle (`app.bundle.js`). This is ok, but what happens if we change our entry point names? What if we decide to take advantage of [better caching](/guides/caching)?
+
+
+## Auto-Generated HTML
+
+In comes the [html-webpack-plugin](/plugins/html-webpack-plugin) to save the day. Using this plugin, you can stop hard-coding the output filenames into a manually-managed file and, instead, sit back as webpack auto-generates an `index.html` file for you. Let's take a look at what you'll need to add to your configuration:
+
+__webpack.config.js__
+
+``` js
+var HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  entry: {
+    app: './index.js',
+    vendor: [ 'react', 'react-dom' ]
+  },
+
+  output: {
+    path: 'dist',
+    filename: '[name].bundle.js'
+  },
+
+  plugins: [
+    new HtmlWebpackPlugin({
+      title: 'Output Management',
+      favicon: './favicon.ico'
+    })
+  ]
+};
+```
+
+This setup will generate the same HTML shown in the example above, excluding the extracted CSS. The plugin allows for many settings including extending your own template, minifying the output, and changing the script injection site. See [its documentation](/plugins/html-webpack-plugin) for more details.
+
+T> Check out the [html-webpack-template](https://github.com/jaketrent/html-webpack-template) extension for even more options including easy insertion of an `appMountId`, `meta` tags, and a `baseHref`.
+
+
+## Multiple HTML Files
+
+To generate multiple HTML files, say for a multi-page web application, you can utilize the [multipage-webpack-plugin](https://github.com/mutualofomaha/multipage-webpack-plugin). This plugin is very similar to the `html-webpack-plugin`, in fact it uses that plugin under the hood, however it can be used to generate an HTML file per entry point.
+
+
+## The Manifest
+
+Let's step back for a second now and ask a more high-level question -- how do these plugins know what files are being spit out? The answer is in the manifest webpack keeps to track how all your modules map to the output bundles. If you're interested in managing webpack's [output](/configuration/output) in other ways, the manifest would be a good place to start. It can be extracted into a json file for easy consumption using the [webpack-manifest-plugin](https://github.com/danethurber/webpack-manifest-plugin).

--- a/content/guides/output-management.md
+++ b/content/guides/output-management.md
@@ -4,7 +4,7 @@ contributors:
   - skipjack
 ---
 
-Managing webpack's [output]() and including it in your HTML files may not seem tough at first, but once you start [using hashes in filenames]() and outputting [multiple bundles](), things can start to get a bit hairy. However, there's no need to fear as a few plugins exist that will make this process much easier to manage.
+Managing webpack's [output](/configuration/output) and including it in your HTML files may not seem tough at first, but once you start [using hashes in filenames](/guides/caching) and outputting [multiple bundles](/guides/code-splitting-libraries), things can start to get a bit hairy. However, there's no need to fear as a few plugins exist that will make this process much easier to manage.
 
 First let's take a look at where you might stand without these plugins:
 
@@ -26,12 +26,12 @@ __index.html__
 </html>
 ```
 
-Here we've loaded a favicon, our stylesheet (extracted with the [extract-text-webpack-plugin](/plugins/extract-text-webpack-plugin)), any libraries (split into [a separate bundle](/guides/code-splitting-libraries)), and finally our main bundle (`app.bundle.js`). This is ok, but what happens if we change our entry point names? What if we decide to take advantage of [better caching](/guides/caching)?
+Here we've loaded a favicon, our stylesheet (extracted with the [`ExtractTextWebpackPlugin`](/plugins/extract-text-webpack-plugin)), any libraries (split into [a separate bundle](/guides/code-splitting-libraries)), and finally our main bundle (`app.bundle.js`). This is ok, but what happens if we change our entry point names? What if we decide to take advantage of [better caching practices](/guides/caching)?
 
 
 ## Auto-Generated HTML
 
-In comes the [html-webpack-plugin](/plugins/html-webpack-plugin) to save the day. Using this plugin, you can stop hard-coding the output filenames into a manually-managed file and, instead, sit back as webpack auto-generates an `index.html` file for you. Let's take a look at what you'll need to add to your configuration:
+In comes the [`HtmlWebpackPlugin`](/plugins/html-webpack-plugin) to save the day. Using this plugin, you can stop hard-coding the output filenames into a manually-managed file and, instead, sit back as webpack auto-generates an `index.html` file for you. Let's take a look at what you'll need to add to your configuration:
 
 __webpack.config.js__
 
@@ -60,14 +60,14 @@ module.exports = {
 
 This setup will generate the same HTML shown in the example above, excluding the extracted CSS. The plugin allows for many settings including extending your own template, minifying the output, and changing the script injection site. See [its documentation](/plugins/html-webpack-plugin) for more details.
 
-T> Check out the [html-webpack-template](https://github.com/jaketrent/html-webpack-template) extension for even more options including easy insertion of an `appMountId`, `meta` tags, and a `baseHref`.
+T> Check out the [`HTMLWebpackTemplate`](https://github.com/jaketrent/html-webpack-template) extension for even more options including easy insertion of an `appMountId`, `meta` tags, and a `baseHref`.
 
 
 ## Multiple HTML Files
 
-To generate multiple HTML files, say for a multi-page web application, you can utilize the [multipage-webpack-plugin](https://github.com/mutualofomaha/multipage-webpack-plugin). This plugin is very similar to the `html-webpack-plugin`, in fact it uses that plugin under the hood, however it can be used to generate an HTML file per entry point.
+To generate multiple HTML files, say for a multi-page web application, you can utilize the [`MultipageWebpackPlugin`](https://github.com/mutualofomaha/multipage-webpack-plugin). This plugin is very similar to the `html-webpack-plugin`, in fact it uses that plugin under the hood, however it can be used to generate an HTML file per entry point.
 
 
 ## The Manifest
 
-Let's step back for a second now and ask a more high-level question -- how do these plugins know what files are being spit out? The answer is in the manifest webpack keeps to track how all your modules map to the output bundles. If you're interested in managing webpack's [output](/configuration/output) in other ways, the manifest would be a good place to start. It can be extracted into a json file for easy consumption using the [webpack-manifest-plugin](https://github.com/danethurber/webpack-manifest-plugin).
+Let's step back for a second now and ask a more high-level question -- how do these plugins know what files are being spit out? The answer is in the manifest webpack keeps to track how all your modules map to the output bundles. If you're interested in managing webpack's [output](/configuration/output) in other ways, the manifest would be a good place to start. It can be extracted into a json file for easy consumption using the [`WebpackManifestPlugin`](https://github.com/danethurber/webpack-manifest-plugin).

--- a/content/guides/output-management.md
+++ b/content/guides/output-management.md
@@ -1,5 +1,5 @@
 ---
-title: Output Management
+title: Managing Built Files
 contributors:
   - skipjack
 ---


### PR DESCRIPTION
Add a best practices and advice guide for managing built files (aka webpack's output).

Resolves #949