### PR TITLE
docs(code-splitting): Rename to code-splitting for consistency

### DIFF
--- a/content/guides/code-splitting-async.md
+++ b/content/guides/code-splitting-async.md
@@ -185,7 +185,7 @@ Note that the promise is [resolved with the module namespace](https://github.com
 ```js
 // Example 1: top-level import
 import * as Component from './component';
-// Example 2: Code-splitting with import()
+// Example 2: Code Splitting with import()
 import('./component').then(Component => /* ... */);
 ```
 
@@ -276,7 +276,7 @@ When you add `bundle.js` in your HTML file and open it in your browser, the `0.b
 
 ### publicPath
 
-`output.publicPath` is an important option when using code-splitting, it is used to tell webpack where to load your bundles on-demand, see the [configuration documentation](/configuration/output/#output-publicpath).
+`output.publicPath` is an important option when using Code Splitting, it is used to tell webpack where to load your bundles on-demand, see the [configuration documentation](/configuration/output/#output-publicpath).
 
 
 ### Chunk name

--- a/content/guides/code-splitting.md
+++ b/content/guides/code-splitting.md
@@ -13,7 +13,7 @@ There are mainly two kinds of code splitting that can be accomplished with webpa
 
 ## Resource splitting for caching and parallel loads
 
-### Vendor code-splitting
+### Vendor Code Splitting
 
 A typical application can depend on many third party libraries for framework/functionality needs. Unlike application code, code present in these libraries does not change often.
 
@@ -28,7 +28,7 @@ This enhances cacheability of your styles and allows the browser to load the sty
 
 Learn [how to split CSS](/guides/code-splitting-css) using the `ExtractTextWebpackPlugin`.
 
-## On demand code-splitting
+## On demand Code Splitting
 
 While resource splitting of the previous kind requires the user to specify the split points upfront in the configuration, one can also create dynamic split points in the application code.
 

--- a/content/guides/code-splitting.md
+++ b/content/guides/code-splitting.md
@@ -11,7 +11,10 @@ Code splitting is one of the most compelling features of webpack. It allows you 
 
 There are mainly two kinds of code splitting that can be accomplished with webpack:
 
-## Resource splitting for caching and parallel loads
+
+## Resource Splitting
+
+Vendor and CSS code splitting methods help with both caching and parallel loading.
 
 ### Vendor Code Splitting
 
@@ -21,14 +24,15 @@ If we keep code from these libraries in its own bundle, separate from the applic
 
 For this to work, the `[hash]` portion in the vendor filename must remain constant, regardless of application code changes. Learn [how to split vendor/library](/guides/code-splitting-libraries) code using the `CommonsChunkPlugin`.
 
-### CSS splitting
+### CSS Splitting
 
 You might also want to split your styles into a separate bundle, independent from application logic.
 This enhances cacheability of your styles and allows the browser to load the styles in-parallel with your application code, thus preventing a FOUC ([flash of unstyled content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content)).
 
 Learn [how to split CSS](/guides/code-splitting-css) using the `ExtractTextWebpackPlugin`.
 
-## On demand Code Splitting
+
+## On Demand Code Splitting
 
 While resource splitting of the previous kind requires the user to specify the split points upfront in the configuration, one can also create dynamic split points in the application code.
 

--- a/content/guides/code-splitting.md
+++ b/content/guides/code-splitting.md
@@ -13,7 +13,7 @@ There are mainly two kinds of code splitting that can be accomplished with webpa
 
 ## Resource splitting for caching and parallel loads
 
-### Vendor code splitting
+### Vendor code-splitting
 
 A typical application can depend on many third party libraries for framework/functionality needs. Unlike application code, code present in these libraries does not change often.
 


### PR DESCRIPTION
Update code splitting titles for consistency.
