### PR TITLE
Added IgnorePlugin at Plugins Index Page

### DIFF
--- a/content/plugins/index.md
+++ b/content/plugins/index.md
@@ -19,6 +19,7 @@ webpack has a rich plugin interface. Most of the features within webpack itself 
 |[`DllPlugin`](/plugins/dll-plugin)|Provide means to split bundles in a way that can drastically improve build time performance.|
 |[`ExtractTextWebpackPlugin`](/plugins/extract-text-webpack-plugin)|Extracts Text (CSS) from your bundles into a separate file (app.bundle.css)|
 |[`HtmlWebpackPlugin`](/plugins/html-webpack-plugin)| Simplifies creation of HTML files (`index.html`) to serve your bundles|
+|[`IgnorePlugin`](/plugins/ignore-plugin)| Excludes certain modules from bundles|
 |[`I18nWebpackPlugin`](/plugins/i18n-webpack-plugin)|Adds i18n support to your bundles|
 |[`LimitChunkCountPlugin`](/plugins/limit-chunk-count-plugin)| Set min/max limits for chunking to fine tune and control chunking|
 |[`NormalModuleReplacementPlugin`](/plugins/normal-module-replacement-plugin)|Replaces resource that matches a regexp|


### PR DESCRIPTION
This adds the `IgnorePlugin Link` at Plugins List Page

It will affect the Plugins Page:
https://webpack.js.org/plugins/

It complements #1014
It is the second try to #1232