### PR TITLE
add required babel plugin for async functions

### DIFF
--- a/content/guides/code-splitting-async.md
+++ b/content/guides/code-splitting-async.md
@@ -134,7 +134,7 @@ Not using the `syntax-dynamic-import` plugin will fail the build with:
 To use ES2017 [`async`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function)/[`await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await) with `import()`:
 
 ```bash
-npm install --save-dev babel-plugin-transform-async-to-generator babel-plugin-transform-regenerator babel-plugin-transform-runtime
+npm install --save-dev babel-plugin-transform-async-to-generator babel-plugin-transform-regenerator babel-plugin-transform-runtime babel-plugin-syntax-async-functions
 ```
 
 __index-es2017.js__

--- a/content/guides/code-splitting-async.md
+++ b/content/guides/code-splitting-async.md
@@ -165,6 +165,7 @@ module.exports = {
         options: {
           presets: [['es2015', {modules: false}]],
           plugins: [
+            'syntax-async-functions',
             'syntax-dynamic-import',
             'transform-async-to-generator',
             'transform-regenerator',


### PR DESCRIPTION
fix webpack config in async/await with dynamic imports to include the `babel-plugin-syntax-async-functions` babel plugin.
