### PR TITLE
docs(guides): update typescript.md

### DIFF
--- a/src/content/guides/typescript.md
+++ b/src/content/guides/typescript.md
@@ -47,7 +47,7 @@ Let's set up a simple configuration to support JSX and compile TypeScript down t
   "compilerOptions": {
     "outDir": "./dist/",
     "noImplicitAny": true,
-    "module": "commonjs",
+    "module": "es6",
     "target": "es5",
     "jsx": "react",
     "allowJs": true


### PR DESCRIPTION
Configure TypeScript to compile modules to ES2015 module syntax,
enabling webpack to resolve the `import` / `export` syntax on it's own.
With this included, the only thing necessary to enable _tree shaking_
is the inclusion of the `UglifyJSPlugin` (which I'm not adding to this
article as it is just centered on getting started with TypeScript).

Resolves #1627