### PR TITLE
docs(config): conflate configuration languages

### DIFF
--- a/content/concepts/configuration.md
+++ b/content/concepts/configuration.md
@@ -3,6 +3,7 @@ title: Configuration
 sort: 6
 contributors:
 - TheLarkInn
+- simon04
 ---
 
 You may have noticed that few webpack configurations look exactly alike. This is because **webpack's configuration file is a JavaScript file that exports an object.** This object is then processed by webpack based upon its defined properties.
@@ -19,9 +20,11 @@ Use these features when appropriate.
 
 **You should NOT use the following things**. Technically you could use them, but it's **not recommended**:
 
-* Access CLI arguments, when using the webpack CLI (instead write your own CLI, or use `--env`)
+* Access CLI arguments, when using the webpack CLI (instead write your own CLI, or [use `--env`](/configuration/configuration-types/))
 * Export non-deterministic values (calling webpack twice should result in the same output files)
 * Write long configurations (instead split the configuration into multiple files)
+
+T> The most important part to take away from this document is that there are many different ways to format and style your webpack configuration. The key is to stick with something consistent that you and your team can understand and maintain.
 
 The following examples below describe how webpack's configuration object can be both expressive and configurable because _it is code_:
 
@@ -43,143 +46,10 @@ module.exports = {
 
 ## Multiple Targets
 
-**webpack.config.js**
+_See_: [Exporting multiple configurations](/configuration/configuration-types/#exporting-multiple-configurations)
 
-```javascript
-var path = require('path');
-var webpack = require('webpack');
-var webpackMerge = require('webpack-merge');
+## Using other Configuration Languages
 
-var baseConfig = {
-  target: 'async-node',
-  entry: {
-    entry: './entry.js'
-  },
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: '[name].js'
-  },
-  plugins: [
-    new webpack.optimize.CommonsChunkPlugin({
-      name: 'inline',
-      filename: 'inline.js',
-      minChunks: Infinity
-    }),
-    new webpack.optimize.AggressiveSplittingPlugin({
-        minSize: 5000,
-        maxSize: 10000
-    }),
-  ]
-};
+webpack accepts configuration files written in multiple programming and data languages.
 
-let targets = ['web', 'webworker', 'node', 'async-node', 'node-webkit', 'electron-main'].map((target) => {
-  let base = webpackMerge(baseConfig, {
-    target: target,
-    output: {
-      path: path.resolve(__dirname, 'dist/' + target),
-      filename: '[name].' + target + '.js'
-    }
-  });
-  return base;
-});
-
-module.exports = targets;
-```
-
-T> The most important part to take away from this document is that there are many different ways to format and style your webpack configuration. The key is to stick with something consistent that you and your team can understand and maintain.
-
-## Using TypeScript
-
-In the example below we use TypeScript to create a class which the angular-cli uses to [generate configs](https://github.com/angular/angular-cli/).
-
-**webpack.config.ts**
-
-```typescript
-import * as webpackMerge from 'webpack-merge';
-import { CliConfig } from './config';
-import {
-  getWebpackCommonConfig,
-  getWebpackDevConfigPartial,
-  getWebpackProdConfigPartial,
-  getWebpackMobileConfigPartial,
-  getWebpackMobileProdConfigPartial
-} from './';
-
-export class NgCliWebpackConfig {
-  // TODO: When webpack2 types are finished let's replace all these any types
-  // so this is more maintainable in the future for devs
-  public config: any;
-  private webpackDevConfigPartial: any;
-  private webpackProdConfigPartial: any;
-  private webpackBaseConfig: any;
-  private webpackMobileConfigPartial: any;
-  private webpackMobileProdConfigPartial: any;
-
-  constructor(public ngCliProject: any, public target: string, public environment: string, outputDir?: string) {
-    const config: CliConfig = CliConfig.fromProject();
-    const appConfig = config.config.apps[0];
-
-    appConfig.outDir = outputDir || appConfig.outDir;
-
-    this.webpackBaseConfig = getWebpackCommonConfig(this.ngCliProject.root, environment, appConfig);
-    this.webpackDevConfigPartial = getWebpackDevConfigPartial(this.ngCliProject.root, appConfig);
-    this.webpackProdConfigPartial = getWebpackProdConfigPartial(this.ngCliProject.root, appConfig);
-
-    if (appConfig.mobile){
-      this.webpackMobileConfigPartial = getWebpackMobileConfigPartial(this.ngCliProject.root, appConfig);
-      this.webpackMobileProdConfigPartial = getWebpackMobileProdConfigPartial(this.ngCliProject.root, appConfig);
-      this.webpackBaseConfig = webpackMerge(this.webpackBaseConfig, this.webpackMobileConfigPartial);
-      this.webpackProdConfigPartial = webpackMerge(this.webpackProdConfigPartial, this.webpackMobileProdConfigPartial);
-    }
-
-    this.generateConfig();
-  }
-
-  generateConfig(): void {
-    switch (this.target) {
-      case "development":
-        this.config = webpackMerge(this.webpackBaseConfig, this.webpackDevConfigPartial);
-        break;
-      case "production":
-        this.config = webpackMerge(this.webpackBaseConfig, this.webpackProdConfigPartial);
-        break;
-      default:
-        throw new Error("Invalid build target. Only 'development' and 'production' are available.");
-        break;
-    }
-  }
-}
-```
-
-## Using JSX
-
-In the example below JSX (React JavaScript Markup) and Babel are used to create a JSON Configuration that webpack can understand. (Courtesy of [Jason Miller](https://twitter.com/_developit))
-
-```javascript
-import h from 'jsxobj';
-
-// example of an imported plugin
-const CustomPlugin = config => ({
-  ...config,
-  name: 'custom-plugin'
-});
-
-export default (
-  <webpack target="web" watch>
-    <entry path="src/index.js" />
-    <resolve>
-      <alias {...{
-        react: 'preact-compat',
-        'react-dom': 'preact-compat'
-      }} />
-    </resolve>
-    <plugins>
-      <uglify-js opts={{
-        compression: true,
-        mangle: false
-      }} />
-      <CustomPlugin foo="bar" />
-    </plugins>
-  </webpack>
-);
-```
+_See_: [Configuration Languages](/configuration/configuration-languages/)

--- a/content/concepts/configuration.md
+++ b/content/concepts/configuration.md
@@ -18,7 +18,7 @@ Because it's a standard Node.js CommonJS module, you **can do the following**:
 
 Use these features when appropriate.
 
-**You should NOT use the following things**. Technically you could use them, but it's **not recommended**:
+While they are technically feasible, **the following practices should be avoided**:
 
 * Access CLI arguments, when using the webpack CLI (instead write your own CLI, or [use `--env`](/configuration/configuration-types/))
 * Export non-deterministic values (calling webpack twice should result in the same output files)

--- a/content/configuration/configuration-languages.md
+++ b/content/configuration/configuration-languages.md
@@ -5,11 +5,42 @@ contributors:
   - sokra
   - skipjack
   - tarang9211
+  - simon04
 ---
 
 webpack accepts configuration files written in multiple programming and data languages. The list of supported file extensions can be found at the [node-interpret](https://github.com/js-cli/js-interpret) package. Using [node-interpret](https://github.com/js-cli/js-interpret), webpack can handle many different types of configuration files.
 
-For example, to use [CoffeeScript](http://coffeescript.org/), you would first install the necessary dependencies:
+## TypeScript
+
+To write the webpack configuration in [TypeScript](http://www.typescriptlang.org/), you would first install the necessary dependencies:
+
+``` bash
+npm install --save-dev typescript ts-node @types/node @types/webpack
+```
+
+and then proceed to write your configuration:
+
+__webpack.config.ts__
+
+```typescript
+import * as webpack from 'webpack';
+import * as path from 'path';
+declare var __dirname;
+
+const config: webpack.Configuration = {
+  entry: './foo.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'foo.bundle.js'
+  }
+};
+
+export default config;
+```
+
+## CoffeeScript
+
+Similarly, to use [CoffeeScript](http://coffeescript.org/), you would first install the necessary dependencies:
 
 ``` bash
 npm i --save-dev coffee-script
@@ -23,6 +54,7 @@ __webpack.config.coffee__
 HtmlWebpackPlugin = require('html-webpack-plugin')
 webpack = require('webpack')
 path = require('path')
+
 config =
   entry: './path/to/my/entry/file.js'
   output:
@@ -36,5 +68,39 @@ config =
     new (webpack.optimize.UglifyJsPlugin)
     new HtmlWebpackPlugin(template: './src/index.html')
   ]
+
 module.exports = config
+```
+
+## JSX
+
+In the example below JSX (React JavaScript Markup) and Babel are used to create a JSON Configuration that webpack can understand. (Courtesy of [Jason Miller](https://twitter.com/_developit/status/769583291666169862))
+
+```javascript
+import h from 'jsxobj';
+
+// example of an imported plugin
+const CustomPlugin = config => ({
+  ...config,
+  name: 'custom-plugin'
+});
+
+export default (
+  <webpack target="web" watch>
+    <entry path="src/index.js" />
+    <resolve>
+      <alias {...{
+        react: 'preact-compat',
+        'react-dom': 'preact-compat'
+      }} />
+    </resolve>
+    <plugins>
+      <uglify-js opts={{
+        compression: true,
+        mangle: false
+      }} />
+      <CustomPlugin foo="bar" />
+    </plugins>
+  </webpack>
+);
 ```


### PR DESCRIPTION
- Move all configuration languages to the corresponding configuration page, away from the concepts page
- Reduce TypeScript example to a minimal working example