### PR TITLE
Add sort for mobile sidebar

### DIFF
--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -44,9 +44,17 @@ const Site = ({
             title: section.path.title,
             url: section.url,
             pages: section.pages.map(page => ({
+              file: page.file,
               title: page.file.title,
               url: page.url
-            }))
+            })).sort(({ file: { attributes: a }}, { file: { attributes: b }}) => {
+              let group1 = a.group.toLowerCase();
+              let group2 = b.group.toLowerCase();
+
+              if (group1 < group2) return -1;
+              if (group1 > group2) return 1;
+              return a.sort - b.sort;
+            })
           }))
       } />
 


### PR DESCRIPTION
Resolve #1758 add missing sort for mobile sidebar. (copy logic from:  [/src/components/Page/Page.jsx#L19-L26](https://github.com/webpack/webpack.js.org/blob/ab2d8ffa05d07d6bc06d784bd548c15b9f95367b/src/components/Page/Page.jsx#L19-L26))