### PR TITLE
Update devtool production recommendations

### DIFF
--- a/src/content/configuration/devtool.md
+++ b/src/content/configuration/devtool.md
@@ -30,7 +30,7 @@ T> Instead of using the `devtool` option you can also use `SourceMapDevToolPlugi
 
 devtool                        | build | rebuild | production | quality
 ------------------------------ | ----- | ------- | ---------- | -----------------------------
-(none)                         | +++   | +++     | no         | bundled code
+(none)                         | +++   | +++     | yes        | bundled code
 eval                           | +++   | +++     | no         | generated code
 cheap-eval-source-map          | +     | ++      | no         | transformed code (lines only)
 cheap-module-eval-source-map   | o     | ++      | no         | original source (lines only)


### PR DESCRIPTION
I believe this is a mistake. As far as I know, `devtool: false` is completely appropriate for production use – but I just talked to a friend who was tempting to enable it because the docs say “Production use: no”.