### PR TITLE
Adds documentation on EvalSourceMapDevToolPlugin

### DIFF
--- a/src/content/plugins/eval-source-map-dev-tool-plugin.md
+++ b/src/content/plugins/eval-source-map-dev-tool-plugin.md
@@ -29,7 +29,7 @@ The following options are supported:
 - `sourceURLTemplate`: Define the sourceURL default: `webpack-internal:///${module.identifier}`
 - `module` (`boolean`): Indicates whether loaders should generate source maps (defaults to `true`).
 - `columns` (`boolean`): Indicates whether column mappings should be used (defaults to `true`).
-- `protocol` (`string`): Allows user to override default protocol (which may cause cross-origin exception)
+- `protocol` (`string`): Allows user to override default protocol (`webpack-internal://`)
 
 T> Setting `module` and/or `columns` to `false` will yield less accurate source maps but will also improve compilation performance significantly.
 
@@ -51,7 +51,10 @@ new webpack.EvalSourceMapDevToolPlugin({
 
 ### Setting sourceURL
 
-Set a URL for source maps. Useful for avoiding cross-origin issues.
+Set a URL for source maps. Useful for avoiding cross-origin issues such as
+  ```
+  A cross-origin error was thrown. React doesn't have access to the actual error object in development. See https://fb.me/react-crossorigin-error for more information.
+```
 
 ``` js
 new webpack.EvalSourceMapDevToolPlugin({

--- a/src/content/plugins/eval-source-map-dev-tool-plugin.md
+++ b/src/content/plugins/eval-source-map-dev-tool-plugin.md
@@ -6,7 +6,7 @@ contributors:
   - kinseyost
 related:
   - title: Building Eval Source Maps
-    url: https://survivejs.com/webpack/building/source-maps/#-sourcemapdevtoolplugin-and-evalsourcemapdevtoolplugin-
+    url: https://survivejs.com/webpack/building/source-maps/#sourcemapdevtoolplugin-and-evalsourcemapdevtoolplugin
 ---
 
 This plugin enables more fine grained control of source map generation. It is an alternative to the [`devtool`](/configuration/devtool/) configuration option.

--- a/src/content/plugins/eval-source-map-dev-tool-plugin.md
+++ b/src/content/plugins/eval-source-map-dev-tool-plugin.md
@@ -51,17 +51,22 @@ new webpack.EvalSourceMapDevToolPlugin({
 
 ### Setting sourceURL
 
-Set a URL for source maps. Useful for avoiding cross-origin issues such as
-  ```
-  A cross-origin error was thrown. React doesn't have access to the actual error object in development. See https://fb.me/react-crossorigin-error for more information.
+Set a URL for source maps. Useful for avoiding cross-origin issues such as:
+
+``` bash
+A cross-origin error was thrown. React doesn't have access to the actual error object in development. See https://fb.me/react-crossorigin-error for more information.
 ```
+
+The option can be set to a function:
 
 ``` js
 new webpack.EvalSourceMapDevToolPlugin({
   sourceURLTemplate: module => `/${module.identifier}`
 })
 ```
-OR
+
+Or a substition string:
+
 ``` js
 new webpack.EvalSourceMapDevToolPlugin({
   sourceURLTemplate: '[all-loaders][resource]'

--- a/src/content/plugins/eval-source-map-dev-tool-plugin.md
+++ b/src/content/plugins/eval-source-map-dev-tool-plugin.md
@@ -1,0 +1,68 @@
+---
+title: EvalSourceMapDevToolPlugin
+contributors:
+  - johnnyreilly
+  - simon04
+  - kinseyost
+related:
+  - title: Building Eval Source Maps
+    url: https://survivejs.com/webpack/building/source-maps/#-sourcemapdevtoolplugin-and-evalsourcemapdevtoolplugin-
+---
+
+This plugin enables more fine grained control of source map generation. It is an alternative to the [`devtool`](/configuration/devtool/) configuration option.
+
+``` js
+new webpack.EvalSourceMapDevToolPlugin(options)
+```
+
+
+## Options
+
+The following options are supported:
+
+- `test` (`string|regex|array`): Include source maps for modules based on their extension (defaults to `.js` and `.css`).
+- `include` (`string|regex|array`): Include source maps for module paths that match the given value.
+- `exclude` (`string|regex|array`): Exclude modules that match the given value from source map generation.
+- `filename` (`string`): Defines the output filename of the SourceMap (will be inlined if no value is provided).
+- `append` (`string`): Appends the given value to the original asset. Usually the `#sourceMappingURL` comment. `[url]` is replaced with a URL to the source map file. `false` disables the appending.
+- `moduleFilenameTemplate` (`string`): See [`output.devtoolModuleFilenameTemplate`](/configuration/output/#output-devtoolmodulefilenametemplate).
+- `sourceURLTemplate`: Define the sourceURL default: `webpack-internal:///${module.identifier}`
+- `module` (`boolean`): Indicates whether loaders should generate source maps (defaults to `true`).
+- `columns` (`boolean`): Indicates whether column mappings should be used (defaults to `true`).
+- `protocol` (`string`): Allows user to override default protocol (which may cause cross-origin exception)
+
+T> Setting `module` and/or `columns` to `false` will yield less accurate source maps but will also improve compilation performance significantly.
+
+
+## Examples
+
+The following examples demonstrate some common use cases for this plugin.
+
+### Exclude Vendor Maps
+
+The following code would exclude source maps for any modules in the `vendor.js` bundle:
+
+``` js
+new webpack.EvalSourceMapDevToolPlugin({
+  filename: '[name].js.map',
+  exclude: ['vendor.js']
+})
+```
+
+### Setting sourceURL
+
+Set a URL for source maps. Useful for avoiding cross-origin issues.
+
+``` js
+new webpack.EvalSourceMapDevToolPlugin({
+  sourceURLTemplate: module => `/${module.identifier}`
+})
+```
+OR
+``` js
+new webpack.EvalSourceMapDevToolPlugin({
+  sourceURLTemplate: '[all-loaders][resource]'
+})
+```
+
+

--- a/src/content/plugins/index.md
+++ b/src/content/plugins/index.md
@@ -35,6 +35,7 @@ Name                                                     | Description
 [`NpmInstallWebpackPlugin`](/plugins/npm-install-webpack-plugin) | Auto-install missing dependencies during development
 [`ProvidePlugin`](/plugins/provide-plugin)                       | Use modules without having to use import/require
 [`SourceMapDevToolPlugin`](/plugins/source-map-dev-tool-plugin)  | Enables a more fine grained control of source maps
+[`EvalSourceMapDevToolPlugin`](/plugins/eval-source-map-dev-tool-plugin)  | Enables a more fine grained control of eval source maps
 [`UglifyjsWebpackPlugin`](/plugins/uglifyjs-webpack-plugin)      | Enables control of the version of UglifyJS in your project
 [`ZopfliWebpackPlugin`](/plugins/zopfli-webpack-plugin)          | Prepare compressed versions of assets with node-zopfli
 


### PR DESCRIPTION
Adds information about existing class as well as an example of usage for `sourceUrlTemplate` which is introduced in PR: https://github.com/webpack/webpack/pull/6272