### PR TITLE
Update information on how tree-shaking may be ineffective

### DIFF
--- a/src/content/guides/tree-shaking.md
+++ b/src/content/guides/tree-shaking.md
@@ -15,6 +15,10 @@ related:
     url: http://www.2ality.com/2015/12/webpack-tree-shaking.html
   - title: webpack 2 Tree Shaking Configuration
     url: https://medium.com/modus-create-front-end-development/webpack-2-tree-shaking-configuration-9f1de90f3233#.15tuaw71x
+  - title: Issue 2867
+    url: https://github.com/webpack/webpack/issues/2867
+  - title: Issue 4784
+    url: https://github.com/webpack/webpack/issues/4784
 ---
 
 _Tree shaking_ is a term commonly used in the JavaScript context for dead-code elimination. It relies on the [static structure](http://exploringjs.com/es6/ch_modules.html#static-module-structure) of ES2015 module syntax, i.e. [`import`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) and [`export`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export). The name and concept have been popularized by the ES2015 module bundler [rollup](https://github.com/rollup/rollup).

--- a/src/content/guides/tree-shaking.md
+++ b/src/content/guides/tree-shaking.md
@@ -144,37 +144,39 @@ With that squared away, we can run another `npm run build` and see if anything h
 
 Notice anything different about `dist/bundle.js`? Clearly the whole bundle is now minified and mangled, but, if you look carefully, you won't see the `square` function included but will see a mangled version of the `cube` function (`function r(e){return e*e*e}n.a=r`). With minification and tree shaking our bundle is now a few bytes smaller! While that may not seem like much in this contrived example, tree shaking can yield a significant decrease in bundle size when working on larger applications with complex dependency trees.
 
+
 ## Caveats
 
-Please note that webpack doesn't perform tree-shaking by itself. It relies on third party tools like [UglifyJS](/plugins/uglifyjs-webpack-plugin/) to perform actual dead code elimination. There are situations where tree-shaking may not be effective. For example, consider the following code:
+Please note that webpack doesn't perform tree-shaking by itself. It relies on third party tools like [UglifyJS](/plugins/uglifyjs-webpack-plugin/) to perform actual dead code elimination. There are situations where tree-shaking may not be effective. For example, consider the following modules:
 
-```typescript
+__transforms.js__
 
-// transforms.js
-
+``` js
 import * as mylib from 'mylib';
 
 export const someVar = mylib.transform({
-  ...
+  // ...
 });
 
 export const someOtherVar = mylib.transform({
-  ...
+  // ...
 });
-
-// index.js
-
-import {someVar} from './style.js';
-
-... use someVar ...
-
 ```
 
-In the code above webpack (and UglifyJS) cannot determine whether or not the call to `mylib.transform` triggers any side-effects. As a result, they err on the safe side and leave both `someVar` and `someOtherVar` in the bundled code.
+__index.js__
 
-In general, when a tool cannot guarantee that a particular code path doesn't lead to side-effects, this code may remain in the generated bundle even if you are sure it shouldn't. Common situations are: invoking a function from a third-party module that webpack and/or the mninifier cannot inspect, re-exporting functions imported from third-party modules, etc.
+``` js
+import { someVar } from './transforms.js';
 
-The code used in this guide assumes you perform tree-shaking using UglifyJS plugin. However, there are other tools such as [webpack-rollup-loader](https://github.com/erikdesjardins/webpack-rollup-loader) or [Babel Minify Webpack Plugin](https://github.com/webpack-contrib/babel-minify-webpack-plugin) that may produce different results depending on your setup.
+// Use `someVar`...
+```
+
+In the code above webpack cannot determine whether or not the call to `mylib.transform` triggers any side-effects. As a result, it errs on the safe side and leaves `someOtherVar` in the bundled code.
+
+In general, when a tool cannot guarantee that a particular code path doesn't lead to side-effects, this code may remain in the generated bundle even if you are sure it shouldn't. Common situations include invoking a function from a third-party module that webpack and/or the minifier cannot inspect, re-exporting functions imported from third-party modules, etc.
+
+The code used in this guide assumes you perform tree-shaking using UglifyJS plugin. However, there are other tools such as [webpack-rollup-loader](https://github.com/erikdesjardins/webpack-rollup-loader) or [Babel Minify Webpack Plugin](/plugins/babel-minify-webpack-plugin) that may produce different results depending on your setup.
+
 
 ## Conclusion
 

--- a/src/content/guides/tree-shaking.md
+++ b/src/content/guides/tree-shaking.md
@@ -21,7 +21,7 @@ _Tree shaking_ is a term commonly used in the JavaScript context for dead-code e
 
 The webpack 2 release came with built-in support for ES2015 modules (alias _harmony modules_) as well as unused module export detection.
 
-**Note**: Webpack doesn't perform tree-shaking by itself. It relies on third party tools like [UglifyJS](/plugins/uglifyjs-webpack-plugin/) to perform actual dead code elimination. There are situations where tree-shaking may not effective. For example, when the tool cannot guarantee that a particular code path doesn't lead to side-effects, it may remain in the generated bundle even if you are sure it shouldn't.
+**Note**: Webpack doesn't perform tree-shaking by itself. It relies on third party tools like [UglifyJS](/plugins/uglifyjs-webpack-plugin/) to perform actual dead code elimination. There are situations where tree-shaking may not effective. For example, when the tool cannot guarantee that a particular code path doesn't lead to side-effects, this code may remain in the generated bundle even if you are sure it shouldn't.
 
 Some of the code below assumes you perform tree-shaking using UglifJS plugin. However, there are other tools such as [webpack-rollup-loader](https://github.com/erikdesjardins/webpack-rollup-loader) or [Babel Minify Webpack Plugin](https://github.com/webpack-contrib/babel-minify-webpack-plugin) that may produce different result depending on your setup.
 

--- a/src/content/guides/tree-shaking.md
+++ b/src/content/guides/tree-shaking.md
@@ -7,6 +7,7 @@ contributors:
   - alexjoverm
   - avant1
   - MijaelWatts
+  - dmitriid
 related:
   - title: Tree shaking with webpack 2, TypeScript and Babel
     url: https://alexjoverm.github.io/2017/03/06/Tree-shaking-with-Webpack-2-TypeScript-and-Babel/
@@ -19,6 +20,10 @@ related:
 _Tree shaking_ is a term commonly used in the JavaScript context for dead-code elimination. It relies on the [static structure](http://exploringjs.com/es6/ch_modules.html#static-module-structure) of ES2015 module syntax, i.e. [`import`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) and [`export`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export). The name and concept have been popularized by the ES2015 module bundler [rollup](https://github.com/rollup/rollup).
 
 The webpack 2 release came with built-in support for ES2015 modules (alias _harmony modules_) as well as unused module export detection.
+
+**Note**: Webpack doesn't perform tree-shaking by itself. It relies on third party tools like [UglifyJS](/plugins/uglifyjs-webpack-plugin/) to perform actual dead code elimination. There are situations where tree-shaking may not effective. For example, when the tool cannot guarantee that a particular code path doesn't lead to side-effects, it may remain in the generated bundle even if you are sure it shouldn't.
+
+Some of the code below assumes you perform tree-shaking using UglifJS plugin. However, there are other tools such as [webpack-rollup-loader](https://github.com/erikdesjardins/webpack-rollup-loader) or [Babel Minify Webpack Plugin](https://github.com/webpack-contrib/babel-minify-webpack-plugin) that may produce different result depending on your setup.
 
 T> The remainder of this guide will stem from [Getting Started](/guides/getting-started). If you haven't read through that guide already, please do so now.
 


### PR DESCRIPTION
https://github.com/webpack/webpack/issues/4784 and https://github.com/webpack/webpack/issues/2867 are serious issues that show that tree-shaking in Webpack is completely broken in certain (common!) situations. 

This change adds a small section to the introduction of tree-shaking explaining what happens and how tree-shaking actually works in Webpack.

[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/