### PR TITLE
Add plus sign on `require('webpack')` line

### DIFF
--- a/src/content/guides/production.md
+++ b/src/content/guides/production.md
@@ -180,7 +180,7 @@ Many libraries will key off the `process.env.NODE_ENV` variable to determine wha
 __webpack.prod.js__
 
 ``` diff
-  const webpack = require('webpack');
++ const webpack = require('webpack');
   const merge = require('webpack-merge');
   const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
   const common = require('./webpack.common.js');


### PR DESCRIPTION
In the "Specify the Environment" section, the line `const webpack = require('webpack');` has no plus sign before it, even though it's a new line of code for that code snippet.

