### PR TITLE
Update hot-module-replacement.md, second argument missing in server.listen call

### DIFF
--- a/src/content/guides/hot-module-replacement.md
+++ b/src/content/guides/hot-module-replacement.md
@@ -13,6 +13,7 @@ contributors:
   - sbaidon
   - gdi2290
   - bdwain
+  - caryli
 related:
   - title: Concepts - Hot Module Replacement
     url: /concepts/hot-module-replacement
@@ -151,7 +152,7 @@ webpackDevServer.addDevServerEntrypoints(config, options);
 const compiler = webpack(config);
 const server = new webpackDevServer(compiler, options);
 
-server.listen(5000, () => {
+server.listen(5000, 'localhost', () => {
   console.log('dev server listening on port 5000');
 });
 ```


### PR DESCRIPTION
Second argument of `server.listen` is the hostname, in this context, `'localhost'`.

Third argument of `server.listen` is the success callback.

https://github.com/webpack/webpack-dev-server/blob/master/lib/Server.js#L552

Currently the success callback is never called to print `'dev server listening on port 5000'` because it is given as the second argument and `fn` is undefined at:

```
600    if (fn) {
601      fn.call(this.listeningApp, err);
602    }
```