### PR TITLE
Update hot-module-replacement.md

### DIFF
--- a/content/guides/hot-module-replacement.md
+++ b/content/guides/hot-module-replacement.md
@@ -11,6 +11,7 @@ contributors:
   - drpicox
   - skipjack
   - gdi2290
+  - evolve2k
 related:
   - title: Concepts - Hot Module Replacement
     url: /concepts/hot-module-replacement
@@ -29,13 +30,13 @@ This feature is great for productivity. Let's take a look at how to set it up wi
 
 ``` js
 const path = require('path');
-const webpack = require('webpack');
++ const webpack = require('webpack');
 
 module.exports = {
   entry: './index.js',
 
   plugins: [
-    new webpack.HotModuleReplacementPlugin() // Enable HMR
+    + new webpack.HotModuleReplacementPlugin() // Enable HMR
   ],
 
   output: {
@@ -45,9 +46,9 @@ module.exports = {
   },
 
   devServer: {
-    hot: true, // Tell the dev-server we're using HMR
+    + hot: true, // Tell the dev-server we're using HMR
     contentBase: path.resolve(__dirname, 'dist'),
-    publicPath: '/'
+    + publicPath: '/'
   }
 };
 ```


### PR DESCRIPTION
Progressing through the tutorial so far, each tute lead on nicely to the next.
This one however breaks the flow and provided no clues as to which lines to add like previous files do.

Basically the convention of the green lines beginning with + signs is not present in this file, breaking the flow of the tutorial at this point.

I've marked up a couple of key ones that would be useful to highlight.
This is helpful as is it is but could probably do with more work also.