### PR TITLE
Typo: Should this be import not export?

### DIFF
--- a/src/content/guides/tree-shaking.md
+++ b/src/content/guides/tree-shaking.md
@@ -104,7 +104,7 @@ function cube(x) {
 }
 ```
 
-Note the `unused harmony export square` comment above. If you look at the code below it, you'll notice that `square` is not being exported, however, it is still included in the bundle. We'll fix that in the next section.
+Note the `unused harmony export square` comment above. If you look at the code below it, you'll notice that `square` is not being imported, however, it is still included in the bundle. We'll fix that in the next section.
 
 
 ## Minify the Output


### PR DESCRIPTION
Tiny thing, but this made more sense to me with `imported` rather than exported. 

I could be wrong though 🙂 