### PR TITLE
Fix issue #1513: Clarify that manifest parameter can also be a string

### DIFF
--- a/content/plugins/dll-plugin.md
+++ b/content/plugins/dll-plugin.md
@@ -36,7 +36,7 @@ Combine this plugin with [`output.library`](/configuration/output/#output-librar
 This plugin is used in the primary webpack config, it references the dll-only-bundle(s) to require pre-built dependencies.
 
 * `context`: (**absolute path**) context of requests in the manifest (or content property)
-* `manifest` (object): an object containing `content` and `name`
+* `manifest` : an object containing `content` and `name` or a string to the absolute path of the JSON manifest to be loaded upon compilation
 * `content` (optional): the mappings from request to module id (defaults to `manifest.content`)
 * `name` (optional): the name where the dll is exposed (defaults to `manifest.name`) (see also [`externals`](/configuration/externals/))
 * `scope` (optional): prefix which is used for accessing the content of the dll


### PR DESCRIPTION
Fixes #1513: Clarify that manifest parameter can also be an absolute path string.

This was added in commit [530fad](https://github.com/webpack/webpack/commit/530fad43b418dbf78c484eda78b5b22fba086ee9)

- [x] Read and sign the CLA. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
