### PR TITLE
Make sure images are responsive

### DIFF
--- a/src/styles/markdown.scss
+++ b/src/styles/markdown.scss
@@ -242,6 +242,7 @@
 
   img {
     max-width: 100%;
+    height: auto;
   }
 
   b, strong {


### PR DESCRIPTION
Prevent stretch images with defined sizes in smaller breakpoints.

**Before**
<img width="495" alt="screen shot 2017-09-03 at 10 55 15 pm" src="https://user-images.githubusercontent.com/3921289/30011221-55786b06-90fb-11e7-83e9-6150005f0205.png">


**After**
<img width="496" alt="screen shot 2017-09-03 at 10 55 11 pm" src="https://user-images.githubusercontent.com/3921289/30011225-59f8333c-90fb-11e7-95d8-0f85cb95c3c1.png">