### PR TITLE
Fix broken link in watch.md

### DIFF
--- a/src/content/configuration/watch.md
+++ b/src/content/configuration/watch.md
@@ -95,7 +95,7 @@ Arch users, add `fs.inotify.max_user_watches=524288` to `/etc/sysctl.d/99-sysctl
 
 ### MacOS fsevents Bug
 
-On MacOS, folders can get corrupted in certain scenarios. See [this article](http://feedback.livereload.com/knowledgebase/articles/86239-os-x-fsevents-bug-may-prevent-monitoring-of-certai).
+On MacOS, folders can get corrupted in certain scenarios. See [this article](https://github.com/livereload/livereload-site/blob/master/livereload.com/_articles/troubleshooting/os-x-fsevents-bug-may-prevent-monitoring-of-certain-folders.md).
 
 ### Windows Paths
 


### PR DESCRIPTION
The link to `feedback.livereload.com` is 404, but the original document in GitHub still exists. This PR simply changes the URL to point to the original Markdown file.