### PR TITLE
Updated Usage Instructions with Fragment Links

### DIFF
--- a/src/content/concepts/loaders.md
+++ b/src/content/concepts/loaders.md
@@ -43,9 +43,9 @@ module.exports = {
 
 There are three ways to use loaders in your application:
 
-* Configuration (recommended): Specify them in your __webpack.config.js__ file.
-* Inline: Specify them explicitly in each `import` statement.
-* CLI: Specify them within a shell command.
+* [Configuration](#configuration) (recommended): Specify them in your __webpack.config.js__ file.
+* [Inline](#inline): Specify them explicitly in each `import` statement.
+* [CLI](#cli): Specify them within a shell command.
 
 
 ### Configuration


### PR DESCRIPTION
This is just a quality of life adjustment that updates the list of ways to use loaders with fragment links to the relevant section in the docs.  In their current state, the section feels like a dead end, abruptly cutting off with three bullet points and no examples. While one can read on and figure it out, there is a break in focus that is quite distracting. No one like to have a "wtf" moment when reading docs so this hopefully reduces that friction and helps people connect the dots.