### PR TITLE
Update Devtool

### DIFF
--- a/content/configuration/devtool.md
+++ b/content/configuration/devtool.md
@@ -26,18 +26,18 @@ Choose a style of [source mapping](http://blog.teamtreehouse.com/introduction-so
 
 T> The webpack repository contains an [example showing the effect of all `devtool` variants](https://github.com/webpack/webpack/tree/master/examples/source-map). Those examples will likely help you to understand the differences.
 
-devtool                      | build | rebuild | production | quality
------------------------------|-------|---------|------------|------------------------------
-eval                         | +++   | +++     | no         | generated code
-inline-source-map            | ++    | ++      | no         | generated code
-cheap-eval-source-map        | +     | ++      | no         | transformed code (lines only)
-cheap-source-map             | +     | o       | yes        | transformed code (lines only)
-cheap-module-eval-source-map | o     | ++      | no         | original source (lines only)
-cheap-module-source-map      | o     | -       | yes        | original source (lines only)
-eval-source-map              | --    | +       | no         | original source
-source-map                   | --    | --      | yes        | original source
-hidden-source-map            | --    | --      | yes        | original source
-nosources-source-map         | --    | --      | yes        | without source content
+devtool                       | build | rebuild | production | quality
+----------------------------- | ----- | ------- | ---------- | -----------------------------
+eval                          | +++   | +++     | no         | generated code
+cheap-eval-source-map         | +     | ++      | no         | transformed code (lines only)
+cheap-source-map              | +     | o       | yes        | transformed code (lines only)
+cheap-module-eval-source-map  | o     | ++      | no         | original source (lines only)
+cheap-module-source-map       | o     | -       | yes        | original source (lines only)
+eval-source-map               | --    | +       | no         | original source
+source-map                    | --    | --      | yes        | original source
+inline-source-map             | --    | --      | no         | original source
+hidden-source-map             | --    | --      | yes        | original source
+nosources-source-map          | --    | --      | yes        | without source content
 
 T> `+` means faster, `-` slower and `o` about the same time
 

--- a/content/configuration/devtool.md
+++ b/content/configuration/devtool.md
@@ -6,11 +6,17 @@ contributors:
   - skipjack
   - SpaceK33z
   - lricoy
+related:
+  - title: Enabling Sourcemaps
+    url: http://survivejs.com/webpack/developing-with-webpack/enabling-sourcemaps/
+  - title: Webpack's Devtool Source Map
+    url: http://cheng.logdown.com/posts/2016/03/25/679045
 ---
 
 This option controls if and how source maps are generated.
 
 Use the [`SourceMapDevToolPlugin`](/plugins/source-map-dev-tool-plugin) for a more fine grained configuration. See the [`source-map-loader`](/loaders/source-map-loader) to deal with existing source maps.
+
 
 ## `devtool`
 
@@ -20,16 +26,18 @@ Choose a style of [source mapping](http://blog.teamtreehouse.com/introduction-so
 
 T> The webpack repository contains an [example showing the effect of all `devtool` variants](https://github.com/webpack/webpack/tree/master/examples/source-map). Those examples will likely help you to understand the differences.
 
- devtool                      | build | rebuild | production | quality
-------------------------------|-------|---------|------------|--------------------------
- eval                         | +++   | +++     | no         | generated code
- cheap-eval-source-map        | +     | ++      | no         | transformed code (lines only)
- cheap-source-map             | +     | o       | yes        | transformed code (lines only)
- cheap-module-eval-source-map | o     | ++      | no         | original source (lines only)
- cheap-module-source-map      | o     | -       | yes        | original source (lines only)
- eval-source-map              | --    | +       | no         | original source
- source-map                   | --    | --      | yes        | original source
- nosources-source-map         | --    | --      | yes        | without source content
+devtool                      | build | rebuild | production | quality
+-----------------------------|-------|---------|------------|------------------------------
+eval                         | +++   | +++     | no         | generated code
+inline-source-map            | ++    | ++      | no         | generated code
+cheap-eval-source-map        | +     | ++      | no         | transformed code (lines only)
+cheap-source-map             | +     | o       | yes        | transformed code (lines only)
+cheap-module-eval-source-map | o     | ++      | no         | original source (lines only)
+cheap-module-source-map      | o     | -       | yes        | original source (lines only)
+eval-source-map              | --    | +       | no         | original source
+source-map                   | --    | --      | yes        | original source
+hidden-source-map            | --    | --      | yes        | original source
+nosources-source-map         | --    | --      | yes        | without source content
 
 T> `+` means faster, `-` slower and `o` about the same time
 
@@ -37,7 +45,12 @@ Some of these values are suited for development and some for production. For dev
 
 W> There are some issues with Source Maps in Chrome. [We need your help!](https://github.com/webpack/webpack/issues/3165).
 
-### For development
+T> See [`output.sourceMapFilename`](/configuration/output#output-sourcemapfilename) to customize the filenames of generated Source Maps.
+
+
+### Development
+
+The following options are ideal for development:
 
 `eval` - Each module is executed with `eval()` and `//@ sourceURL`. This is pretty fast. The main disadvantage is that it doesn't display line numbers correctly since it gets mapped to transpiled code instead of the original code.
 
@@ -45,9 +58,14 @@ W> There are some issues with Source Maps in Chrome. [We need your help!](https:
 
 `eval-source-map` - Each module is executed with `eval()` and a SourceMap is added as a DataUrl to the `eval()`. Initially it is slow, but it provides fast rebuild speed and yields real files. Line numbers are correctly mapped since it gets mapped to the original code.
 
-`cheap-module-eval-source-map` - Like `eval-source-map`, each module is executed with `eval()` and a SourceMap is added as a DataUrl to the `eval()`. It is "cheap" because it doesn't have column mappings, it only maps line numbers.
+`cheap-eval-source-map` - Similar to `eval-source-map`, each module is executed with `eval()` and a Source Map is added as a Data URL.
 
-### For production
+`cheap-module-eval-source-map` - Like `eval-source-map`, each module is executed with `eval()` and a Source Map is added as a Data URL. It is "cheap" because it doesn't have column mappings, it only maps line numbers.
+
+
+### Production
+
+These options are typically used in production:
 
 `source-map` - A full SourceMap is emitted as a separate file. It adds a reference comment to the bundle so development tools know where to find it.
 
@@ -58,12 +76,3 @@ W> There are some issues with Source Maps in Chrome. [We need your help!](https:
 `cheap-module-source-map` - A SourceMap without column-mappings that simplifies loaded Source Maps to a single mapping per line.
 
 `nosources-source-map` - A SourceMap is created without the `sourcesContent` in it. It can be used to map stack traces on the client without exposing all of the source code.
-
-T> See [`output.sourceMapFilename`](/configuration/output#output-sourcemapfilename) to customize the filenames of generated Source Maps.
-
-?> This page needs more information to make it easier for users to choose a good option.
-
-# References
-
-- [Enabling Sourcemaps](http://survivejs.com/webpack/developing-with-webpack/enabling-sourcemaps/)
-- [webpack devtool source map](http://cheng.logdown.com/posts/2016/03/25/679045)

--- a/content/configuration/devtool.md
+++ b/content/configuration/devtool.md
@@ -58,9 +58,9 @@ The following options are ideal for development:
 
 `eval-source-map` - Each module is executed with `eval()` and a SourceMap is added as a DataUrl to the `eval()`. Initially it is slow, but it provides fast rebuild speed and yields real files. Line numbers are correctly mapped since it gets mapped to the original code.
 
-`cheap-eval-source-map` - Similar to `eval-source-map`, each module is executed with `eval()` and a Source Map is added as a Data URL.
+`cheap-eval-source-map` - Similar to `eval-source-map`, each module is executed with `eval()`. However, with this option the Source Map is passed as a Data URL to the `eval()` call. It is "cheap" because it doesn't have column mappings, it only maps line numbers.
 
-`cheap-module-eval-source-map` - Like `eval-source-map`, each module is executed with `eval()` and a Source Map is added as a Data URL. It is "cheap" because it doesn't have column mappings, it only maps line numbers.
+`cheap-module-eval-source-map` - Similar to `cheap-eval-source-map`, however in this case this case loaders are able to process the mapping for better results.
 
 
 ### Production


### PR DESCRIPTION
Update devtool.md and add missing options.

Adds missing bits for the `inline-source-map`, `hidden-source-map` and `cheap-eval-source-map` options. Also did a bit of cleanup...

Resolves #686