### PR TITLE
fix(shield): webpack version from npm

### DIFF
--- a/components/organization/organization.jsx
+++ b/components/organization/organization.jsx
@@ -2,14 +2,9 @@ import React from 'react';
 import Container from '../container/container';
 import Contributors from '../contributors/contributors';
 import Link from '../link/link';
+import Shield from '../shield/shield';
 import Items from './projects.json';
 import './organization-style';
-
-let Shield = props => (
-  <img src={
-    `https://img.shields.io/${props.content}.svg?label=${props.label}&style=flat-square&maxAge=3600` 
-  } />
-);
 
 export default props => {
   return (
@@ -32,29 +27,29 @@ export default props => {
               <Shield content={ `npm/dm/${org.npm}`} label="npm" />
               &nbsp;
               <Shield content={ `github/stars/${org.repo}` } label="&#10029;" />
-              
+
               <h6>Activity</h6>
-              <Shield 
+              <Shield
                 content={ `github/commits-since/${org.repo}/${encodeURIComponent("master@{6 months ago}")}` }
                 label="6m" />
               &nbsp;
-              <Shield 
+              <Shield
                 content={ `github/commits-since/${org.repo}/${encodeURIComponent("master@{3 months ago}")}` }
                 label="3m" />
               &nbsp;
-              <Shield 
+              <Shield
                 content={ `github/commits-since/${org.repo}/${encodeURIComponent("master@{1 month ago}")}` }
                 label="1m" />
               &nbsp;
-              <Shield 
+              <Shield
                 content={ `github/commits-since/${org.repo}/${encodeURIComponent("master@{1 week ago}")}` }
                 label="1w" />
-              
+
               <h6>Issues and PRs</h6>
               <Shield content={ `github/issues-raw/${org.repo}` } label="issues" />
               &nbsp;
               <Shield content={ `github/issues-pr-raw/${org.repo}` } label="prs" />
-              
+
               <h6>Maintainers</h6>
               {
                 (() => {
@@ -64,7 +59,7 @@ export default props => {
                   } else return <Link to="https://github.com/webpack/webpack/issues/2734">Maintainer needed...</Link>;
                 })()
               }
-              
+
             </div>
           ))
         }

--- a/components/shield/shield.jsx
+++ b/components/shield/shield.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default props => (
+  <img src={
+    `https://img.shields.io/${props.content}.svg?label=${props.label}&style=flat-square&maxAge=3600`
+  } />
+);

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import Shield from '../shield/shield';
 import SidebarItem from '../sidebar-item/sidebar-item';
 
 export default class Sidebar extends Component {
@@ -30,7 +31,7 @@ export default class Sidebar extends Component {
 
         <div className="sidebar__inner">
           <a href="https://github.com/webpack/webpack/releases">
-            <img src="https://img.shields.io/github/release/webpack/webpack.svg?style=flat-square" alt="GitHub release" />
+            <Shield content="npm/v/webpack" label="webpack" />
           </a>
 
           <SidebarItem

--- a/content/guides/installation.md
+++ b/content/guides/installation.md
@@ -19,7 +19,7 @@ Before we begin, make sure you have a fresh version of [Node.js](https://nodejs.
 
 The latest webpack release is:
 
-[![GitHub release](https://img.shields.io/github/release/webpack/webpack.svg?style=flat-square)](https://github.com/webpack/webpack/releases)
+[![GitHub release](https://img.shields.io/npm/v/webpack.svg?label=webpack&style=flat-square&maxAge=3600)](https://github.com/webpack/webpack/releases)
 
 To install the latest release or a specific version, run one of the following commands:
 


### PR DESCRIPTION
Obtain latest webpack version from npm instead of the latest GitHub release.

Fixes #1420.