### PR TITLE
docs(guides): fix `source-map` discrepancy in production.md

### DIFF
--- a/src/content/guides/production.md
+++ b/src/content/guides/production.md
@@ -195,7 +195,7 @@ __webpack.prod.js__
   const common = require('./webpack.common.js');
 
   module.exports = merge(common, {
-    devtool: 'cheap-module-source-map',
+    devtool: 'source-map',
     plugins: [
       new UglifyJSPlugin({
         sourceMap: true


### PR DESCRIPTION
The webpack.prod.js code example in the 'Specify the Evironment'
section shows 'cheap-module-source-map' for the devtool field which is
not recommended for production. This section should show 'source-map'
to be consistent with the webpack.prod.js in the previous
'Source Mapping' section.