### PR TITLE
docs: fixed wrong path to bundle.js in getting started guide

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -133,7 +133,7 @@ __dist/index.html__
    </head>
    <body>
 -    <script src="./src/index.js"></script>
-+    <script src="bundle.js"></script>
++    <script src="dist/bundle.js"></script>
    </body>
   </html>
 ```


### PR DESCRIPTION
fixed wrong path to bundle.js for one example in the getting started guide