### PR TITLE
 Add reference to UglifyJsPlugin dependency

### DIFF
--- a/src/content/plugins/source-map-dev-tool-plugin.md
+++ b/src/content/plugins/source-map-dev-tool-plugin.md
@@ -40,6 +40,7 @@ The `fileContext` option is useful when you want to store source maps in an uppe
 
 T> Setting `module` and/or `columns` to `false` will yield less accurate source maps but will also improve compilation performance significantly.
 
+W> Remember that when using the [`UglifyJSPlugin`](/plugins/uglify-js-plugin), you must utilize the `sourceMap` option.
 
 ## Examples
 
@@ -92,17 +93,4 @@ Will produce the following URL:
 
 ``` js
 https://example.com/project/sourcemaps/bundle-[hash].js.map`
-```
-
-## Dependencies
-
-If you are also using `UglifyJsPlugin` then source maps will only be generated if you set the `sourceMap: true` property.
-
-``` js
-plugins: [
-    new webpack.optimize.UglifyJsPlugin({ comments: false, sourceMap: true }),
-    new webpack.SourceMapDevToolPlugin({
-        filename: '[file].map'
-    })
-]
 ```

--- a/src/content/plugins/source-map-dev-tool-plugin.md
+++ b/src/content/plugins/source-map-dev-tool-plugin.md
@@ -92,3 +92,16 @@ Will produce the following URL:
 ``` js
 https://example.com/project/sourcemaps/bundle-[hash].js.map`
 ```
+
+## Dependencies
+
+If you are also using `webpack.optimize.UglifyJsPlugin` then source maps will only be generated if you set the `sourceMap: true` property.
+
+``` js
+plugins: [
+    new webpack.optimize.UglifyJsPlugin({ comments: false, sourceMap: true }),
+    new webpack.SourceMapDevToolPlugin({
+        filename: '[file].map'
+    })
+]
+```

--- a/src/content/plugins/source-map-dev-tool-plugin.md
+++ b/src/content/plugins/source-map-dev-tool-plugin.md
@@ -3,6 +3,7 @@ title: SourceMapDevToolPlugin
 contributors:
   - johnnyreilly
   - simon04
+  - neilkennedy
 related:
   - title: Building Source Maps
     url: https://survivejs.com/webpack/building/source-maps/#-sourcemapdevtoolplugin-and-evalsourcemapdevtoolplugin-
@@ -95,7 +96,7 @@ https://example.com/project/sourcemaps/bundle-[hash].js.map`
 
 ## Dependencies
 
-If you are also using `webpack.optimize.UglifyJsPlugin` then source maps will only be generated if you set the `sourceMap: true` property.
+If you are also using `UglifyJsPlugin` then source maps will only be generated if you set the `sourceMap: true` property.
 
 ``` js
 plugins: [


### PR DESCRIPTION
Added a dependency section to mention that a source map will not be generated if the user is also using the `UglifyJsPlugin` and has not set the `sourceMap` property to `true`.