### PR TITLE
Fix missing parameter in doResolve()

### DIFF
--- a/content/api/plugins/resolver.md
+++ b/content/api/plugins/resolver.md
@@ -13,7 +13,7 @@ To join paths any plugin should use `this.join`. It normalizes the paths. There 
 
 A bailing async `forEach` implementation is available on `this.forEachBail(array, iterator, callback)`.
 
-To pass the request to other resolving plugins, use the `this.doResolve(types: String|String[], request: Request, callback)` method. `types` are multiple possible request types that are tested in order of preference.
+To pass the request to other resolving plugins, use the `this.doResolve(types: String|String[], request: Request, message: String, callback)` method. `types` are multiple possible request types that are tested in order of preference.
 
 ``` javascript
 interface Request {


### PR DESCRIPTION
The `doResolve()` signature code was missing the `message` parameter, resulting in a `TypeError: Cannot read property 'stack' of undefined` (originating from the [Resolver.js](https://github.com/webpack/enhanced-resolve/blob/master/lib/Resolver.js#L88)) when used as shown.

I assume the parameter wasn't yet present in webpack 1, at least appearances of `doResolve` on the internet commonly refer to usage without the `message` parameter.