### PR TITLE
Linking compiler docs on plugins page

### DIFF
--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -11,7 +11,7 @@ A plugin for `webpack` consists of
 
 - A named JavaScript function.
 - Defines `apply` method in it's prototype.
-- Specifies webpack's event hook to attach itself.
+- Specifies an [event hook](/api/compiler/#event-hooks) on which to bind itself.
 - Manipulates webpack internal instance specific data.
 - Invokes webpack provided callback after functionality is complete.
 


### PR DESCRIPTION
While authoring plugins the list of hooks is essential knowledge, so link to hooks documentation page should be accessible in the top of plugins authoring guide.
The exact location is not very important, but it should be easy to find.

(for newcomer like myself it was not easy to realize the link between compiler api and plugins at first)
