### PR TITLE
docs(guides): add middleware tip to the hmr guide

### DIFF
--- a/src/content/guides/hot-module-replacement.md
+++ b/src/content/guides/hot-module-replacement.md
@@ -162,6 +162,8 @@ server.listen(5000, 'localhost', () => {
 });
 ```
 
+T> If you're [using `webpack-dev-middleware`](/guides/development#using-webpack-dev-middleware), check out the [`webpack-hot-middleware`](https://github.com/glenjamin/webpack-hot-middleware) package to enable HMR on your custom dev server.
+
 
 ## Gotchas
 


### PR DESCRIPTION
Add small tip to the "Hot Module Replacement" guide for `webpack-dev-middleware` users.

Resolves #1682