### PR TITLE
docs(config): add output.libraryExport description (#1379)

### DIFF
--- a/content/configuration/output.md
+++ b/content/configuration/output.md
@@ -316,6 +316,8 @@ T> Read the [authoring libraries guide](/guides/author-libraries) guide for more
 
 Configure which module or modules will be exposed via the `libraryTarget`.
 
+The default value `_entry_return_` is the namespace or default module returned by your entry file.
+
 The examples below demonstrate the effect of this config when using `libraryTarget: "var"`, but any target may be used.
 
 The following configurations are supported:

--- a/content/configuration/output.md
+++ b/content/configuration/output.md
@@ -342,18 +342,14 @@ var MyModule = _entry_return_.MyModule;
 MyModule.doSomething();
 ```
 
-`libraryExport: ["MyModule", "MySecondModule"]` - **Each specified module** will be **independently** assigned to the library target:
+`libraryExport: ["MyModule", "MySubModule"]` - The array is interpreted as a **path to a module** to be assigned to the library target:
 
 ```javascript
-// if your entry exports modules `MyModule` and `MySecondModule`
-var MyModule = _entry_return_.MyModule;
-var MySecondModule = _entry_return_.MySecondModule;
+// if your entry exports `MyModule` which in turn exports `MySubModule`
+var MySubModule = _entry_return_.MyModule.MySubModule;
 
-MyModule.doSomething();
-MySecondModule.doSomethingElse();
+MySubModule.doSomething();
 ```
-
-
 
 
 ## `output.libraryTarget`

--- a/content/configuration/output.md
+++ b/content/configuration/output.md
@@ -310,7 +310,46 @@ T> Read the [authoring libraries guide](/guides/author-libraries) guide for more
 
 `string` or `string[]` (since webpack 3.0.0)
 
-Allows to select an export for the library.
+> Default: `_entry_return_`
+
+Configure which module or modules will be exposed via the `libraryTarget`.
+
+The examples below demonstrate the effect of this config when using `libraryTarget: "var"`, but any target may be used.
+
+The following configurations are supported:
+
+`libraryExport: "default"` - The **default export of your entry point** will be assigned to the library target:
+
+```javascript
+// if your entry has a default export of `MyDefaultModule`
+var MyDefaultModule = _entry_return_.default;
+
+// your users will use your library like:
+MyDefaultModule.doSomething();
+```
+
+`libraryExport: "MyModule"` - The **specified module** will be assigned to the library target:
+
+```javascript
+// if your entry exports a module `MyModule`
+var MyModule = _entry_return_.MyModule;
+
+// your users will use your library like:
+MyModule.doSomething();
+```
+
+`libraryExport: ["MyModule", "MySecondModule"]` - **Each specified module** will be **independently** assigned to the library target:
+
+```javascript
+// if your entry exports modules `MyModule` and `MySecondModule`
+var MyModule = _entry_return_.MyModule;
+var MySecondModule = _entry_return_.MySecondModule;
+
+MyModule.doSomething();
+MySecondModule.doSomethingElse();
+```
+
+
 
 
 ## `output.libraryTarget`


### PR DESCRIPTION
Really keen for some feedback on the examples I used and whether they are technically correct. Have only used `libraryExport` very briefly for my own purposes, but thought I'd get the ball rolling on some better docs for it.

What is the correct default value for this config?
Are there any libraryTarget combinations which produce inconsistent results?
Anything else someone may need to know about using this config?

cc: @skipjack @mbraint @sokra 

Resolves #1379 
