### PR TITLE
docs(guides): fix diff display for webpack.config.js entry object

### DIFF
--- a/src/content/guides/output-management.md
+++ b/src/content/guides/output-management.md
@@ -5,6 +5,7 @@ contributors:
   - skipjack
   - TheDutchCoder
   - sudarsangp
+  - JGJP
 ---
 
 T> This guide extends on code examples found in the [`Asset Management`](/guides/asset-management) guide.
@@ -89,11 +90,11 @@ __webpack.config.js__
   const path = require('path');
 
   module.exports = {
-    entry: {
--     index: './src/index.js',
+-   entry: './src/index.js',
++   entry: {
 +     app: './src/index.js',
 +     print: './src/print.js'
-    },
++   },
     output: {
 -     filename: 'bundle.js',
 +     filename: '[name].bundle.js',


### PR DESCRIPTION
Resolves #1743

Fixed the first diff display for webpack.config.js in the [Output Management](https://webpack.js.org/guides/output-management/) guide.
In the guide, the addition of an additional entry point is shown but the change from a string ([from the previous tutorial](https://webpack.js.org/guides/asset-management/)) to an object is not made clear.
