### PR TITLE
docs(guides): Fix typos in development.md

### DIFF
--- a/content/guides/development.md
+++ b/content/guides/development.md
@@ -8,7 +8,7 @@ contributors:
   - TheDutchCoder
 ---
 
-T> This guide extends on code examples found in the [`Output Management`](/guides/output-management) guide.
+T> This guide extends on code examples found in the [Output Management](/guides/output-management) guide.
 
 If you've been following the guides, you should have a solid understanding of some of the webpack basics. Before we continue, let's look into setting up a development environment to make our lives a little easier.
 
@@ -19,7 +19,7 @@ W> The tools in this guide are __only meant for development__, please __avoid__ 
 
 When webpack bundles your source code, it can become difficult to track down errors and warnings to their original location. For example, if you bundle three source files (`a.js`, `b.js`, and `c.js`) into one bundle (`bundle.js`) and one of the source files contains an error, the stack trace will simply point to `bundle.js`. This isn't always helpful as you probably want to know exactly which source file the error came from.
 
-In order to make it easier to track down errors and warnings, JavaScript offers [`source maps`](http://blog.teamtreehouse.com/introduction-source-maps), which maps your compiled code back to your original source code. If an error originates from `b.js`, the Source Map will tell you exactly that.
+In order to make it easier to track down errors and warnings, JavaScript offers [source maps](http://blog.teamtreehouse.com/introduction-source-maps), which maps your compiled code back to your original source code. If an error originates from `b.js`, the source map will tell you exactly that.
 
 There are a lot of [different options](/configuration/devtool) available when it comes to source maps, be sure to check them out so you can configure them to your needs.
 
@@ -88,12 +88,12 @@ Now open the resulting `index.html` file in your browser. Click the button and l
     at HTMLButtonElement.printMe (print.js:2)
  ```
 
-We can see that the error also contains a reference to the file (`print.js`) and line number (2) where the error occurred. This is great, because now we know exactly where to look to fix the issue.
+We can see that the error also contains a reference to the file (`print.js`) and line number (2) where the error occurred. This is great, because now we know exactly where to look in order to fix the issue.
 
 
 ## Choosing a Development Tool
 
-W> Some text editors have a "safe write" function that might interfere with some of the following tools. Read [`Adjusting Your text Editor`](#adjusting-your-text-editor) for a solution to these issue.
+W> Some text editors have a "safe write" function that might interfere with some of the following tools. Read [Adjusting Your text Editor](#adjusting-your-text-editor) for a solution to these issues.
 
 It quickly becomes a hassle to manually run `npm run build` everytime you want to compile your code.
 
@@ -153,7 +153,7 @@ __src/print.js__
   }
 ```
 
-Now save your file and check the terminal window. You should see webpack automatically recompile the changed module!
+Now save your file and check the terminal window. You should see that webpack automatically recompiles the changed module!
 
 The only downside is that you have to refresh your browser in order to see the changes. It would be much nicer if that would happen automatically as well, so let's try `webpack-dev-server` which will do exactly that.
 
@@ -242,7 +242,7 @@ T> Now that your server is working, you might want to give [Hot Module Replaceme
 
 ## Adjusting Your Text Editor
 
-When using automatic compilation of your code, you could run into issues when saving your files. Some editors have a "safe write "feature that can potentially interfere with recompilation.
+When using automatic compilation of your code, you could run into issues when saving your files. Some editors have a "safe write" feature that can potentially interfere with recompilation.
 
 To disable this feature in some common editors, see the list below:
 
@@ -254,4 +254,4 @@ To disable this feature in some common editors, see the list below:
 
 ## Conclusion
 
-Now that you've learned how to automatically compile your and run a simple development server, you can check out the next guide, which will cover [Hot Module Replacement](/guides/hot-module-replacement).
+Now that you've learned how to automatically compile your code and run a simple development server, you can check out the next guide, which will cover [Hot Module Replacement](/guides/hot-module-replacement).


### PR DESCRIPTION
Also adds some words to make sentence flow a little better and removes backticks for non code-related words.
