### PR TITLE
 docs(config) update how to write the webpack configuration with typescript

### DIFF
--- a/src/content/configuration/configuration-languages.md
+++ b/src/content/configuration/configuration-languages.md
@@ -40,44 +40,44 @@ const config: webpack.Configuration = {
 export default config;
 ```
 
-Next check your tsconfig.json:
+Not that you'll also need to check your `tsconfig.json` file. If the module in `compilerOptions` in `tsconfig.json` is `commonjs`, the setting is complete, else webpack will fail with an error. This occurs because `ts-node` does not support any module syntax other than `commonjs`.
 
-If the module in compilerOptions in tsconfig.json is commonjs, the setting is complete, else webpack will fail with an error.
-This problem is occurring because ts-node does not support the module syntax of other than commonjs module.
-We have a two solutions.
+There are two solutions to this issue:
 
-- modify tsconfig.json
-- install tsconfig-paths
+- Modify `tsconfig.json`.
+- Install `tsconfig-paths`.
 
-First solution:
+The __first option__ is to open your `tsconfig.json` file and look for `compilerOptions`. Set `target` to `"ES5"` and `module` to `"CommonJS"` (or completely remove the `module` option).
 
-In `tsconfig.json` look for `compilerOptions`. Set `target` to `"ES5"` and `module` to `"CommonJS"` (or completely remove the `module` option).
+The __second option__ is to install the `tsconfig-paths` package:
 
-Second solution:
-
-First install tsconfig-paths
-
-```bash
+``` bash
 npm install --save-dev tsconfig-paths
 ```
 
-T>ts-node can resolve tsconfig.json using the environment variable provided by tsconfig-path.
+And create a separate TypeScript configuration specifically for your webpack configs:
 
-Then set the environment variable `process.env.TS_NODE_PROJECT` provided by tsconfig-path like this.
+__tsconfig-for-webpack-config.json__
 
-```json
-//tsconfig-for-webpack-config.json
+``` json
 {
   "compilerOptions": {
     "module": "commonjs",
     "target": "es5"
   }
 }
+```
 
-//package.json
+T> `ts-node` can resolve a `tsconfig.json` file using the environment variable provided by `tsconfig-path`.
+
+Then set the environment variable `process.env.TS_NODE_PROJECT` provided by `tsconfig-path` like so:
+
+__package.json__
+
+```
 {
   "scripts": {
-      "build": "TS_NODE_PROJECT=\"tsconfig-for-webpack-config.json\" webpack"
+    "build": "TS_NODE_PROJECT=\"tsconfig-for-webpack-config.json\" webpack"
   }
 }
 ```

--- a/src/content/configuration/configuration-languages.md
+++ b/src/content/configuration/configuration-languages.md
@@ -7,6 +7,7 @@ contributors:
   - tarang9211
   - simon04
   - peterblazejewicz
+  - youta1119
 ---
 
 webpack accepts configuration files written in multiple programming and data languages. The list of supported file extensions can be found at the [node-interpret](https://github.com/js-cli/js-interpret) package. Using [node-interpret](https://github.com/js-cli/js-interpret), webpack can handle many different types of configuration files.
@@ -37,6 +38,46 @@ const config: webpack.Configuration = {
 };
 
 export default config;
+```
+
+next check your tsconfig.json:
+
+If module in compilerOptions in tsconfig.json is commonjs, setting is complete, else webpack getting error.
+This problem is occurring because ts-node does not support the module syntax of other than commonjs module.
+We have a two solutions.
+- modify tsconfig.json
+- install tsconfig-paths
+
+First solution:
+
+edit module in compilerOptions in tsconfig.json. please setting commonjs.
+
+Secoud solution:
+
+first install tsconfig-paths
+
+```bash
+npm install --save-dev tsconfig-paths
+```
+
+T>ts-node can resolve tsconfig.json using the environment variable provided by tsconfig-path.
+
+and setting environment variable `process.env.TS_NODE_PROJECT` provided by tsconfig-path like this.
+
+```json
+//tsconfig-for-webpack-config.json
+{
+  "compilerOptions": {
+    "module": "commonjs"
+  }
+}
+
+//package.json
+{
+  "scripts": {
+      "build": "TS_NODE_PROJECT=\"tsconfig-for-webpack-config.json\" webpack"
+  }
+}
 ```
 
 

--- a/src/content/configuration/configuration-languages.md
+++ b/src/content/configuration/configuration-languages.md
@@ -40,21 +40,22 @@ const config: webpack.Configuration = {
 export default config;
 ```
 
-next check your tsconfig.json:
+Next check your tsconfig.json:
 
-If module in compilerOptions in tsconfig.json is commonjs, setting is complete, else webpack getting error.
+If the module in compilerOptions in tsconfig.json is commonjs, the setting is complete, else webpack getting error.
 This problem is occurring because ts-node does not support the module syntax of other than commonjs module.
 We have a two solutions.
+
 - modify tsconfig.json
 - install tsconfig-paths
 
 First solution:
 
-edit module in compilerOptions in tsconfig.json. please setting commonjs.
+Edit module in compilerOptions in tsconfig.json. Please setting commonjs.
 
-Secoud solution:
+Second solution:
 
-first install tsconfig-paths
+First install tsconfig-paths
 
 ```bash
 npm install --save-dev tsconfig-paths

--- a/src/content/configuration/configuration-languages.md
+++ b/src/content/configuration/configuration-languages.md
@@ -74,7 +74,7 @@ Then set the environment variable `process.env.TS_NODE_PROJECT` provided by `tsc
 
 __package.json__
 
-```
+```json
 {
   "scripts": {
     "build": "TS_NODE_PROJECT=\"tsconfig-for-webpack-config.json\" webpack"

--- a/src/content/configuration/configuration-languages.md
+++ b/src/content/configuration/configuration-languages.md
@@ -42,7 +42,7 @@ export default config;
 
 Next check your tsconfig.json:
 
-If the module in compilerOptions in tsconfig.json is commonjs, the setting is complete, else webpack getting error.
+If the module in compilerOptions in tsconfig.json is commonjs, the setting is complete, else webpack will fail with an error.
 This problem is occurring because ts-node does not support the module syntax of other than commonjs module.
 We have a two solutions.
 
@@ -51,7 +51,7 @@ We have a two solutions.
 
 First solution:
 
-Edit module in compilerOptions in tsconfig.json. Please setting commonjs.
+In `tsconfig.json` look for `compilerOptions`. Set `target` to `"ES5"` and `module` to `"CommonJS"` (or completely remove the `module` option).
 
 Second solution:
 
@@ -63,7 +63,7 @@ npm install --save-dev tsconfig-paths
 
 T>ts-node can resolve tsconfig.json using the environment variable provided by tsconfig-path.
 
-and setting environment variable `process.env.TS_NODE_PROJECT` provided by tsconfig-path like this.
+Then set the environment variable `process.env.TS_NODE_PROJECT` provided by tsconfig-path like this.
 
 ```json
 //tsconfig-for-webpack-config.json

--- a/src/content/configuration/configuration-languages.md
+++ b/src/content/configuration/configuration-languages.md
@@ -69,7 +69,8 @@ Then set the environment variable `process.env.TS_NODE_PROJECT` provided by tsco
 //tsconfig-for-webpack-config.json
 {
   "compilerOptions": {
-    "module": "commonjs"
+    "module": "commonjs",
+    "target": "es5"
   }
 }
 


### PR DESCRIPTION
issue #1735 
Update how to write the webpack configuration with typescript. Current configuration is wrong.
ts-node dosenot  support the module syntax of other than commonjs module. 
So, if module in compilerOptions in tsconfig.json is not commonjs, webpack getting error. like this.

```bash
(function (exports, require, module, __filename, __dirname) { import * as path from "path";
                                                              ^^^^^^

SyntaxError: Unexpected token import
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:588:28)
    at Module.m._compile (/Users/hogefuga/webpack-config-with-typescript/node_modules/ts-node/src/index.ts:392:23)

```
I have a two solution.
1. modify tsconfig.json
1. install tsconfig-paths

### First solution:

edit module in compilerOptions in tsconfig.json. please setting commonjs.

### Secoud solution:

first install tsconfig-paths

```bash
npm install --save-dev tsconfig-paths
```

**ts-node can resolve tsconfig.json using the environment variable provided by tsconfig-path.**

and setting environment variable `process.env.TS_NODE_PROJECT` provided by tsconfig-path like this.

```json
//tsconfig-for-webpack-config.json
{
  "compilerOptions": {
    "module": "commonjs"
  }
}

//package.json
{
  "scripts": {
      "build": "TS_NODE_PROJECT=\"tsconfig-for-webpack-config.json\" webpack"
  }
}
```
I make sample project. please see [this repository](https://github.com/youta1119/webpack-config-with-typescript)