### PR TITLE
Mixed Module Syntaxes

### DIFF
--- a/content/api/module-methods.md
+++ b/content/api/module-methods.md
@@ -13,6 +13,8 @@ related:
 
 This section covers all methods available in code compiled with webpack. When using webpack to bundle your application, you can pick from a variety of module syntax styles including [ES6](https://en.wikipedia.org/wiki/ECMAScript#6th_Edition_-_ECMAScript_2015), [CommonJS](https://en.wikipedia.org/wiki/CommonJS), and [AMD](https://en.wikipedia.org/wiki/Asynchronous_module_definition).
 
+W> While webpack supports multiple module syntaxes, we recommend following a single syntax for consistency and to avoid odd behaviors/bugs. Here's [one example](https://github.com/webpack/webpack.js.org/issues/552) of mixing ES6 and CommonJS, however there are surely others.
+
 
 ## ES6 (Recommended)
 


### PR DESCRIPTION
Add warning about mixing module syntaxes in _Module API - Methods_.

Resolves #552 

