### PR TITLE
docs(guides): rename 'runtime' to 'manifest' in caching.md

### DIFF
--- a/src/content/guides/caching.md
+++ b/src/content/guides/caching.md
@@ -135,7 +135,7 @@ __webpack.config.js__
 -     })
 +     }),
 +     new webpack.optimize.CommonsChunkPlugin({
-+       name: 'runtime'
++       name: 'manifest'
 +     })
     ],
     output: {
@@ -145,16 +145,16 @@ __webpack.config.js__
   };
 ```
 
-Let's run another build to see the extracted `runtime` bundle:
+Let's run another build to see the extracted `manifest` bundle:
 
 ``` bash
 Hash: 80552632979856ddab34
 Version: webpack 3.3.0
 Time: 1512ms
-                          Asset       Size  Chunks                    Chunk Names
-   main.5ec8e954e32d66dee1aa.js     542 kB       0  [emitted]  [big]  main
-runtime.719796322be98041fff2.js    5.82 kB       1  [emitted]         runtime
-                     index.html  275 bytes          [emitted]
+                           Asset       Size  Chunks                    Chunk Names
+    main.5ec8e954e32d66dee1aa.js     542 kB       0  [emitted]  [big]  main
+manifest.719796322be98041fff2.js    5.82 kB       1  [emitted]         manifest
+                      index.html  275 bytes          [emitted]
    [0] ./src/index.js 336 bytes {0} [built]
    [2] (webpack)/buildin/global.js 509 bytes {0} [built]
    [3] (webpack)/buildin/module.js 517 bytes {0} [built]
