### PR TITLE
docs(guides): update hot-module-replacement.md

### DIFF
--- a/src/content/guides/hot-module-replacement.md
+++ b/src/content/guides/hot-module-replacement.md
@@ -14,6 +14,7 @@ contributors:
   - gdi2290
   - bdwain
   - caryli
+  - xgirma
 related:
   - title: Concepts - Hot Module Replacement
     url: /concepts/hot-module-replacement
@@ -40,6 +41,7 @@ __webpack.config.js__
   const path = require('path');
   const HtmlWebpackPlugin = require('html-webpack-plugin');
 + const webpack = require('webpack');
+  const CleanWebpackPlugin = require('clean-webpack-plugin');
 
   module.exports = {
     entry: {

--- a/src/content/guides/hot-module-replacement.md
+++ b/src/content/guides/hot-module-replacement.md
@@ -40,8 +40,8 @@ __webpack.config.js__
 ``` diff
   const path = require('path');
   const HtmlWebpackPlugin = require('html-webpack-plugin');
-+ const webpack = require('webpack');
   const CleanWebpackPlugin = require('clean-webpack-plugin');
++ const webpack = require('webpack');
 
   module.exports = {
     entry: {


### PR DESCRIPTION
The first listing (webpack.config.js) on `hot-module-replacement.md` section have no import for `clean-webpack-plugin` module, while the module is used in the `plugins` section of the example config. 
