### PR TITLE
A new --concatenate-modules flag

### DIFF
--- a/src/content/api/cli.md
+++ b/src/content/api/cli.md
@@ -225,11 +225,12 @@ Parameter                 | Explanation
 
 These options allow you to manipulate optimisations for a production build using webpack
 
-Parameter                   | Explanation                                            | Plugin Used
---------------------------- | -------------------------------------------------------|----------------------
-`--optimize-max-chunks`     | Try to keep the chunk count below a limit              | [LimitChunkCountPlugin](/plugins/limit-chunk-count-plugin)
-`--optimize-min-chunk-size` | Try to keep the chunk size above a limit               | [MinChunkSizePlugin](/plugins/min-chunk-size-plugin)
-`--optimize-minimize`       | Minimize javascript and switches loaders to minimizing | [UglifyJsPlugin](/plugins/uglifyjs-webpack-plugin/) & [LoaderOptionsPlugin](/plugins/loader-options-plugin/)
+Parameter                   | Explanation                                                     | Plugin Used
+--------------------------- | ----------------------------------------------------------------|----------------------
+`--optimize-max-chunks`     | Try to keep the chunk count below a limit                       | [LimitChunkCountPlugin](/plugins/limit-chunk-count-plugin)
+`--optimize-min-chunk-size` | Try to keep the chunk size above a limit                        | [MinChunkSizePlugin](/plugins/min-chunk-size-plugin)
+`--optimize-minimize`       | Minimize javascript and switches loaders to minimizing          | [UglifyJsPlugin](/plugins/uglifyjs-webpack-plugin/) & [LoaderOptionsPlugin](/plugins/loader-options-plugin/)
+`--concatenate-modules`     | Concatenate ES modules to remove module wrappers where possible | [ModuleConcatenationPlugin](/plugins/module-concatenation-plugin/)
 
 
 ### Resolve Options
@@ -294,7 +295,7 @@ Parameter         | Explanation                              | Usage
 Shortcut | Replaces
 ---------|----------------------------
 -d       | `--debug --devtool cheap-module-eval-source-map --output-pathinfo`
--p       | `--optimize-minimize --define process.env.NODE_ENV="production"`, see [building for production](/guides/production)
+-p       | `--optimize-minimize --define process.env.NODE_ENV="production" --concatenate-modules`, see [building for production](/guides/production)
 
 
 ### Profiling

--- a/src/content/guides/production.md
+++ b/src/content/guides/production.md
@@ -239,7 +239,7 @@ __src/index.js__
 
 ## Module Concatenation
 
-By default, webpack wraps each module into a function. This helps helps to isolate them, but brings additional overhead. You can try reducing this overhead by enabling [`ModuleConcatenationPlugin`](/plugins/module-concatenation-plugin) which, where possible, merges multiple modules together in a single module wrapper:
+By default, webpack wraps each module into a function. Wrapping helps to isolate them but brings additional overhead. You can try reducing this overhead by enabling the [`ModuleConcatenationPlugin`](/plugins/module-concatenation-plugin), which, where possible, merges multiple modules in a single module wrapper:
 
 __webpack.prod.js__
 

--- a/src/content/guides/production.md
+++ b/src/content/guides/production.md
@@ -205,7 +205,7 @@ __webpack.prod.js__
 +       'process.env': {
 +         'NODE_ENV': JSON.stringify('production')
 +       }
-+     })
++     }),
     ]
   })
 ```
@@ -244,25 +244,38 @@ By default, webpack wraps each module into a function. This helps helps to isola
 __webpack.prod.js__
 
 ```diff
-+ const webpack = require('webpack');
+  const webpack = require('webpack');
   const merge = require('webpack-merge');
+  const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
   const common = require('./webpack.common.js');
 
   module.exports = merge(common, {
+    devtool: 'cheap-module-source-map',
     plugins: [
-+     new webpack.optimize.ModuleConcatenationPlugin()
+      new UglifyJSPlugin({
+        sourceMap: true
+      }),
+      new webpack.DefinePlugin({
+        'process.env': {
+          'NODE_ENV': JSON.stringify('production')
+        }
+      }),
++     new webpack.optimize.ModuleConcatenationPlugin(),
     ]
   })
 ```
 
 Read more about module concatenation [in the plugin docs](/plugins/module-concatenation-plugin).
 
+
 ## CLI Alternatives
 
+
 Some of what has been described above is also achievable via the command line:
-* the `--optimize-minimize` flag will include the `UglifyJSPlugin` behind the scenes;
-* the `--define process.env.NODE_ENV="'production'"` will do the same for the `DefinePlugin` instance described above;
-* the `--concatenate-modules` flag will enable the `ModuleConcatenationPlugin`.
+
+- `--optimize-minimize` flag will include the `UglifyJSPlugin` behind the scenes;
+- `--define process.env.NODE_ENV="'production'"` will do the same for the `DefinePlugin` instance described above;
+- `--concatenate-modules` flag will enable the `ModuleConcatenationPlugin`.
 
 And, `webpack -p` will automatically invoke all those flags and thus the plugins to be included.
 

--- a/src/content/guides/production.md
+++ b/src/content/guides/production.md
@@ -200,12 +200,13 @@ __webpack.prod.js__
     plugins: [
       new UglifyJSPlugin({
         sourceMap: true
-      }),
+-     })
++     }),
 +     new webpack.DefinePlugin({
 +       'process.env': {
 +         'NODE_ENV': JSON.stringify('production')
 +       }
-+     }),
++     })
     ]
   })
 ```
