### PR TITLE
Use normal function to fix scope in loader

### DIFF
--- a/src/content/contribute/writing-a-loader.md
+++ b/src/content/contribute/writing-a-loader.md
@@ -234,13 +234,15 @@ __src/loader.js__
 ``` js
 import { getOptions } from 'loader-utils';
 
-export default source => {
+function loader(source) {
   const options = getOptions(this);
 
   source = source.replace(/\[name\]/g, options.name);
 
   return `export default ${ JSON.stringify(source) }`;
 };
+
+export default loader;
 ```
 
 We'll use this loader to process the following file:

--- a/src/content/contribute/writing-a-loader.md
+++ b/src/content/contribute/writing-a-loader.md
@@ -234,15 +234,13 @@ __src/loader.js__
 ``` js
 import { getOptions } from 'loader-utils';
 
-function loader(source) {
+export default function loader(source) {
   const options = getOptions(this);
 
   source = source.replace(/\[name\]/g, options.name);
 
   return `export default ${ JSON.stringify(source) }`;
 };
-
-export default loader;
 ```
 
 We'll use this loader to process the following file:


### PR DESCRIPTION
When using an arrow function, `this` is undefined.
When using a normal function, `this` is the loaderContext.

(tested using the tutorial on this page)
