### PR TITLE
Loader order changed from chonological to reverse

### DIFF
--- a/src/content/concepts/loaders.md
+++ b/src/content/concepts/loaders.md
@@ -101,7 +101,7 @@ This uses the `jade-loader` for `.jade` files, and the [`style-loader`](/loaders
 
 ## Loader Features
 
-* Loaders can be chained. They are applied in a pipeline to the resource. A chain of loaders are compiled chronologically. The first loader in a chain of loaders returns a value to the next. At the end loader, webpack expects JavaScript to be returned.
+* Loaders can be chained. They are applied in a pipeline to the resource. A chain of loaders are executed in reverse order. The first loader in a chain of loaders returns a value to the next. At the end loader, webpack expects JavaScript to be returned.
 * Loaders can be synchronous or asynchronous.
 * Loaders run in Node.js and can do everything that’s possible there.
 * Loaders accept query parameters. This can be used to pass configuration to the loader.


### PR DESCRIPTION
When one starts to learn about loaders it's very confusing.
[This](https://webpack.js.org/contribute/writing-a-loader/#complex-usage) explains the behaviour much better.

_describe your changes..._

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
