### PR TITLE
Remove hanging comma from exclude in rules

### DIFF
--- a/content/guides/typescript.md
+++ b/content/guides/typescript.md
@@ -58,7 +58,7 @@ module.exports = {
      {
        test: /\.tsx?$/,
        use: 'ts-loader',
-       exclude: /node_modules/,
+       exclude: /node_modules/
      }
    ]
  },


### PR DESCRIPTION
Unnecessary lingering comma @ the end of the exclude line. This just removes the comma.
