### PR TITLE
docs(guides): link required babel plugin for async

### DIFF
--- a/src/content/guides/code-splitting.md
+++ b/src/content/guides/code-splitting.md
@@ -21,6 +21,7 @@ contributors:
   - rouzbeh84
   - shaodahong
   - sudarsangp
+  - kcolton
 ---
 
 T> This guide extends the examples provided in [Getting Started](/guides/getting-started) and [Output Management](/guides/output-management). Please make sure you are at least familiar with the examples provided in them.
@@ -263,7 +264,7 @@ lodash.bundle.js   541 kB       0  [emitted]  [big]  lodash
    [3] (webpack)/buildin/module.js 517 bytes {0} [built]
 ```
 
-If you've enabled [`async` functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) via a pre-processor like babel, note that you can simplify the code as `import()` statements just return promises:
+If you've enabled [`async` functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) via a pre-processor like Babel + [Syntax Dynamic Import Babel Plugin](https://babeljs.io/docs/plugins/syntax-dynamic-import/#installation), note that you can simplify the code as `import()` statements just return promises:
 
 __src/index.js__
 

--- a/src/content/guides/code-splitting.md
+++ b/src/content/guides/code-splitting.md
@@ -264,7 +264,7 @@ lodash.bundle.js   541 kB       0  [emitted]  [big]  lodash
    [3] (webpack)/buildin/module.js 517 bytes {0} [built]
 ```
 
-If you've enabled [`async` functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) via a pre-processor like Babel and the [Syntax Dynamic Import Babel Plugin](https://babeljs.io/docs/plugins/syntax-dynamic-import/#installation), note that you can simplify the code as `import()` statements return promises:
+As `import()` returns a promise, it can be used with [`async` functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function). However, this requires using a pre-processor like Babel and the [Syntax Dynamic Import Babel Plugin](https://babeljs.io/docs/plugins/syntax-dynamic-import/#installation). Here's how it would simplify the code:
 
 __src/index.js__
 

--- a/src/content/guides/code-splitting.md
+++ b/src/content/guides/code-splitting.md
@@ -264,7 +264,7 @@ lodash.bundle.js   541 kB       0  [emitted]  [big]  lodash
    [3] (webpack)/buildin/module.js 517 bytes {0} [built]
 ```
 
-If you've enabled [`async` functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) via a pre-processor like Babel + [Syntax Dynamic Import Babel Plugin](https://babeljs.io/docs/plugins/syntax-dynamic-import/#installation), note that you can simplify the code as `import()` statements just return promises:
+If you've enabled [`async` functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) via a pre-processor like Babel and the [Syntax Dynamic Import Babel Plugin](https://babeljs.io/docs/plugins/syntax-dynamic-import/#installation), note that you can simplify the code as `import()` statements return promises:
 
 __src/index.js__
 


### PR DESCRIPTION
Adds links to additional requirements to make `await import` example work. 

Just using babel and `babel-loader` is not enough.

You need the [Syntax-Dynamic-Import Babel Plugin](https://babeljs.io/docs/plugins/syntax-dynamic-import/#installation) installed as a devDependency and added to .babelrc as a plugin

Instructions on the linked page should allow anyone familiar with `babel-loader` to get the example running no problem.

There are a lot of outdated solutions floating around that mislead or push to older `require` syntax,. Referencing the current required packages to see the example in action is helpful.

In the [comments of the babel plugin page](http://discuss.babeljs.io/t/syntax-dynamic-import-babel/799/7?u=kcolton), I have a [working gist](https://gist.github.com/kcolton/2d6dba9dd11f7db450e7900c039e16f6) that shows how it all fits together.
