### PR TITLE
Replace contenthash with chunkhash

### DIFF
--- a/content/guides/caching.md
+++ b/content/guides/caching.md
@@ -105,7 +105,7 @@ __webpack.config.js__
 +     })
     ],
     output: {
-      filename: '[name].[contenthash].js',
+      filename: '[name].[chunkhash].js',
       path: path.resolve(__dirname, 'dist')
     }
   };


### PR DESCRIPTION
previous source code use `chunkhash`, the second example should use `chunkhash` too no?
