### PR TITLE
Document new `output.devtoolNamespace` option

### DIFF
--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -9,6 +9,7 @@ contributors:
   - irth
   - fvgs
   - dhurlburtusa
+  - MagicDuck
 ---
 
 The top-level `output` key contains set of options instructing webpack on how and where it should output your bundles, assets and anything else you bundle or load with webpack.
@@ -128,7 +129,7 @@ This option is only used when [`devtool`](/configuration/devtool) uses an option
 Customize the names used in each source map's `sources` array. This can be done by passing a template string or function. For example, when using `devtool: 'eval'`, this is the default:
 
 ``` js
-devtoolModuleFilenameTemplate: "webpack:///[resource-path]?[loaders]"
+devtoolModuleFilenameTemplate: "webpack://[namespace]/[resource-path]?[loaders]"
 ```
 
 The following substitutions are available in template strings (via webpack's internal [`ModuleFilenameHelpers`](https://github.com/webpack/webpack/blob/master/lib/ModuleFilenameHelpers.js)):
@@ -142,6 +143,7 @@ The following substitutions are available in template strings (via webpack's int
 | [loaders]                | Explicit loaders and params up to the name of the first loader |
 | [resource]               | The path used to resolve the file and any query params used on the first loader |
 | [resource-path]          | The path used to resolve the file without any query params |
+| [namespace]              | The modules namespace. This is usually the library name when building as a library, empty otherwise |
 
 When using a function, the same options are available camel-cased via the `info` parameter:
 
@@ -153,6 +155,12 @@ devtoolModuleFilenameTemplate: info => {
 
 If multiple modules would result in the same name, [`output.devtoolFallbackModuleFilenameTemplate`](#output-devtoolfallbackmodulefilenametemplate) is used instead for these modules.
 
+## `output.devtoolNamespace`
+
+`string`
+
+This option determines the modules namespace used with the [`output.devtoolModuleFilenameTemplate`](#output-devtoolmodulefilenametemplate). When not specified, it will default to the value of: [`output.library`](#output-library). It's use is to prevent source file path collisions in sourcemaps when loading multiple libraries built with webpack.
+For example, if you have 2 libraries, with namespaces `library1` and `library2`, which both have a file `./src/index.js` (with potentially different contents), they will expose these files as `webpack://library1/./src/index.js` and `webpack://library2/./src/index.js`.
 
 ## `output.filename`
 

--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -155,12 +155,15 @@ devtoolModuleFilenameTemplate: info => {
 
 If multiple modules would result in the same name, [`output.devtoolFallbackModuleFilenameTemplate`](#output-devtoolfallbackmodulefilenametemplate) is used instead for these modules.
 
+
 ## `output.devtoolNamespace`
 
 `string`
 
 This option determines the modules namespace used with the [`output.devtoolModuleFilenameTemplate`](#output-devtoolmodulefilenametemplate). When not specified, it will default to the value of: [`output.library`](#output-library). It's use is to prevent source file path collisions in sourcemaps when loading multiple libraries built with webpack.
+
 For example, if you have 2 libraries, with namespaces `library1` and `library2`, which both have a file `./src/index.js` (with potentially different contents), they will expose these files as `webpack://library1/./src/index.js` and `webpack://library2/./src/index.js`.
+
 
 ## `output.filename`
 


### PR DESCRIPTION
added docs for new `output.devtoolNamespace` option and [namespace] placeholder.
