### PR TITLE
Show default config file name in the documentation

### DIFF
--- a/src/content/configuration/index.md
+++ b/src/content/configuration/index.md
@@ -23,6 +23,8 @@ T> Notice that throughout the configuration we use Node's built-in [path module]
 
 Click on the name of each option in the configuration code below to jump to the detailed documentation. Also note that the items with arrows can be expanded to show more examples and, in some cases, more advanced configuration.
 
+__webpack.config.js__
+
 ``` js-with-links-with-details
 const path = require('path');
 


### PR DESCRIPTION
Added default config file name _(webpack.config.js)_ to the documentation.