### PR TITLE
Consistent quote use

### DIFF
--- a/src/content/guides/typescript.md
+++ b/src/content/guides/typescript.md
@@ -78,7 +78,7 @@ module.exports = {
     ]
   },
   resolve: {
-    extensions: [ ".tsx", ".ts", ".js" ]
+    extensions: [ '.tsx', '.ts', '.js' ]
   },
   output: {
     filename: 'bundle.js',
@@ -139,7 +139,7 @@ __webpack.config.js__
       ]
     },
     resolve: {
-      extensions: [ ".tsx", ".ts", ".js" ]
+      extensions: [ '.tsx', '.ts', '.js' ]
     },
     output: {
       filename: 'bundle.js',


### PR DESCRIPTION
The quote usage in the config file was inconsistent. With this change it should be single where possible.