### PR TITLE
Port Plugin Documentation

### DIFF
--- a/content/plugins/prefetch-plugin.md
+++ b/content/plugins/prefetch-plugin.md
@@ -1,0 +1,17 @@
+---
+title: PrefetchPlugin
+contributors:
+  - skipjack
+---
+
+Prefetch normal module requests, causing them to be resolved and built before the first `import` or `require` of that module occurs. Using this plugin can boost performance. Try to profile the build first to determine clever prefetching points.
+
+``` javascript
+new webpack.PrefetchPlugin([context], request)
+```
+
+
+## Options
+
+- `context`: An absolute path to a directory
+- `request`: A request string for a normal module

--- a/content/plugins/watch-ignore-plugin.md
+++ b/content/plugins/watch-ignore-plugin.md
@@ -1,0 +1,16 @@
+---
+title: WatchIgnorePlugin
+contributors:
+  - skipjack
+---
+
+Ignore the specified files, i.e. those matching the provided paths or regular expressions, while in [watch mode](/configuration/watch).
+
+``` javascript
+new webpack.WatchIgnorePlugin(paths)
+```
+
+
+## Options
+
+- `paths` (array): A list of RegExps or absolute paths to directories or files that should be ignored


### PR DESCRIPTION
Port documentation for the `WatchIgnorePlugin` and `PrefetchPlugin` from here:

https://github.com/webpack/docs/wiki/list-of-plugins

Resolves #126 
Resolves #1378 