### PR TITLE
Update CommonsChunkPlugin Docs

### DIFF
--- a/src/content/plugins/commons-chunk-plugin.md
+++ b/src/content/plugins/commons-chunk-plugin.md
@@ -201,7 +201,7 @@ new webpack.optimize.CommonsChunkPlugin({
   name: "vendor",
   minChunks: function (module) {
     // this assumes your vendor imports exist in the node_modules directory
-    return module.context && module.context.indexOf("node_modules") !== -1;
+    return module.context && module.context.includes("node_modules");
   }
 })
 ```


### PR DESCRIPTION
Really minor update to the plugin docs but I think `.includes()` is more readable that `.indexOf()` for people less familiar with javascript.
