### PR TITLE
Update docs for default value for stats.toString({colors})

### DIFF
--- a/src/content/configuration/stats.md
+++ b/src/content/configuration/stats.md
@@ -62,7 +62,7 @@ stats: {
   // Context directory for request shortening
   context: "../src/",
   // `webpack --colors` equivalent
-  colors: true,
+  colors: false,
   // Display the distance from the entry point for each module
   depth: false,
   // Display the entry points with the corresponding bundles


### PR DESCRIPTION
Doc incorrectly states the default value is `true`, but it is `false`. See https://github.com/webpack/webpack/blob/master/lib/Stats.js#L512