### PR TITLE
Update writing-a-loader.md

### DIFF
--- a/src/content/contribute/writing-a-loader.md
+++ b/src/content/contribute/writing-a-loader.md
@@ -124,7 +124,7 @@ __loader.js__
 
 ``` js
 import { getOptions } from 'loader-utils';
-import { validateOptions } from 'schema-utils';
+import validateOptions from 'schema-utils';
 
 const schema = {
   type: object,


### PR DESCRIPTION
Fix import statement. `validateOptions` is exported as a default module