### PR TITLE
docs(guides): add redirects for old code-splitting guides

### DIFF
--- a/antwar.config.js
+++ b/antwar.config.js
@@ -67,8 +67,11 @@ module.exports = {
           /^\.\/.*\.md$/
         );
       }, {
-        'code-splitting-import': '/guides/code-splitting-async',
-        'code-splitting-require': '/guides/code-splitting-async/#require-ensure-',
+        'code-splitting-import': '/guides/code-splitting',
+        'code-splitting-require': '/guides/code-splitting',
+        'code-splitting-async': '/guides/code-splitting',
+        'code-splitting-css': '/guides/code-splitting',
+        'code-splitting-libraries': '/guides/code-splitting',
         'why-webpack': '/guides/comparison',
         'production-build': '/guides/production'
       }


### PR DESCRIPTION
See https://github.com/webpack/webpack.js.org/pull/1338#issuecomment-313519967

cc @Krinkle 