### PR TITLE
Add documentation to devServer.proxy

### DIFF
--- a/content/configuration/dev-server.md
+++ b/content/configuration/dev-server.md
@@ -579,6 +579,14 @@ proxy: {
 }
 ```
 
+If you want to proxy multiple, specific paths to the same target, you can use an array of one or more objects with a `context` property:
+
+```js
+proxy: [{
+  context: ["/auth", "/api"],
+  target: "http://localhost:3000",
+}]
+```
 
 ## `devServer.progress` - CLI only
 


### PR DESCRIPTION
Add an example of proxying to the same target from multiple contexts. A similar example was in the Webpack 1.x docs, I just tried it in Webpack 3.4.1 and it still works.
