### PR TITLE
Adding warning about overwriting process

### DIFF
--- a/content/plugins/define-plugin.md
+++ b/content/plugins/define-plugin.md
@@ -83,6 +83,8 @@ new webpack.DefinePlugin({
 })
 ```
 
+W> When defining values for `process` prefer `'process.env.NODE_ENV': JSON.stringify('production')` over `process: { env: { NODE_ENV: JSON.stringify('production') } }`. Using the latter will overwrite the `process` object which can break compatibility with some modules that expect other values on the process object to be defined.
+
 
 ## Service URLs
 


### PR DESCRIPTION
See these issues for references:

https://github.com/egoist/poi/pull/193
https://github.com/chentsulin/electron-react-boilerplate/pull/245/files

Basically using something like the below example will break the process object compatibility that webpack includes. This just gives a warning about that. 

```javascript
new webpack.DefinePlugin({
   process: {
      env: {
         NODE_ENV: JSON.stringify('production')
      }
   }
})
```
