### PR TITLE
Update Function.prototype.apply link

### DIFF
--- a/src/content/concepts/plugins.md
+++ b/src/content/concepts/plugins.md
@@ -33,7 +33,7 @@ ConsoleLogOnBuildWebpackPlugin.prototype.apply = function(compiler) {
 };
 ```
 
-T> As a clever JavaScript developer you may remember the `Function.prototype.apply` method. Because of this method you can pass any function as plugin (`this` will point to the `compiler`). You can use this style to inline custom plugins in your configuration.
+T> As a clever JavaScript developer you may remember the [`Function.prototype.apply`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply) method. Because of this method you can pass any function as plugin (`this` will point to the `compiler`). You can use this style to inline custom plugins in your configuration.
 
 
 ## Usage


### PR DESCRIPTION
Added Mozilla Docs link for Function.prototype.apply text. It has been mentioned above, but would good to have on this place as well.

 