### PR TITLE
docs(configuration): add details on resolve.symlink and npm link

### DIFF
--- a/src/content/configuration/module.md
+++ b/src/content/configuration/module.md
@@ -56,7 +56,7 @@ In a Rule the properties [`test`](#rule-test), [`include`](#rule-include), [`exc
 
 When using multiple conditions, all conditions must match.
 
-W> Be careful! The resource is the _resolved_ path of the file, which means symlinked resources are the real path _not_ the symlink location. This is good to remember when using tools that symlink packages (like `npm link`), common conditions like `/node_modules/` may inadvertently miss symlinked files. Note that you can turn off symlink resolving (so that resources are their symlink locations) via [`resolve.symlinks`](/configuration/resolve#resolve-symlinks).
+W> Be careful! The resource is the _resolved_ path of the file, which means symlinked resources are the real path _not_ the symlink location. This is good to remember when using tools that symlink packages (like `npm link`), common conditions like `/node_modules/` may inadvertently miss symlinked files. Note that you can turn off symlink resolving (so that resources are resolved to the symlink path) via [`resolve.symlinks`](/configuration/resolve#resolve-symlinks).
 
 
 ### Rule results

--- a/src/content/configuration/module.md
+++ b/src/content/configuration/module.md
@@ -56,7 +56,7 @@ In a Rule the properties [`test`](#rule-test), [`include`](#rule-include), [`exc
 
 When using multiple conditions, all conditions must match.
 
-W> Be careful! The resource is the _resolved_ path of the file, which means symlinked resources are the real path _not_ the symlink location. This is good to remember when using tools that symlink packages (like `npm link`), common conditions like `/node_modules/` may inadvertently miss symlinked files.
+W> Be careful! The resource is the _resolved_ path of the file, which means symlinked resources are the real path _not_ the symlink location. This is good to remember when using tools that symlink packages (like `npm link`), common conditions like `/node_modules/` may inadvertently miss symlinked files. Note that you can turn off symlink resolving (so that resources are their symlink locations) via [`resolve.symlinks`](/configuration/resolve#resolve-symlinks).
 
 
 ### Rule results

--- a/src/content/configuration/resolve.md
+++ b/src/content/configuration/resolve.md
@@ -258,7 +258,11 @@ plugins: [
 
 `boolean`
 
-Whether to resolve symlinks to their symlinked location. Default:
+Whether to resolve symlinks to their symlinked location.
+
+When enabled, symlinked resources are resolved to their _real_ path, not their symlinked location. Note that this may cause module resolution to fail when using tools that symlink packages (like `npm link`).
+
+`resolve.symlinks` defaults to:
 
 ```js
 symlinks: true


### PR DESCRIPTION
From discussion in https://github.com/webpack/webpack/issues/811#issuecomment-309797397.

Adds a few notes about how `resolve.symlinks` and `npm link` play together (I assume `npm link` to be the most common tool for symlinking packages). Specifically, turning off `resolve.symlinks` may solve some problems users have with modules not resolving properly in their symlinked packages.