@@ -188,7 +188,7 @@ __webpack.config.js__
 +       name: 'vendor'
 +     }),
       new webpack.optimize.CommonsChunkPlugin({
-        name: 'runtime'
+        name: 'manifest'
       })
     ],
     output: {
@@ -198,7 +198,7 @@ __webpack.config.js__
   };
 ```
 
-W> Note that order matters here. The `'vendor'` instance of the `CommonsChunkPlugin` must be included prior to the `'runtime'` instance.
+W> Note that order matters here. The `'vendor'` instance of the `CommonsChunkPlugin` must be included prior to the `'manifest'` instance.
 
 Let's run another build to see our new `vendor` bundle:
 
@@ -206,11 +206,11 @@ Let's run another build to see our new `vendor` bundle:
 Hash: 69eb92ebf8935413280d
 Version: webpack 3.3.0
 Time: 1502ms
-                          Asset       Size  Chunks                    Chunk Names
- vendor.8196d409d2f988123318.js     541 kB       0  [emitted]  [big]  vendor
-   main.0ac0ae2d4a11214ccd19.js  791 bytes       1  [emitted]         main
-runtime.004a1114de8bcf026622.js    5.85 kB       2  [emitted]         runtime
-                     index.html  352 bytes          [emitted]
+                           Asset       Size  Chunks                    Chunk Names
+  vendor.8196d409d2f988123318.js     541 kB       0  [emitted]  [big]  vendor
+    main.0ac0ae2d4a11214ccd19.js  791 bytes       1  [emitted]         main
+manifest.004a1114de8bcf026622.js    5.85 kB       2  [emitted]         manifest
+                      index.html  352 bytes          [emitted]
    [1] ./src/index.js 336 bytes {1} [built]
    [2] (webpack)/buildin/global.js 509 bytes {0} [built]
    [3] (webpack)/buildin/module.js 517 bytes {0} [built]
@@ -269,11 +269,11 @@ Running another build, we would expect only our `main` bundle's hash to change, 
 Hash: d38a06644fdbb898d795
 Version: webpack 3.3.0
 Time: 1445ms
-                          Asset       Size  Chunks                    Chunk Names
- vendor.a7561fb0e9a071baadb9.js     541 kB       0  [emitted]  [big]  vendor
-   main.b746e3eb72875af2caa9.js    1.22 kB       1  [emitted]         main
-runtime.1400d5af64fc1b7b3a45.js    5.85 kB       2  [emitted]         runtime
-                     index.html  352 bytes          [emitted]
+                           Asset       Size  Chunks                    Chunk Names
+  vendor.a7561fb0e9a071baadb9.js     541 kB       0  [emitted]  [big]  vendor
+    main.b746e3eb72875af2caa9.js    1.22 kB       1  [emitted]         main
+manifest.1400d5af64fc1b7b3a45.js    5.85 kB       2  [emitted]         manifest
+                      index.html  352 bytes          [emitted]
    [1] ./src/index.js 421 bytes {1} [built]
    [2] (webpack)/buildin/global.js 509 bytes {0} [built]
    [3] (webpack)/buildin/module.js 517 bytes {0} [built]
@@ -286,7 +286,7 @@ runtime.1400d5af64fc1b7b3a45.js    5.85 kB       2  [emitted]         runtime
 
 - The `main` bundle changed because of its new content.
 - The `vendor` bundle changed because its `module.id` was changed.
-- And, the `runtime` bundle changed because it now contains a reference to a new module.
+- And, the `manifest` bundle changed because it now contains a reference to a new module.
 
 The first and last are expected -- it's the `vendor` hash we want to fix. Luckily, there are two plugins we can use to resolve this issue. The first is the [`NamedModulesPlugin`](/plugins/named-modules-plugin), which will use the path to the module rather than a numerical identifier. While this plugin is useful during development for more readable output, it does take a bit longer to run. The second option is the [`HashedModuleIdsPlugin`](/plugins/hashed-module-ids-plugin), which is recommended for production builds:
 
@@ -315,7 +315,7 @@ __webpack.config.js__
         name: 'vendor'
       }),
       new webpack.optimize.CommonsChunkPlugin({
-        name: 'runtime'
+        name: 'manifest'
       })
     ],
     output: {
@@ -331,11 +331,11 @@ Now, despite any new local dependencies, our `vendor` hash should stay consisten
 Hash: 1f49b42afb9a5acfbaff
 Version: webpack 3.3.0
 Time: 1372ms
-                          Asset       Size  Chunks                    Chunk Names
- vendor.eed6dcc3b30cfa138aaa.js     541 kB       0  [emitted]  [big]  vendor
-   main.d103ac311788fcb7e329.js    1.22 kB       1  [emitted]         main
-runtime.d2a6dc1ccece13f5a164.js    5.85 kB       2  [emitted]         runtime
-                     index.html  352 bytes          [emitted]
+                           Asset       Size  Chunks                    Chunk Names
+  vendor.eed6dcc3b30cfa138aaa.js     541 kB       0  [emitted]  [big]  vendor
+    main.d103ac311788fcb7e329.js    1.22 kB       1  [emitted]         main
+manifest.d2a6dc1ccece13f5a164.js    5.85 kB       2  [emitted]         manifest
+                      index.html  352 bytes          [emitted]
 [3Di9] ./src/print.js 62 bytes {1} [built]
 [3IRH] (webpack)/buildin/module.js 517 bytes {0} [built]
 [DuR2] (webpack)/buildin/global.js 509 bytes {0} [built]
@@ -373,11 +373,11 @@ And finally run our build again:
 Hash: 37e1358f135c0b992f72
 Version: webpack 3.3.0
 Time: 1557ms
-                          Asset       Size  Chunks                    Chunk Names
- vendor.eed6dcc3b30cfa138aaa.js     541 kB       0  [emitted]  [big]  vendor
-   main.fc7f38e648da79db2aba.js  891 bytes       1  [emitted]         main
-runtime.bb5820632fb66c3fb357.js    5.85 kB       2  [emitted]         runtime
-                     index.html  352 bytes          [emitted]
+                           Asset       Size  Chunks                    Chunk Names
+  vendor.eed6dcc3b30cfa138aaa.js     541 kB       0  [emitted]  [big]  vendor
+    main.fc7f38e648da79db2aba.js  891 bytes       1  [emitted]         main
+manifest.bb5820632fb66c3fb357.js    5.85 kB       2  [emitted]         manifest
+                      index.html  352 bytes          [emitted]
 [3IRH] (webpack)/buildin/module.js 517 bytes {0} [built]
 [DuR2] (webpack)/buildin/global.js 509 bytes {0} [built]
    [0] multi lodash 28 bytes {0} [built]


### PR DESCRIPTION
Preserve CommonsChunkPlugin boilerplate naming consistency as
referenced in the [CommonsChunkPlugin manifest file][1] 
documentation when extracting webpack runtime and manifest
boilerplate.

[1]:https://webpack.js.org/plugins/commons-chunk-plugin/#manifest-file