### PR TITLE
Fix source-map configuration in webpack.prod.js

### DIFF
--- a/src/content/guides/production.md
+++ b/src/content/guides/production.md
@@ -167,7 +167,10 @@ __webpack.prod.js__
   module.exports = merge(common, {
 +   devtool: 'source-map',
     plugins: [
-      new UglifyJSPlugin()
+-     new UglifyJSPlugin()
++     new UglifyJSPlugin({
++       sourceMap: true
++     })
     ]
   })
 ```


### PR DESCRIPTION
To make the 'source-map' setting work in webpack.prod.js file, we must provide the `sourceMap: true` option to UglifyJSPlugin, as described in the Webpack documentation at https://webpack.js.org/configuration/devtool/#production