### PR TITLE
Moment successor lib Luxon will load properly

### DIFF
--- a/src/content/plugins/ignore-plugin.md
+++ b/src/content/plugins/ignore-plugin.md
@@ -23,3 +23,5 @@ As of [moment](https://momentjs.com/) 2.18, all locales are bundled together wit
 ```js
 new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)
 ```
+
+**Note from the Moment team:** We shipped a [new libarary called Luxon](https://moment.github.io/luxon/) in November of 2017. Luxon has an API extremely similar to Moment's, but it is smaller, immutable, and properly modularized. We recommend this library for all projects that require only evergreen browser support.


### PR DESCRIPTION
Adding a note that Moment has a successor library, Luxon, with a very similar API that will load properly in webpack - along with a lot of other benefits.