### PR TITLE
Add Redirect to Production Guide

### DIFF
--- a/antwar.config.js
+++ b/antwar.config.js
@@ -69,7 +69,8 @@ module.exports = {
       }, {
         'code-splitting-import': '/guides/code-splitting-async',
         'code-splitting-require': '/guides/code-splitting-async/#require-ensure-',
-        'why-webpack': '/guides/comparison'
+        'why-webpack': '/guides/comparison',
+        'production-build': '/guides/production'
       }
     ),
 


### PR DESCRIPTION
Noticed a broken link to `production-build` in the react documentation, and there are probably others out there as well.