### PR TITLE
docs(guides): update production.md

### DIFF
--- a/src/content/guides/hot-module-replacement.md
+++ b/src/content/guides/hot-module-replacement.md
@@ -14,7 +14,6 @@ contributors:
   - gdi2290
   - bdwain
   - caryli
-  - xgirma
 related:
   - title: Concepts - Hot Module Replacement
     url: /concepts/hot-module-replacement
@@ -41,7 +40,6 @@ __webpack.config.js__
   const path = require('path');
   const HtmlWebpackPlugin = require('html-webpack-plugin');
 + const webpack = require('webpack');
-  const CleanWebpackPlugin = require('clean-webpack-plugin');
 
   module.exports = {
     entry: {

--- a/src/content/guides/hot-module-replacement.md
+++ b/src/content/guides/hot-module-replacement.md
@@ -14,6 +14,7 @@ contributors:
   - gdi2290
   - bdwain
   - caryli
+  - xgirma
 related:
   - title: Concepts - Hot Module Replacement
     url: /concepts/hot-module-replacement
@@ -40,6 +41,7 @@ __webpack.config.js__
   const path = require('path');
   const HtmlWebpackPlugin = require('html-webpack-plugin');
 + const webpack = require('webpack');
+  const CleanWebpackPlugin = require('clean-webpack-plugin');
 
   module.exports = {
     entry: {

--- a/src/content/guides/production.md
+++ b/src/content/guides/production.md
@@ -14,6 +14,7 @@ contributors:
   - skipjack
   - xgqfrms
   - kelset
+  - xgirma
 ---
 
 In this guide we'll dive into some of the best practices and utilities for building a production site or application.
@@ -128,6 +129,7 @@ __package.json__
     "author": "",
     "license": "ISC",
     "devDependencies": {
+      "clean-webpack-plugin": "^0.1.17",
       "css-loader": "^0.28.4",
       "csv-loader": "^2.1.1",
       "express": "^4.15.3",
@@ -136,6 +138,8 @@ __package.json__
       "style-loader": "^0.18.2",
       "webpack": "^3.0.0",
       "webpack-dev-middleware": "^1.12.0",
+      "webpack-dev-server": "^2.9.1",
+      "webpack-merge": "^4.1.0",
       "xml-loader": "^1.2.1"
     }
   }


### PR DESCRIPTION
In the guides, `production.md` under the **NPM Scripts** section, the listing `package.json` _devDependencies_ is missing modules require to run `npm run build` and `npm start`.When I follow the example in the page and execute `npm run build` the following error will shown:

`$ npm run build`
> Error: Cannot find module 'webpack-merge'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
...
> Error: Cannot find module 'clean-webpack-plugin'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
...

`$ npm start` 
> webpack-dev-server --open --config webpack.dev.js
sh: webpack-dev-server: command not found
npm ERR! Darwin 16.7.0

Hence, including these three modules in the `package.json` listing.