### PR TITLE
Points out that outputFileSystem needs of methods

### DIFF
--- a/content/api/node.md
+++ b/content/api/node.md
@@ -277,4 +277,4 @@ compiler.run((err, stats) => {
 });
 ```
 
-T> The output file system you provide needs to be compatible with Node’s own [`fs`](https://nodejs.org/api/fs.html) module interface, and other two helper methods `mkdirp`, `join` are also needed.
+T> The output file system you provide needs to be compatible with Node’s own [`fs`](https://nodejs.org/api/fs.html) module interface, which requires the `mkdirp` and `join` helper methods.

--- a/content/api/node.md
+++ b/content/api/node.md
@@ -277,4 +277,4 @@ compiler.run((err, stats) => {
 });
 ```
 
-T> The output file system you provide needs to be compatible with Node’s own [`fs`](https://nodejs.org/api/fs.html) module interface.
+T> The output file system you provide needs to be compatible with Node’s own [`fs`](https://nodejs.org/api/fs.html) module interface, and other two helper methods `mkdirp`, `join` are also needed.


### PR DESCRIPTION
the `mkdirp` and `join` are also needed by [`outputFileSystem`](https://github.com/webpack/webpack/blob/efc576c8b744e7a015ab26f1f46932ba3ca7d4f1/lib/node/NodeOutputFileSystem.js).


