### PR TITLE
Fix typo in docs

### DIFF
--- a/content/concepts/index.md
+++ b/content/concepts/index.md
@@ -63,7 +63,7 @@ The `output` property has [many more configurable features](/configuration/outpu
 
 ## Loaders
 
-The goal is to have all of the assets in your project to be **webpack's** concern and not the browser's. (This doesn't mean that they all have to be bundled together). webpack treats [every file (.css, .html, .scss, .jpg, etc.) as a module](/concepts/modules). However, webpack **only understands JavaScript**.
+The goal is to have all of the assets in your project be **webpack's** concern and not the browser's. (This doesn't mean that they all have to be bundled together). webpack treats [every file (.css, .html, .scss, .jpg, etc.) as a module](/concepts/modules). However, webpack **only understands JavaScript**.
 
 **Loaders in webpack _transform these files into modules_ as they are added to your dependency graph.**
 


### PR DESCRIPTION
"The goal is **to have** .... **to be**"

should be

"The goal is **to have** ... **be**"