### PR TITLE
Miscellaneous Edits

### DIFF
--- a/content/api/loaders.md
+++ b/content/api/loaders.md
@@ -139,10 +139,10 @@ In the example: `"/abc/loader1.js?xyz!/abc/node_modules/loader2/index.js!/abc/re
 
 ### `this.query`
 
-1. In case the loader was configured with an [`options`](/configuration/module/#useentry) object, this will be a reference to the object.
+1. If the loader was configured with an [`options`](/configuration/module/#useentry) object, this will point to that object.
 2. If the loader has no `options`, but was invoked with a query string, this will be a string starting with `?`.
 
-T> Use the [`getOptions` method from the `loader-utils`](https://github.com/webpack/loader-utils#getoptions) to extract the given loader options.
+W> This property is deprecated as `options` is replacing `query`. Use the [`getOptions` method from the `loader-utils`](https://github.com/webpack/loader-utils#getoptions) to extract the given loader options.
 
 
 ### `this.callback`

--- a/content/api/loaders.md
+++ b/content/api/loaders.md
@@ -11,7 +11,7 @@ Loaders are transformations that are applied on the source code of a module. The
 
 ## How to write a loader
 
-A loader is just a JavaScript module that exports a function. The [loader runner](https://github.com/webpack/loader-runner) calls this function and passes the result of the previous loader or the resource file into it. The `this` context of the function is filled-in by webpack and the [loader runner](https://github.com/webpack/loader-runner) with some useful methods that allow the loader (among other things) to change its invocation style to async, or get query parameters. 
+A loader is just a JavaScript module that exports a function. The [loader runner](https://github.com/webpack/loader-runner) calls this function and passes the result of the previous loader or the resource file into it. The `this` context of the function is filled-in by webpack and the [loader runner](https://github.com/webpack/loader-runner) with some useful methods that allow the loader (among other things) to change its invocation style to async, or get query parameters.
 
 The first loader is passed one argument: the content of the resource file. The compiler expects a result from the last loader. The result should be a `String` or a `Buffer` (which is converted to a string), representing the JavaScript source code of the module. An optional SourceMap result (as JSON object) may also be passed.
 
@@ -120,7 +120,7 @@ require("./loader1?xyz!loader2!./resource?rrr");
 
 ### `this.version`
 
-**Loader API version.** Currently `2`. This is useful for providing backwards compatibility. Using the version you can specify custom logic or fallbacks for breaking changes.  
+**Loader API version.** Currently `2`. This is useful for providing backwards compatibility. Using the version you can specify custom logic or fallbacks for breaking changes.
 
 
 ### `this.context`
@@ -201,15 +201,17 @@ In the example:
 
 ```javascript
 [
-  { request: "/abc/loader1.js?xyz",
-	path: "/abc/loader1.js",
-	query: "?xyz",
-	module: [Function]
+  {
+    request: "/abc/loader1.js?xyz",
+    path: "/abc/loader1.js",
+    query: "?xyz",
+    module: [Function]
   },
-  { request: "/abc/node_modules/loader2/index.js",
-	path: "/abc/node_modules/loader2/index.js",
-	query: "",
-	module: [Function]
+  {
+    request: "/abc/node_modules/loader2/index.js",
+    path: "/abc/node_modules/loader2/index.js",
+    query: "",
+    module: [Function]
   }
 ]
 ```
@@ -305,7 +307,7 @@ addDependency(file: string)
 dependency(file: string) // shortcut
 ```
 
-Adds a file as dependency of the loader result in order to make them watchable. For example, [`html-loader`](https://github.com/webpack/html-loader) uses this technique as it finds `src` and `src-set` attributes. Then, it sets the url's for those attributes as dependencies of the html file that is parsed.  
+Adds a file as dependency of the loader result in order to make them watchable. For example, [`html-loader`](https://github.com/webpack/html-loader) uses this technique as it finds `src` and `src-set` attributes. Then, it sets the url's for those attributes as dependencies of the html file that is parsed.
 
 
 ### `this.addContextDependency`

--- a/content/api/plugins/compilation.md
+++ b/content/api/plugins/compilation.md
@@ -75,12 +75,12 @@ Optimize the chunks.
 //optimize chunks may be run several times in a compilation
 
 compilation.plugin('optimize-chunks', function(chunks) {
-    //unless you specified multiple entries in your config
-    //there's only one chunk at this point
+    // Unless you've specified multiple entries in your config
+    // there's only one chunk at this point
     chunks.forEach(function (chunk) {
-        //chunks have circular references to their modules
+        // Chunks have circular references to their modules
         chunk.modules.forEach(function (module){
-            //module.loaders, module.rawRequest, module.dependencies, etc.
+            // module.loaders, module.rawRequest, module.dependencies, etc.
         });
     });
 });

--- a/content/api/plugins/module-factories.md
+++ b/content/api/plugins/module-factories.md
@@ -9,8 +9,8 @@ sort: 5
 
 Before the factory starts resolving. The `data` object has these properties:
 
-* `context` The absolute path of the directory for resolving.
-* `request` The request of the expression.
+* `context`: The absolute path of the directory for resolving.
+* `request`: The request of the expression.
 
 Plugins are allowed to modify the object or to pass a new similar object to the callback.
 
@@ -18,12 +18,12 @@ Plugins are allowed to modify the object or to pass a new similar object to the 
 
 After the factory has resolved the request. The `data` object has these properties:
 
-* `request` The resolved request. It acts as an identifier for the NormalModule.
-* `userRequest` The request the user entered. It's resolved, but does not contain pre or post loaders.
-* `rawRequest` The unresolved request.
-* `loaders` A array of resolved loaders. This is passed to the NormalModule and they will be executed.
-* `resource` The resource. It will be loaded by the NormalModule.
-* `parser` The parser that will be used by the NormalModule.
+* `request`: The resolved request. It acts as an identifier for the NormalModule.
+* `userRequest`: The request the user entered. It's resolved, but does not contain pre or post loaders.
+* `rawRequest`: The unresolved request.
+* `loaders`: A array of resolved loaders. This is passed to the NormalModule and they will be executed.
+* `resource`: The resource. It will be loaded by the NormalModule.
+* `parser`: The parser that will be used by the NormalModule.
 
 ## `ContextModuleFactory`
 

--- a/content/api/plugins/resolver.md
+++ b/content/api/plugins/resolver.md
@@ -3,9 +3,9 @@ title: Resolver
 sort: 5
 ---
 
-* `compiler.resolvers.normal` Resolver for a normal module
-* `compiler.resolvers.context` Resolver for a context module
-* `compiler.resolvers.loader` Resolver for a loader
+* `compiler.resolvers.normal`: Resolver for a normal module
+* `compiler.resolvers.context`: Resolver for a context module
+* `compiler.resolvers.loader`: Resolver for a loader
 
 Any plugin should use `this.fileSystem` as fileSystem, as it's cached. It only has async named functions, but they may behave sync, if the user uses a sync file system implementation (i. e. in enhanced-require).
 
@@ -43,25 +43,31 @@ interface Request {
 }
 ```
 
+
 ## `resolve(context: String, request: String)`
 
 Before the resolving process starts.
+
 
 ## `resolve-step(types: String[], request: Request)`
 
 Before a single step in the resolving process starts.
 
+
 ## `module(request: Request)` async waterfall
 
 A module request is found and should be resolved.
+
 
 ## `directory(request: Request)` async waterfall
 
 A directory request is found and should be resolved.
 
+
 ## `file(request: Request)` async waterfall
 
 A file request is found and should be resolved.
+
 
 ## The plugins may offer more extensions points
 
@@ -71,9 +77,11 @@ The process for normal modules and contexts is `module -> module-module -> direc
 
 The process for loaders is `module -> module-loader-module -> module-module -> directory -> file`.
 
+
 ## `module-module`
 
 A module should be looked up in a specified directory. `path` contains the directory.
+
 
 ## `module-loader-module` (only for loaders)
 

--- a/content/concepts/index.md
+++ b/content/concepts/index.md
@@ -14,6 +14,7 @@ It is [incredibly configurable](/configuration), but to get started you only nee
 
 This document is intended to give a **high-level** overview of these concepts, while providing links to detailed concept specific use-cases.
 
+
 ## Entry
 
 webpack creates a graph of all of your application's dependencies. The starting point of this graph is known as an _entry point_. The _entry point_ tells webpack _where to start_ and follows the graph of dependencies to know _what to bundle_. You can think of your application's _entry point_ as the **contextual root** or **the first file to kick off your app**.
@@ -34,6 +35,7 @@ There are multiple ways to declare your `entry` property that are specific to yo
 
 [Learn more!](/concepts/entry-points)
 
+
 ## Output
 
 Once you've bundled all of your assets together, you still need to tell webpack **where** to bundle your application. The webpack `output` property tells webpack **how to treat bundled code**.
@@ -52,7 +54,7 @@ module.exports = {
 };
 ```
 
-In the example above, we use the `output.filename` and the `output.path` properties to tell webpack the name of our bundle and where we want it to be emitted to. 
+In the example above, we use the `output.filename` and the `output.path` properties to tell webpack the name of our bundle and where we want it to be emitted to.
 
 T> You may see the term **emitted** or **emit** used throughout our documentation and [plugin API](/api/plugins). This is a fancy term for "produced or discharged".
 
@@ -85,7 +87,7 @@ const config = {
   },
   module: {
     rules: [
-      {test: /\.txt$/, use: 'raw-loader'}
+      { test: /\.txt$/, use: 'raw-loader' }
     ]
   }
 };
@@ -102,6 +104,7 @@ W> It is important to remember when defining rules in your webpack config, you a
 There are more specific properties to define on loaders that we haven't yet covered.
 
 [Learn more!](/concepts/loaders)
+
 
 ## Plugins
 
@@ -124,7 +127,7 @@ const config = {
   },
   module: {
     rules: [
-      {test: /\.txt$/, use: 'raw-loader'}
+      { test: /\.txt$/, use: 'raw-loader' }
     ]
   },
   plugins: [

--- a/content/concepts/loaders.md
+++ b/content/concepts/loaders.md
@@ -11,57 +11,47 @@ contributors:
   - jhnns
 ---
 
-Loaders are transformations that are applied on the source code of a module. They allow you to preprocess files as you `require()` or “load” them. Thus, loaders are kind of like “tasks” in other build tools, and provide a powerful way to handle front-end build steps. Loaders can transform files from a different language (like TypeScript) to JavaScript, or inline images as data URLs. Loaders even allow you to do things like `require()` CSS files right in your JavaScript!
+Loaders are transformations that are applied on the source code of a module. They allow you to pre-process files as you `import` or “load” them. Thus, loaders are kind of like “tasks” in other build tools, and provide a powerful way to handle front-end build steps. Loaders can transform files from a different language (like TypeScript) to JavaScript, or inline images as data URLs. Loaders even allow you to do things like `import` CSS files directly from your JavaScript modules!
+
 
 ## Example
 
-For example, you can use loaders to tell webpack to load a CSS file or to convert TypeScript to JavaScript. Firstly, install the corresponding loaders:
+For example, you can use loaders to tell webpack to load a CSS file or to convert TypeScript to JavaScript. To do this, you would start by installing the loaders you need:
 
 ``` bash
 npm install --save-dev css-loader
 npm install --save-dev ts-loader
 ```
 
-Secondly, configure in your `webpack.config.js` that for every `.css` file the [`css-loader`](/loaders/css-loader) should be used and analogously for `.ts` files and the `ts-loader`:
+And then instruct webpack to use the [`css-loader`](/loaders/css-loader) for every `.css` file the and the ['ts-loader'](https://github.com/TypeStrong/ts-loader) for all `.ts` files:
 
 **webpack.config.js**
 
-```js-with-links-with-details
+``` js
 module.exports = {
   module: {
     rules: [
-      {test: /\.css$/, use: ['css-loader'](/loaders/css-loader)},
-      {test: /\.ts$/, use: ['ts-loader'](https://github.com/TypeStrong/ts-loader)}
+      { test: /\.css$/, use: 'css-loader' },
+      { test: /\.ts$/, use: 'ts-loader' }
     ]
   }
 };
 ```
 
-Note that according to the [configuration options](/configuration#options), the following specifications define the identical loader usage:
 
-```js-with-links-with-details
-{test: /\.css$/, [loader](/configuration/module#rule-loader): 'css-loader'}
-// or equivalently
-{test: /\.css$/, [use](/configuration/module#rule-use): 'css-loader'}
-// or equivalently
-{test: /\.css$/, [use](/configuration/module#rule-use): {
-  loader: 'css-loader',
-  options: {}
-}}
-```
-
-## Configuration
+## Using Loaders
 
 There are three ways to use loaders in your application:
 
-* via configuration
-* explicit in the `require` statement
-* via CLI
+* Configuration (recommended): Specify them in your __webpack.config.js__ file.
+* Inline: Specify them explicitly in each `import` statement.
+* CLI: Specify them within a shell command.
 
-### Via `webpack.config.js`
+
+### Configuration
 
 [`module.rules`](/configuration/module/#module-rules) allows you to specify several loaders within your webpack configuration.
-This is a concise way to display loaders, and helps to maintain clean code. It also offers you a full overview of each respective loader.
+This is a concise way to display loaders, and helps to maintain clean code. It also offers you a full overview of each respective loader:
 
 ```js-with-links-with-details
   module: {
@@ -69,7 +59,7 @@ This is a concise way to display loaders, and helps to maintain clean code. It a
       {
         test: /\.css$/,
         use: [
-          { loader: ['style-loader'](/loaders/style-loader)},
+          { loader: ['style-loader'](/loaders/style-loader) },
           {
             loader: ['css-loader'](/loaders/css-loader),
             options: {
@@ -82,29 +72,32 @@ This is a concise way to display loaders, and helps to maintain clean code. It a
   }
 ```
 
-### Via `require`
 
-It's possible to specify the loaders in the `require` statement (or `define`, `require.ensure`, etc.). Separate loaders from the resource with `!`. Each part is resolved relative to the current directory.
+### Inline
+
+It's possible to specify loaders in an `import` statement, or any [equivalent "importing" method](/api/module-methods). Separate loaders from the resource with `!`. Each part is resolved relative to the current directory.
 
 ```js
-require('style-loader!css-loader?modules!./styles.css');
+import Styles from 'style-loader!css-loader?modules!./styles.css';
 ```
 
 It's possible to overwrite any loaders in the configuration by prefixing the entire rule with `!`.
 
-Options can be passed with a query parameter, just like on the web (`?key=value&foo=bar`). It's also possible to use a JSON object (`?{"key":"value","foo":"bar"}`).
+Options can be passed with a query parameter, e.g. `?key=value&foo=bar`, or a JSON object, e.g. `?{"key":"value","foo":"bar"}`.
 
-T> Use `module.rules` whenever possible, as this will reduce boilerplate in your source code and allows you to debug or locate a loader faster if something goes south.
+T> Use `module.rules` whenever possible, as this will reduce boilerplate in your source code and allow you to debug or locate a loader faster if something goes south.
 
-### Via CLI
 
-Optionally, you could also use loaders through the CLI:
+### CLI
+
+You can also use loaders through the CLI:
 
 ```sh
 webpack --module-bind jade-loader --module-bind 'css=style-loader!css-loader'
 ```
 
 This uses the `jade-loader` for `.jade` files, and the [`style-loader`](/loaders/style-loader) and [`css-loader`](/loaders/css-loader) for `.css` files.
+
 
 ## Loader Features
 
@@ -120,8 +113,9 @@ This uses the `jade-loader` for `.jade` files, and the [`style-loader`](/loaders
 Loaders allow more power in the JavaScript ecosystem through preprocessing
 functions (loaders). Users now have more flexibility to include fine-grained logic such as compression, packaging, language translations and [more](/loaders).
 
+
 ## Resolving Loaders
 
 Loaders follow the standard [module resolution](/concepts/module-resolution/). In most cases it will be loaders from the [module path](/concepts/module-resolution/#module-paths) (think `npm install`, `node_modules`).
 
-A loader module is expected to export a function and be written in NodeJS compatible JavaScript. In the common case you manage loaders with npm, but you can also have loaders as files in your app. By convention, loaders are usually named `xxx-loader` (e.g. `json-loader`). See ["How to Write a Loader?"](/development/how-to-write-a-loader) for more information.
+A loader module is expected to export a function and be written in Node.js compatible JavaScript. They are most commonly managed with npm, but you can also have custom loaders as files within your application. By convention, loaders are usually named `xxx-loader` (e.g. `json-loader`). See ["How to Write a Loader?"](/development/how-to-write-a-loader) for more information.

--- a/content/concepts/output.md
+++ b/content/concepts/output.md
@@ -9,13 +9,13 @@ contributors:
 
 Options affecting the output of the compilation. `output` options tell webpack how to write the compiled files to disk. Note that, while there can be multiple `entry` points, only one `output` configuration is specified.
 
+
 ## Usage
 
-The minimum requirements for the `output` property in your webpack config is to set its value to an object including the following two things :
+The minimum requirements for the `output` property in your webpack config is to set its value to an object including the following two things:
 
-Your preferred `filename` of the compiled file: `// main.js || bundle.js || index.js`
-
-An [`output.path`](#output-path) as an **absolute path** for what directory you prefer it to go in once bundled.
+- A `filename` to use for the output file(s).
+- An absolute `path` to your preferred output directory.
 
 **webpack.config.js**
 
@@ -30,79 +30,12 @@ const config = {
 module.exports = config;
 ```
 
-## Options
+This configuration would output a single `bundle.js` file into the `/home/proj/public/assets` directory.
 
-The following is a list of values you can pass to the `output` property.
 
-### `output.chunkFilename`
+## Multiple Entry Points
 
-The filename of non-entry chunks as a relative path inside the `output.path` directory.
-
-`[id]` is replaced by the id of the chunk.
-
-`[name]` is replaced by the name of the chunk (or with the id when the chunk has no name).
-
-`[hash]` is replaced by the hash of the compilation.
-
-`[chunkhash]` is replaced by the hash of the chunk.
-
-### `output.crossOriginLoading`
-
-This option enables cross-origin loading of chunks.
-
-Possible values are:
-
-`false` - Disable cross-origin loading.
-
-`"anonymous"` - Cross-origin loading is enabled. When using `anonymous` no credentials will be sent with the request.
-
-`"use-credentials"` - Cross-origin loading is enabled and credentials will be sent with the request.
-
-For more information on cross-origin loading see [MDN](https://developer.mozilla.org/en/docs/Web/HTML/Element/script#attr-crossorigin)
-
-> Default: `false`
-
-> see also [library](/guides/author-libraries/)
-
-> see also [Development Tools](/guides/development/#choosing-a-tool)
-
-### `output.devtoolLineToLine`
-
-Enable line-to-line mapped mode for all/specified modules. Line-to-line mapped mode uses a simple SourceMap where each line of the generated source is mapped to the same line of the original source. It's a performance optimization. Only use it if your performance needs to be better and you are sure that input lines match which generated lines.
-
-`true` enables it for all modules (not recommended)
-
-An object `{test, include, exclude}` similar to `module.loaders` enables it for specific files.
-
-> Default: `false`
-
-### `output.filename`
-
-Specifies the name of each output file on disk. You must **not** specify an absolute path here! The `output.path` option determines the location on disk the files are written. `filename` is used solely for naming the individual files.
-
-**single entry**
-
-```javascript
-{
-  entry: './src/app.js',
-  output: {
-    filename: 'bundle.js',
-    path: __dirname + '/build'
-  }
-}
-
-// writes to disk: ./build/bundle.js
-```
-
-**multiple entries**
-
-If your configuration creates more than a single "chunk" (as with multiple entry points or when using plugins like CommonsChunkPlugin), you should use substitutions to ensure that each file has a unique name.
-
-`[name]` is replaced by the name of the chunk.
-
-`[hash]` is replaced by the hash of the compilation.
-
-`[chunkhash]` is replaced by the hash of the chunk.
+If your configuration creates more than a single "chunk" (as with multiple entry points or when using plugins like CommonsChunkPlugin), you should use [substitutions](/config/output#output-filename) to ensure that each file has a unique name.
 
 ```javascript
 {
@@ -112,121 +45,31 @@ If your configuration creates more than a single "chunk" (as with multiple entry
   },
   output: {
     filename: '[name].js',
-    path: __dirname + '/build'
+    path: __dirname + '/dist'
   }
 }
 
-// writes to disk: ./build/app.js, ./build/search.js
+// writes to disk: ./dist/app.js, ./dist/search.js
 ```
 
-### `output.hotUpdateChunkFilename`
 
-The filename of the Hot Update Chunks. They are inside the `output.path` directory.
+## Advanced
 
-`[id]` is replaced by the id of the chunk.
-
-`[hash]` is replaced by the hash of the compilation. (The last hash stored in the records)
-
-> Default: `"[id].[hash].hot-update.js"`
-
-### `output.hotUpdateFunction`
-
-The JSONP function used by webpack for async loading of hot update chunks.
-
-> Default: `"webpackHotUpdate"`
-
-### `output.hotUpdateMainFilename`
-
-The filename of the Hot Update Main File. It is inside the `output.path` directory.
-
-`[hash]` is replaced by the hash of the compilation. (The last hash stored in the records)
-
-> Default: `"[hash].hot-update.json"`
-
-### `output.jsonpFunction`
-
-The JSONP function used by webpack for async loading of chunks.
-
-A shorter function may reduce the file size a bit. Use a different identifier when having multiple webpack instances on a single page.
-
-> Default: `"webpackJsonp"`
-
-### `output.library`
-
-If set, export the bundle as library. `output.library` is the name.
-
-Use this if you are writing a library and want to publish it as single file.
-
-### `output.libraryTarget`
-
-Which format to export the library:
-
-`"var"` - Export by setting a variable: `var Library = xxx` (default)
-
-`"this"` - Export by setting a property of `this`: `this["Library"] = xxx`
-
-`"commonjs"` - Export by setting a property of `exports`: `exports["Library"] = xxx`
-
-`"commonjs2"` - Export by setting `module.exports`: `module.exports = xxx`
-
-`"amd"` - Export to AMD (optionally named - set the name via the library option)
-
-`"umd"` - Export to AMD, CommonJS2 or as property in root
-
-> Default: `"var"`
-
-If `output.library` is not set, but `output.libraryTarget` is set to a value other than `var`, every property of the exported object is copied (Except `amd`, `commonjs2` and `umd`).
-
-### `output.path`
-
-The output directory as an **absolute path** (required).
-
-`[hash]` is replaced by the hash of the compilation.
+Here's a more complicated example of using a CDN and hashes for assets:
 
 **config.js**
 
 ```javascript
 output: {
-    path: "/home/proj/public/assets",
-    publicPath: "/assets/"
+  path: "/home/proj/cdn/assets/[hash]",
+  publicPath: "http://cdn.example.com/assets/[hash]/"
 }
 ```
 
-**index.html**
-
-```html
-<head>
-  <link href="/assets/spinner.gif"/>
-</head>
-```
-
-And a more complicated example of using a CDN and hashes for assets.
-
-**config.js**
+In cases when the eventual `publicPath` of output files isn't known at compile time, it can be left blank and set dynamically at runtime in the entry point file. If you don't know the `publicPath` while compiling, you can omit it and set `__webpack_public_path__` on your entry point.
 
 ```javascript
-output: {
-    path: "/home/proj/cdn/assets/[hash]",
-    publicPath: "http://cdn.example.com/assets/[hash]/"
-}
-```
-
-**Note:** In cases when the eventual `publicPath` of output files isn't known at compile time, it can be left blank and set dynamically at runtime in the entry point file. If you don't know the `publicPath` while compiling, you can omit it and set `__webpack_public_path__` on your entry point.
-
-```javascript
- __webpack_public_path__ = myRuntimePublicPath
+__webpack_public_path__ = myRuntimePublicPath
 
 // rest of your application entry
 ```
-
-### `output.sourceMapFilename`
-
-Source Map filenames for JavaScript modules.
-
-* `[file]` is replaced by the filename of the JavaScript file.
-* `[id]` is replaced by the id of the chunk.
-* `[hash]` is replaced by the hash of the compilation.
-* `[contenthash]` is replaced by the hash of the extracted file (since webpack 3.0.0).
-
-> Default: `"[file].map"`
-

--- a/content/concepts/output.md
+++ b/content/concepts/output.md
@@ -7,7 +7,7 @@ contributors:
   - rouzbeh84
 ---
 
-Options affecting the output of the compilation. `output` options tell webpack how to write the compiled files to disk. Note that, while there can be multiple `entry` points, only one `output` configuration is specified.
+Configuring the `output` configuration options tell webpack how to write the compiled files to disk. Note that, while there can be multiple `entry` points, only one `output` configuration is specified.
 
 
 ## Usage
@@ -35,7 +35,7 @@ This configuration would output a single `bundle.js` file into the `/home/proj/p
 
 ## Multiple Entry Points
 
-If your configuration creates more than a single "chunk" (as with multiple entry points or when using plugins like CommonsChunkPlugin), you should use [substitutions](/config/output#output-filename) to ensure that each file has a unique name.
+If your configuration creates more than a single "chunk" (as with multiple entry points or when using plugins like CommonsChunkPlugin), you should use [substitutions](/configuration/output#output-filename) to ensure that each file has a unique name.
 
 ```javascript
 {

--- a/content/concepts/plugins.md
+++ b/content/concepts/plugins.md
@@ -62,7 +62,7 @@ const config = {
     rules: [
       {
         test: /\.(js|jsx)$/,
-        loader: 'babel-loader'
+        use: 'babel-loader'
       }
     ]
   },

--- a/content/configuration/module.md
+++ b/content/configuration/module.md
@@ -41,7 +41,7 @@ An array of [Rules](#rule) which are matched to requests when modules are create
 A Rule can be separated into three parts — Conditions, Results and nested Rules.
 
 
-### Rule conditions
+### Rule Conditions
 
 There are two input values for the conditions:
 
@@ -124,9 +124,9 @@ A [`Condition`](#condition) matched with the issuer. See details in [`Rule` cond
 
 ## `Rule.loaders`
 
-`Rule.loaders` is an alias to `Rule.use`. See [`Rule.use`](#rule-use) for details.
+W> This option is __deprecated__ in favor of `Rule.use`.
 
-It exists for compatibility reasons. Use `Rule.use` instead.
+`Rule.loaders` is an alias to `Rule.use`. See [`Rule.use`](#rule-use) for details.
 
 
 ## `Rule.oneOf`
@@ -134,11 +134,11 @@ It exists for compatibility reasons. Use `Rule.use` instead.
 An array of [`Rules`](#rule) from which only the first matching Rule is used when the Rule matches.
 
 
-## `Rule.options / Rule.query`
+## `Rule.options` / `Rule.query`
 
 `Rule.options` and `Rule.query` are shortcuts to `Rule.use: [ { options } ]`. See [`Rule.use`](#rule-use) and [`UseEntry.options`](#useentry) for details.
 
-`Rule.query` only exists for compatibility reasons. Use `Rule.options` instead.
+W> `Rule.query` is deprecated in favor of `Rule.options` and `UseEntry.options`.
 
 
 ## `Rule.parser`
@@ -196,9 +196,7 @@ Loaders can be chained by passing multiple loaders, which will be applied from r
 
 ```javascript
 use: [
-  {
-    loader: 'style-loader'
-  },
+  'style-loader',
   {
     loader: 'css-loader',
     options: {

--- a/content/configuration/module.md
+++ b/content/configuration/module.md
@@ -78,7 +78,7 @@ The [`parser`](#rule-parser) property affects the parser options.
 
 ## Nested rules
 
-Nested rules can be specified under the properties [`rules`](#rule-rules) and [`oneOf`](#rule-oneof). 
+Nested rules can be specified under the properties [`rules`](#rule-rules) and [`oneOf`](#rule-oneof).
 
 These rules are evaluated when the Rule condition matches.
 
@@ -273,14 +273,14 @@ For compatibility a `query` property is also possible, which is an alias for the
 }
 ```
 
-Note that webpack needs to generate a unique module identifier from the resource and all loaders including options. It tries to do this with a `JSON.stringify` of the options object. This is fine in 99.9% of cases, but may be not unique if you apply the same loaders with different options to the resource and the options have some stringified values. 
+Note that webpack needs to generate a unique module identifier from the resource and all loaders including options. It tries to do this with a `JSON.stringify` of the options object. This is fine in 99.9% of cases, but may be not unique if you apply the same loaders with different options to the resource and the options have some stringified values.
 
 It also breaks if the options object cannot be stringified (i.e. circular JSON). Because of this you can have a `ident` property in the options object which is used as unique identifier.
 
 
 ## Module Contexts
 
-(Deprecated)
+> Avoid using these options as they are __deprecated__ and will soon be removed.
 
 These options describe the default settings for the context created when a dynamic dependency is encountered.
 
@@ -309,7 +309,7 @@ module: {
 }
 ```
 
-Note: You can use the `ContextReplacementPlugin` to modify these values for individual dependencies. This also removes the warning.
+T> You can use the `ContextReplacementPlugin` to modify these values for individual dependencies. This also removes the warning.
 
 A few use cases:
 

--- a/content/configuration/output.md
+++ b/content/configuration/output.md
@@ -17,7 +17,7 @@ The top-level `output` key contains set of options instructing webpack on how an
 
 `string`
 
-This option determines the name of on-demand loaded chunk files. See [`output.filename`](#output-filename) option for details on the possible values.
+This option determines the name of non-entry chunk files. See [`output.filename`](#output-filename) option for details on the possible values.
 
 Note that these filenames need to be generated at runtime to send the requests for chunks. Because of this, placeholders like `[name]` and `[chunkhash]` need to add a mapping from chunk id to placeholder value to the output bundle with the webpack runtime. This increases the size and may invalidate the bundle when placeholder value for any chunk changes.
 

--- a/content/configuration/output.md
+++ b/content/configuration/output.md
@@ -59,7 +59,7 @@ See [`output.devtoolModuleFilenameTemplate`](#output-devtoolmodulefilenametempla
 
 `boolean | object`
 
-(Deprecated: Not really used, not really usable, write an issue if you have a different opinion)
+> Avoid using this option as it is __deprecated__ and will soon be removed.
 
 Enables line to line mapping for all or some modules. This produces a simple source map where each line of the generated source is mapped to the same line of the original source. This is a performance optimization and should only be used if all input lines match generated lines.
 
@@ -345,7 +345,7 @@ Note that your entry chunk must be defined with the `define` property, if not, w
 
 ```javascript
 define([], function() {
-	// This module returns is what your entry chunk returns
+  // This module returns is what your entry chunk returns
 });
 ```
 
@@ -355,8 +355,8 @@ So, with the following configuration...
 
 ```javascript
 output: {
-	library: "MyLibrary",
-	libraryTarget: "amd"
+  library: "MyLibrary",
+  libraryTarget: "amd"
 }
 ```
 
@@ -364,7 +364,7 @@ users will be able to call your library like so:
 
 ```javascript
 require(['MyLibrary'], function(MyLibrary) {
-	// Do something with the library...
+  // Do something with the library...
 });
 ```
 
@@ -375,8 +375,8 @@ In this case, you need the `library` property to name your module:
 
 ```javascript
 output: {
-	library: "MyLibrary",
-	libraryTarget: "umd"
+  library: "MyLibrary",
+  libraryTarget: "umd"
 }
 ```
 
@@ -384,16 +384,16 @@ And finally the output is:
 
 ```javascript
 (function webpackUniversalModuleDefinition(root, factory) {
-	if(typeof exports === 'object' && typeof module === 'object')
-		module.exports = factory();
-	else if(typeof define === 'function' && define.amd)
-		define([], factory);
-	else if(typeof exports === 'object')
-		exports["MyLibrary"] = factory();
-	else
-		root["MyLibrary"] = factory();
+  if(typeof exports === 'object' && typeof module === 'object')
+    module.exports = factory();
+  else if(typeof define === 'function' && define.amd)
+    define([], factory);
+  else if(typeof exports === 'object')
+    exports["MyLibrary"] = factory();
+  else
+    root["MyLibrary"] = factory();
 })(this, function() {
-	//what this module returns is what your entry chunk returns
+  //what this module returns is what your entry chunk returns
 });
 ```
 

--- a/content/guides/caching.md
+++ b/content/guides/caching.md
@@ -34,8 +34,7 @@ application.js?build=1
 application.css?build=1
 ```
 
-It is even easier to do with webpack. Each webpack build generates a unique hash which can be used to compose a filename, by including output [placeholders](/concepts/output/#options).
-The following example config will generate 2 files (1 per entry) with hashes in filenames:
+It is even easier to do with webpack. Each webpack build generates a unique hash which can be used to compose a filename, by including output [substitutions](/configuration/output#output-filename). The following example config will generate 2 files (1 per entry) with hashes in filenames:
 
 ```js
 // webpack.config.js

--- a/content/guides/hot-module-replacement.md
+++ b/content/guides/hot-module-replacement.md
@@ -159,6 +159,6 @@ There are many other loaders and examples out in the community to make HMR inter
 - [React Hot Loader](https://github.com/gaearon/react-hot-loader): Tweak react components in real time.
 - [Vue Loader](https://github.com/vuejs/vue-loader): This loader supports HMR for vue components out of the box.
 - [Elm Hot Loader](https://github.com/fluxxu/elm-hot-loader): Supports HMR for the Elm programming language.
-- [Redux HMR](https://survivejs.com/webpack/appendices/hmr-with-react/#configuring-hmr-with-redux): No loader or plugin necessary! A simple change
+- [Redux HMR](https://survivejs.com/webpack/appendices/hmr-with-react/#configuring-hmr-with-redux): No loader or plugin necessary! A simple change to your main store file is all that's required.
 
 T> If you know of any other loaders or plugins that help with or enhance Hot Module Replacement please submit a pull request to add to this list!

--- a/content/guides/typescript.md
+++ b/content/guides/typescript.md
@@ -57,7 +57,7 @@ module.exports = {
    rules: [
      {
        test: /\.tsx?$/,
-       loader: 'ts-loader',
+       use: 'ts-loader',
        exclude: /node_modules/,
      }
    ]


### PR DESCRIPTION
> In resolving #569, I had to grep through much of the docs to look for loader usage inconsistencies. In doing this I noticed a variety of other minor (and some not-so-minor) things that needed fixing so I'm addressing them here as well. This should probably have been split into multiple PRs but if the reviewers just view the commits instead of the full diff it shouldn't be so bad (sorry it's late and I'm tired 😞).

A bunch of cleanup including...

- Resolving some formatting inconsistencies
- De-duplicating content between `/concepts/output` and `/configuration/output`
- Clarifying loader usage and configuration (see #569)

Resolves #569

cc @dmitriid (see [this commit][1] in particular)

[1]: https://github.com/webpack/webpack.js.org/pull/1339/commits/9171a0a9fceaeaea6bdced3f8ada50215317d587