### PR TITLE
docs: Fix typo

### DIFF
--- a/src/content/plugins/module-concatenation-plugin.md
+++ b/src/content/plugins/module-concatenation-plugin.md
@@ -72,8 +72,8 @@ function tryToAdd(group, module) {
   if (!result) {
     return false;
   }
-  module.dependencies.forEach(depenency => {
-    tryToAdd(group, depenency);
+  module.dependencies.forEach(dependency => {
+    tryToAdd(group, dependency);
   });
   group.merge(nextGroup);
   return true;


### PR DESCRIPTION
Just noticed a 'dependency' typo.