### PR TITLE
Add note on how plugins can intercept stats

### DIFF
--- a/src/content/configuration/stats.md
+++ b/src/content/configuration/stats.md
@@ -13,6 +13,8 @@ The `stats` option lets you precisely control what bundle information gets displ
 
 T> For webpack-dev-server, this property needs to be in the `devServer` object.
 
+T> Some plugins, such as `webpack-dev-middleware`, intercept `stats`. Therefore you must set `stats` in that plugin's config.
+
 W> This option does not have any effect when using the Node.js API.
 
 ## `stats`


### PR DESCRIPTION
I was trying to suppress some stats in my project which used the webpack Node API, so I set my stats object according to that documentation. It wasn't working, and I had no idea why. That's [until I asked on SO](https://stackoverflow.com/questions/48452322/webpack-builds-twice-and-ignores-stats-option/48453063) and was told webpack-dev-middleware intercepts stats. It's not obvious that happens, so I want to add this note for devs to be aware of such things.