### PR TITLE
Path fix for output managment guide

### DIFF
--- a/content/guides/output-management.md
+++ b/content/guides/output-management.md
@@ -37,6 +37,7 @@ In comes the [`HtmlWebpackPlugin`](/plugins/html-webpack-plugin) to save the day
 __webpack.config.js__
 
 ``` js
+var path = require('path');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
@@ -46,7 +47,7 @@ module.exports = {
   },
 
   output: {
-    path: 'dist',
+    path: path.resolve(__dirname, 'dist'),
     filename: '[name].bundle.js'
   },
 


### PR DESCRIPTION
Solving the following error:
```
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.output.path: The provided value "dist" is not an absolute path!
```
Now it also uses the same output path as the "Getting started"  >  "Using a Configuration" guide.
