### PR TITLE
docs(guides) Reverted the changes from #1158

### DIFF
--- a/content/guides/author-libraries.md
+++ b/content/guides/author-libraries.md
@@ -129,8 +129,6 @@ module.exports = {
 
 This means that your library expects a dependency named `lodash` to be available in the consumer's environment.
 
-If your library targets UMD, it's important to add all of the above mentioned ways of loading the external (`commonjs`, `commonjs2`, `amd` and `root`) as leaving one out will cause strange errors for a consumer trying to load your library in that environment.
-
 If you only plan on using your library as a dependency in another webpack bundle, you may specify externals as an array.
 
 ```javascript


### PR DESCRIPTION
The note from #1158 are now obsolete since webpack/webpack#4771 has been fixed.