### PR TITLE
Fixing output managment entry config

### DIFF
--- a/content/guides/output-management.md
+++ b/content/guides/output-management.md
@@ -41,7 +41,7 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
   entry: {
-    app: './index.js',
+    app: './src/index.js',
     vendor: [ 'react', 'react-dom' ]
   },
 


### PR DESCRIPTION
Solving the following error: 
```
ERROR in Entry module not found: Error: Can't resolve './index.js' in '/home/peteruithoven/Projects/www/webpack/webpack3/output-managment'
```

1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Make sure your PR complies with [the writer's guide](https://webpack.js.org/writers-guide/).
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
4. Remove these instructions from your PR as they are for your eyes only.
