### PR TITLE
Add postcss-loader

### DIFF
--- a/content/guides/asset-management.md
+++ b/content/guides/asset-management.md
@@ -42,7 +42,7 @@ module.exports = {
 
 This enables you to `import './style.css'` into the file that depends on that styling. Now, when that module is run, a `<style>` tag with the stringified css will be inserted into the `<head>` of your html file.
 
-T> Note that you can also [split your CSS](/guides/code-splitting-css) for better load times in production. On top of that, loaders exist for pretty much any flavor of CSS you can think of -- [postcss](https://github.com/postcss/postcss-loader), [sass](/loaders/sass-loader), and [less](/loaders/less-loader) to name a few.
+T> Note that you can also [split your CSS](/guides/code-splitting-css) for better load times in production. On top of that, loaders exist for pretty much any flavor of CSS you can think of -- [postcss](/loaders/postcss-loader), [sass](/loaders/sass-loader), and [less](/loaders/less-loader) to name a few.
 
 
 ## Loading Images

--- a/content/loaders/index.md
+++ b/content/loaders/index.md
@@ -50,8 +50,8 @@ Loaders are activated by using `loadername!` prefixes in `require()` statements,
 * [`css-loader`](/loaders/css-loader) Loads CSS file with resolved imports and returns CSS code
 * [`less-loader`](/loaders/less-loader) Loads and compiles a LESS file
 * [`sass-loader`](/loaders/sass-loader) Loads and compiles a SASS/SCSS file
+* [`postcss-loader`](/loaders/postcss-loader) Loads and transforms a CSS/SSS file using [PostCSS](http://postcss.org)
 * `stylus-loader` Loads and compiles a Stylus file
-* `postcss-loader` Loads and transforms a CSS/SSS file using [PostCSS](http://postcss.org)
 
 
 ## Linting && Testing

--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -10,6 +10,7 @@ cp -rf ./content/plugins/ ./generated/plugins
 # Fetch webpack-contrib (and various other) loader repositories
 ./scripts/fetch_package_names.js "webpack-contrib" "-loader" | ./scripts/fetch_package_files.js "README.md" "./generated/loaders"
 ./scripts/fetch_package_names.js "babel" "babel-loader" | ./scripts/fetch_package_files.js "README.md" "./generated/loaders"
+./scripts/fetch_package_names.js "postcss" "postcss-loader" | ./scripts/fetch_package_files.js "README.md" "./generated/loaders"
 ./scripts/fetch_package_names.js "peerigon" "extract-loader" | ./scripts/fetch_package_files.js "README.md" "./generated/loaders"
 
 # Fetch webpack-contrib (and various other) plugin repositories

--- a/scripts/fetch_package_files.js
+++ b/scripts/fetch_package_files.js
@@ -77,7 +77,8 @@ function fetchPackageFiles(options, finalCb) {
             .replace(/https?:\/\/github.com\/(webpack|webpack-contrib)\/([-A-za-z0-9]+-loader\/?)([)"])/g, '/loaders/$2/$3') // modify loader links
             .replace(/https?:\/\/github.com\/(webpack|webpack-contrib)\/([-A-za-z0-9]+-plugin\/?)([)"])/g, '/plugins/$2/$3') // modify plugin links
             .replace(/<h2[^>]*>/g, '## ') // replace any <h2> with ##
-            .replace(/<\/h2>/g, ''); // drop </h2>
+            .replace(/<\/h2>/g, '') // drop </h2>
+            .replace(/<!--[\s\S]*?-->/g, ''); // drop comments
         }
 
         var title = pkg.name;


### PR DESCRIPTION
Add postcss-loader to the loaders documentation. Did a few things:

- Added a new `fetch` line to pull in the readme (similar to the others)
- Had to drop html comments as that seems to be another thing not supported by our markdown process 😢  (just for reference #178)
- Updated and added some links to the new page

Fixes #1202 