### PR TITLE
Remove local type def from TypeScript snippet

### DIFF
--- a/src/content/configuration/configuration-languages.md
+++ b/src/content/configuration/configuration-languages.md
@@ -6,6 +6,7 @@ contributors:
   - skipjack
   - tarang9211
   - simon04
+  - peterblazejewicz
 ---
 
 webpack accepts configuration files written in multiple programming and data languages. The list of supported file extensions can be found at the [node-interpret](https://github.com/js-cli/js-interpret) package. Using [node-interpret](https://github.com/js-cli/js-interpret), webpack can handle many different types of configuration files.
@@ -26,7 +27,6 @@ __webpack.config.ts__
 ```typescript
 import * as webpack from 'webpack';
 import * as path from 'path';
-declare var __dirname;
 
 const config: webpack.Configuration = {
   entry: './foo.js',


### PR DESCRIPTION
The @types/node type definition module already declares `__dirname` type:
https://git.io/v5Dr9

Thanks!