### PR TITLE
docs(target): fix a small typo 

### DIFF
--- a/content/configuration/target.md
+++ b/content/configuration/target.md
@@ -29,7 +29,7 @@ Option                | Description
 ~~`electron`~~        | Alias for `electron-main`
 `electron-main`       | Compile for [Electron](http://electron.atom.io/) for main process.
 `electron-renderer`   | Compile for [Electron](http://electron.atom.io/) for renderer process, providing a target using `JsonpTemplatePlugin`, `FunctionModulePlugin` for browser environments and `NodeTargetPlugin` and `ExternalsPlugin` for CommonJS and Electron built-in modules.
-`node`                | Compile for usage in a Node.js-like environment (uses Node.js `require` to load chunks) |
+`node`                | Compile for usage in a Node.js-like environment (uses Node.js `require` to load chunks)
 `node-webkit`         | Compile for usage in WebKit and uses JSONP for chunk loading. Allows importing of built-in Node.js modules and [`nw.gui`](http://docs.nwjs.io/en/latest/) (experimental)
 `web`                 | Compile for usage in a browser-like environment **(default)**
 `webworker`           | Compile as WebWorker


### PR DESCRIPTION
An extra '|'  is causing an extra table cell which causes the table to overflow into the margin at https://webpack.js.org/configuration/target/
