### PR TITLE
docs(api): begin work on stats json documentation

### DIFF
--- a/content/api/stats.md
+++ b/content/api/stats.md
@@ -1,0 +1,167 @@
+---
+title: Stats JSON
+sort: 1
+contributors:
+  - skipjack
+---
+
+When compiling source code with webpack, users can generate a JSON file containing statistics about modules. These statistics can be used to analyze an application's dependency graph as well as to optimize compilation speed. The file is typically generated with the following CLI command:
+
+``` bash
+webpack --profile --json > compilation-stats.json
+```
+
+The `--json > compilation-stats.json` flag indicates to webpack that it should emit the `compilation-stats.json` containing the dependency graph and various other build information. Typically, the `--profile` flag is also added so that a `profile` section is added to each [`modules` object]() containing module-specific compilation stats.
+
+
+## Structure
+
+``` js-with-links
+{
+  "version": "1.4.13", // Version of webpack used for the compilation
+  "hash": "11593e3b3ac85436984a", // Compilation specific hash
+  "time": 2469, // Compilation time in milliseconds (?)
+  "filteredModules": 0, // ?
+  "assetsByChunkName": {
+    // Chunk name to emitted asset mapping
+    "main": "web.js?h=11593e3b3ac85436984a",
+    "named-chunk": "named-chunk.web.js"
+  },
+  "assets": [
+    // A list of [asset objects](#assets-objects)
+  ],
+  "chunks": [
+    // A list of [chunk objects](#chunks-objects)
+  ],
+  "modules": [
+    // A list of [module objects](#modules-objects)
+  ],
+  "errors": [
+    // A list of [error strings](#errors-and-warnings)
+  ],
+  "warnings": [
+    // A list of [warning strings](#errors-and-warnings)
+  ]
+}
+```
+
+
+### Asset Objects
+
+Each `assets` object represents an `output` file emitted from the compilation. They all follow the a similar structure:
+
+``` js
+{
+  "chunkNames": [], // The chunks this asset contains ?
+  "chunks": [ 10, 6 ], // The chunk IDs this asset contains ?
+  "emitted": true, // Whether or not the asset made it to the `output` directory ?
+  "name": "10.web.js", // The `output` filename
+  "size": 1058 // The size of the file in bytes ?
+}
+```
+
+
+### Chunk Objects
+
+Each `chunks` object represents a group of modules known as a [chunk](/glossary#chunk). Each object follows the following structure:
+
+``` js
+{
+  "entry": true, // Whether or not it's an entry chunk
+  "files": [
+    // An array of filename strings that contain this chunk (?)
+  ],
+  "filteredModules": 0, // ?
+  "id": 0, // The ID of this chunk
+  "initial": true, // ?
+  "modules": [
+    // A list of [module objects](#modules-objects)
+  ],
+  "names": [
+    // An list of chunk names contained within this chunk (?)
+  ],
+  "origins": [
+    // See the description below...
+  ],
+  "parents": [], // Parent chunk IDs? Names?
+  "rendered": true, // ?
+  "size": 188057 // Chunk size in bytes (?)
+}
+```
+
+The `chunks` object will also contain a list of `origins` describing how the given chunk originated. Each `origins` object follows the following schema:
+
+``` js
+{
+  "loc": "", // Lines of code that generated this chunk (?)
+  "module": "(webpack)\\test\\browsertest\\lib\\index.web.js", // ?
+  "moduleId": 0, // The ID of the module
+  "moduleIdentifier": "(webpack)\\test\\browsertest\\lib\\index.web.js", // ?
+  "moduleName": "./lib/index.web.js", // ?
+  "name": "main", // ?
+  "reasons": [
+    // A list of the same `reasons` found in [module objects](#module-objects)
+  ]
+}
+```
+
+
+### Module Objects
+
+What good would these statistics be without some description of the compiled application's actual modules? Each module in the dependency graph is represented by the following structure:
+
+``` js
+{
+  "assets": [], // A list of [asset objects](#asset-objects) (?)
+  "built": true, // Maybe this means compiled, loaded or output (?)
+  "cacheable": true, // Whether or not this module is cacheable (?)
+  "chunks": [
+    // IDs of chunks that contain this module (?)
+  ],
+  "errors": 0, // Number of errors when resolving or processing the module (?)
+  "failed": false, // Whether or not compilation failed on this module (?)
+  "id": 0, // The ID of the module
+  "identifier": "(webpack)\\test\\browsertest\\lib\\index.web.js", // Another ID ?
+  "name": "./lib/index.web.js", // Path to the actual file
+  "optional": false, // ?
+  "prefetched": false, // Whether or not the module was prefetched (a build optimization)
+  "profile": {
+    // Module specific compilation stats corresponding to the [`--profile` flag](/api/cli#profiling)
+    "building": 73,
+    "dependencies": 242,
+    "factory": 11
+  },
+  "reasons": [
+    // See the description below...
+  ],
+  "size": 3593, // Module size in bytes?
+  "source": "// Should not break it...\r\nif(typeof...", // The stringified raw source (?)
+  "warnings": 0 // Number of warnings when resolving or processing the module (?)
+}
+```
+
+Every module also contains a list of `reasons` objects describing why that module was included in the dependency graph. Each "reason" is very similar to the `origins` objects seen above in the [chunk objects](#chunk-objects) section:
+
+``` js
+{
+  "loc": "33:24-93", // Lines of code that caused the module to be included
+  "module": "./lib/index.web.js", // ?
+  "moduleId": 0, // The ID of the module
+  "moduleIdentifier": "(webpack)\\test\\browsertest\\lib\\index.web.js", // ?
+  "moduleName": "./lib/index.web.js", // ?
+  "type": "require.context", // The [type of request](/api/module-methods) used
+  "userRequest": "../../cases" // ?
+}
+```
+
+
+### Errors and Warnings
+
+The `errors` and `warnings` properties each contain a list of strings. Each string contains a message and stack trace:
+
+``` bash
+../cases/parsing/browserify/index.js
+Critical dependencies:
+2:114-121 This seem to be a pre-built javascript file. Even while this is possible, it's not recommended. Try to require to orginal source to get better results.
+ @ ../cases/parsing/browserify/index.js 2:114-121
+```

--- a/content/api/stats.md
+++ b/content/api/stats.md
@@ -11,30 +11,36 @@ When compiling source code with webpack, users can generate a JSON file containi
 webpack --profile --json > compilation-stats.json
 ```
 
-The `--json > compilation-stats.json` flag indicates to webpack that it should emit the `compilation-stats.json` containing the dependency graph and various other build information. Typically, the `--profile` flag is also added so that a `profile` section is added to each [`modules` object]() containing module-specific compilation stats.
+The `--json > compilation-stats.json` flag indicates to webpack that it should emit the `compilation-stats.json` containing the dependency graph and various other build information. Typically, the `--profile` flag is also added so that a `profile` section is added to each [`modules` object](#module-objects) containing module-specific compilation stats.
 
 
 ## Structure
+
+The top-level structure of the output JSON file is fairly straightforward but there are a few nested data structures as well. Each nested structure has a dedicated section below to make this document more consumable. Note that you can click links within the top-level structure below to jump to relevant sections and documentation:
 
 ``` js-with-links
 {
   "version": "1.4.13", // Version of webpack used for the compilation
   "hash": "11593e3b3ac85436984a", // Compilation specific hash
-  "time": 2469, // Compilation time in milliseconds (?)
-  "filteredModules": 0, // ?
+  "time": 2469, // Compilation time in milliseconds
+  "filteredModules": 0, // A count of excluded modules when [`exclude`](/configuration/stats/#stats) is passed to the [`toJSON`](/api/node/#stats-tojson-options-) method
   "assetsByChunkName": {
-    // Chunk name to emitted asset mapping
+    // Chunk name to emitted asset(s) mapping
     "main": "web.js?h=11593e3b3ac85436984a",
-    "named-chunk": "named-chunk.web.js"
+    "named-chunk": "named-chunk.web.js",
+    "other-chunk": [
+      "other-chunk.js",
+      "other-chunk.css"
+    ]
   },
   "assets": [
-    // A list of [asset objects](#assets-objects)
+    // A list of [asset objects](#asset-objects)
   ],
   "chunks": [
-    // A list of [chunk objects](#chunks-objects)
+    // A list of [chunk objects](#chunk-objects)
   ],
   "modules": [
-    // A list of [module objects](#modules-objects)
+    // A list of [module objects](#module-objects)
   ],
   "errors": [
     // A list of [error strings](#errors-and-warnings)
@@ -52,11 +58,11 @@ Each `assets` object represents an `output` file emitted from the compilation. T
 
 ``` js
 {
-  "chunkNames": [], // The chunks this asset contains ?
-  "chunks": [ 10, 6 ], // The chunk IDs this asset contains ?
-  "emitted": true, // Whether or not the asset made it to the `output` directory ?
+  "chunkNames": [], // The chunks this asset contains
+  "chunks": [ 10, 6 ], // The chunk IDs this asset contains
+  "emitted": true, // Indicates whether or not the asset made it to the `output` directory
   "name": "10.web.js", // The `output` filename
-  "size": 1058 // The size of the file in bytes ?
+  "size": 1058 // The size of the file in bytes
 }
 ```
 
@@ -65,40 +71,41 @@ Each `assets` object represents an `output` file emitted from the compilation. T
 
 Each `chunks` object represents a group of modules known as a [chunk](/glossary#chunk). Each object follows the following structure:
 
-``` js
+``` js-with-links
 {
-  "entry": true, // Whether or not it's an entry chunk
+  "entry": true, // Indicates whether or not the chunk contains the webpack runtime
   "files": [
-    // An array of filename strings that contain this chunk (?)
+    // An array of filename strings that contain this chunk
   ],
-  "filteredModules": 0, // ?
+  "filteredModules": 0, // See the description in the [top-level structure](#structure) above
   "id": 0, // The ID of this chunk
-  "initial": true, // ?
+  "initial": true, // Indicates whether this chunk is loaded on initial page load or [on demand](/guides/lazy-loading)
   "modules": [
     // A list of [module objects](#modules-objects)
+    "web.js?h=11593e3b3ac85436984a"
   ],
   "names": [
-    // An list of chunk names contained within this chunk (?)
+    // An list of chunk names contained within this chunk
   ],
   "origins": [
     // See the description below...
   ],
-  "parents": [], // Parent chunk IDs? Names?
-  "rendered": true, // ?
-  "size": 188057 // Chunk size in bytes (?)
+  "parents": [], // Parent chunk IDs
+  "rendered": true, // Indicates whether or not the chunk went through Code Generation
+  "size": 188057 // Chunk size in bytes
 }
 ```
 
 The `chunks` object will also contain a list of `origins` describing how the given chunk originated. Each `origins` object follows the following schema:
 
-``` js
+``` js-with-links
 {
-  "loc": "", // Lines of code that generated this chunk (?)
-  "module": "(webpack)\\test\\browsertest\\lib\\index.web.js", // ?
+  "loc": "", // Lines of code that generated this chunk
+  "module": "(webpack)\\test\\browsertest\\lib\\index.web.js", // Path to the module
   "moduleId": 0, // The ID of the module
-  "moduleIdentifier": "(webpack)\\test\\browsertest\\lib\\index.web.js", // ?
-  "moduleName": "./lib/index.web.js", // ?
-  "name": "main", // ?
+  "moduleIdentifier": "(webpack)\\test\\browsertest\\lib\\index.web.js", // Path to the module
+  "moduleName": "./lib/index.web.js", // Relative path to the module
+  "name": "main", // The name of the chunk
   "reasons": [
     // A list of the same `reasons` found in [module objects](#module-objects)
   ]
@@ -110,47 +117,49 @@ The `chunks` object will also contain a list of `origins` describing how the giv
 
 What good would these statistics be without some description of the compiled application's actual modules? Each module in the dependency graph is represented by the following structure:
 
-``` js
+``` js-with-links
 {
-  "assets": [], // A list of [asset objects](#asset-objects) (?)
-  "built": true, // Maybe this means compiled, loaded or output (?)
-  "cacheable": true, // Whether or not this module is cacheable (?)
-  "chunks": [
-    // IDs of chunks that contain this module (?)
+  "assets": [
+    // A list of [asset objects](#asset-objects)
   ],
-  "errors": 0, // Number of errors when resolving or processing the module (?)
-  "failed": false, // Whether or not compilation failed on this module (?)
-  "id": 0, // The ID of the module
-  "identifier": "(webpack)\\test\\browsertest\\lib\\index.web.js", // Another ID ?
+  "built": true, // Indicates that the module went through [Loaders](/concepts/loaders), Parsing, and Code Generation
+  "cacheable": true, // Whether or not this module is cacheable
+  "chunks": [
+    // IDs of chunks that contain this module
+  ],
+  "errors": 0, // Number of errors when resolving or processing the module
+  "failed": false, // Whether or not compilation failed on this module
+  "id": 0, // The ID of the module (analagous to [`module.id`](/api/module-variables#module-id-commonjs-))
+  "identifier": "(webpack)\\test\\browsertest\\lib\\index.web.js", // A unique ID used internally
   "name": "./lib/index.web.js", // Path to the actual file
-  "optional": false, // ?
-  "prefetched": false, // Whether or not the module was prefetched (a build optimization)
+  "optional": false, // All requests to this module are with `try... catch` blocks (irrelevant with ESM)
+  "prefetched": false, // Indicates whether or not the module was [prefetched](/plugins/prefetch-plugin)
   "profile": {
-    // Module specific compilation stats corresponding to the [`--profile` flag](/api/cli#profiling)
-    "building": 73,
-    "dependencies": 242,
-    "factory": 11
+    // Module specific compilation stats corresponding to the [`--profile` flag](/api/cli#profiling) (in milliseconds)
+    "building": 73, // Loading and parsing
+    "dependencies": 242, // Building dependencies
+    "factory": 11 // Resolving dependencies
   },
   "reasons": [
     // See the description below...
   ],
-  "size": 3593, // Module size in bytes?
-  "source": "// Should not break it...\r\nif(typeof...", // The stringified raw source (?)
-  "warnings": 0 // Number of warnings when resolving or processing the module (?)
+  "size": 3593, // Estimated size of the module in bytes
+  "source": "// Should not break it...\r\nif(typeof...", // The stringified raw source
+  "warnings": 0 // Number of warnings when resolving or processing the module
 }
 ```
 
 Every module also contains a list of `reasons` objects describing why that module was included in the dependency graph. Each "reason" is very similar to the `origins` objects seen above in the [chunk objects](#chunk-objects) section:
 
-``` js
+``` js-with-links
 {
   "loc": "33:24-93", // Lines of code that caused the module to be included
-  "module": "./lib/index.web.js", // ?
+  "module": "./lib/index.web.js", // Relative path to the module based on [context](/configuration/entry-context/#context)
   "moduleId": 0, // The ID of the module
-  "moduleIdentifier": "(webpack)\\test\\browsertest\\lib\\index.web.js", // ?
-  "moduleName": "./lib/index.web.js", // ?
+  "moduleIdentifier": "(webpack)\\test\\browsertest\\lib\\index.web.js", // Path to the module
+  "moduleName": "./lib/index.web.js", // A more readable name for the module (used for "pretty-printing")
   "type": "require.context", // The [type of request](/api/module-methods) used
-  "userRequest": "../../cases" // ?
+  "userRequest": "../../cases" // Raw string used for the `import` or `require` request
 }
 ```
 

--- a/content/api/stats.md
+++ b/content/api/stats.md
@@ -149,7 +149,7 @@ What good would these statistics be without some description of the compiled app
 }
 ```
 
-Every module also contains a list of `reasons` objects describing why that module was included in the dependency graph. Each "reason" is very similar to the `origins` objects seen above in the [chunk objects](#chunk-objects) section:
+Every module also contains a list of `reasons` objects describing why that module was included in the dependency graph. Each "reason" is similar to the `origins` seen above in the [chunk objects](#chunk-objects) section:
 
 ``` js-with-links
 {

--- a/content/api/stats.md
+++ b/content/api/stats.md
@@ -23,7 +23,7 @@ The top-level structure of the output JSON file is fairly straightforward but th
   "version": "1.4.13", // Version of webpack used for the compilation
   "hash": "11593e3b3ac85436984a", // Compilation specific hash
   "time": 2469, // Compilation time in milliseconds
-  "filteredModules": 0, // A count of excluded modules when [`exclude`](/configuration/stats/#stats) is passed to the [`toJSON`](/api/node/#stats-tojson-options-) method
+  "filteredModules": 0, // A count of excluded modules when [`exclude`](/configuration/stats/#stats) is passed to the [`toJson`](/api/node/#stats-tojson-options-) method
   "assetsByChunkName": {
     // Chunk name to emitted asset(s) mapping
     "main": "web.js?h=11593e3b3ac85436984a",
@@ -174,3 +174,5 @@ Critical dependencies:
 2:114-121 This seem to be a pre-built javascript file. Even while this is possible, it's not recommended. Try to require to orginal source to get better results.
  @ ../cases/parsing/browserify/index.js 2:114-121
 ```
+
+W> Note that the stack traces are removed when `errorDetails: false` is passed to the `toJson` method. The `errorDetails` option is set to `true` by default.


### PR DESCRIPTION
Add page to document the output of...

``` bash
webpack --profile --json > compilation-stats.json
```

We still need to go through and fill in the blanks before this can be merged.

Resolves #491 

cc @dmitriid @walfly