### PR TITLE
Update docs with info-verbosity option

### DIFF
--- a/src/content/configuration/watch.md
+++ b/src/content/configuration/watch.md
@@ -71,6 +71,13 @@ poll: 1000 // Check for changes every second
 T> If watching does not work for you, try out this option. Watching does not work with NFS and machines in VirtualBox.
 
 
+## `info-verbosity`
+
+`string`: `none` `info` `verbose`
+
+Controls verbosity of the lifecycle messaging e.g. `Started watching files...`. Setting `info-verbosity` to `verbose` will also message to console at the beginning and the end of incremental build. `info-verbosity` is set to `info` by default.
+
+
 ## Troubleshooting
 
 If you are experiencing any issues, please see the following notes. There are a variety of reasons why webpack might miss a file change.

--- a/src/content/configuration/watch.md
+++ b/src/content/configuration/watch.md
@@ -5,6 +5,7 @@ contributors:
   - sokra
   - skipjack
   - SpaceK33z
+  - EugeneHlushko
 ---
 
 webpack can watch files and recompile whenever they change. This page explains how to enable this and a couple of tweaks you can make if watching does not work properly for you.

--- a/src/content/configuration/watch.md
+++ b/src/content/configuration/watch.md
@@ -10,6 +10,7 @@ contributors:
 
 webpack can watch files and recompile whenever they change. This page explains how to enable this and a couple of tweaks you can make if watching does not work properly for you.
 
+
 ## `watch`
 
 `boolean`
@@ -21,6 +22,7 @@ watch: false
 ```
 
 T> In webpack-dev-server and webpack-dev-middleware watch mode is enabled by default.
+
 
 ## `watchOptions`
 
@@ -35,6 +37,7 @@ watchOptions: {
 }
 ```
 
+
 ## `watchOptions.aggregateTimeout`
 
 `number`
@@ -44,6 +47,7 @@ Add a delay before rebuilding once the first file changed. This allows webpack t
 ```js
 aggregateTimeout: 300 // The default
 ```
+
 
 ## `watchOptions.ignored`
 
@@ -58,6 +62,7 @@ It is also possible to use [anymatch](https://github.com/es128/anymatch) pattern
 ```js
 ignored: "files/**/*.js"
 ```
+
 
 ## `watchOptions.poll`
 
@@ -76,11 +81,12 @@ T> If watching does not work for you, try out this option. Watching does not wor
 
 `string`: `none` `info` `verbose`
 
-Controls verbosity of the lifecycle messaging e.g. `Started watching files...`. Setting `info-verbosity` to `verbose` will also message to console at the beginning and the end of incremental build. `info-verbosity` is set to `info` by default.
+Controls verbosity of the lifecycle messaging, e.g. the `Started watching files...` log. Setting `info-verbosity` to `verbose` will also message to console at the beginning and the end of incremental build. `info-verbosity` is set to `info` by default.
 
 ```bash
 webpack --watch --info-verbosity verbose
 ```
+
 
 ## Troubleshooting
 

--- a/src/content/configuration/watch.md
+++ b/src/content/configuration/watch.md
@@ -77,6 +77,9 @@ T> If watching does not work for you, try out this option. Watching does not wor
 
 Controls verbosity of the lifecycle messaging e.g. `Started watching files...`. Setting `info-verbosity` to `verbose` will also message to console at the beginning and the end of incremental build. `info-verbosity` is set to `info` by default.
 
+```bash
+webpack --watch --info-verbosity verbose
+```
 
 ## Troubleshooting
 


### PR DESCRIPTION
Add the newly added `info-verbosity` to the docs. Reference to addition: webpack/webpack-cli#200


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
