### PR TITLE
Fix: typo in link

### DIFF
--- a/src/content/api/stats.md
+++ b/src/content/api/stats.md
@@ -81,7 +81,7 @@ Each `chunks` object represents a group of modules known as a [chunk](/glossary#
   "id": 0, // The ID of this chunk
   "initial": true, // Indicates whether this chunk is loaded on initial page load or [on demand](/guides/lazy-loading)
   "modules": [
-    // A list of [module objects](#modules-objects)
+    // A list of [module objects](#module-objects)
     "web.js?h=11593e3b3ac85436984a"
   ],
   "names": [


### PR DESCRIPTION
Fix: typo in link


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
