### PR TITLE
Add webpack-dev-server troubleshooting tip

### DIFF
--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -43,6 +43,9 @@ If you're using dev-server through the Node.js API, the options in `devServer` w
 
 W> Be aware that when [exporting multiple configurations](/configuration/configuration-types/#exporting-multiple-configurations) only the `devServer` options for the first configuration will be taken into account and used for all the configurations in the array.
 
+### Troubleshooting
+
+T> If you're having trouble, navigating to the `/webpack-dev-server` route will show where files are served. For example, `http://localhost:9000/webpack-dev-server`.
 
 ## `devServer.clientLogLevel`
 
@@ -272,7 +275,7 @@ Shows a full-screen overlay in the browser when there are compiler errors or war
 overlay: true
 ```
 
-If you want to show warnings as well as errors: 
+If you want to show warnings as well as errors:
 
 ```js
 overlay: {

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -43,9 +43,8 @@ If you're using dev-server through the Node.js API, the options in `devServer` w
 
 W> Be aware that when [exporting multiple configurations](/configuration/configuration-types/#exporting-multiple-configurations) only the `devServer` options for the first configuration will be taken into account and used for all the configurations in the array.
 
-### Troubleshooting
-
 T> If you're having trouble, navigating to the `/webpack-dev-server` route will show where files are served. For example, `http://localhost:9000/webpack-dev-server`.
+
 
 ## `devServer.clientLogLevel`
 


### PR DESCRIPTION
I suspect that this should probably go into its own section, but I'm not too sure, especially since the content is so thin.

I realize that this may seem like an unnecessary tip to experts, but I found it helpful - in my case, I had put a screwy output.filename in a quick project which had messed it up, so the logged output of `webpack output is served from /` wasn't quite right. Discovered this trick at http://stackoverflow.com/a/42592398/4200039

Hopefully a troubleshooting section can be expanded which in the long run will reduce the load of new issues opened.