### PR TITLE
add __webpack_public_path__ docs

### DIFF
--- a/content/configuration/output.md
+++ b/content/configuration/output.md
@@ -507,6 +507,17 @@ publicPath: "../assets/", // relative to HTML page
 publicPath: "", // relative to HTML page (same directory)
 ```
 
+In cases where the `publicPath` of output files can't be known at compile time, it can be left blank and set dynamically at runtime in the entry file using the [free variable](http://stackoverflow.com/questions/12934929/what-are-free-variables) `__webpack_public_path__`. 
+
+E.g.:
+```javascript
+ __webpack_public_path__ = myRuntimePublicPath
+
+// rest of your application entry
+```
+
+See [this discussion](https://github.com/webpack/webpack/issues/2776#issuecomment-233208623) for more information on `__webpack_public_path__`.
+
 
 ## `output.sourceMapFilename`
 


### PR DESCRIPTION
One would naturally look to the `publicPath` documentation when searching for solutions to setting  it at runtime.
