### PR TITLE
Make “learn more” links self-explanatory

### DIFF
--- a/src/content/api/index.md
+++ b/src/content/api/index.md
@@ -19,7 +19,7 @@ The Command Line Interface (CLI) to configure and interact with your build. It i
 
 When processing modules with webpack, it is important to understand the different module syntaxes -- specifically the [methods](/api/module-methods) and [variables](/api/module-variables) -- that are supported.
 
-[Learn more about the modules!](/api/module-methods)
+[Learn more about modules!](/api/module-methods)
 
 
 ## Node
@@ -33,11 +33,11 @@ While most users can get away with just using the CLI along with a configuration
 
 Loaders are transformations that are applied to the source code of a module. They are written as functions that accept source code as a parameter and return a new version of that code with transformations applied.
 
-[Learn more about the loaders!](/api/loaders)
+[Learn more about loaders!](/api/loaders)
 
 
 ## Plugins
 
 The plugin interface provided by webpack allows users to tap directly into the compilation process. Plugins can register handlers on lifecycle hooks that run at different points in the compilation process. When each hook is executed, the plugin will have full access to the current state of the compilation.
 
-[Learn more about the plugins!](/api/plugins)
+[Learn more about plugins!](/api/plugins)

--- a/src/content/api/index.md
+++ b/src/content/api/index.md
@@ -12,32 +12,32 @@ A variety of interfaces are available to customize the compilation process. Some
 
 The Command Line Interface (CLI) to configure and interact with your build. It is especially useful in the case of early prototyping and profiling. For the most part, the CLI is simply used to kick off the process using a configuration file and a few flags (e.g. `--env`).
 
-[Learn more!](/api/cli)
+[Learn more about the CLI!](/api/cli)
 
 
 ## Module
 
 When processing modules with webpack, it is important to understand the different module syntaxes -- specifically the [methods](/api/module-methods) and [variables](/api/module-variables) -- that are supported.
 
-[Learn more!](/api/module-methods)
+[Learn more about the modules!](/api/module-methods)
 
 
 ## Node
 
 While most users can get away with just using the CLI along with a configuration file, more fine-grained control of the compilation can be achieved via the Node interface. This includes passing multiple configurations, programmatically running or watching, and collecting stats.
 
-[Learn more!](/api/node)
+[Learn more about the Node API!](/api/node)
 
 
 ## Loaders
 
 Loaders are transformations that are applied to the source code of a module. They are written as functions that accept source code as a parameter and return a new version of that code with transformations applied.
 
-[Learn more!](/api/loaders)
+[Learn more about the loaders!](/api/loaders)
 
 
 ## Plugins
 
 The plugin interface provided by webpack allows users to tap directly into the compilation process. Plugins can register handlers on lifecycle hooks that run at different points in the compilation process. When each hook is executed, the plugin will have full access to the current state of the compilation.
 
-[Learn more!](/api/plugins)
+[Learn more about the plugins!](/api/plugins)


### PR DESCRIPTION
Some assistive technologies such as screen readers have options to list links in a page to allow rapid browsing and navigation. These links are listed without their surrounding context, making them sometimes hard to understand.

This pull-request qualifies “learn more” links to make them self-explanatory so that a screen-reader user can easily figure out which link points to which documentation.

---

I didn’t manage to do a screenshot with the links list from VoiceOver open (as keyboard shortcuts control the rotor) but I did snap a picture so you see what it looks like.

![Links list from VoiceOver menu](https://user-images.githubusercontent.com/1889710/35124994-5f475a16-fca8-11e7-8019-a863f4cd34bd.jpg)

