### PR TITLE
Remove inaccurate information and fix spelling/grammar

### DIFF
--- a/content/configuration/output.md
+++ b/content/configuration/output.md
@@ -7,6 +7,7 @@ contributors:
   - tomasAlabes
   - mattce
   - irth
+  - fvgs
 ---
 
 The top-level `output` key contains set of options instructing webpack on how and where it should output your bundles, assets and anything else you bundle or load with webpack.
@@ -142,11 +143,9 @@ Using hashes based on each chunks' content:
 filename: "[chunkhash].bundle.js"
 ```
 
-Make sure the read the [Caching guide](/guides/caching) for details. There are more steps involved than just setting this option.
+Make sure to read the [Caching guide](/guides/caching) for details. There are more steps involved than just setting this option.
 
-The default value is `"[name].js"`.
-
-Note this option is called filename but you are still allowed to something like `"js/[name]/bundle.js"` to create a folder structure.
+Note this option is called filename but you are still allowed to use something like `"js/[name]/bundle.js"` to create a folder structure.
 
 Note this options does not affect output files for on-demand-loaded chunks. For these files the [`output.chunkFilename`](#output-chunkfilename) option is used. It also doesn't affect files created by loaders. For these files see loader options.
 


### PR DESCRIPTION
Running webpack without an `output.filename` produces the following error and causes the command to fail

```
Error: 'output.filename' is required, either in config file or as --output-filename
```

Thus, stating there is a default value is incorrect. This removes that statement from the docs.