### PR TITLE
swapping `Usage` content to not be header links

### DIFF
--- a/content/plugins/dll-plugin.md
+++ b/content/plugins/dll-plugin.md
@@ -97,7 +97,7 @@ new webpack.DllReferencePlugin({
 
 ## Examples
 
-### [vendor](https://github.com/webpack/webpack/tree/master/examples/dll) and [user](https://github.com/webpack/webpack/tree/master/examples/dll-user)
+[Vendor](https://github.com/webpack/webpack/tree/master/examples/dll) and [User](https://github.com/webpack/webpack/tree/master/examples/dll-user)
 
 _Two separate example folders. Demonstrates scope and context._
 


### PR DESCRIPTION
this is for #1306 

Unless I'm missing something Usage links but the Examples subheaders are being pulled into sidebar when they shouldn't be?

[screen recording of `Usage` working as expected](https://cl.ly/lIGm)

closes #1306 