### PR TITLE
docs(plugins): clarify and simplify `SourceMapDevToolPlugin` docs

### DIFF
--- a/src/content/plugins/source-map-dev-tool-plugin.md
+++ b/src/content/plugins/source-map-dev-tool-plugin.md
@@ -8,7 +8,7 @@ related:
     url: https://survivejs.com/webpack/building/source-maps/#-sourcemapdevtoolplugin-and-evalsourcemapdevtoolplugin-
 ---
 
-This plugin enables a more fine grained control of [source maps added via the `devtool` option](/configuration/devtool/).
+This plugin enables more fine grained control of source map generation. It is an alternative to the [`devtool`](/configuration/devtool/) configuration option.
 
 ```javascript
 new webpack.SourceMapDevToolPlugin(options)
@@ -19,13 +19,20 @@ new webpack.SourceMapDevToolPlugin(options)
 
 The following options are supported:
 
-* `options.test` / `options.include` / `options.exclude` (`string|RegExp|Array`): Used to determine which assets should be processed. Each one can be a `RegExp` (asset filename is matched), a `string` (asset filename need to start with this string) or an `Array` of those (any of them need to be matched). `test` defaults to `.js` and `.css` files if omitted.
-* `options.filename` (`string`): defines the output filename of the SourceMap. If no value is provided the source map is inlined.
-* `options.append` (`string`): is appended to the original asset. Usually the `#sourceMappingURL` comment. `[url]` is replaced with a URL to the source map file. `false` disables the appending.
-* `options.moduleFilenameTemplate` / `options.fallbackModuleFilenameTemplate` (`string`): see [`output.devtoolModuleFilenameTemplate`](/configuration/output/#output-devtoolmodulefilenametemplate).
-* `options.module` (`boolean`):  (defaults to `true`) When `false` loaders do not generate source maps and the transformed code is used as source instead.
-* `options.columns` (`boolean`):  (defaults to `true`) When `false` column mappings in source maps are ignored and a faster source map implementation is used.
-* `options.lineToLine` (`{test: string|RegExp|Array, include: string|RegExp|Array, exclude: string|RegExp|Array}` matched modules uses simple (faster) line to line source mappings.
+- `test` (`string|regex|array`): Include source maps for modules based on their extension (defaults to `.js` and `.css`).
+- `include` (`string|regex|array`): Include source maps for module paths that match the given value.
+- `exclude` (`string|regex|array`): Exclude modules that match the given value from source map generation.
+- `filename` (`string`): Defines the output filename of the SourceMap (will be inlined if no value is provided).
+- `append` (`string`): Appends the given value to the original asset. Usually the `#sourceMappingURL` comment. `[url]` is replaced with a URL to the source map file. `false` disables the appending.
+- `moduleFilenameTemplate` (`string`): See [`output.devtoolModuleFilenameTemplate`](/configuration/output/#output-devtoolmodulefilenametemplate).
+- `fallbackModuleFilenameTemplate` (`string`): See link above.
+- `module` (`boolean`): Indicates whether loaders should generate source maps (defaults to `true`).
+- `columns` (`boolean`): Indicates whether column mappings should be used (defaults to `true`).
+- `lineToLine` (`object`): Simplify and speed up source mapping by using line to line source mappings for matched modules.**
+
+The `lineToLine` object allows for the same `test`, `include`, and `exclude` options described above.
+
+T> Setting `module` and/or `columns` to `false` will yield less accurate source maps but will also improve compilation performance significantly.
 
 
 ## Usage: Exclude Vendor Maps


### PR DESCRIPTION
Try to resolve the confusion from #1556. Also update the options
section to clean things up a bit both for readability and grammar.

Resolves #1556 