### PR TITLE
Replace `use` with `loader`

### DIFF
--- a/content/guides/typescript.md
+++ b/content/guides/typescript.md
@@ -57,7 +57,7 @@ module.exports = {
    rules: [
      {
        test: /\.tsx?$/,
-       use: 'ts-loader',
+       loader: 'ts-loader',
        exclude: /node_modules/,
      }
    ]


### PR DESCRIPTION
keyword `use` throws error with webpack 3.