### PR TITLE
@line-62 : webpack has first letter capitalised.

### DIFF
--- a/src/content/guides/hot-module-replacement.md
+++ b/src/content/guides/hot-module-replacement.md
@@ -59,7 +59,7 @@ __webpack.config.js__
       new HtmlWebpackPlugin({
         title: 'Hot Module Replacement'
       }),
-+     new Webpack.NamedModulesPlugin(),
++     new webpack.NamedModulesPlugin(),
 +     new webpack.HotModuleReplacementPlugin()
     ],
     output: {


### PR DESCRIPTION
_describe your changes..._
@line-62 : webpack has first letter capitalised. (documentation guides/hot-module-replacement)


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
