### PR TITLE
docs(guides): Add vue example to lazy loading

### DIFF
--- a/content/guides/lazy-loading.md
+++ b/content/guides/lazy-loading.md
@@ -107,3 +107,4 @@ Child html-webpack-plugin for "index.html":
 Many frameworks and libraries have their own recommendations on how this should be accomplished within their methodologies. Here are a few examples:
 
 - React: [Code Splitting and Lazy Loading](https://reacttraining.com/react-router/web/guides/code-splitting)
+- Vue: [Lazy Load in Vue using Webpack's code splitting](https://alexjoverm.github.io/2017/07/16/Lazy-load-in-Vue-using-Webpack-s-code-splitting/)


### PR DESCRIPTION
Hi @TheLarkInn, as you told me on Twitter, here's my PR.

For context, I've just written an article ["Lazy loading in Vue using Webpack's code splitting"](https://alexjoverm.github.io/2017/07/16/Lazy-load-in-Vue-using-Webpack-s-code-splitting/) and asked @TheLarkInn to take a quick look. Actually anyone, feedback is appreciated, it should be less than 5 min reading.

And thought it could be useful for the frameworks section on https://webpack.js.org/guides/lazy-loading/