### PR TITLE
Add documentation for devServer cli options

### DIFF
--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -74,6 +74,11 @@ allowedHosts: [
 ]
 ```
 
+To use this option with the CLI pass the `--allowed-hosts` option a comma-delimited string.
+
+```
+webpack-dev-server --entry /entry/file --output-path /output/path --allowed-hosts .host.com,host2.com
+```
 
 ## `devServer.clientLogLevel`
 

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -421,6 +421,20 @@ Usage via the CLI
 webpack-dev-server --pfx /path/to/file.pfx
 ```
 
+## `devServer.pfxPassphrase`
+
+`string`
+
+The passphrase to a SSL PFX file.
+```js
+pfxPassphrase: 'passphrase'
+```
+
+Usage via the CLI
+```
+webpack-dev-server --pfx-passphrase passphrase
+```
+
 ## `devServer.port` - CLI only
 
 `number`

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -621,6 +621,21 @@ setup(app){
 }
 ```
 
+## `devServer.socket`
+
+`string`
+
+The Unix socket to listen to (instead of a host).
+
+```js
+socket: 'socket'
+```
+
+Usage via the CLI
+```
+webpack-dev-server --socket socket
+```
+
 
 ## `devServer.staticOptions`
 

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -549,7 +549,7 @@ webpack-dev-server --progress
 ```
 
 
-## `devServer.public` - CLI only
+## `devServer.public`
 
 `string`
 
@@ -559,6 +559,11 @@ For example, the dev-server is proxied by nginx, and available on `myapp.test`:
 
 ```js
 public: "myapp.test:80"
+```
+
+Usage via the CLI
+```
+webpack-dev-server --public myapp.test:80
 ```
 
 

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -237,7 +237,7 @@ hot: true
 T> Note that you must also include a `new webpack.HotModuleReplacementPlugin()` to fully enable HMR. See the [HMR concepts page](/concepts/hot-module-replacement) for more information.
 
 
-## `devServer.hotOnly` - CLI only
+## `devServer.hotOnly`
 
 `boolean`
 
