### PR TITLE
Correct path of bundle on index.html

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -133,7 +133,7 @@ __dist/index.html__
    </head>
    <body>
 -    <script src="./src/index.js"></script>
-+    <script src="bundle.js"></script>
++    <script src="dist/bundle.js"></script>
    </body>
   </html>
 ```


### PR DESCRIPTION
The command line to run `webpack` in the example is:
``` bash
./node_modules/.bin/webpack src/index.js dist/bundle.js
```

But `index.html` points to `bundle.js` when it should point to `dist/bundle.js`.
