### PR TITLE
docs(plugins): use const in webpack config and correct build output

### DIFF
--- a/content/guides/asset-management.md
+++ b/content/guides/asset-management.md
@@ -5,6 +5,7 @@ contributors:
   - skipjack
   - michael-ciniawsky
   - TheDutchCoder
+  - sudarsangp
 ---
 
 If you've been following the guides from the start, you will now have a small project that shows "Hello webpack". Now let's try to incorporate some other assets, like images, to see how they can be handled.
@@ -43,7 +44,7 @@ npm install --save-dev style-loader css-loader
 __webpack.config.js__
 
 ``` diff
-  var path = require('path');
+  const path = require('path');
 
   module.exports = {
     entry: './src/index.js',
@@ -150,7 +151,7 @@ npm install --save-dev file-loader
 __webpack.config.js__
 
 ``` diff
-  var path = require('path');
+  const path = require('path');
 
   module.exports = {
     entry: './src/index.js',
@@ -268,7 +269,7 @@ So what about other assets like fonts? The file and url loaders will take any fi
 __webpack.config.js__
 
 ``` diff
-  var path = require('path');
+  const path = require('path');
 
   module.exports = {
     entry: './src/index.js',
@@ -382,7 +383,7 @@ npm install --save-dev csv-loader xml-loader
 __webpack.config.js__
 
 ``` diff
-  var path = require('path');
+  const path = require('path');
 
   module.exports = {
     entry: './src/index.js',
@@ -542,7 +543,7 @@ __project__
 __webpack.config.js__
 
 ``` diff
-  var path = require('path');
+  const path = require('path');
 
   module.exports = {
     entry: './src/index.js',

--- a/content/guides/getting-started.md
+++ b/content/guides/getting-started.md
@@ -11,6 +11,7 @@ contributors:
   - aaronang
   - jecoopr
   - TheDutchCoder
+  - sudarsangp
 ---
 
 As you may already know, webpack is used to compile JavaScript modules. Once [installed](/guides/installation), you can interface with webpack either from its [CLI](/api/cli) or [API](/api/node). If you're still new to webpack, please read through the [core concepts](/concepts) and [this comparison](/comparison) to learn why you might use it over the other tools that are out in the community.
@@ -188,7 +189,7 @@ __project__
 __webpack.config.js__
 
 ``` javascript
-var path = require('path');
+const path = require('path');
 
 module.exports = {
   entry: './src/index.js',

--- a/content/guides/output-management.md
+++ b/content/guides/output-management.md
@@ -4,6 +4,7 @@ sort: 4
 contributors:
   - skipjack
   - TheDutchCoder
+  - sudarsangp
 ---
 
 T> This guide extends on code examples found in the [`Asset Management`](/guides/asset-management) guide.
@@ -160,7 +161,7 @@ Hash: 81f82697c19b5f49aebd
 Version: webpack 2.6.1
 Time: 854ms
            Asset       Size  Chunks                    Chunk Names
-vendor.bundle.js     544 kB       0  [emitted]  [big]  vendor
+ print.bundle.js     544 kB       0  [emitted]  [big]  print
    app.bundle.js    2.81 kB       1  [emitted]         app
       index.html  249 bytes          [emitted]
    [0] ./~/lodash/lodash.js 540 kB {0} [built]


### PR DESCRIPTION
**const** for path instead of **var** to ensure consistency in webpack config file
build output use **print** instead of **vendor** for asset and chunk name