### PR TITLE
Fix incorrect stated default of __filename/__dirname

### DIFF
--- a/src/content/configuration/node.md
+++ b/src/content/configuration/node.md
@@ -74,7 +74,7 @@ See [the source](https://github.com/webpack/webpack/blob/master/buildin/global.j
 
 `boolean | "mock"`
 
-Default: `true`
+Default: `"mock"`
 
 Options:
 
@@ -87,7 +87,7 @@ Options:
 
 `boolean | "mock"`
 
-Default: `true`
+Default: `"mock"`
 
 Options:
 


### PR DESCRIPTION
Per [WebpackOptionsDefaulter][1], the default value of `node.__filename` and `node.__dirname` are `"mock"`, not `true`. This is correctly listed earlier in the file, but the listed defaults under the individual option sections were incorrect.

[1]: https://github.com/webpack/webpack/blob/aaa6eea68f42517ac8af0f4aa454951cddfcef62/lib/WebpackOptionsDefaulter.js#L77