### PR TITLE
docs(plugins): Clarify the case of ModuleConcatenationPlugin + Babel

### DIFF
--- a/src/content/plugins/module-concatenation-plugin.md
+++ b/src/content/plugins/module-concatenation-plugin.md
@@ -19,7 +19,7 @@ new webpack.optimize.ModuleConcatenationPlugin()
 >
 > Scope hoisting is specifically a feature made possible by ECMAScript Module syntax. Because of this webpack may fallback to normal bundling based on what kind of modules you are using, and [other conditions](https://medium.com/webpack/webpack-freelancing-log-book-week-5-7-4764be3266f5).
 
-W> please keep in mind that this plugin will not affect the build in case ECMAScript modules are processed into either of supported module systems. E.g. Babel transforms ES Modules to commonjs by default (see: [Babel ES2015 Preset options: modules](https://babeljs.io/docs/plugins/preset-es2015/#optionsmodules)).
+W> Keep in mind that this plugin will only be applied to [ES6 modules](/api/module-methods/#es6-recommended-) processed directly by webpack. When using a transpiler, you'll need to disable module processing (e.g. the [`modules`](https://babeljs.io/docs/plugins/preset-es2015/#optionsmodules) option in Babel).
 
 
 ## Optimization Bailouts

--- a/src/content/plugins/module-concatenation-plugin.md
+++ b/src/content/plugins/module-concatenation-plugin.md
@@ -19,6 +19,8 @@ new webpack.optimize.ModuleConcatenationPlugin()
 >
 > Scope hoisting is specifically a feature made possible by ECMAScript Module syntax. Because of this webpack may fallback to normal bundling based on what kind of modules you are using, and [other conditions](https://medium.com/webpack/webpack-freelancing-log-book-week-5-7-4764be3266f5).
 
+W> please keep in mind that this plugin will not affect the build in case ECMAScript modules are processed into either of supported module systems. E.g. Babel transforms ES Modules to commonjs by default (see: [Babel ES2015 Preset options: modules](https://babeljs.io/docs/plugins/preset-es2015/#optionsmodules)).
+
 
 ## Optimization Bailouts
 


### PR DESCRIPTION
Adds more information about why the plugin may cause no effect in case Babel

Related:
- https://github.com/webpack/webpack/issues/5199#issuecomment-354348034