### PR TITLE
add missing diff in importing CleanWebpackPlugin

### DIFF
--- a/content/guides/output-management.md
+++ b/content/guides/output-management.md
@@ -199,7 +199,7 @@ __webpack.config.js__
 ``` diff
   const path = require('path');
   const HtmlWebpackPlugin = require('html-webpack-plugin');
-  const CleanWebpackPlugin = require('clean-webpack-plugin');
++ const CleanWebpackPlugin = require('clean-webpack-plugin');
 
   module.exports = {
     entry: {


### PR DESCRIPTION
There was missing 

``` diff 
+ const CleanWebpackPlugin = require('clean-webpack-plugin'); 
```

In [example](https://webpack.js.org/guides/output-management/#cleaning-up-the-dist-folder):

``` diff
  const path = require('path');
  const HtmlWebpackPlugin = require('html-webpack-plugin');
  const CleanWebpackPlugin = require('clean-webpack-plugin'); 

  module.exports = {
    entry: {
      app: './src/index.js',
      vendor: ['lodash']
    },
    plugins: [
+     new CleanWebpackPlugin(['dist']),
      new HtmlWebpackPlugin({
        title: 'Output Management',
        filename: 'index.html',
        template: 'src/index.html'
      })
    ],
    output: {
      filename: '[name].bundle.js',
      path: path.resolve(__dirname, 'dist')
    }
  };
```