### PR TITLE
docs(config): clarify use of wildcard with proxy url matching

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -629,6 +629,16 @@ proxy: [{
 }]
 ```
 
+[Micromatch](https://www.npmjs.com/package/micromatch#matching-features) wildcard expressions are also supported:
+
+```js
+proxy: [{
+  context: ["/admin/**", "**/api/**", "(@/index.html/)"],
+  target: "http://localhost:3000",
+}]
+```
+But you may not mix plain text and wildcard expressions in the same context array
+
 ## `devServer.progress` - CLI only
 
 `boolean`


### PR DESCRIPTION
Clarify the possibility of using micromatch expressions inside the proxy's context array

_describe your changes..._

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
