### PR TITLE
Improve lint:links - exclude support images/links

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "fetch": "scripts/fetch.sh",
     "init:generated": "mkdirp ./generated/loaders && mkdirp ./generated/plugins ",
     "lint": "run-s lint:*",
-    "lint:links": "hyperlink -r build/index.html | ./scripts/check-links.js --skip 10",
+    "lint:links": "hyperlink -r build/index.html | ./scripts/check-links.js",
     "lint:js": "eslint . --ext .js --ext .jsx",
     "lint:markdown": "markdownlint --config ./.markdownlint.json *.md ./content/**/*.md",
     "lint:social": "alex ./**/*.md",

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -22,7 +22,8 @@ function checkLinks(args) {
   var name = null;
 
   tap.on('complete', function(res) {
-    const failures = res.failures;
+    const failures = res.failures.filter(failure => !failure.diag || !failure.diag.at ||
+        !failure.diag.at.match(/class="(support__item|support__backers-avatar|support__sponsors-avatar)"/));
 
     if (failures.length > 0) {
       console.log(formatFailures(failures));


### PR DESCRIPTION
* Ignore failures on sponsor/backer images/links
* Do not allow any other failure to not miss broken links such as https://github.com/webpack/webpack.js.org/pull/1188 or https://github.com/webpack-contrib/less-loader/pull/194