### PR TITLE
Wrong devtool type at Production>Source Mapping guide

### DIFF
--- a/src/content/guides/production.md
+++ b/src/content/guides/production.md
@@ -155,7 +155,7 @@ If you decide to try another, just make sure your new choice also drops dead cod
 
 ## Source Mapping
 
-We encourage you to have source maps enabled in production, as they are useful for debugging as well as running benchmark tests. That said, you should choose one with a fairly quick build speed that's recommended for production use (see [`devtool`](/configuration/devtool)). For this guide, we'll use the `cheap-module-source-map` option in _production_ as opposed to the `inline-source-map` we used in _development_:
+We encourage you to have source maps enabled in production, as they are useful for debugging as well as running benchmark tests. That said, you should choose one with a fairly quick build speed that's recommended for production use (see [`devtool`](/configuration/devtool)). For this guide, we'll use the `source-map` option in _production_ as opposed to the `inline-source-map` we used in _development_:
 
 __webpack.prod.js__
 
@@ -165,7 +165,7 @@ __webpack.prod.js__
   const common = require('./webpack.common.js');
 
   module.exports = merge(common, {
-+   devtool: 'cheap-module-source-map',
++   devtool: 'source-map',
     plugins: [
       new UglifyJSPlugin()
     ]


### PR DESCRIPTION
### Problem

At the [Production - Source Mapping guide](https://webpack.js.org/guides/production/#source-mapping), there's a suggestion to use a *devtool style* not supposed for production use, as the [Devtool guide explains](https://webpack.js.org/configuration/devtool/#devtool).

### Solution

Suggest a *devtool style* suited for production, based on the [Devtool guide](https://webpack.js.org/configuration/devtool/#devtool).