### PR TITLE
website(css): changed the css to fix the text inside code tag which was overflowing the parent div

### DIFF
--- a/src/styles/markdown.scss
+++ b/src/styles/markdown.scss
@@ -259,7 +259,7 @@
     font-size: 90%;
     margin: 0 2px;
     padding: 2px 6px;
-    white-space: nowrap;
+    white-space: normal;
     background-color: transparentize(getColor(fiord), 0.94);
     border-radius: 3px;
     text-shadow: 0 1px 0 transparentize(getColor(white), 0.4);


### PR DESCRIPTION
Changes:
File ```src/styles/markdown.scss```
This PR changes the css ```white-space:normal``` for ```<code></code>``` tag to avoid overflowing the content wrt to the parent div.
![screen shot 2017-11-11 at 9 18 25 pm](https://user-images.githubusercontent.com/11384858/32746642-499ee864-c8dc-11e7-918e-1a1342cc9a6b.png)
![screen shot 2017-11-11 at 9 18 37 pm](https://user-images.githubusercontent.com/11384858/32746653-4d8e5d38-c8dc-11e7-8653-e5234233e68b.png)
