### PR TITLE
README: fix the href to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To develop, please pull the project, `cd` into the directory and run:
 
 If you want to fetch the documentation on additional loaders/plugins hosted in [separate repositories](https://github.com/webpack), run `npm run fetch`.
 
-For more information see the [contributors page](https://github.com/webpack/webpack.js.org/blob/master/CONTRIBUTING.md)
+For more information see the [contributors page](https://github.com/webpack/webpack.js.org/blob/master/.github/CONTRIBUTING.md)
 
 ## Content Progress
 


### PR DESCRIPTION
The link to the CONTRIBUTING.md file in this project's README currently returns a 404. This PR corrects the href.