@@ -247,6 +247,10 @@ Enables Hot Module Replacement (see [`devServer.hot`](#devserver-hot)) without p
 hotOnly: true
 ```
 
+Usage via the CLI
+```
+webpack-dev-server --hot-only
+```
 
 ## `devServer.https`
 

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -283,6 +283,14 @@ https: {
 
 This object is passed straight to Node.js HTTPS module, so see the [HTTPS documentation](https://nodejs.org/api/https.html) for more information.
 
+## `devServer.info` - CLI only
+
+`boolean`
+
+Output cli information. It is enabled by default.
+```
+webpack-dev-server --info=false
+```
 
 ## `devServer.inline` - CLI only
 

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -161,6 +161,11 @@ To disable `contentBase`:
 contentBase: false
 ```
 
+Usage via the CLI
+```
+webpack-dev-server --content-base /path/to/content/dir
+```
+
 
 ## `devServer.filename` 🔑
 

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -170,6 +170,20 @@ Usage via the CLI
 webpack-dev-server --content-base /path/to/content/dir
 ```
 
+## `devServer.disableHostCheck`
+
+`boolean`
+
+When set to true this option bypasses host checking. THIS IS NOT RECOMMENDED as apps that do not check the host are vulnerable to DNS rebinding attacks.
+
+```js
+disableHostCheck: true
+```
+
+Usage via the CLI
+```
+webpack-dev-server --disable-host-check
+```
 
 ## `devServer.filename` 🔑
 

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -417,6 +417,9 @@ proxy: {
 `boolean`
 
 Output running progress to console.
+```
+webpack-dev-server --progress
+```
 
 
 ## `devServer.public` - CLI only

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -406,6 +406,21 @@ overlay: {
 }
 ```
 
+## `devServer.pfx`
+
+`string`
+
+Path to a SSL pfx file.
+
+```js
+pfx: '/path/to/file.pfx'
+```
+
+Usage via the CLI
+```
+webpack-dev-server --pfx /path/to/file.pfx
+```
+
 ## `devServer.port` - CLI only
 
 `number`

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -449,7 +449,7 @@ Usage via the CLI
 webpack-dev-server --pfx-passphrase passphrase
 ```
 
-## `devServer.port` - CLI only
+## `devServer.port`
 
 `number`
 
@@ -459,6 +459,10 @@ Specify a port number to listen for requests on:
 port: 8080
 ```
 
+Usage via the CLI
+```
+webpack-dev-server --port 8080
+```
 
 ## `devServer.proxy`
 

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -340,6 +340,21 @@ Usage via the CLI
 webpack-dev-server --open
 ```
 
+## `devServer.openPage`
+
+`string`
+
+Specify a page to navigate to when opening the browser.
+
+```js
+openPage: '/different/page'
+```
+
+Usage via the CLI
+```
+webpack-dev-server --open-page "/different/page"
+```
+
 ## `devServer.overlay`
 
 `boolean` `object`

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -661,6 +661,10 @@ watchContentBase: true
 
 It is disabled by default.
 
+Usage via the CLI
+```
+webpack-dev-server --watch-content-base
+```
 
 ## `devServer.watchOptions` 🔑
 

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -548,6 +548,21 @@ This option closes the server when stdin ends.
 webpack-dev-server --stdin
 ```
 
+## `devServer.useLocalIp`
+
+`boolean`
+
+This option lets the browser open with your local IP.
+
+```js
+useLocalIp: true
+```
+
+Usage via the CLI
+```
+webpack-dev-server --useLocalIp
+```
+
 ## `devServer.watchContentBase`
 
 `boolean`

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -523,6 +523,15 @@ For more information, see the [**stats documentation**](/configuration/stats).
 
 T> This option has no effect when used with `quiet` or `noInfo`.
 
+## `devServer.stdin` - CLI only
+
+`boolean`
+
+This option closes the server when stdin ends.
+
+```
+webpack-dev-server --stdin
+```
 
 ## `devServer.watchContentBase`
 

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -229,6 +229,11 @@ historyApiFallback: {
 }
 ```
 
+Usage via the CLI
+```
+webpack-dev-server --history-api-fallback
+```
+
 For more options and information, see the [connect-history-api-fallback](https://github.com/bripkens/connect-history-api-fallback) documentation.
 
 

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -109,6 +109,15 @@ Possible values are `none`, `error`, `warning` or `info` (default).
 
 Note that the console will *always* show bundle errors and warnings. This option only effects the message before it.
 
+## `devServer.color` - CLI only
+
+`boolean`
+
+Enables/Disables colors on the console.
+```
+webpack-dev-server --color
+```
+
 
 ## `devServer.compress`
 

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -361,7 +361,7 @@ webpack-dev-server --info=false
 ```
 
 
-## `devServer.inline` - CLI only
+## `devServer.inline`
 
 `boolean`
 

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -134,6 +134,10 @@ Enable [gzip compression](https://betterexplained.com/articles/how-to-optimize-y
 compress: true
 ```
 
+Usage via the CLI
+```
+webpack-dev-server --compress
+```
 
 ## `devServer.contentBase`
 

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -76,9 +76,10 @@ allowedHosts: [
 
 To use this option with the CLI pass the `--allowed-hosts` option a comma-delimited string.
 
-```
+```bash
 webpack-dev-server --entry /entry/file --output-path /output/path --allowed-hosts .host.com,host2.com
 ```
+
 
 ## `devServer.bonjour`
 
@@ -89,9 +90,11 @@ bonjour: true
 ```
 
 Usage via the CLI
-```
+
+```bash
 webpack-dev-server --bonjour
 ```
+
 
 ## `devServer.clientLogLevel`
 
@@ -106,7 +109,8 @@ clientLogLevel: "none"
 ```
 
 Usage via the CLI
-```
+
+```bash
 webpack-dev-server --client-log-level none
 ```
 
@@ -114,12 +118,14 @@ Possible values are `none`, `error`, `warning` or `info` (default).
 
 Note that the console will *always* show bundle errors and warnings. This option only effects the message before it.
 
+
 ## `devServer.color` - CLI only
 
 `boolean`
 
 Enables/Disables colors on the console.
-```
+
+```bash
 webpack-dev-server --color
 ```
 
@@ -135,9 +141,11 @@ compress: true
 ```
 
 Usage via the CLI
-```
+
+```bash
 webpack-dev-server --compress
 ```
+
 
 ## `devServer.contentBase`
 
@@ -166,9 +174,11 @@ contentBase: false
 ```
 
 Usage via the CLI
-```
+
+```bash
 webpack-dev-server --content-base /path/to/content/dir
 ```
+
 
 ## `devServer.disableHostCheck`
 
@@ -181,9 +191,11 @@ disableHostCheck: true
 ```
 
 Usage via the CLI
-```
+
+```bash
 webpack-dev-server --disable-host-check
 ```
+
 
 ## `devServer.filename` 🔑
 
@@ -248,7 +260,8 @@ historyApiFallback: {
 ```
 
 Usage via the CLI
-```
+
+```bash
 webpack-dev-server --history-api-fallback
 ```
 
@@ -266,7 +279,8 @@ host: "0.0.0.0"
 ```
 
 Usage via the CLI
-```
+
+```bash
 webpack-dev-server --host 0.0.0.0
 ```
 
@@ -295,9 +309,11 @@ hotOnly: true
 ```
 
 Usage via the CLI
-```
+
+```bash
 webpack-dev-server --hot-only
 ```
+
 
 ## `devServer.https`
 
@@ -322,23 +338,28 @@ https: {
 This object is passed straight to Node.js HTTPS module, so see the [HTTPS documentation](https://nodejs.org/api/https.html) for more information.
 
 Usage via the CLI
-```
+
+```bash
 webpack-dev-server --https
 ```
 
 To pass your own certificate via the CLI use the following options
-```
+
+```bash
 webpack-dev-server --https --key /path/to/server.key --cert /path/to/server.crt --cacert /path/to/ca.pem
 ```
+
 
 ## `devServer.info` - CLI only
 
 `boolean`
 
 Output cli information. It is enabled by default.
-```
+
+```bash
 webpack-dev-server --info=false
 ```
+
 
 ## `devServer.inline` - CLI only
 
@@ -353,7 +374,8 @@ inline: false
 ```
 
 Usage via the CLI
-```
+
+```bash
 webpack-dev-server --inline=false
 ```
 
@@ -371,7 +393,8 @@ lazy: true
 ```
 
 Usage via the CLI
-```
+
+```bash
 webpack-dev-server --lazy
 ```
 
@@ -390,6 +413,7 @@ With `noInfo` enabled, messages like the webpack bundle information that is show
 noInfo: true
 ```
 
+
 ## `devServer.open`
 
 `boolean`
@@ -401,9 +425,11 @@ open: true
 ```
 
 Usage via the CLI
-```
+
+```bash
 webpack-dev-server --open
 ```
+
 
 ## `devServer.openPage`
 
@@ -416,9 +442,11 @@ openPage: '/different/page'
 ```
 
 Usage via the CLI
-```
+
+```bash
 webpack-dev-server --open-page "/different/page"
 ```
+
 
 ## `devServer.overlay`
 
@@ -439,6 +467,7 @@ overlay: {
 }
 ```
 
+
 ## `devServer.pfx`
 
 `string`
@@ -450,23 +479,28 @@ pfx: '/path/to/file.pfx'
 ```
 
 Usage via the CLI
-```
+
+```bash
 webpack-dev-server --pfx /path/to/file.pfx
 ```
+
 
 ## `devServer.pfxPassphrase`
 
 `string`
 
 The passphrase to a SSL PFX file.
+
 ```js
 pfxPassphrase: 'passphrase'
 ```
 
 Usage via the CLI
-```
+
+```bash
 webpack-dev-server --pfx-passphrase passphrase
 ```
+
 
 ## `devServer.port`
 
@@ -479,9 +513,11 @@ port: 8080
 ```
 
 Usage via the CLI
-```
+
+```bash
 webpack-dev-server --port 8080
 ```
+
 
 ## `devServer.proxy`
 
@@ -549,7 +585,8 @@ proxy: {
 `boolean`
 
 Output running progress to console.
-```
+
+```bash
 webpack-dev-server --progress
 ```
 
@@ -567,7 +604,8 @@ public: "myapp.test:80"
 ```
 
 Usage via the CLI
-```
+
+```bash
 webpack-dev-server --public myapp.test:80
 ```
 
@@ -612,9 +650,11 @@ quiet: true
 ```
 
 Usage via the CLI
-```
+
+```bash
 webpack-dev-server --quiet
 ```
+
 
 ## `devServer.setup`
 
@@ -631,6 +671,7 @@ setup(app){
 }
 ```
 
+
 ## `devServer.socket`
 
 `string`
@@ -642,7 +683,8 @@ socket: 'socket'
 ```
 
 Usage via the CLI
-```
+
+```bash
 webpack-dev-server --socket socket
 ```
 
@@ -676,15 +718,17 @@ For more information, see the [**stats documentation**](/configuration/stats).
 
 T> This option has no effect when used with `quiet` or `noInfo`.
 
+
 ## `devServer.stdin` - CLI only
 
 `boolean`
 
 This option closes the server when stdin ends.
 
-```
+```bash
 webpack-dev-server --stdin
 ```
+
 
 ## `devServer.useLocalIp`
 
@@ -697,9 +741,11 @@ useLocalIp: true
 ```
 
 Usage via the CLI
-```
+
+```bash
 webpack-dev-server --useLocalIp
 ```
+
 
 ## `devServer.watchContentBase`
 
@@ -714,9 +760,11 @@ watchContentBase: true
 It is disabled by default.
 
 Usage via the CLI
-```
+
+```bash
 webpack-dev-server --watch-content-base
 ```
+
 
 ## `devServer.watchOptions` 🔑
 

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -525,6 +525,11 @@ With `quiet` enabled, nothing except the initial startup information will be wri
 quiet: true
 ```
 
+Usage via the CLI
+```
+webpack-dev-server --quiet
+```
+
 ## `devServer.setup`
 
 `function`

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -255,7 +255,7 @@ webpack-dev-server --history-api-fallback
 For more options and information, see the [connect-history-api-fallback](https://github.com/bripkens/connect-history-api-fallback) documentation.
 
 
-## `devServer.host` - CLI only
+## `devServer.host`
 
 `string`
 
@@ -263,6 +263,11 @@ Specify a host to use. By default this is `localhost`. If you want your server t
 
 ```js
 host: "0.0.0.0"
+```
+
+Usage via the CLI
+```
+webpack-dev-server --host 0.0.0.0
 ```
 
 

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -296,6 +296,11 @@ When `lazy` is enabled, the dev-server will only compile the bundle when it gets
 lazy: true
 ```
 
+Usage via the CLI
+```
+webpack-dev-server --lazy
+```
+
 T> `watchOptions` will have no effect when used with **lazy mode**.
 
 T> If you use the CLI, make sure **inline mode** is disabled.

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -288,6 +288,16 @@ https: {
 
 This object is passed straight to Node.js HTTPS module, so see the [HTTPS documentation](https://nodejs.org/api/https.html) for more information.
 
+Usage via the CLI
+```
+webpack-dev-server --https
+```
+
+To pass your own certificate via the CLI use the following options
+```
+webpack-dev-server --https --key /path/to/server.key --cert /path/to/server.crt --cacert /path/to/ca.pem
+```
+
 ## `devServer.info` - CLI only
 
 `boolean`

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -283,6 +283,11 @@ It is also possible to use **iframe mode**, which uses an `<iframe>` under a not
 inline: false
 ```
 
+Usage via the CLI
+```
+webpack-dev-server --inline=false
+```
+
 T> Inline mode is recommended when using Hot Module Replacement.
 
 

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -80,6 +80,19 @@ To use this option with the CLI pass the `--allowed-hosts` option a comma-delimi
 webpack-dev-server --entry /entry/file --output-path /output/path --allowed-hosts .host.com,host2.com
 ```
 
+## `devServer.bonjour`
+
+This option broadcasts the server via ZeroConf networking on start
+
+```js
+bonjour: true
+```
+
+Usage via the CLI
+```
+webpack-dev-server --bonjour
+```
+
 ## `devServer.clientLogLevel`
 
 `string`

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -105,6 +105,11 @@ You can prevent all these messages from showing, by using this option:
 clientLogLevel: "none"
 ```
 
+Usage via the CLI
+```
+webpack-dev-server --client-log-level none
+```
+
 Possible values are `none`, `error`, `warning` or `info` (default).
 
 Note that the console will *always* show bundle errors and warnings. This option only effects the message before it.

--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -325,6 +325,21 @@ With `noInfo` enabled, messages like the webpack bundle information that is show
 noInfo: true
 ```
 
+## `devServer.open`
+
+`boolean`
+
+When `open` is enabled, the dev server will open the browser.
+
+```js
+open: true
+```
+
+Usage via the CLI
+```
+webpack-dev-server --open
+```
+
 ## `devServer.overlay`
 
 `boolean` `object`


### PR DESCRIPTION
Originally was just adding documentation for the allowedHosts cli option https://github.com/webpack/webpack-dev-server/pull/1012.

However, because there was no documentation for other CLI options I went ahead and added those too.