### PR TITLE
Clarify that HMRPlugin is added automatically by --hot

### DIFF
--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -295,7 +295,7 @@ Enable webpack's Hot Module Replacement feature:
 hot: true
 ```
 
-T> Note that you must also include a `new webpack.HotModuleReplacementPlugin()` to fully enable HMR. See the [HMR concepts page](/concepts/hot-module-replacement) for more information.
+T> Note that `webpack.HotModuleReplacementPlugin` is required to fully enable HMR. If `webpack` or `webpack-dev-server` are launched with the `--hot` option, this plugin will be added automatically, so you may not need to add this to your `webpack.config.js`. See the [HMR concepts page](/concepts/hot-module-replacement) for more information.
 
 
 ## `devServer.hotOnly`


### PR DESCRIPTION
The current docs say HotModuleReplacementPlugin "must" be included, but after inspecting the source, my conclusion was that webpack [adds HotModuleReplacementPlugin automatically](https://github.com/webpack/webpack/blob/master/bin/convert-argv.js#L400-L404) if you specify `--hot`, so adding this to webpack.config.js ought to usually be unnecessary. We are successfully using HMR with `webpack-dev-server` without adding the plugin explicitly, so that seems like further evidence.

I think the docs should specify that HMRPlugin doesn't need to be added explicitly if you're using the `--hot` option.