### PR TITLE
Update docs with troubleshooting information: watching section

### DIFF
--- a/src/content/configuration/watch.md
+++ b/src/content/configuration/watch.md
@@ -70,11 +70,12 @@ poll: 1000 // Check for changes every second
 
 T> If watching does not work for you, try out this option. Watching does not work with NFS and machines in VirtualBox.
 
-# Troubleshooting
 
-## Webpack doesn't recompile on change while watching
+## Troubleshooting
 
-### File changes are seen, but no files are updated
+### Missed Compilations
+
+### Changes are seen, but no files are updated
 
 Verify that webpack is not being notified of changes by running webpack with the --progress flag. If progress shows on save but no files are outputted, it is likely a configuration issue, not a file watching issue.
 

--- a/src/content/configuration/watch.md
+++ b/src/content/configuration/watch.md
@@ -73,8 +73,6 @@ T> If watching does not work for you, try out this option. Watching does not wor
 
 ## Troubleshooting
 
-### Missed Compilations
-
 ### Changes are seen, but no files are updated
 
 Verify that webpack is not being notified of changes by running webpack with the --progress flag. If progress shows on save but no files are outputted, it is likely a configuration issue, not a file watching issue.

--- a/src/content/configuration/watch.md
+++ b/src/content/configuration/watch.md
@@ -74,9 +74,9 @@ T> If watching does not work for you, try out this option. Watching does not wor
 
 ## Webpack doesn't recompile on change while watching
 
-### File changes are being seen, just no files are being updated
+### File changes are seen, but no files are updated
 
-Verify that webpack is not being notified of changes by running with the --progress flag. If progress shows on save but no files are output, it is likely a configuration issue, not a file watching issue.
+Verify that webpack is not being notified of changes by running webpack with the --progress flag. If progress shows on save but no files are outputted, it is likely a configuration issue, not a file watching issue.
 
 ```bash
 webpack --watch --progress
@@ -90,23 +90,21 @@ Verify that you have enough available watchers in your system. If this value is 
 cat /proc/sys/fs/inotify/max_user_watches
 ```
 
-Arch users, add `fs.inotify.max_user_watches=524288` to `/etc/sysctl.d/99-sysctl.conf` and then execute `sysctl --system`. Ubuntu users (and possibly others): `echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p`.
+Arch users, add `fs.inotify.max_user_watches=524288` to `/etc/sysctl.d/99-sysctl.conf` and then execute `sysctl --system`. Ubuntu users (and possibly others), execute: `echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p`.
 
 ### macOS fsevents bug
 
-On macOS folders can get corrupted. See this article:
-
-[OS X FSEvents bug may prevent monitoring of certain folders](http://feedback.livereload.com/knowledgebase/articles/86239-os-x-fsevents-bug-may-prevent-monitoring-of-certai)
+On macOS folders can get corrupted. [See this article](http://feedback.livereload.com/knowledgebase/articles/86239-os-x-fsevents-bug-may-prevent-monitoring-of-certai)
 
 ### Windows paths
 
-webpack expects absolute paths for many config options. `__dirname + "/app/folder"` is wrong, because windows uses `\` as path separator. This breaks some stuff.
+Because webpack expects absolute paths for many config options such as `__dirname + "/app/folder"` the Windows `\` path separator can break some functionality.
 
 Use the correct separators. I.e. `path.resolve(__dirname, "app/folder")` or `path.join(__dirname, "app", "folder")`.
 
 ### Vim
 
-On some machines Vim is preconfigured with the [backupcopy option](http://vimdoc.sourceforge.net/htmldoc/options.html#'backupcopy') set to **auto**. This could potentially cause problems with the system's file watching mechanism. Switching this option to `yes` will make sure a copy of the file is made and the original one overwritten on save. 
+On some machines Vim is preconfigured with the [backupcopy option](http://vimdoc.sourceforge.net/htmldoc/options.html#'backupcopy') set to `auto`. This could potentially cause problems with the system's file watching mechanism. Switching this option to `yes` will make sure a copy of the file is made and the original one overwritten on save. 
 
 `:set backupcopy=yes`
 

--- a/src/content/configuration/watch.md
+++ b/src/content/configuration/watch.md
@@ -73,7 +73,9 @@ T> If watching does not work for you, try out this option. Watching does not wor
 
 ## Troubleshooting
 
-### Changes are seen, but no files are updated
+If you are experiencing any issues, please see the following notes. There are a variety of reasons why webpack might miss a file change.
+
+### Changes Seen But Not Processed
 
 Verify that webpack is not being notified of changes by running webpack with the --progress flag. If progress shows on save but no files are outputted, it is likely a configuration issue, not a file watching issue.
 
@@ -81,7 +83,7 @@ Verify that webpack is not being notified of changes by running webpack with the
 webpack --watch --progress
 ```
 
-### Not enough watchers
+### Not Enough Watchers
 
 Verify that you have enough available watchers in your system. If this value is too low, the file watcher in Webpack won't recognize the changes:
 
@@ -91,11 +93,11 @@ cat /proc/sys/fs/inotify/max_user_watches
 
 Arch users, add `fs.inotify.max_user_watches=524288` to `/etc/sysctl.d/99-sysctl.conf` and then execute `sysctl --system`. Ubuntu users (and possibly others), execute: `echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p`.
 
-### macOS fsevents bug
+### MacOS fsevents Bug
 
-On macOS folders can get corrupted. [See this article](http://feedback.livereload.com/knowledgebase/articles/86239-os-x-fsevents-bug-may-prevent-monitoring-of-certai)
+On MacOS, folders can get corrupted in certain scenarios. See [this article](http://feedback.livereload.com/knowledgebase/articles/86239-os-x-fsevents-bug-may-prevent-monitoring-of-certai).
 
-### Windows paths
+### Windows Paths
 
 Because webpack expects absolute paths for many config options such as `__dirname + "/app/folder"` the Windows `\` path separator can break some functionality.
 
@@ -107,6 +109,6 @@ On some machines Vim is preconfigured with the [backupcopy option](http://vimdoc
 
 `:set backupcopy=yes`
 
-### File saves in WebStorm don't trigger the watcher
+### Saving in WebStorm
 
 When using the JetBrains WebStorm IDE, you may find that saving changed files does not trigger the watcher as you might expect. Try disabling the `safe write` option in the settings, which determines whether files are saved to a temporary location first before the originals are overwritten: uncheck `File > Settings... > System Settings > Use "safe write" (save changes to a temporary file first)`.


### PR DESCRIPTION
After accidentally getting onto @sokra and @gaearon discussion of old docs missing page on twitter, i decided to send a PR with troubleshooting section for webpack watch. This makes it easier to find and to make people link to our docs website instead of old wiki page.

[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/

  