### PR TITLE
Typo on the API Docs Page

### DIFF
--- a/src/content/api/stats.md
+++ b/src/content/api/stats.md
@@ -54,7 +54,7 @@ The top-level structure of the output JSON file is fairly straightforward but th
 
 ### Asset Objects
 
-Each `assets` object represents an `output` file emitted from the compilation. They all follow the a similar structure:
+Each `assets` object represents an `output` file emitted from the compilation. They all follow a similar structure:
 
 ``` js
 {


### PR DESCRIPTION
They all follow ~~the~~ a similar Structure to `They all follow a`


