### PR TITLE
Keep `guides/development.md` more consistent

### DIFF
--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -214,7 +214,7 @@ __package.json__
     "main": "webpack.config.js",
     "scripts": {
       "test": "echo \"Error: no test specified\" && exit 1",
-      "watch": "webpack --progress --watch",
+      "watch": "webpack --watch",
 +     "start": "webpack-dev-server --open",
       "build": "webpack"
     },
@@ -331,7 +331,7 @@ __package.json__
     "main": "webpack.config.js",
     "scripts": {
       "test": "echo \"Error: no test specified\" && exit 1",
-      "watch": "webpack --progress --watch",
+      "watch": "webpack --watch",
       "start": "webpack-dev-server --open",
 +     "server": "node server.js",
       "build": "webpack"

--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -6,6 +6,7 @@ contributors:
   - rafde
   - fvgs
   - TheDutchCoder
+  - WojciechKo
 ---
 
 T> This guide extends on code examples found in the [Output Management](/guides/output-management) guide.


### PR DESCRIPTION
Remove `--progress` option that wasn't introduce in previous `package.json` snippets in order to prevent confusion.

[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
