### PR TITLE
Further Reading / Related Links

### DIFF
--- a/antwar.config.js
+++ b/antwar.config.js
@@ -254,6 +254,9 @@ function processPage() {
     },
     contributors: function(o) {
       return Array.isArray(o.file.contributors) && o.file.contributors.length && o.file.contributors.slice().sort();
+    },
+    related: function(o) {
+      return Array.isArray(o.file.related) ? o.file.related : []
     }
   };
 }

--- a/components/page/page.jsx
+++ b/components/page/page.jsx
@@ -40,24 +40,13 @@ export default ({ section, page }) => (
           <h3>Further Reading</h3>
           <ul>
             {
-              page.related.map((string, index) => {
-                let link = string.split(' | ');
-
-                if ( link.length !== 2 ) {
-                  throw new Error(
-                    `Invalid related link: ${string}\r\n` +
-                    `Use this format: link title | http://example.com`
-                  );
-                }
-
-                return (
-                  <li key={ index }>
-                    <a href={ link[1] }>
-                      { link[0] }
-                    </a>
-                  </li>
-                );
-              })
+              page.related.map((link, index) => (
+                <li key={ index }>
+                  <a href={ link.url }>
+                    { link.title }
+                  </a>
+                </li>
+              ))
             }
           </ul>
         </div>

--- a/components/page/page.jsx
+++ b/components/page/page.jsx
@@ -10,43 +10,70 @@ import '../sidebar/sidebar-style';
 import '../sponsors/sponsors-style';
 import '../gitter/gitter-style';
 
-export default ({ section, page }) => {
-  return (
-    <Container className="page">
+export default ({ section, page }) => (
+  <Container className="page">
+    <Interactive
+      id="components/sidebar/sidebar.jsx"
+      component={ Sidebar }
+      sectionName={ section.name }
+      pages={ section.pages().map(page => ({
+        url: page.url,
+        title: page.title,
+        anchors: page.anchors
+      })) }
+      currentPage={ page.url.replace('/index', '') } />
+
+    <section className="page__content">
+      <h1>{ page.title }</h1>
+
+      <PageLinks
+        page={ page }
+        section={ section.name } />
+
+      <div dangerouslySetInnerHTML={{
+        __html: page.content
+      }} />
+
+      { page.related.length > 0 ? (
+        <div>
+          <hr />
+          <h3>Further Reading</h3>
+          <ul>
+            {
+              page.related.map((string, index) => {
+                let link = string.split(' | ');
+
+                if ( link.length !== 2 ) {
+                  throw new Error(
+                    `Invalid related link: ${string}\r\n` +
+                    `Use this format: link title | http://example.com`
+                  );
+                }
+
+                return (
+                  <li key={ index }>
+                    <a href={ link[1] }>
+                      { link[0] }
+                    </a>
+                  </li>
+                );
+              })
+            }
+          </ul>
+        </div>
+      ) : null }
+
+      { page.contributors.length > 0 ? (
+        <div>
+          <hr />
+          <h3>Contributors</h3>
+          <Contributors contributors={ page.contributors } />
+        </div>
+      ) : null }
+
       <Interactive
-        id="components/sidebar/sidebar.jsx"
-        component={ Sidebar }
-        sectionName={ section.name }
-        pages={ section.pages().map(page => ({
-          url: page.url,
-          title: page.title,
-          anchors: page.anchors
-        })) }
-        currentPage={ page.url.replace('/index', '') } />
-
-      <section className="page__content">
-        <h1>{ page.title }</h1>
-
-        <PageLinks
-          page={ page }
-          section={ section.name } />
-
-        <div dangerouslySetInnerHTML={{
-          __html: page.content
-        }} />
-
-        { page.contributors.length > 0 ? (
-          <div>
-            <hr />
-            <h3>Contributors</h3>
-            <Contributors contributors={ page.contributors } />
-          </div>
-        ) : null }
-
-        <Interactive
-          id="components/gitter/gitter.jsx"
-          component={ Gitter } />
-      </section>
-    </Container>
-  );
-};
+        id="components/gitter/gitter.jsx"
+        component={ Gitter } />
+    </section>
+  </Container>
+);

--- a/content/api/cli.md
+++ b/content/api/cli.md
@@ -4,6 +4,12 @@ sort: 2
 contributors:
   - ev1stensberg
   - simon04
+related:
+  - Analyzing Build Statistics | https://survivejs.com/webpack/optimizing-build/analyzing-build-statistics/
+  - Three simple ways to inspect a webpack bundle | https://medium.com/@joeclever/three-simple-ways-to-inspect-a-webpack-bundle-7f6a8fe7195d#.7d2i06mjx
+  - Optimising your application bundle size with webpack | https://hackernoon.com/optimising-your-application-bundle-size-with-webpack-e85b00bab579#.5w5ko08pq
+  - Analyzing & optimizing your webpack bundle | https://medium.com/@ahmedelgabri/analyzing-optimizing-your-webpack-bundle-8590818af4df#.hce4vdjs9
+  - Analysing and minimising the size of client side bundle with webpack and source-map-explorer | https://medium.com/@nimgrg/analysing-and-minimising-the-size-of-client-side-bundle-with-webpack-and-source-map-explorer-41096559beca#.c3t2srr8x
 ---
 
 webpack provides a Command Line Interface (CLI) to configure and interact with your build. This is mostly useful in case of early prototyping, profiling, writing npm scripts or personal customization of the build.
@@ -116,17 +122,7 @@ webpack --json
 webpack --json > stats.json
 ```
 
-In every other case, webpack prints out a set of stats showing bundle, chunk and timing details. Using this option the output can be a JSON object.
-This response is accepted by webpack's [analyse tool](https://webpack.github.com/analyse), or chrisbateman's [webpack-visualizer](https://chrisbateman.github.io/webpack-visualizer/), or th0r's [webpack-bundle-analyzer](https://github.com/th0r/webpack-bundle-analyzer).
-The analyse tool will take in the JSON and provide all the details of the build in graphical form.
-
-*Further reading:*
-
-* [Analyzing Build Statistics](https://survivejs.com/webpack/optimizing-build/analyzing-build-statistics/)
-* [Three simple ways to inspect a webpack bundle](https://medium.com/@joeclever/three-simple-ways-to-inspect-a-webpack-bundle-7f6a8fe7195d#.7d2i06mjx)
-* [Optimising your application bundle size with webpack](https://hackernoon.com/optimising-your-application-bundle-size-with-webpack-e85b00bab579#.5w5ko08pq)
-* [Analyzing & optimizing your webpack bundle](https://medium.com/@ahmedelgabri/analyzing-optimizing-your-webpack-bundle-8590818af4df#.hce4vdjs9)
-* [Analysing and minimising the size of client side bundle with webpack and source-map-explorer](https://medium.com/@nimgrg/analysing-and-minimising-the-size-of-client-side-bundle-with-webpack-and-source-map-explorer-41096559beca#.c3t2srr8x)
+In every other case, webpack prints out a set of stats showing bundle, chunk and timing details. Using this option the output can be a JSON object. This response is accepted by webpack's [analyse tool](https://webpack.github.com/analyse), or chrisbateman's [webpack-visualizer](https://chrisbateman.github.io/webpack-visualizer/), or th0r's [webpack-bundle-analyzer](https://github.com/th0r/webpack-bundle-analyzer). The analyse tool will take in the JSON and provide all the details of the build in graphical form.
 
 
 ### Output Options

--- a/content/api/cli.md
+++ b/content/api/cli.md
@@ -5,11 +5,16 @@ contributors:
   - ev1stensberg
   - simon04
 related:
-  - Analyzing Build Statistics | https://survivejs.com/webpack/optimizing-build/analyzing-build-statistics/
-  - Three simple ways to inspect a webpack bundle | https://medium.com/@joeclever/three-simple-ways-to-inspect-a-webpack-bundle-7f6a8fe7195d#.7d2i06mjx
-  - Optimising your application bundle size with webpack | https://hackernoon.com/optimising-your-application-bundle-size-with-webpack-e85b00bab579#.5w5ko08pq
-  - Analyzing & optimizing your webpack bundle | https://medium.com/@ahmedelgabri/analyzing-optimizing-your-webpack-bundle-8590818af4df#.hce4vdjs9
-  - Analysing and minimising the size of client side bundle with webpack and source-map-explorer | https://medium.com/@nimgrg/analysing-and-minimising-the-size-of-client-side-bundle-with-webpack-and-source-map-explorer-41096559beca#.c3t2srr8x
+  - title: Analyzing Build Statistics
+    url: https://survivejs.com/webpack/optimizing-build/analyzing-build-statistics/
+  - title: Three simple ways to inspect a webpack bundle
+    url: https://medium.com/@joeclever/three-simple-ways-to-inspect-a-webpack-bundle-7f6a8fe7195d#.7d2i06mjx
+  - title: Optimising your application bundle size with webpack
+    url: https://hackernoon.com/optimising-your-application-bundle-size-with-webpack-e85b00bab579#.5w5ko08pq
+  - title: Analyzing & optimizing your webpack bundle
+    url: https://medium.com/@ahmedelgabri/analyzing-optimizing-your-webpack-bundle-8590818af4df#.hce4vdjs9
+  - title: Analysing and minimising the size of client side bundle with webpack and source-map-explorer
+    url: https://medium.com/@nimgrg/analysing-and-minimising-the-size-of-client-side-bundle-with-webpack-and-source-map-explorer-41096559beca#.c3t2srr8x
 ---
 
 webpack provides a Command Line Interface (CLI) to configure and interact with your build. This is mostly useful in case of early prototyping, profiling, writing npm scripts or personal customization of the build.

--- a/content/guides/code-splitting-async.md
+++ b/content/guides/code-splitting-async.md
@@ -7,11 +7,13 @@ contributors:
   - pksjce
   - rahulcs
   - johnstew
+related:
+  - Lazy Loading ES2015 Modules in the Browser | https://dzone.com/articles/lazy-loading-es2015-modules-in-the-browser
 ---
 
 This guide documents how to split your bundle into chunks which can be downloaded asynchronously at a later time. For instance, this allows to serve a minimal bootstrap bundle first and to asynchronously additional features later.
 
-webpack supports two similar techniques to achieve this goal: using `import()` (preferred, ECMAScript proposal) and `require.ensure()` (legacy, webpack specific). 
+webpack supports two similar techniques to achieve this goal: using `import()` (preferred, ECMAScript proposal) and `require.ensure()` (legacy, webpack specific).
 
 
 ## Dynamic import: `import()`
@@ -309,8 +311,3 @@ To execute `b.js`, we will have to require it in a sync manner like `require('./
 * `require.ensure()`
 * * https://github.com/webpack/webpack/tree/master/examples/code-splitting
 * * https://github.com/webpack/webpack/tree/master/examples/named-chunks – illustrates the use of `chunkName`
-
-
-## Weblinks
-
-* [Lazy Loading ES2015 Modules in the Browser](https://dzone.com/articles/lazy-loading-es2015-modules-in-the-browser)

--- a/content/guides/code-splitting-async.md
+++ b/content/guides/code-splitting-async.md
@@ -8,7 +8,8 @@ contributors:
   - rahulcs
   - johnstew
 related:
-  - Lazy Loading ES2015 Modules in the Browser | https://dzone.com/articles/lazy-loading-es2015-modules-in-the-browser
+  - title: Lazy Loading ES2015 Modules in the Browser
+    url: https://dzone.com/articles/lazy-loading-es2015-modules-in-the-browser
 ---
 
 This guide documents how to split your bundle into chunks which can be downloaded asynchronously at a later time. For instance, this allows to serve a minimal bootstrap bundle first and to asynchronously additional features later.

--- a/content/guides/tree-shaking.md
+++ b/content/guides/tree-shaking.md
@@ -5,9 +5,12 @@ contributors:
   - zacanger
   - alexjoverm
 related:
-  - Tree shaking with webpack 2, TypeScript and Babel | https://alexjoverm.github.io/2017/03/06/Tree-shaking-with-Webpack-2-TypeScript-and-Babel/
-  - Tree-shaking with webpack 2 and Babel 6 | http://www.2ality.com/2015/12/webpack-tree-shaking.html
-  - webpack 2 Tree Shaking Configuration | https://medium.com/modus-create-front-end-development/webpack-2-tree-shaking-configuration-9f1de90f3233#.15tuaw71x
+  - title: Tree shaking with webpack 2, TypeScript and Babel
+    url: https://alexjoverm.github.io/2017/03/06/Tree-shaking-with-Webpack-2-TypeScript-and-Babel/
+  - title: Tree-shaking with webpack 2 and Babel 6
+    url: http://www.2ality.com/2015/12/webpack-tree-shaking.html
+  - title: webpack 2 Tree Shaking Configuration
+    url: https://medium.com/modus-create-front-end-development/webpack-2-tree-shaking-configuration-9f1de90f3233#.15tuaw71x
 ---
 
 _Tree shaking_ is a term commonly used in the JavaScript context for dead-code elimination, or more precisely, live-code import. It relies on ES2015 module [import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import)/[export](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) for the [static structure](http://exploringjs.com/es6/ch_modules.html#static-module-structure) of its module system. The name and concept have been popularized by the ES2015 module bundler [rollup](https://github.com/rollup/rollup).

--- a/content/guides/tree-shaking.md
+++ b/content/guides/tree-shaking.md
@@ -4,6 +4,10 @@ contributors:
   - simon04
   - zacanger
   - alexjoverm
+related:
+  - Tree shaking with webpack 2, TypeScript and Babel | https://alexjoverm.github.io/2017/03/06/Tree-shaking-with-Webpack-2-TypeScript-and-Babel/
+  - Tree-shaking with webpack 2 and Babel 6 | http://www.2ality.com/2015/12/webpack-tree-shaking.html
+  - webpack 2 Tree Shaking Configuration | https://medium.com/modus-create-front-end-development/webpack-2-tree-shaking-configuration-9f1de90f3233#.15tuaw71x
 ---
 
 _Tree shaking_ is a term commonly used in the JavaScript context for dead-code elimination, or more precisely, live-code import. It relies on ES2015 module [import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import)/[export](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) for the [static structure](http://exploringjs.com/es6/ch_modules.html#static-module-structure) of its module system. The name and concept have been popularized by the ES2015 module bundler [rollup](https://github.com/rollup/rollup).
@@ -76,10 +80,3 @@ function(e,t,n){"use strict";function r(e){return e*e*e}t.a=r}
 /* ... */
 function(e,t,n){"use strict";Object.defineProperty(t,"__esModule",{value:!0});var r=n(0);console.log(n.i(r.a)(5))}
 ```
-
-
-## Weblinks
-
-* [Tree shaking with webpack 2, TypeScript and Babel](https://alexjoverm.github.io/2017/03/06/Tree-shaking-with-Webpack-2-TypeScript-and-Babel/)
-* [Tree-shaking with webpack 2 and Babel 6](http://www.2ality.com/2015/12/webpack-tree-shaking.html)
-* [webpack 2 Tree Shaking Configuration](https://medium.com/modus-create-front-end-development/webpack-2-tree-shaking-configuration-9f1de90f3233#.15tuaw71x)

--- a/content/plugins/dll-plugin.md
+++ b/content/plugins/dll-plugin.md
@@ -6,6 +6,8 @@ contributors:
   - opiepj
   - simon04
   - skipjack
+related:
+  - code splitting example | https://github.com/webpack/webpack/tree/master/examples/explicit-vendor-chunk/README.md
 ---
 
 ## Introduction
@@ -101,11 +103,6 @@ new webpack.DllReferencePlugin({
 _Two separate example folders. Demonstrates scope and context._
 
 T> Multiple `DllPlugins` and multiple `DllReferencePlugins`.
-
-
-### Related
-
-* [code splitting example](https://github.com/webpack/webpack/tree/master/examples/explicit-vendor-chunk/README.md)
 
 
 ## References

--- a/content/plugins/dll-plugin.md
+++ b/content/plugins/dll-plugin.md
@@ -7,7 +7,8 @@ contributors:
   - simon04
   - skipjack
 related:
-  - code splitting example | https://github.com/webpack/webpack/tree/master/examples/explicit-vendor-chunk/README.md
+  - title: Code Splitting Example
+    url: https://github.com/webpack/webpack/tree/master/examples/explicit-vendor-chunk/README.md
 ---
 
 ## Introduction


### PR DESCRIPTION
Allow a `related` section in the yaml frontmatter of any markdown file to add a __Further Reading__ section containing the `related` links.

Example:

![image](https://cloud.githubusercontent.com/assets/8988697/25836209/fede6700-3452-11e7-9cc0-b8593eefcc5a.png)

Resolves #94 
