### PR TITLE
Update to hyperlink 2.8.0. Refs #1210 refs Munter/hyperlink#117

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "fetch": "scripts/fetch.sh",
     "init:generated": "mkdirp ./generated/loaders && mkdirp ./generated/plugins ",
     "lint": "run-s lint:*",
-    "lint:links": "node --max-old-space-size=5000 ./node_modules/.bin/hyperlink -r build/index.html | ./scripts/check-links.js",
+    "lint:links": "hyperlink -r build/index.html | ./scripts/check-links.js",
     "lint:js": "eslint . --ext .js --ext .jsx",
     "lint:markdown": "markdownlint --config ./.markdownlint.json *.md ./content/**/*.md",
     "lint:social": "alex ./**/*.md",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "github": "^5.2.3",
     "html-webpack-plugin": "^2.22.0",
     "http-server": "^0.9.0",
-    "hyperlink": "^2.7.0",
+    "hyperlink": "^2.8.0",
     "json-loader": "^0.5.4",
     "lodash": "^4.16.1",
     "markdown-loader": "^0.1.7",


### PR DESCRIPTION
Reduces hyperlink memory footprint and speeds up external link checks. This should make link linting run correctly again
