### PR TITLE
grammar

### DIFF
--- a/src/content/concepts/output.md
+++ b/src/content/concepts/output.md
@@ -7,7 +7,7 @@ contributors:
   - rouzbeh84
 ---
 
-Configuring the `output` configuration options tell webpack how to write the compiled files to disk. Note that, while there can be multiple `entry` points, only one `output` configuration is specified.
+Configuring the `output` configuration options tells webpack how to write the compiled files to disk. Note that, while there can be multiple `entry` points, only one `output` configuration is specified.
 
 
 ## Usage


### PR DESCRIPTION
> MINI-LESSON: A gerund is an -ing verb that acts as a noun. When the gerund serves as the subject of the sentence, the verb should be singular, even if the object of the gerund is plural: Editing papers is tough work. Even though papers is plural, the phrase editing papers is singular and requires the singular verb is.

http://uwf.edu/writinglabapp/minilessons/mini-lesson_9x.htm

Configuring [the `output` configuration options] tells...

_describe your changes..._

This fixes a _super-minor_ grammatical error.
