### PR TITLE
A11y fixes

### DIFF
--- a/components/dropdown/dropdown.jsx
+++ b/components/dropdown/dropdown.jsx
@@ -17,7 +17,7 @@ export default class Dropdown extends React.Component {
 				onMouseOver={ this._toggle.bind(this, true) }
 				onMouseLeave={ this._toggle.bind(this, false) }>
 				<img
-				className="dropdown__language"
+				  className="dropdown__language"
 					alt="select language"
 					src={ LanguageIcon } />
         {/* Commented out until media breakpoints are in place

--- a/components/dropdown/dropdown.jsx
+++ b/components/dropdown/dropdown.jsx
@@ -12,14 +12,14 @@ export default class Dropdown extends React.Component {
 
 		return (
 			<div
-                                tabIndex="0"
+				tabIndex="0"
 				className={ `dropdown ${className}` }
 				onMouseOver={ this._toggle.bind(this, true) }
 				onMouseLeave={ this._toggle.bind(this, false) }>
 				<img
-          className="dropdown__language"
-                  alt="select language"
-          src={ LanguageIcon } />
+				className="dropdown__language"
+					alt="select language"
+					src={ LanguageIcon } />
         {/* Commented out until media breakpoints are in place
         <span>{ items[0].title }</span> */}
 				<i className="dropdown__arrow" />

--- a/components/dropdown/dropdown.jsx
+++ b/components/dropdown/dropdown.jsx
@@ -12,11 +12,13 @@ export default class Dropdown extends React.Component {
 
 		return (
 			<div
+                                tabIndex="0"
 				className={ `dropdown ${className}` }
 				onMouseOver={ this._toggle.bind(this, true) }
 				onMouseLeave={ this._toggle.bind(this, false) }>
 				<img
           className="dropdown__language"
+                  alt="select language"
           src={ LanguageIcon } />
         {/* Commented out until media breakpoints are in place
         <span>{ items[0].title }</span> */}

--- a/components/footer/footer.jsx
+++ b/components/footer/footer.jsx
@@ -19,7 +19,7 @@ export default (props) => {
 
         <section className="footer__middle">
           <Link to="/" className="footer__icon">
-            <img src={ Icon } />
+            <img src={ Icon } alt="webpack icon"/>
           </Link>
         </section>
 

--- a/components/logo/logo.jsx
+++ b/components/logo/logo.jsx
@@ -3,6 +3,6 @@ import Logo from '../../assets/site-logo.svg';
 
 export default () => {
   return (
-    <img className="logo" src={ Logo } />
+    <img className="logo" src={ Logo } alt="webpack logo" />
   );
 };

--- a/components/notification-bar/notification-bar-style.scss
+++ b/components/notification-bar/notification-bar-style.scss
@@ -32,6 +32,11 @@
 }
 
 .notification-bar__close {
+  color: getColor(white);
+  font-size: 16px;
+  padding: 0;
+  background: none;
+  border: none;
   position: absolute;
   top: 10px;
   right: 1em;

--- a/components/notification-bar/notification-bar.jsx
+++ b/components/notification-bar/notification-bar.jsx
@@ -18,7 +18,7 @@ export default class NotificationBar extends React.Component {
           <p>
             Buy the brand-new webpack stickers at <a href="http://www.unixstickers.com/tag/webpack">Unixstickers!</a>
             {localStorageIsEnabled ?
-              <i
+              <button
                 className="notification-bar__close icon-cross"
                 onClick={ this._close.bind(this) } /> :
               null

--- a/components/splash-viz/splash-viz.jsx
+++ b/components/splash-viz/splash-viz.jsx
@@ -19,7 +19,7 @@ export default class SplashViz extends React.Component {
           </TextRotator>
         </h1>
         <div className="splash-viz__modules">
-          <img src={ Modules }/>
+          <img src={ Modules } alt="dependency bundling graphic"/>
         </div>
         <Cube className="splash-viz__cube" depth={ 120 } repeatDelay={ 5000 } continuous/>
       </section>


### PR DESCRIPTION
When using the site I noticed a few accessibility issues that I thought would be easy enough to fix, so I did so.

in this PR I changed the 'close' icon that shows up in the notification bar to a button so that it can be accessed with a keyboard and then triggered with the enter key... of course in doing so I needed to change some of the styling.  Currently the appearance of the button is identical to the original.

I also added some alt-texts to the images that are on the front page of the website.  Without these texts a screenreader will humorously read the filenames of the images: `cd0bb358c45b584743d8ce4991777c42.svg` (one letter at a time of course)

There is some more similar work that can be done on the site if this type of thing is appreciated, and I'd be glad to do it as I get time.