### PR TITLE
docs(guides): update hot-module-replacement.md

### DIFF
--- a/src/content/guides/hot-module-replacement.md
+++ b/src/content/guides/hot-module-replacement.md
@@ -59,6 +59,7 @@ __webpack.config.js__
       new HtmlWebpackPlugin({
         title: 'Hot Module Replacement'
       }),
++     new Webpack.NamedModulesPlugin(),
 +     new webpack.HotModuleReplacementPlugin()
     ],
     output: {
@@ -68,9 +69,9 @@ __webpack.config.js__
   };
 ```
 
-You can also use the CLI to modify the [webpack-dev-server](https://github.com/webpack/webpack-dev-server) configuration with the following command: `webpack-dev-server --hotOnly`.
+T> You can use the CLI to modify the [webpack-dev-server](https://github.com/webpack/webpack-dev-server) configuration with the following command: `webpack-dev-server --hotOnly`.
 
-To get it up and running let's run `npm start` from the command line.
+Note that we've also added the `NamedModulesPlugin` to make it easier to see which dependencies are being patched. To start, we'll get the dev server up and running by executing an `npm start` from the command line.
 
 Now let's update the `index.js` file so that when a change inside `print.js` is detected we tell webpack to accept the updated module.
 


### PR DESCRIPTION
Add the `NamedModulesPlugin` for easier debugging as the relative paths
to each updated dependency will be shown in the patch messages.

Resolves #1623 