### PR TITLE
Code Splitting Guide Update

### DIFF
--- a/content/guides/code-splitting.md
+++ b/content/guides/code-splitting.md
@@ -161,7 +161,8 @@ Here are some other useful plugins and loaders provide by the community for spli
 - [`bundle-loader`](/loaders/bundle-loader): Used to split code and lazy load the resulting bundles.
 - [`promise-loader`](https://github.com/gaearon/promise-loader): Similar to the `bundle-loader` but uses promises.
 
-T> This is also very commonly used to split chunks between vendor and application code that can have common dependencies using [Explicit Vendor Chunks](/plugins/commons-chunk-plugin/#explicit-vendor-chunk)
+T> The [`CommonsChunkPlugin`](/plugins/commons-chunk-plugin) is also used to split vendor modules from core application code using [explicit vendor chunks](/plugins/commons-chunk-plugin/#explicit-vendor-chunk).
+
 
 ## Dynamic Imports
 

--- a/content/guides/code-splitting.md
+++ b/content/guides/code-splitting.md
@@ -18,6 +18,7 @@ contributors:
   - skipjack
   - jakearchibald
   - TheDutchCoder
+  - rouzbeh84
 ---
 
 T> This guide extends the examples provided in [Getting Started](/guides/getting-started) and [Managing Built Files](/guides/output-management). Please make sure you are at least familiar with the examples provided in them.
@@ -137,7 +138,7 @@ __webpack.config.js__
   };
 ```
 
-With the `CommonsChunkPlugin` in place, we should now see the duplicate dependency removed from our `index.bundle.js`. The plugin should notice that we've separated `lodash` out to a separate chunk and remove the dead weight from our main bundle. Let's do an `npm run build` to see if it worked:
+With the [`CommonsChunkPlugin`](/plugins/commons-chunk-plugin) in place, we should now see the duplicate dependency removed from our `index.bundle.js`. The plugin should notice that we've separated `lodash` out to a separate chunk and remove the dead weight from our main bundle. Let's do an `npm run build` to see if it worked:
 
 ``` bash
 Hash: 70a59f8d46ff12575481
@@ -160,12 +161,13 @@ Here are some other useful plugins and loaders provide by the community for spli
 - [`bundle-loader`](/loaders/bundle-loader): Used to split code and lazy load the resulting bundles.
 - [`promise-loader`](https://github.com/gaearon/promise-loader): Similar to the `bundle-loader` but uses promises.
 
+T> This is also very commonly used to split chunks between vendor and application code that can have common dependencies using [Explicit Vendor Chunks](/plugins/commons-chunk-plugin/#explicit-vendor-chunk)
 
 ## Dynamic Imports
 
 Two similar techniques are supported by webpack when it comes to dynamic code splitting. The first and more preferable approach is use to the [`import()` syntax](/api/module-methods#import-) that conforms to the [ECMAScript proposal](https://github.com/tc39/proposal-dynamic-import) for dynamic imports. The legacy, webpack-specific approach is to use [`require.ensure`](/api/module-methods#require-ensure). Let's try using the first of these two approaches...
 
-Before we start, let's remove the extra `entry` and `CommonsChunkPlugin` from our config as they won't be needed for this next demonstration:
+Before we start, let's remove the extra [`entry`](/concepts/entry-points/) and [`CommonsChunkPlugin`](/plugins/commons-chunk-plugin) from our config as they won't be needed for this next demonstration:
 
 __webpack.config.js__
 
@@ -212,7 +214,7 @@ webpack-demo
 |- /node_modules
 ```
 
-Now, instead of statically importing lodash, we'll use dynamic importing to separate a chunk:
+Now, instead of statically importing `lodash`, we'll use dynamic importing to separate a chunk:
 
 __src/index.js__
 
@@ -241,7 +243,7 @@ __src/index.js__
 + })
 ```
 
-Note the use of `webpackChunkName` in the comment. This will cause our separate bundle to be named `lodash.bundle.js` instead of just `[id].bundle.js`. For more information on `webpackChunkName` and the other available options, see the [`import()` documentation](/api/module-methods#import-). Let's run webpack to see lodash separated out to a separate bundle:
+Note the use of `webpackChunkName` in the comment. This will cause our separate bundle to be named `lodash.bundle.js` instead of just `[id].bundle.js`. For more information on `webpackChunkName` and the other available options, see the [`import()` documentation](/api/module-methods#import-). Let's run webpack to see `lodash` separated out to a separate bundle:
 
 ``` bash
 Hash: a27e5bf1dd73c675d5c9


### PR DESCRIPTION
updating [code-splitting](/guides/code-splitting/#components/sidebar/sidebar.jsx) to link/mention explicit vendor splitting per #1366 