### PR TITLE
docs: Fix formatting

### DIFF
--- a/src/components/NotificationBar/NotificationBar.jsx
+++ b/src/components/NotificationBar/NotificationBar.jsx
@@ -13,8 +13,8 @@ export default class NotificationBar extends React.Component {
       <div className={ `notification-bar ${dismissedMod}` }>
         <Container className="notification-bar__inner">
           <p>
-            Sponsor webpack and get apparel from the <a href="https://webpack.threadless.com">official shop</a>&nbsp;
-            or get stickers <a href="http://www.unixstickers.com/tag/webpack">here</a>! All proceeds go to our&nbsp;
+            Sponsor webpack and get apparel from the <a href="https://webpack.threadless.com">official shop</a>{' '}
+            or get stickers <a href="http://www.unixstickers.com/tag/webpack">here</a>! All proceeds go to our{' '}
             <a href="https://opencollective.com/webpack">open collective</a>!
           </p>
           { localStorageIsEnabled ?

--- a/src/components/StarterKits/StarterKits.jsx
+++ b/src/components/StarterKits/StarterKits.jsx
@@ -15,20 +15,20 @@ const StarterKits = props => (
     <h1>Starter Kits</h1>
 
     <p>
-      The following table contains a curated list of starter kits that can&nbsp;
-      be used as a jumping off point for webpack-based projects. To add a new&nbsp;
-      kit to the list please visit&nbsp;
-      <Link to="https://github.com/ahfarmer/tool-list">this repository</Link>&nbsp;
-      and submit a PR against this file:&nbsp;
+      The following table contains a curated list of starter kits that can
+      be used as a jumping off point for webpack-based projects. To add a new
+      kit to the list please visit{' '}
+      <Link to="https://github.com/ahfarmer/tool-list">this repository</Link>{' '}
+      and submit a PR against this file:
       <code>generator/starterProjectUrls.js</code>.
     </p>
 
     <blockquote className="warning">
       <div className="tip-content">
-        Boilerplates should be used as <b>Proof of Concepts</b> to help you learn&nbsp;
-        different webpack techniques for various frameworks. Make sure you understand&nbsp;
-        what's going on in them and avoid copy and paste coding. Also note that none&nbsp;
-        of these are officially supported by webpack. If you run into an issue, please&nbsp;
+        Boilerplates should be used as <strong>Proof of Concepts</strong> to help you learn
+        different webpack techniques for various frameworks. Make sure you understand
+        what's going on in them and avoid copy and paste coding. Also note that none
+        of these are officially supported by webpack. If you run into an issue, please
         report that to the maintainer(s) of the repository.
       </div>
     </blockquote>

--- a/src/content/guides/migrating.md
+++ b/src/content/guides/migrating.md
@@ -544,7 +544,7 @@ webpack now supports template strings in expressions. This means you can start u
 
 ### Configuration Promise
 
-webpack now supports returning a `Promise` from the configuration file. This allows to do async processing in you configuration file.
+webpack now supports returning a `Promise` from the configuration file. This allows to do async processing in your configuration file.
 
 **webpack.config.js**
 

--- a/src/content/guides/migrating.md
+++ b/src/content/guides/migrating.md
@@ -544,7 +544,7 @@ webpack now supports template strings in expressions. This means you can start u
 
 ### Configuration Promise
 
-webpack now supports returning a `Promise` from the configuration file. This allows to do async processing in your configuration file.
+webpack now supports returning a `Promise` from the configuration file. This allows async processing in your configuration file.
 
 **webpack.config.js**
 


### PR DESCRIPTION
`&nbsp;` shouldn't be used as they are wider than normal spaces. In some cases, the `&nbsp;`s aren't necessary. The rest can be replaced with `{' '}` instead.

### Before

<img width="994" alt="screen shot 2017-12-26 at 9 29 29 pm" src="https://user-images.githubusercontent.com/1315101/34371698-4368a6b4-ea84-11e7-9895-5035409a2677.png">

Note the spacing between (`can` and `be`) and (`learn` and `different`) is wider than usual.

### After

<img width="985" alt="screen shot 2017-12-26 at 9 30 42 pm" src="https://user-images.githubusercontent.com/1315101/34371703-496008d2-ea84-11e7-9b8a-7499ffdcacb8.png">
