### PR TITLE
Update Index Page

### DIFF
--- a/components/splash/splash-style.scss
+++ b/components/splash/splash-style.scss
@@ -10,6 +10,11 @@
       background-color:#f3f3f3;
     }
 
+    p {
+      margin: 0 auto;
+      max-width: 800px;
+    }
+
     .container {
       padding:5em 1em;
 

--- a/components/support/support-style.scss
+++ b/components/support/support-style.scss
@@ -4,7 +4,18 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  padding: 1em 0.5em;
+  padding: 0 0.5em 1em;
+
+  &__description {
+    flex: 0 0 100%;
+    margin-bottom: 1em;
+  }
+
+  &__rank {
+    text-transform: capitalize;
+
+    &:after { content: ' '; }
+  }
 
   &__item {
     position: relative;

--- a/components/support/support.jsx
+++ b/components/support/support.jsx
@@ -51,7 +51,7 @@ export default class Support extends React.Component {
           { type === 'sponsors' ? (
             <p>
               <b className="support__rank">{ rank } sponsors</b>
-              <span>are those who have pledged { minimum ? `$${minimum}` : '' } { maximum ? `to $${maximum}` : 'or more' } to webpack.</span>
+              <span>are those who have pledged { minimum ? `$${minimum}` : 'up' } { maximum ? `to $${maximum}` : 'or more' } to webpack.</span>
             </p>
           ) : (
             <p>

--- a/components/support/support.jsx
+++ b/components/support/support.jsx
@@ -47,6 +47,19 @@ export default class Support extends React.Component {
 
     return (
       <div className="support">
+        <div className="support__description">
+          { type === 'sponsors' ? (
+            <p>
+              <b className="support__rank">{ rank } sponsors</b>
+              <span>are those who have pledged { minimum ? `$${minimum}` : '' } { maximum ? `to $${maximum}` : 'or more' } to webpack.</span>
+            </p>
+          ) : (
+            <p>
+              The following <b>Backers</b> are individuals who have contributed various amounts of money in order to help support webpack. Every little bit helps, and we appreciate even the smallest contributions.
+            </p>
+          )}
+        </div>
+
         {
           supporters.map((supporter, index) => (
             <a key={ supporter.id || supporter.username || index }

--- a/content/index.md
+++ b/content/index.md
@@ -6,25 +6,22 @@ title: webpack
 
 <div class="homepage__wrap">
 <div class="homepage__left">
-
-**app.js**
+__app.js__
 
 ```js
 import bar from './bar';
 
 bar();
 ```
-
-</div><div class="homepage__right">
-
-**bar.js**
+</div>
+<div class="homepage__right">
+__bar.js__
 
 ```js
 export default function bar() {
   //
 }
 ```
-
 </div>
 </div>
 
@@ -33,8 +30,7 @@ export default function bar() {
 
 <div class="homepage__wrap">
 <div class="homepage__left">
-
-**webpack.config.js**
+__webpack.config.js__
 
 ```js
 module.exports = {
@@ -44,10 +40,9 @@ module.exports = {
   }
 }
 ```
-
-</div><div class="homepage__right">
-
-**page.html**
+</div>
+<div class="homepage__right">
+__page.html__
 
 ```html
 <html>
@@ -62,7 +57,6 @@ module.exports = {
 ```
 
 Then run `webpack` on the command-line to create `bundle.js`.
-
 </div>
 </div>
 

--- a/content/index.md
+++ b/content/index.md
@@ -62,4 +62,4 @@ Then run `webpack` on the command-line to create `bundle.js`.
 
 ## It's that simple
 
-## [Get Started](/guides/getting-started)
+__[Get Started](/guides/getting-started)__ quickly in our __Guides__ section, or dig into the __[Concepts](/concepts)__ section for more high-level information on the core notions behind behind webpack.


### PR DESCRIPTION
This is both a follow up to #1466 and resolves #1300. The index page now contains short descriptions for each sponsor/backer section:

![image](https://user-images.githubusercontent.com/8988697/29003922-8dae24b8-7a8d-11e7-8d6f-b796d2d5ce9b.png)

cc @sokra @xdamman @joshmosh