### PR TITLE
Improve LibraryTarget Docs

### DIFF
--- a/content/configuration/index.md
+++ b/content/configuration/index.md
@@ -62,7 +62,6 @@ module.exports = {
     <details><summary>[libraryTarget](/configuration/output#output-librarytarget): "umd", // universal module definition</summary>
         [libraryTarget](/configuration/output#output-librarytarget): "umd2", // universal module definition
         [libraryTarget](/configuration/output#output-librarytarget): "commonjs2", // exported with module.exports
-        [libraryTarget](/configuration/output#output-librarytarget): "commonjs-module", // exports with module.exports
         [libraryTarget](/configuration/output#output-librarytarget): "commonjs", // exported as properties to exports
         [libraryTarget](/configuration/output#output-librarytarget): "amd", // defined with AMD defined method
         [libraryTarget](/configuration/output#output-librarytarget): "this", // property set on this

--- a/content/configuration/index.md
+++ b/content/configuration/index.md
@@ -305,7 +305,7 @@ module.exports = {
     </details>
     [maxAssetSize](/configuration/performance#performance-maxassetsize): 200000, // int (in bytes),
     [maxEntrypointSize](/configuration/performance#performance-maxentrypointsize): 400000, // int (in bytes)
-    [assetFilter](/configuration/performance#performance-assetfilter): function(assetFilename) { 
+    [assetFilter](/configuration/performance#performance-assetfilter): function(assetFilename) {
       // Function predicate that provides asset filenames
       return assetFilename.endsWith('.css') || assetFilename.endsWith('.js');
     }
@@ -317,7 +317,7 @@ module.exports = {
   [devtool](/configuration/devtool): "hidden-source-map", // SourceMap without reference in original file
   [devtool](/configuration/devtool): "cheap-source-map", // cheap-variant of SourceMap without module mappings
   [devtool](/configuration/devtool): "cheap-module-source-map", // cheap-variant of SourceMap with module mappings
-  [devtool](/configuration/devtool): "eval", // no SourceMap, but named modules. Fastest at the expense of detail. 
+  [devtool](/configuration/devtool): "eval", // no SourceMap, but named modules. Fastest at the expense of detail.
   </details>
   // enhance debugging by adding meta info for the browser devtools
   // source-map most detailed at the expense of build speed.
@@ -384,8 +384,8 @@ module.exports = {
     // ...
   ],
   // list of additional plugins
-  
-  
+
+
   <details><summary>/* Advanced configuration (click to show) */</summary>
 
   [resolveLoader](/configuration/resolve#resolveloader): { /* same as resolve */ }
@@ -393,10 +393,10 @@ module.exports = {
 
   [profile](other-options#profile): true, // boolean
   // capture timing information
-  
+
   [bail](other-options#bail): true, //boolean
   // fail out on the first error instead of tolerating it.
-  
+
   [cache](other-options#cache): false, // boolean
   // disable/enable caching
 

--- a/content/configuration/output.md
+++ b/content/configuration/output.md
@@ -335,10 +335,7 @@ module.exports = _entry_return_;
 require("MyLibrary").doSomething();
 ```
 
-_Wondering the difference between CommonJS and CommonJS2? Check [this](https://github.com/webpack/webpack/issues/1114) out (they are pretty much the same)._
-
-
-`libraryTarget: "commonjs-module"` - Expose it using the `module.exports` object (`output.library` is ignored), `__esModule` is defined (it's threaded as ES2015 Module in interop mode)
+T> Wondering the difference between CommonJS and CommonJS2? Check [this](https://github.com/webpack/webpack/issues/1114) out (they are pretty much the same).
 
 
 `libraryTarget: "amd"` - In this case webpack will make your library an AMD module.

--- a/content/configuration/output.md
+++ b/content/configuration/output.md
@@ -245,8 +245,6 @@ If using the [`output.library`](#output-library) option, the library name is aut
 
 `string`
 
-Read the [library guide](/guides/author-libraries) for details.
-
 Use `library`, and `libraryTarget` below, when writing a JavaScript library that should export values, which can be used by other code depending on it. Pass a string with the name of the library:
 
 ``` js
@@ -257,6 +255,8 @@ The name is used depending on the value of the [`output.libraryTarget`](#output-
 
 Note that `output.libraryTarget` defaults to `var`. This means if only `output.library` is used it is exported as variable declaration (when used as script tag it's available in the global scope after execution).
 
+T> Read the [authoring libraries guide](/guides/author-libraries) guide for more information on `output.library` as well as `ouput.libraryTarget`.
+
 
 ## `output.libraryTarget`
 
@@ -264,14 +264,9 @@ Note that `output.libraryTarget` defaults to `var`. This means if only `output.l
 
 > Default: `"var"`
 
-Read the [library guide](/guides/author-libraries) for details.
-
 Configure how the library will be exposed. Any one of the following options can be used.
 
-> To give your library a name, set the `output.library` config to it (the examples assume `library: "MyLibrary"`)
-
 The following options are supported:
-
 
 `libraryTarget: "var"` - (default) When your library is loaded, the **return value of your entry point** will be assigned to a variable:
 
@@ -340,22 +335,17 @@ T> Wondering the difference between CommonJS and CommonJS2? Check [this](https:/
 
 `libraryTarget: "amd"` - In this case webpack will make your library an AMD module.
 
-But there is a very important pre-requisite, your entry chunk must be defined with the define property, if not, webpack will create the AMD module, but without dependencies.
-The output will be something like this:
+Note that your entry chunk must be defined with the `define` property, if not, webpack will create the AMD module, but without dependencies. The output will be something like this:
 
 ```javascript
 define([], function() {
-	//what this module returns is what your entry chunk returns
+	// This module returns is what your entry chunk returns
 });
 ```
 
-But if you download this script, you may get an error: `define is not defined`, it’s ok! If you are distributing your library with AMD, then your users need to use RequireJS to load it.
+If you download this script, you may get an error: `define is not defined`, it’s ok! If you are distributing your library with AMD, then your users need to use RequireJS to load it. Once you have RequireJS loaded, you can load your library.
 
-Now that you have RequireJS loaded, you can load your library.
-
-But, `require([ _what?_ ])`?
-
-`output.library`!
+So, with the following configuration...
 
 ```javascript
 output: {
@@ -364,25 +354,16 @@ output: {
 }
 ```
 
-So your module will be like:
+users will be able to call your library like so:
 
 ```javascript
-define("MyLibrary", [], function() {
-	//what this module returns is what your entry chunk returns
+require(['MyLibrary'], function(MyLibrary) {
+	// Do something with the library...
 });
 ```
 
-And you can use it like this:
 
-```javascript
-// And then your users will be able to do:
-require(["MyLibrary"], function(MyLibrary){
-	MyLibrary.doSomething();
-});
-```
-
-`libraryTarget: "umd"` - This is a way for your library to work with all the module definitions (and where aren't modules at all).
-It will work with CommonJS, AMD and as global variable. You can check the [UMD Repository](https://github.com/umdjs/umd) to know more about it.
+`libraryTarget: "umd"` - This is a way for your library to work with all the module definitions (and where aren't modules at all). It will work with CommonJS, AMD and as global variable. Take a look at the [UMD Repository](https://github.com/umdjs/umd) to learn more.
 
 In this case, you need the `library` property to name your module:
 

--- a/content/configuration/output.md
+++ b/content/configuration/output.md
@@ -152,15 +152,15 @@ Note this options does not affect output files for on-demand-loaded chunks. For 
 
 The following substitutions are available in template strings (via webpack's internal [`TemplatedPathPlugin`](https://github.com/webpack/webpack/blob/master/lib/TemplatedPathPlugin.js)):
 
-| Template    | Description |
-| ----------- | ----------- |
-| [hash]      | The hash of the module identifier |
-| [chunkhash] | The hash of the chunk content |
-| [name]      | The module name |
-| [id]        | The module identifier |
-| [file]      | The module filename |
+| Template    | Description                                                                         |
+| ----------- | ----------------------------------------------------------------------------------- |
+| [hash]      | The hash of the module identifier                                                   |
+| [chunkhash] | The hash of the chunk content                                                       |
+| [name]      | The module name                                                                     |
+| [id]        | The module identifier                                                               |
+| [file]      | The module filename                                                                 |
 | [filebase]  | The module [basename](https://nodejs.org/api/path.html#path_path_basename_path_ext) |
-| [query]     | The module query, i.e., the string following `?` in the filename |
+| [query]     | The module query, i.e., the string following `?` in the filename                    |
 
 The lengths of `[hash]` and `[chunkhash]` can be specified using `[hash:16]` (defaults to 20). Alternatively, specify [`output.hashDigestLength`](#output-hashdigestlength) to configure the length globally.
 

--- a/content/guides/author-libraries.md
+++ b/content/guides/author-libraries.md
@@ -197,7 +197,7 @@ module.exports = {
     output: {
         ...
         library: 'webpackNumbers',
-        libraryTarget: 'umd' // Possible value - amd, commonjs, commonjs2, commonjs-module, this, var
+        libraryTarget: 'umd'
     }
     ...
 };

--- a/content/guides/author-libraries.md
+++ b/content/guides/author-libraries.md
@@ -202,7 +202,7 @@ module.exports = {
 };
 ```
 
-If `library` is set and `libraryTarget` is not, `libraryTarget` defaults to `var` as specified in the [config reference](/configuration/output).
+If `library` is set and `libraryTarget` is not, `libraryTarget` defaults to `var` as specified in the [output configuration documentation](/configuration/output). See [`output.libraryTarget`](/configuration/output#output-librarytarget) there for a detailed list of all available options.
 
 
 ### Final Steps

--- a/content/guides/author-libraries.md
+++ b/content/guides/author-libraries.md
@@ -1,10 +1,10 @@
 ---
 title: Authoring Libraries
 contributors:
-    - pksjce
-    - johnstew
-    - simon04
-    - 5angel
+  - pksjce
+  - johnstew
+  - simon04
+  - 5angel
 ---
 
 webpack is a tool which can be used to bundle application code and also to bundle library code. If you are the author of a JavaScript library and are looking to streamline your bundle strategy then this document will help you.
@@ -186,8 +186,7 @@ module.exports = {
 };
 ```
 
-This makes your library bundle to be available as a global variable when imported.
-To make the library compatible with other environments, add `libraryTarget` property to the config.
+This makes your library bundle to be available as a global variable when imported. To make the library compatible with other environments, add `libraryTarget` property to the config.
 
 __webpack.config.js__
 


### PR DESCRIPTION
Removes the `commonjs-module` option (#545) and cleans up some of the surrounding docs.

Resolves #545