### PR TITLE
Fix typo in sourceType example.

### DIFF
--- a/src/content/plugins/dll-plugin.md
+++ b/src/content/plugins/dll-plugin.md
@@ -90,7 +90,7 @@ new webpack.DllReferencePlugin({
   manifest: require("./manifest.json"),
   name: "./my-dll.js",
   scope: "xyz",
-  sourceType: "commonsjs2"
+  sourceType: "commonjs2"
 })
 ```
 


### PR DESCRIPTION
Fix typo in sourceType example from `commonsjs2` to the correct one `commonjs2`
# Before
There was a typo in the sourceType example, trying to run a build with that configuration will throw an error.
![image](https://user-images.githubusercontent.com/7824284/30155870-b0d72b90-93c6-11e7-9fa7-165d4a14b751.png)

# After
Fix the value to the correct name `commonjs2`.
