### PR TITLE
docs(concepts): Direct new-comers to read about JS modules

### DIFF
--- a/src/content/concepts/index.md
+++ b/src/content/concepts/index.md
@@ -12,7 +12,7 @@ contributors:
 
 At its core, *webpack* is a _static module bundler_ for modern JavaScript applications. When webpack processes your application, it recursively builds a _dependency graph_ that includes every module your application needs, then packages all of those modules into one or more _bundles_.
 
-T> Learn more about JavaScript modules and webpack modules [here](/modules).
+T> Learn more about JavaScript modules and webpack modules [here](/concepts/modules).
 
 It is [incredibly configurable](/configuration), but to get started you only need to understand four **Core Concepts**:
 

--- a/src/content/concepts/index.md
+++ b/src/content/concepts/index.md
@@ -12,6 +12,8 @@ contributors:
 
 At its core, *webpack* is a _static module bundler_ for modern JavaScript applications. When webpack processes your application, it recursively builds a _dependency graph_ that includes every module your application needs, then packages all of those modules into one or more _bundles_.
 
+T> Learn more about JavaScript modules and webpack modules [here](/modules).
+
 It is [incredibly configurable](/configuration), but to get started you only need to understand four **Core Concepts**:
 
 - Entry

--- a/src/content/concepts/modules.md
+++ b/src/content/concepts/modules.md
@@ -5,6 +5,9 @@ contributors:
   - TheLarkInn
   - simon04
   - rouzbeh84
+related:
+   - title: JavaScript Module Systems Showdown
+     url: https://auth0.com/blog/javascript-module-systems-showdown/
 ---
 
 In [modular programming](https://en.wikipedia.org/wiki/Modular_programming), developers break programs up into discrete chunks of functionality called a _module_.


### PR DESCRIPTION
Added a direction to learn about JS modules when reading the concepts page, meant mostly for new-comers. Because the modules doc page does not discuss the JS module systems, I also added a further reading link on this subject.

This is after a colleague of mine had an issue understanding what and why about webpack when reading the docs. What he was missing is an understanding of JS modules. You can't understand a *module* bundler without knowing modules.