### PR TITLE
Add an introduction for the “scope hoisting” term

### DIFF
--- a/src/content/plugins/module-concatenation-plugin.md
+++ b/src/content/plugins/module-concatenation-plugin.md
@@ -15,7 +15,9 @@ This plugin will enable the same concatenation behavior in webpack.
 new webpack.optimize.ModuleConcatenationPlugin()
 ```
 
-> Scope Hoisting is specifically a feature made possible by ECMAScript Module syntax. Because of this webpack may fallback to normal bundling based on what kind of modules you are using, and [other conditions](https://medium.com/webpack/webpack-freelancing-log-book-week-5-7-4764be3266f5).
+> This concatenation behavior is called “scope hoisting.”
+>
+> Scope hoisting is specifically a feature made possible by ECMAScript Module syntax. Because of this webpack may fallback to normal bundling based on what kind of modules you are using, and [other conditions](https://medium.com/webpack/webpack-freelancing-log-book-week-5-7-4764be3266f5).
 
 
 ## Optimization Bailouts


### PR DESCRIPTION
This adds a link between “this concatenation behavior” and “scope hoisting” terms. Without this, a new person might be confused what exactly “scope hoisting” is (because it appears without any visible connection to the previous content).
