### PR TITLE
fix definition of `webpack -p`

### DIFF
--- a/content/guides/production.md
+++ b/content/guides/production.md
@@ -20,7 +20,7 @@ The following article describes the best practices and tools to use when using w
 
 ## The Automatic Way
 
-Running `webpack -p` (or equivalently `webpack --optimize-minimize --define process.env.NODE_ENV="production"`). This performs the following steps:
+Running `webpack -p` (or equivalently `webpack --optimize-minimize --define process.env.NODE_ENV="'production'"`). This performs the following steps:
 
 - Minification using `UglifyJsPlugin`
 - Runs the `LoaderOptionsPlugin` (see its [documentation](/plugins/loader-options-plugin))


### PR DESCRIPTION
fix definition of `webpack -p` command line option expansion, at the top of this page its missing the needed single quotes which are present down below. this caused me some grief ;)

incidentally `--optimize-minimize --define process.env.NODE_ENV="'production'"` *doesnt* produce the same result as `-p` for me, only the first correctly causes react to build in production mode without the attedent warnings. this is with webpack 1.15.0 and react 15.6.1. I assume this is a doc issue rather than something i need to create as an issue on either react or webpack but let me know if im wrong here.