### PR TITLE
Use shorten form for `process.env.NODE_ENV`

### DIFF
--- a/src/content/guides/production.md
+++ b/src/content/guides/production.md
@@ -201,9 +201,7 @@ __webpack.prod.js__
         sourceMap: true
       }),
 +     new webpack.DefinePlugin({
-+       'process.env': {
-+         'NODE_ENV': JSON.stringify('production')
-+       }
++       'process.env.NODE_ENV': JSON.stringify('production')
 +     })
     ]
   })


### PR DESCRIPTION
Shorten form for `DefinePlugin` example.