### PR TITLE
Introduced better fix for pipes escaping in Markdown table cells

### DIFF
--- a/src/utilities/markdown.js
+++ b/src/utilities/markdown.js
@@ -231,27 +231,12 @@ function handleTable(t) {
   header += handleTableRow(cell);
 
   for (let i = 0; i < t.cells.length; i++) {
+
     let row = t.cells[i];
+
+    row = fixPipesEscapingForTableRow(row);
+
     cell = '';
-
-
-    // Fix escaped '|' characters
-    // See https://github.com/chjj/marked/issues/595
-    let erroneous = row.map(item => item.endsWith('\\') ? item : null).filter(item => item);
-
-    if ( erroneous.length > 0 ) {
-      erroneous.forEach(string => {
-        let errorIndex = row.findIndex(item => item === string);
-        let nextIndex = errorIndex + 1;
-        let value = row[errorIndex];
-
-        if (value) {
-          row[errorIndex] = `${value.slice(0, -1)}|${row[nextIndex]}`;
-          row.splice(nextIndex, 1);
-        }
-      });
-    }
-
 
     for (let j = 0; j < row.length; j++) {
       cell += handleTableCell(this.inline.output(row[j]), {
@@ -381,4 +366,62 @@ function handleTok() {
       return this.renderer.paragraph(this.parseText());
     }
   }
+}
+
+
+/**
+ * Fixes escaped '|' characters in table cells.
+ * @link https://github.com/chjj/marked/issues/595
+ */
+function fixPipesEscapingForTableRow (row) {
+
+  const fixedRow = [];
+
+  let index = 0;
+
+  let handlingBroken = false;
+
+  while (index < row.length) {
+
+    const cellString = row[index];
+
+    if (isBroken(cellString) && !handlingBroken) {
+
+      // Starting to handle broken chain by creating first cell to append content to.
+      handlingBroken = true;
+      fixedRow.push(fixBroken(cellString));
+
+    } else if (!isBroken(cellString) && handlingBroken) {
+
+      // Finishing to handle broken chain by appending the last element to the current cell.
+      fixedRow[fixedRow.length - 1] += cellString;
+      handlingBroken = false;
+
+    } else if (isBroken(cellString) && handlingBroken) {
+
+      // Appending next broken cell to the current cell.
+      fixedRow[fixedRow.length - 1] += fixBroken(cellString);
+
+    } else {
+
+      // Just adding cell normally.
+      fixedRow.push(cellString);
+
+    }
+
+    index++;
+
+  }
+
+  return fixedRow;
+
+
+  function isBroken (cellString) {
+    return cellString.endsWith('\\');
+  }
+
+  function fixBroken (cellString) {
+    return cellString.replace(/\\$/, '|');
+  }
+
 }

--- a/src/utilities/markdown.js
+++ b/src/utilities/markdown.js
@@ -231,11 +231,9 @@ function handleTable(t) {
   header += handleTableRow(cell);
 
   for (let i = 0; i < t.cells.length; i++) {
-
     let row = t.cells[i];
 
     row = fixPipesEscapingForTableRow(row);
-
     cell = '';
 
     for (let j = 0; j < row.length; j++) {
@@ -373,48 +371,38 @@ function handleTok() {
  * Fixes escaped '|' characters in table cells.
  * @link https://github.com/chjj/marked/issues/595
  */
-function fixPipesEscapingForTableRow (row) {
-
+function fixPipesEscapingForTableRow(row) {
   const fixedRow = [];
-
   let index = 0;
-
   let handlingBroken = false;
 
   while (index < row.length) {
-
     const cellString = row[index];
 
     if (isBroken(cellString) && !handlingBroken) {
-
       // Starting to handle broken chain by creating first cell to append content to.
       handlingBroken = true;
       fixedRow.push(fixBroken(cellString));
 
     } else if (!isBroken(cellString) && handlingBroken) {
-
       // Finishing to handle broken chain by appending the last element to the current cell.
       fixedRow[fixedRow.length - 1] += cellString;
       handlingBroken = false;
 
     } else if (isBroken(cellString) && handlingBroken) {
-
       // Appending next broken cell to the current cell.
       fixedRow[fixedRow.length - 1] += fixBroken(cellString);
 
     } else {
-
       // Just adding cell normally.
       fixedRow.push(cellString);
 
     }
 
     index++;
-
   }
 
   return fixedRow;
-
 
   function isBroken (cellString) {
     return cellString.endsWith('\\');
@@ -423,5 +411,4 @@ function fixPipesEscapingForTableRow (row) {
   function fixBroken (cellString) {
     return cellString.replace(/\\$/, '|');
   }
-
 }


### PR DESCRIPTION
I've noticed that table's row in [UglifyjsWebpackPlugin documentation](https://webpack.js.org/plugins/uglifyjs-webpack-plugin/#options) was broken:

![uglifyjswebpackplugin](https://user-images.githubusercontent.com/1702725/31044600-1f9bb48a-a5db-11e7-8258-5f350f0be2fc.png)

I've tried to fix the source file, but it appeared to be correct. After further investigation the problem was related to this issue: https://github.com/chjj/marked/issues/595.

I've found the piece of code, which was responsible for fixing it in this repo and rewritten it to handle more broad use cases (it was working only for the single pipe in the table cell and was failing for multiple pipes). I've used finite state machine approach to implement table row parser, which fixes this issue.

The result:

![localhost-3000-plugins-uglifyjs-webpack-plugin-](https://user-images.githubusercontent.com/1702725/31044642-ba8cb714-a5db-11e7-9294-65520bdc258a.png)

I hope the implementation is correct, but please verify it.

Thanks.