### PR TITLE
Improve sidebar and gitter components' performance (Was: 'Use passive event listeners for scroll events')

### DIFF
--- a/components/gitter/gitter.jsx
+++ b/components/gitter/gitter.jsx
@@ -3,6 +3,11 @@ import testPassiveListeners from '../../utilities/test-passive-listeners';
 
 const supportsPassive = testPassiveListeners() !== false;
 
+let footerHeight;
+if (typeof window !== 'undefined') {
+    footerHeight = document.querySelector('footer').offsetHeight;
+}
+
 export default class Gitter extends React.Component {
   constructor(props) {
     super(props);
@@ -52,7 +57,6 @@ export default class Gitter extends React.Component {
     let { scrollY, innerHeight } = window;
     let { scrollHeight } = document.body;
     let distToBottom = scrollHeight - scrollY - innerHeight;
-    let footerHeight = document.querySelector('footer').offsetHeight;
 
     this.setState({
       offset: distToBottom < footerHeight ? footerHeight - distToBottom : 0

--- a/components/gitter/gitter.jsx
+++ b/components/gitter/gitter.jsx
@@ -4,9 +4,6 @@ import testPassiveListeners from '../../utilities/test-passive-listeners';
 const supportsPassive = testPassiveListeners() !== false;
 
 let footerHeight;
-if (typeof window !== 'undefined') {
-    footerHeight = document.querySelector('footer').offsetHeight;
-}
 
 export default class Gitter extends React.Component {
   constructor(props) {
@@ -57,6 +54,9 @@ export default class Gitter extends React.Component {
     let { scrollY, innerHeight } = window;
     let { scrollHeight } = document.body;
     let distToBottom = scrollHeight - scrollY - innerHeight;
+    if (!footerHeight) {
+      footerHeight = document.querySelector('footer').innerHeight;
+    }
 
     this.setState({
       offset: distToBottom < footerHeight ? footerHeight - distToBottom : 0

--- a/components/gitter/gitter.jsx
+++ b/components/gitter/gitter.jsx
@@ -32,14 +32,15 @@ export default class Gitter extends React.Component {
     );
 
     document.addEventListener(
-      'scroll', 
-      this._recalculate.bind(this)
+      'scroll',
+      this._recalculate.bind(this),
+      { passive: true }
     );
   }
 
   componentWillUnmount() {
     document.removeEventListener(
-      'scroll', 
+      'scroll',
       this._recalculate.bind(this)
     );
   }

--- a/components/gitter/gitter.jsx
+++ b/components/gitter/gitter.jsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import testPassiveListeners from '../../utilities/test-passive-listeners';
+
+const supportsPassive = testPassiveListeners() !== false;
 
 export default class Gitter extends React.Component {
   constructor(props) {
@@ -14,8 +17,8 @@ export default class Gitter extends React.Component {
 
     return (
       <span className="gitter">
-        <div 
-          className="gitter__button js-gitter-toggle-chat-button" 
+        <div
+          className="gitter__button js-gitter-toggle-chat-button"
           style={{
             marginBottom: offset
           }}>
@@ -34,7 +37,7 @@ export default class Gitter extends React.Component {
     document.addEventListener(
       'scroll',
       this._recalculate.bind(this),
-      { passive: true }
+      supportsPassive ? { passive: true } : false
     );
   }
 

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -1,5 +1,8 @@
 import React, { Component } from 'react';
 import SidebarItem from '../sidebar-item/sidebar-item';
+import testPassiveListeners from '../../utilities/test-passive-listeners';
+
+const supportsPassive = testPassiveListeners() !== false;
 
 export default class Sidebar extends Component {
   constructor(props) {
@@ -65,7 +68,7 @@ export default class Sidebar extends Component {
     document.addEventListener(
       'scroll',
       this._recalculate.bind(this),
-      { passive: true }
+      supportsPassive ? { passive: true } : false
     );
   }
 

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -64,7 +64,8 @@ export default class Sidebar extends Component {
 
     document.addEventListener(
       'scroll',
-      this._recalculate.bind(this)
+      this._recalculate.bind(this),
+      { passive: true }
     );
   }
 

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -4,6 +4,13 @@ import testPassiveListeners from '../../utilities/test-passive-listeners';
 
 const supportsPassive = testPassiveListeners() !== false;
 
+let effectiveHeaderHeight;
+let footerHeight;
+if (typeof window !== 'undefined') {
+    effectiveHeaderHeight = document.querySelector('header').offsetHeight + document.querySelector('.notification-bar').offsetHeight;
+    footerHeight = document.querySelector('footer').offsetHeight;
+}
+
 export default class Sidebar extends Component {
   constructor(props) {
     super(props);
@@ -88,16 +95,14 @@ export default class Sidebar extends Component {
     let { scrollHeight } = document.body;
     let { offsetHeight: sidebarHeight } = this._container;
     let { offsetWidth: parentWidth, offsetHeight: parentHeight } = this._container.parentNode;
-    let headerHeight = document.querySelector('header').offsetHeight + document.querySelector('.notification-bar').offsetHeight;
-    let footerHeight = document.querySelector('footer').offsetHeight;
     let distToBottom = scrollHeight - scrollY - innerHeight;
 
     // Calculate the space that the footer and header are actually occupying
-    let headerSpace = scrollY > headerHeight ? 0 : headerHeight - scrollY;
+    let headerSpace = scrollY > effectiveHeaderHeight ? 0 : effectiveHeaderHeight - scrollY;
     let footerSpace = distToBottom > footerHeight ? 0 : footerHeight - distToBottom;
 
     this.setState({
-      fixed: scrollY >= headerHeight && sidebarHeight < parentHeight,
+      fixed: scrollY >= effectiveHeaderHeight && sidebarHeight < parentHeight,
       availableHeight: innerHeight - headerSpace - footerSpace,
       maxWidth: parentWidth
     });

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -6,10 +6,6 @@ const supportsPassive = testPassiveListeners() !== false;
 
 let effectiveHeaderHeight;
 let footerHeight;
-if (typeof window !== 'undefined') {
-    effectiveHeaderHeight = document.querySelector('header').offsetHeight + document.querySelector('.notification-bar').offsetHeight;
-    footerHeight = document.querySelector('footer').offsetHeight;
-}
 
 export default class Sidebar extends Component {
   constructor(props) {
@@ -96,6 +92,10 @@ export default class Sidebar extends Component {
     let { offsetHeight: sidebarHeight } = this._container;
     let { offsetWidth: parentWidth, offsetHeight: parentHeight } = this._container.parentNode;
     let distToBottom = scrollHeight - scrollY - innerHeight;
+    if (!effectiveHeaderHeight || !footerHeight) {
+      effectiveHeaderHeight = document.querySelector('header').offsetHeight + document.querySelector('.notification-bar').offsetHeight;
+      footerHeight = document.querySelector('footer').offsetHeight;
+    }
 
     // Calculate the space that the footer and header are actually occupying
     let headerSpace = scrollY > effectiveHeaderHeight ? 0 : effectiveHeaderHeight - scrollY;

--- a/utilities/test-passive-listeners.js
+++ b/utilities/test-passive-listeners.js
@@ -1,0 +1,20 @@
+/**
+ * Test if passive event listeners are supported.
+ *
+ * {@link https://github.com/Modernizr/Modernizr/blob/master/feature-detects/dom/passiveeventlisteners.js}
+ * @return {undefined|bool} Returns false on error.
+ */
+module.exports = function() {
+  const test = "passiveListenersTest";
+  let supportsPassive = false;
+    try {
+      const opts = Object.defineProperty({}, 'passive', {
+        get() {
+          supportsPassive = true;
+        }
+      });
+      window.addEventListener('test', null, opts);
+    } catch (e) {
+      return false;
+    }
+};

--- a/utilities/test-passive-listeners.js
+++ b/utilities/test-passive-listeners.js
@@ -7,14 +7,14 @@
 module.exports = function() {
   const test = "passiveListenersTest";
   let supportsPassive = false;
-    try {
-      const opts = Object.defineProperty({}, 'passive', {
-        get() {
-          supportsPassive = true;
-        }
-      });
-      window.addEventListener('test', null, opts);
-    } catch (e) {
-      return false;
-    }
+  try {
+    const opts = Object.defineProperty({}, 'passive', {
+      get() {
+        supportsPassive = true;
+      }
+    });
+    window.addEventListener('test', null, opts);
+  } catch (e) {
+    return false;
+  }
 };

--- a/utilities/test-passive-listeners.js
+++ b/utilities/test-passive-listeners.js
@@ -6,10 +6,10 @@
  */
 module.exports = function() {
   const test = "passiveListenersTest";
-  let supportsPassive = false;
+  var supportsPassive = false;
   try {
     const opts = Object.defineProperty({}, 'passive', {
-      get() {
+      get: function() {
         supportsPassive = true;
       }
     });

--- a/utilities/test-passive-listeners.js
+++ b/utilities/test-passive-listeners.js
@@ -5,7 +5,7 @@
  * @return {undefined|bool} Returns false on error.
  */
 module.exports = function() {
-  const test = "passiveListenersTest";
+  const test = 'passiveListenersTest';
   var supportsPassive = false;
   try {
     const opts = Object.defineProperty({}, 'passive', {


### PR DESCRIPTION
This PR adds the `passive: true` flag to `addEventListener` calls that monitor the scroll event, which indicates to the browser that the listener function will not call `preventDefault`. That lets the browser make some optimizations which improve performance.

As a note this would be much more performant and simpler using either `position: sticky` or alternating between `position: fixed` and `absolute` based on scroll position, as JS would be eliminated. On my machine the `_recalculate()` function called each scroll event consumes around 60ms (15fps)