### PR TITLE
fix(plugins): babili has been renamed to babel-minify

### DIFF
--- a/content/plugins/index.md
+++ b/content/plugins/index.md
@@ -13,7 +13,7 @@ webpack has a rich plugin interface. Most of the features within webpack itself 
 Name                                                     | Description
 -------------------------------------------------------- | -----------
 [`AggressiveSplittingPlugin`](/plugins/aggressive-splitting-plugin) | Splits the original chunks into smaller chunks
-[`BabiliWebpackPlugin`](/plugins/babili-webpack-plugin)  | Babel based minification: [Babili](https://github.com/babel/babili)
+[`BabelMinifyWebpackPlugin`](/plugins/babel-minify-webpack-plugin) | Minification with [babel-minify](https://github.com/babel/minify)
 [`BannerPlugin`](/plugins/banner-plugin)                 | Add a banner to the top of each generated chunk
 [`CommonsChunkPlugin`](/plugins/commons-chunk-plugin)    | Extract common modules shared between chunks
 [`ComponentWebpackPlugin`](/plugins/component-webpack-plugin) | Use components with webpack


### PR DESCRIPTION
This should fix the errors found in some other PRs' CI builds.