@@ -259,8 +260,9 @@ __webpack.prod.js__
         'process.env': {
           'NODE_ENV': JSON.stringify('production')
         }
-      }),
-+     new webpack.optimize.ModuleConcatenationPlugin(),
+-     })
++     }),
++     new webpack.optimize.ModuleConcatenationPlugin()
     ]
   })
 ```

--- a/src/content/guides/production.md
+++ b/src/content/guides/production.md
@@ -15,6 +15,7 @@ contributors:
   - xgqfrms
   - kelset
   - xgirma
+  - iamakulov
 ---
 
 In this guide we'll dive into some of the best practices and utilities for building a production site or application.
@@ -236,9 +237,33 @@ __src/index.js__
   document.body.appendChild(component());
 ```
 
+## Module Concatenation
+
+By default, webpack wraps each module into a function. This helps helps to isolate them, but brings additional overhead. You can try reducing this overhead by enabling [`ModuleConcatenationPlugin`](/plugins/module-concatenation-plugin) which, where possible, merges multiple modules together in a single module wrapper:
+
+__webpack.prod.js__
+
+```diff
++ const webpack = require('webpack');
+  const merge = require('webpack-merge');
+  const common = require('./webpack.common.js');
+
+  module.exports = merge(common, {
+    plugins: [
++     new webpack.optimize.ModuleConcatenationPlugin()
+    ]
+  })
+```
+
+Read more about module concatenation [in the plugin docs](/plugins/module-concatenation-plugin).
 
 ## CLI Alternatives
 
-Some of what has been described above is also achievable via the command line. For example, the `--optimize-minimize` flag will include the `UglifyJSPlugin` behind the scenes. The `--define process.env.NODE_ENV="'production'"` will do the same for the `DefinePlugin` instance described above. And, `webpack -p` will automatically invoke both those flags and thus the plugins to be included.
+Some of what has been described above is also achievable via the command line:
+* the `--optimize-minimize` flag will include the `UglifyJSPlugin` behind the scenes;
+* the `--define process.env.NODE_ENV="'production'"` will do the same for the `DefinePlugin` instance described above;
+* the `--concatenate-modules` flag will enable the `ModuleConcatenationPlugin`.
+
+And, `webpack -p` will automatically invoke all those flags and thus the plugins to be included.
 
 While these short hand methods are nice, we usually recommend just using the configuration as it's better to understand exactly what is being done for you in both cases. The configuration also gives you more control on fine tuning other options within both plugins.

--- a/src/content/guides/production.md
+++ b/src/content/guides/production.md
@@ -275,9 +275,9 @@ Read more about module concatenation [in the plugin docs](/plugins/module-concat
 
 Some of what has been described above is also achievable via the command line:
 
-- `--optimize-minimize` flag will include the `UglifyJSPlugin` behind the scenes;
-- `--define process.env.NODE_ENV="'production'"` will do the same for the `DefinePlugin` instance described above;
-- `--concatenate-modules` flag will enable the `ModuleConcatenationPlugin`.
+- `--optimize-minimize` will include the `UglifyJSPlugin` behind the scenes;
+- `--define process.env.NODE_ENV="'production'"` will replicate the `DefinePlugin` instance above;
+- `--concatenate-modules` will enable the `ModuleConcatenationPlugin`.
 
 And, `webpack -p` will automatically invoke all those flags and thus the plugins to be included.
 


### PR DESCRIPTION
This adds documentation for the new `--concatenate-modules` CLI flag (see https://github.com/webpack/webpack/pull/5914).

Additionally, this documents `ModuleConcatenationPlugin` in the Production guide. I believe it’s reasonable to do this because the `--concatenate-modules` flag is included under the `-p` umbrella.