### PR TITLE
Test for Local Storage

### DIFF
--- a/components/notification-bar/notification-bar.jsx
+++ b/components/notification-bar/notification-bar.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Container from '../container/container';
+import testLocalStorage from '../../utilities/test-local-storage';
 
 const version = '1';
 
@@ -41,7 +42,7 @@ export default class NotificationBar extends React.Component {
    * @return {boolean} - Whether or not the current message was dismissed
    */
   get _dismissed() {
-    if (typeof window !== 'undefined') {
+    if (testLocalStorage()) {
       return localStorage.getItem('notification-dismissed') === version;
 
     } else return false;

--- a/components/notification-bar/notification-bar.jsx
+++ b/components/notification-bar/notification-bar.jsx
@@ -3,6 +3,7 @@ import Container from '../container/container';
 import testLocalStorage from '../../utilities/test-local-storage';
 
 const version = '1';
+const localStorageIsEnabled = testLocalStorage() !== false;
 
 export default class NotificationBar extends React.Component {
   render() {
@@ -16,10 +17,12 @@ export default class NotificationBar extends React.Component {
           </p>
           <p>
             Buy the brand-new webpack stickers at <a href="http://www.unixstickers.com/tag/webpack">Unixstickers!</a>
-
-            <i
-              className="notification-bar__close icon-cross"
-              onClick={ this._close.bind(this) } />
+            {localStorageIsEnabled ?
+              <i
+                className="notification-bar__close icon-cross"
+                onClick={ this._close.bind(this) } /> :
+              null
+            }
           </p>
         </Container>
       </div>
@@ -32,7 +35,9 @@ export default class NotificationBar extends React.Component {
    * @param {object} e - Click event
    */
   _close(e) {
-    localStorage.setItem('notification-dismissed', version);
+    if (localStorageIsEnabled) {
+      localStorage.setItem('notification-dismissed', version);
+    }
     this.forceUpdate();
   }
 
@@ -42,7 +47,7 @@ export default class NotificationBar extends React.Component {
    * @return {boolean} - Whether or not the current message was dismissed
    */
   get _dismissed() {
-    if (testLocalStorage()) {
+    if (localStorageIsEnabled) {
       return localStorage.getItem('notification-dismissed') === version;
 
     } else return false;

--- a/utilities/test-local-storage.js
+++ b/utilities/test-local-storage.js
@@ -1,0 +1,15 @@
+/**
+ * Test if localStorage is enabled.
+ *
+ * {@link https://github.com/Modernizr/Modernizr/blob/master/feature-detects/storage/localstorage.js}
+ * @return {undefined|bool} Returns false on error.
+ */
+module.exports = function() {
+  const test = "localStorageTest";
+  try {
+    localStorage.setItem(test, test);
+    localStorage.removeItem(test);
+  } catch (e) {
+    return false;
+  }
+};


### PR DESCRIPTION
Addresses https://github.com/webpack/webpack.js.org/issues/1247

- Adds a utility function to test for `localStorage` via https://github.com/Modernizr/Modernizr/blob/master/feature-detects/storage/localstorage.js
- Tests for `localStorage` everywhere it may be accessed in `components/notification-bar/notification-bar.jsx`
- If `localStorage` is disabled, the notification bar is rendered without the icon to close it. This means that users with `localStorage` disabled will have no way to dismiss the notification bar (which seems like a fair compromise).