### PR TITLE
Fix import typo in code example.

### DIFF
--- a/content/guides/hot-module-replacement.md
+++ b/content/guides/hot-module-replacement.md
@@ -55,7 +55,7 @@ Not too bad, huh? Let's test it out using `module.hot.accept`...
 __index.js__
 
 ``` js
-import Lib from './library';
+import Library from './library';
 
 if (module.hot) {
   module.hot.accept('./library', function() {


### PR DESCRIPTION
Current documentation is importing a module called `Lib`, but is being used as `Library` later on in the code example. I simply changed `Lib` to `Library` to better clarify.
