### PR TITLE
docs(configuration): added missing semicolon for consistency in plugins.md

### DIFF
--- a/src/content/configuration/plugins.md
+++ b/src/content/configuration/plugins.md
@@ -29,7 +29,7 @@ plugins: [
 A more complex example, using multiple plugins, might look something like this:
 
 ```js
-var webpack = require('webpack')
+var webpack = require('webpack');
 // importing plugins that do not come by default in webpack
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var DashboardPlugin = require('webpack-dashboard/plugin');


### PR DESCRIPTION
The final code block was missing a semicolon from the end of the first line; added it in to match the other require statements.