### PR TITLE
Fix wrong path to bundled result js file

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -133,7 +133,7 @@ __dist/index.html__
    </head>
    <body>
 -    <script src="./src/index.js"></script>
-+    <script src="bundle.js"></script>
++    <script src="./dist/bundle.js"></script>
    </body>
   </html>
 ```


### PR DESCRIPTION
Correct the path to the bundled js file in the index.html as stated in the guide.