### PR TITLE
docs: consistent typesetting of webpack versions

### DIFF
--- a/content/guides/code-splitting-async.md
+++ b/content/guides/code-splitting-async.md
@@ -241,7 +241,7 @@ async function main() {
 
 ### `System.import` is deprecated
 
-The use of `System.import` in webpack [did not fit the proposed spec](https://github.com/webpack/webpack/issues/2163), so it was deprecated in [v2.1.0-beta.28](https://github.com/webpack/webpack/releases/tag/v2.1.0-beta.28) in favor of `import()`.
+The use of `System.import` in webpack [did not fit the proposed spec](https://github.com/webpack/webpack/issues/2163), so it was deprecated in webpack [2.1.0-beta.28](https://github.com/webpack/webpack/releases/tag/v2.1.0-beta.28) in favor of `import()`.
 
 
 ## `require.ensure()`

--- a/content/guides/migrating.md
+++ b/content/guides/migrating.md
@@ -616,11 +616,11 @@ Loaders are now cacheable by default. Loaders must opt-out if they are not cache
 
 ### Complex options
 
-__webpack v1__ only supports `JSON.stringify`-able options for loaders.
+__webpack 1__ only supports `JSON.stringify`-able options for loaders.
 
-__webpack v2__ now supports any JS object as loader options.
+__webpack 2__ now supports any JS object as loader options.
 
-Before [v2.2.1](https://github.com/webpack/webpack/releases/tag/v2.2.1) (i.e. from v2.0.0 through v2.2.0), using complex options required using `ident` for the `options` object to allow its reference from other loaders. __This was removed in v2.2.1__ and thus current migrations do not require any use of the `ident` key.
+Before webpack [2.2.1](https://github.com/webpack/webpack/releases/tag/v2.2.1) (i.e. from 2.0.0 through 2.2.0), using complex options required using `ident` for the `options` object to allow its reference from other loaders. __This was removed in 2.2.1__ and thus current migrations do not require any use of the `ident` key.
 
 ```diff
 {

--- a/content/plugins/loader-options-plugin.md
+++ b/content/plugins/loader-options-plugin.md
@@ -5,7 +5,7 @@ contributors:
   - skipjack
 ---
 
-The `LoaderOptionsPlugin` is unlike other plugins in that it is built for migration from webpack version 1 to version 2. In webpack v2, the schema for a `webpack.config.js` became stricter; no longer open for extension by other loaders and plugins. The intention is that you pass `options` directly to loaders and plugins (i.e. `options` are __not__ global or shared).
+The `LoaderOptionsPlugin` is unlike other plugins in that it is built for migration from webpack 1 to 2. In webpack 2, the schema for a `webpack.config.js` became stricter; no longer open for extension by other loaders and plugins. The intention is that you pass `options` directly to loaders and plugins (i.e. `options` are __not__ global or shared).
 
 However, until a loader has been updated to depend upon options being passed directly to them, the `LoaderOptionsPlugin` exists to bridge the gap. You can configure global loader options with this plugin and all loaders will receive these options.
 


### PR DESCRIPTION
To comply with https://webpack.js.org/writers-guide/#typesetting