### PR TITLE
An example for using an array in the object form.

### DIFF
--- a/content/configuration/externals.md
+++ b/content/configuration/externals.md
@@ -88,9 +88,17 @@ externals : {
     root: "_" // indicates global variable
   }
 }
+
+// or
+
+externals : {
+  subtract : {
+    root: ["math", "subtract"]
+  }
+}
 ```
 
-This syntax is used to describe all the possible ways that an external library can be available. `lodash` here is available as `lodash` under AMD and CommonJS module systems but available as `_` in a global variable form.
+This syntax is used to describe all the possible ways that an external library can be available. `lodash` here is available as `lodash` under AMD and CommonJS module systems but available as `_` in a global variable form. `subtract` here is available via the property `subtract` under the global `math` object (e.g. `window['math']['subtract']`).
 
 
 ### function


### PR DESCRIPTION
To make it easier to discover use case reported by webpack/webpack#4665 
from the documentation, as the existing array example only convey/imply 
that only modules are supported by this construct.
