### PR TITLE
docs(guides): Typo in Output-Management

### DIFF
--- a/content/guides/output-management.md
+++ b/content/guides/output-management.md
@@ -199,7 +199,7 @@ __webpack.config.js__
 ``` diff
   const path = require('path');
   const HtmlWebpackPlugin = require('html-webpack-plugin');
-  const CleanWebpackPlugin = require('clean-webpack-plugin');
++ const CleanWebpackPlugin = require('clean-webpack-plugin');
 
   module.exports = {
     entry: {


### PR DESCRIPTION
Hi there,

there was a typo in one of the diffs in the output-management.md guide. This PR fixes that.

Regards.

PS: CLA is signed
