### PR TITLE
Add missing bash output to caching.md

### DIFF
--- a/content/guides/caching.md
+++ b/content/guides/caching.md
@@ -90,9 +90,25 @@ Child html-webpack-plugin for "index.html":
         + 2 hidden modules
 ```
 
-As you can see the bundle's name now reflects its content (via the hash). If we run another build without making any changes, we'd expect that filename to stay the same. However, upon running it, we'll see that this is not the case:
+As you can see the bundle's name now reflects its content (via the hash). If we run another build without making any changes, we'd expect that filename to stay the same. However, if you were to run it again, we may find that this is not the case:
 
-?> Add bash output
+``` bash
+Hash: f7a289a94c5e4cd1e566
+Version: webpack 3.5.1
+Time: 835ms
+                       Asset       Size  Chunks                    Chunk Names
+main.205199ab45963f6a62ec.js     544 kB       0  [emitted]  [big]  main
+                  index.html  197 bytes          [emitted]
+   [0] ./src/index.js 216 bytes {0} [built]
+   [2] (webpack)/buildin/global.js 509 bytes {0} [built]
+   [3] (webpack)/buildin/module.js 517 bytes {0} [built]
+    + 1 hidden module
+Child html-webpack-plugin for "index.html":
+     1 asset
+       [2] (webpack)/buildin/global.js 509 bytes {0} [built]
+       [3] (webpack)/buildin/module.js 517 bytes {0} [built]
+        + 2 hidden modules
+```
 
 This is because webpack includes certain boilerplate, specifically the runtime and manifest, in the entry chunk.
 

--- a/content/guides/caching.md
+++ b/content/guides/caching.md
@@ -96,6 +96,7 @@ As you can see the bundle's name now reflects its content (via the hash). If we 
 
 This is because webpack includes certain boilerplate, specifically the runtime and manifest, in the entry chunk.
 
+W> Output may differ depending on your current webpack version. Newer versions may not have all the same issues with hashing as some older versions, but we still recommend the following steps to be safe.
 
 ## Extracting Boilerplate
 

--- a/content/guides/caching.md
+++ b/content/guides/caching.md
@@ -72,7 +72,23 @@ __webpack.config.js__
 
 Running our build script, `npm run build`, with this configuration should produce the following output:
 
-?> Add bash output
+``` bash
+Hash: f7a289a94c5e4cd1e566
+Version: webpack 3.5.1
+Time: 835ms
+                       Asset       Size  Chunks                    Chunk Names
+main.7e2c49a622975ebd9b7e.js     544 kB       0  [emitted]  [big]  main
+                  index.html  197 bytes          [emitted]
+   [0] ./src/index.js 216 bytes {0} [built]
+   [2] (webpack)/buildin/global.js 509 bytes {0} [built]
+   [3] (webpack)/buildin/module.js 517 bytes {0} [built]
+    + 1 hidden module
+Child html-webpack-plugin for "index.html":
+     1 asset
+       [2] (webpack)/buildin/global.js 509 bytes {0} [built]
+       [3] (webpack)/buildin/module.js 517 bytes {0} [built]
+        + 2 hidden modules
+```
 
 As you can see the bundle's name now reflects its content (via the hash). If we run another build without making any changes, we'd expect that filename to stay the same. However, upon running it, we'll see that this is not the case:
 

--- a/content/guides/caching.md
+++ b/content/guides/caching.md
@@ -90,7 +90,7 @@ Child html-webpack-plugin for "index.html":
         + 2 hidden modules
 ```
 
-As you can see the bundle's name now reflects its content (via the hash). If we run another build without making any changes, we'd expect that filename to stay the same. However, if you were to run it again, we may find that this is not the case:
+As you can see the bundle's name now reflects its content (via the hash). If we run another build without making any changes, we'd expect that filename to stay the same. However, if we were to run it again, we may find that this is not the case:
 
 ``` bash
 Hash: f7a289a94c5e4cd1e566

--- a/content/guides/caching.md
+++ b/content/guides/caching.md
@@ -5,6 +5,7 @@ contributors:
   - okonet
   - jouni-kantola
   - skipjack
+  - dannycjones
 related:
   - title: Predictable Long Term Caching
     url: https://medium.com/webpack/predictable-long-term-caching-with-webpack-d3eee1d3fa31


### PR DESCRIPTION
I've filled in one of the two missing bash outputs.

However I don't actually get the expected output when running the command `npm run build` multiple times... 

``` bash
npm run build

> webpack-docs-stuff@1.0.0 build /Users/danny/tmp/webpack-docs-stuff
> webpack

clean-webpack-plugin: /Users/danny/tmp/webpack-docs-stuff/dist has been removed.
Hash: f7a289a94c5e4cd1e566
Version: webpack 3.5.1
Time: 579ms
                       Asset       Size  Chunks                    Chunk Names
main.7e2c49a622975ebd9b7e.js     544 kB       0  [emitted]  [big]  main
                  index.html  197 bytes          [emitted]
   [0] ./src/index.js 216 bytes {0} [built]
   [2] (webpack)/buildin/global.js 509 bytes {0} [built]
   [3] (webpack)/buildin/module.js 517 bytes {0} [built]
    + 1 hidden module
Child html-webpack-plugin for "index.html":
     1 asset
       [2] (webpack)/buildin/global.js 509 bytes {0} [built]
       [3] (webpack)/buildin/module.js 517 bytes {0} [built]
        + 2 hidden modules
```

Running the second time...
``` bash
npm run build

> webpack-docs-stuff@1.0.0 build /Users/danny/tmp/webpack-docs-stuff
> webpack

clean-webpack-plugin: /Users/danny/tmp/webpack-docs-stuff/dist has been removed.
Hash: f7a289a94c5e4cd1e566
Version: webpack 3.5.1
Time: 572ms
                       Asset       Size  Chunks                    Chunk Names
main.7e2c49a622975ebd9b7e.js     544 kB       0  [emitted]  [big]  main
                  index.html  197 bytes          [emitted]
   [0] ./src/index.js 216 bytes {0} [built]
   [2] (webpack)/buildin/global.js 509 bytes {0} [built]
   [3] (webpack)/buildin/module.js 517 bytes {0} [built]
    + 1 hidden module
Child html-webpack-plugin for "index.html":
     1 asset
       [2] (webpack)/buildin/global.js 509 bytes {0} [built]
       [3] (webpack)/buildin/module.js 517 bytes {0} [built]
        + 2 hidden modules
```

The chunk hash `7e2c49a622975ebd9b7e` is the same in both cases.