### PR TITLE
Update cli.md

### DIFF
--- a/src/content/api/cli.md
+++ b/src/content/api/cli.md
@@ -202,7 +202,7 @@ Parameter    | Explanation                                      | Input type | D
 `--debug`    | Switch loaders to debug mode                     | boolean    | false
 `--devtool`  | Define [source map type](/configuration/devtool/) for the bundled resources | string | -
 `--progress` | Print compilation progress in percentage         | boolean    | false
-
+`--display-error-details` | Display details about errors | boolean | false 
 
 ### Module Options
 


### PR DESCRIPTION
Added parameter `--display-error-details` to section Debug Options:
`--display-error-details	Display details about errors	boolean	false`

It is mentioned already in the "Stats Options", but deserves to be in under debug options, very useful parameter.