### PR TITLE
Use full "npm install" command instead of abbreviated "npm i"

### DIFF
--- a/src/content/contribute/writing-a-loader.md
+++ b/src/content/contribute/writing-a-loader.md
@@ -209,7 +209,7 @@ For instance, the `sass-loader` [specifies `node-sass`](https://github.com/webpa
 So you've written a loader, followed the guidelines above, and have it set up to run locally. What's next? Let's go through a simple unit testing example to ensure our loader is working the way we expect. We'll be using the [Jest](https://facebook.github.io/jest/) framework to do this. We'll also install `babel-jest` and some presets that will allow us to use the `import` / `export` and `async` / `await`. Let's start by installing and saving these as a `devDependencies`:
 
 ``` bash
-npm i --save-dev jest babel-jest babel-preset-env
+npm install --save-dev jest babel-jest babel-preset-env
 ```
 
 __.babelrc__
@@ -254,7 +254,7 @@ Hey [name]!
 Pay close attention to this next step as we'll be using the [Node.js API](/api/node) and [`memory-fs`](https://github.com/webpack/memory-fs) to execute webpack. This lets us avoid emitting `output` to disk and will give us access to the `stats` data which we can use to grab our transformed module:
 
 ``` bash
-npm i --save-dev webpack memory-fs
+npm install --save-dev webpack memory-fs
 ```
 
 __test/compiler.js__

--- a/src/content/guides/integrations.md
+++ b/src/content/guides/integrations.md
@@ -27,7 +27,7 @@ So while webpack's core focus is bundling, there are a variety of extensions tha
 For those using Grunt, we recommend the [`grunt-webpack`](https://www.npmjs.com/package/grunt-webpack) package. With `grunt-webpack` you can run webpack or [webpack-dev-server](https://github.com/webpack/webpack-dev-server) as a task, get access to stats within [template tags](https://gruntjs.com/api/grunt.template), split development and production configurations and more. Start by installing `grunt-webpack` as well as `webpack` itself if you haven't already:
 
 ``` bash
-npm i --save-dev grunt-webpack webpack
+npm install --save-dev grunt-webpack webpack
 ```
 
 Then register a configuration and load the task:
@@ -60,7 +60,7 @@ For more information, please visit the [repository](https://github.com/webpack-c
 Gulp is also a fairly straightforward integration with the help of the [`webpack-stream`](https://github.com/shama/webpack-stream) package (a.k.a. `gulp-webpack`). In this case, it is unnecessary to install `webpack` separately as it is a direct dependency of `webpack-stream`:
 
 ``` bash
-npm i --save-dev webpack-stream
+npm install --save-dev webpack-stream
 ```
 
 Just `require('webpack-stream')` instead of `webpack` and optionally pass it an configuration:
@@ -87,7 +87,7 @@ For more information, please visit the [repository](https://github.com/shama/web
 The [`mocha-webpack`](https://github.com/zinserjan/mocha-webpack) utility can be used for a clean integration with Mocha. The repository offers more details on the pros and cons but essentially `mocha-webpack` is a simple wrapper that provides almost the same CLI as Mocha itself and provides various webpack functionality like an improved watch mode and improved path resolution. Here is a small example of how you would install it and use it to run a test suite (found within `./test`):
 
 ``` bash
-npm i --save-dev webpack mocha mocha-webpack
+npm install --save-dev webpack mocha mocha-webpack
 mocha-webpack 'test/**/*.js'
 ```
 
@@ -99,7 +99,7 @@ For more information, please visit the [repository](https://github.com/zinserjan
 The [`karma-webpack`](https://github.com/webpack-contrib/karma-webpack) package allows you to use webpack to pre-process files in [Karma](http://karma-runner.github.io/1.0/index.html). It also makes use of [`webpack-dev-middleware`](https://github.com/webpack/webpack-dev-middleware) and allows passing configurations for both. A simple example may look something like this:
 
 ``` bash
-npm i --save-dev webpack karma karma-webpack
+npm install --save-dev webpack karma karma-webpack
 ```
 
 __karma.conf.js__

--- a/src/content/guides/shimming.md
+++ b/src/content/guides/shimming.md
@@ -264,7 +264,7 @@ Almost everything we've discussed thus far has been in relation to handling lega
 There's a lot of ways to load polyfills. For example, to include the [`babel-polyfill`](https://babeljs.io/docs/usage/polyfill/) we might simply:
 
 ``` bash
-npm i --save babel-polyfill
+npm install --save babel-polyfill
 ```
 
 and `import` it so as to include it in our main bundle:
@@ -292,7 +292,7 @@ Now while this is one approach, __including polyfills in the main bundle is not 
 Let's move our `import` to a new file and add the [`whatwg-fetch`](https://github.com/github/fetch) polyfill:
 
 ``` bash
-npm i --save whatwg-fetch
+npm install --save whatwg-fetch
 ```
 
 __src/index.js__

--- a/src/content/guides/tree-shaking.md
+++ b/src/content/guides/tree-shaking.md
@@ -114,7 +114,7 @@ So we've cued up our "dead code" to be dropped by using the `import` and `export
 Let's start by installing it:
 
 ``` bash
-npm i --save-dev uglifyjs-webpack-plugin
+npm install --save-dev uglifyjs-webpack-plugin
 ```
 
 And then adding it into our config:


### PR DESCRIPTION
Most of the guides use the full command, so follow that.

Also it's clearer for beginners who is not familiar with npm.