### PR TITLE
Change externals module contexts documentation from `global` to `root`

### DIFF
--- a/content/configuration/externals.md
+++ b/content/configuration/externals.md
@@ -48,7 +48,7 @@ $('.my-element').animate(...);
 
 The bundle with external dependencies can be used in various module contexts, such as [CommonJS, AMD, global and ES2015 modules](/concepts/modules). The external library may be available in any of these forms:
 
-* __global__ - An external library can be available as a global variable. The consumer can achieve this by including the external library in a script tag. This is the default setting for externals.
+* __root__ - An external library can be available as a global variable. The consumer can achieve this by including the external library in a script tag. This is the default setting for externals.
 * __commonjs__ -  The consumer application may be using a CommonJS module system and hence the external library should be available as a CommonJS module.
 * __commonjs2__ -  Similar to the above line but where the export is `module.exports.default`.
 * __amd__ - Similar to the above line but using AMD module system.


### PR DESCRIPTION
The currently deployed documentation indicates that there are 4 module contexts you can specify under the externals config - `global`, `commonjs`, `commonjs2`, and `amd`, which contradicts both the examples that surround it, and the actual library functionality. 

This just changes the word "global" to "root" in the section that lists the module contexts.
