### PR TITLE
Debugging Walkthrough in the Contribute Section

### DIFF
--- a/src/content/contribute/debugging.md
+++ b/src/content/contribute/debugging.md
@@ -14,18 +14,27 @@ related:
 
 When contributing to the core repo, writing a loader/plugin, or even just working on complex project, debugging tools can be central to your workflow. Whether the problem is slow performance on a large project or an unhelpful traceback, the following utilities can make figuring it out less painful.
 
-- The [`stats` data]() made available through [Node]() and the [CLI]().
+- The [`stats` data](/api/stats) made available through [Node](/api/node#stats-object) and the [CLI](/api/cli#common-options).
 - Chrome __DevTools__ via `node-nightly` and the latest Node.js versions.
 
 
 ## Stats
 
-...
+Whether you want to sift through [this data](/api/stats) manually or use a tool to process it, the `stats` data can be extremely useful when debugging build issues. We won't go in depth here as there's an [entire page](/api/stats) dedicated to its contents, but know that you can use it to find the following information:
+
+- The contents of every module.
+- The modules contained within every chunk.
+- Per module compilation and resolving stats.
+- Build errors and warnings.
+- The relationships between modules.
+- And much more...
+
+On top of that, the official [analyze tool](https://github.com/webpack/analyse) and [various others](/guides/code-splitting#bundle-analysis) will accept this data and visualize it in various ways.
 
 
 ## DevTools
 
-While [`console`]() statements may work well in simpler scenarios, sometimes a more robust solution is needed. As most front-end developers already know, Chrome DevTools are a life saver when debugging web applications, _but they don’t have to stop there_. As of Node v6.3.0+, developers can use the built-in `--inspect` flag to debug a node program in DevTools.
+While [`console`](https://nodejs.org/api/console.html) statements may work well in simpler scenarios, sometimes a more robust solution is needed. As most front-end developers already know, Chrome DevTools are a life saver when debugging web applications, _but they don’t have to stop there_. As of Node v6.3.0+, developers can use the built-in `--inspect` flag to debug a node program in DevTools.
 
 This gives you the power to easily create breakpoints, debug memory usage, expose and examine objects in the console, and much more. In this short demo, we'll utilize the [`node-nightly`](https://github.com/hemanth/node-nightly) package which provides access to the latest and greatest inpecting capabilites.
 
@@ -56,8 +65,6 @@ Debugger listening on ws://127.0.0.1:9229/c624201a-250f-416e-a018-300bbec7be2c
 For help see https://nodejs.org/en/docs/inspector
 ```
 
-Now jump to [chrome://inspect](chrome://inspect) and you should see any active scripts you've inspected under the _Remote Target_ header. Click the "inspect" link under each script to open a dedicated debugger or the _Open dedicated DevTools for Node_ link for a session that will autoconnect. You can also check out the [NiM extension](https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj), a handy Chrome plugin that will automatically open a DevTools tab every time you `--inspect` a script.
+Now jump to `chrome://inspect` in the browser and you should see any active scripts you've inspected under the _Remote Target_ header. Click the "inspect" link under each script to open a dedicated debugger or the _Open dedicated DevTools for Node_ link for a session that will autoconnect. You can also check out the [NiM extension](https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj), a handy Chrome plugin that will automatically open a DevTools tab every time you `--inspect` a script.
 
-Not too shabby, huh? We recommend using the `--inspect-brk` flag which will break on the first statement of the script allowing you to go through the source to set breakpoints and start/stop the build as you please. Also, don't forget that you can still pass arguments to the script. For example, if you have multiple configuration files you could still pass `--config webpack.prod.js` to specify the one you'd like to debug.
-
-
+We recommend using the `--inspect-brk` flag which will break on the first statement of the script allowing you to go through the source to set breakpoints and start/stop the build as you please. Also, don't forget that you can still pass arguments to the script. For example, if you have multiple configuration files you could pass `--config webpack.prod.js` to specify the configuration you'd like to debug.

--- a/src/content/contribute/debugging.md
+++ b/src/content/contribute/debugging.md
@@ -1,0 +1,63 @@
+---
+title: Debugging
+sort: 7
+contributors:
+  - skipjack
+related:
+  - title: Learn and Debug webpack with Chrome DevTools!
+    url: https://medium.com/webpack/webpack-bits-learn-and-debug-webpack-with-chrome-dev-tools-da1c5b19554b
+  - title: Debugging Guide | Node
+    url: https://nodejs.org/en/docs/guides/debugging-getting-started/
+  - title: Debugging Node.js with Chrome DevTools
+    url: https://medium.com/@paul_irish/debugging-node-js-nightlies-with-chrome-devtools-7c4a1b95ae27
+---
+
+When contributing to the core repo, writing a loader/plugin, or even just working on complex project, debugging tools can be central to your workflow. Whether the problem is slow performance on a large project or an unhelpful traceback, the following utilities can make figuring it out less painful.
+
+- The [`stats` data]() made available through [Node]() and the [CLI]().
+- Chrome __DevTools__ via `node-nightly` and the latest Node.js versions.
+
+
+## Stats
+
+...
+
+
+## DevTools
+
+While [`console`]() statements may work well in simpler scenarios, sometimes a more robust solution is needed. As most front-end developers already know, Chrome DevTools are a life saver when debugging web applications, _but they don’t have to stop there_. As of Node v6.3.0+, developers can use the built-in `--inspect` flag to debug a node program in DevTools.
+
+This gives you the power to easily create breakpoints, debug memory usage, expose and examine objects in the console, and much more. In this short demo, we'll utilize the [`node-nightly`](https://github.com/hemanth/node-nightly) package which provides access to the latest and greatest inpecting capabilites.
+
+W> The `--inspect` interface has been available since v6.3.0 so feel to try it out with your local version, but be warned that certain features and flags may differ from the ones in this demo.
+
+Let's start by installing it globally:
+
+``` bash
+npm install --global node-nightly
+```
+
+Now, we'll need to run it once to finish the installation:
+
+``` bash
+node-nightly
+```
+
+Now, we can simply use `node-nightly` along with the `--inspect` flag to start our build in any webpack-based project. Note that we cannot run NPM `scripts`, e.g. `npm run build`, so we'll have specify the full `node_modules` path:
+
+``` bash
+node-nightly --inspect ./node_modules/webpack/bin/webpack.js
+```
+
+Which should output something like:
+
+``` bash
+Debugger listening on ws://127.0.0.1:9229/c624201a-250f-416e-a018-300bbec7be2c
+For help see https://nodejs.org/en/docs/inspector
+```
+
+Now jump to [chrome://inspect](chrome://inspect) and you should see any active scripts you've inspected under the _Remote Target_ header. Click the "inspect" link under each script to open a dedicated debugger or the _Open dedicated DevTools for Node_ link for a session that will autoconnect. You can also check out the [NiM extension](https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj), a handy Chrome plugin that will automatically open a DevTools tab every time you `--inspect` a script.
+
+Not too shabby, huh? We recommend using the `--inspect-brk` flag which will break on the first statement of the script allowing you to go through the source to set breakpoints and start/stop the build as you please. Also, don't forget that you can still pass arguments to the script. For example, if you have multiple configuration files you could still pass `--config webpack.prod.js` to specify the one you'd like to debug.
+
+

--- a/src/content/contribute/plugin-patterns.md
+++ b/src/content/contribute/plugin-patterns.md
@@ -1,6 +1,6 @@
 ---
 title: Plugin Patterns
-sort: 4
+sort: 5
 ---
 
 Plugins grant unlimited opportunity to perform customizations within the webpack build system. This allows you to create custom asset types, perform unique build modifications, or even enhance the webpack runtime while using middleware. The following are some features of webpack that become useful while writing plugins.

--- a/src/content/contribute/release-process.md
+++ b/src/content/contribute/release-process.md
@@ -1,6 +1,6 @@
 ---
 title: Release Process
-sort: 5
+sort: 6
 contributors:
   - d3viant0ne
   - sokra

--- a/src/content/contribute/writers-guide.md
+++ b/src/content/contribute/writers-guide.md
@@ -1,5 +1,6 @@
 ---
 title: Writer's Guide
+sort: 2
 ---
 
 The following sections contain all you need to know about editing and formatting the content within this site. Make sure to do some research before starting your edits or additions. Sometimes the toughest part is finding where the content should live and determining whether or not it already exists.

--- a/src/content/contribute/writing-a-loader.md
+++ b/src/content/contribute/writing-a-loader.md
@@ -1,6 +1,6 @@
 ---
 title: Writing a Loader
-sort: 2
+sort: 3
 contributors:
   - asulaiman
 ---

--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -1,6 +1,6 @@
 ---
 title: Writing a Plugin
-sort: 3
+sort: 4
 ---
 
 Plugins expose the full potential of the webpack engine to third-party developers. Using staged build callbacks, developers can introduce their own behaviors into the webpack build process. Building plugins is a bit more advanced than building loaders, because you'll need to understand some of the webpack low-level internals to hook into them. Be prepared to read some source code!


### PR DESCRIPTION
Add a debugging guide that contains information on using `stats` data and debugging webpack via Chrome's _DevTools_ (#90). This should be a good home for any other common debugging tips and tricks.

Resolves #90 

cc @bebraw @TheLarkInn @pksjce wanted to knock #90 off the list but please feel free to submit follow up PRs with any modifications, enhancements, corrections, etc.