### PR TITLE
Update getting-started.md

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -257,6 +257,7 @@ bundle.js  544 kB       0  [emitted]  [big]  main
    [3] (webpack)/buildin/module.js 517 bytes {0} [built]
     + 1 hidden module
 ```
+Add `--display-error-details` for detailed error messages, .i.e. `npm run build --display-error-details`.
 
 T> Custom parameters can be passed to webpack by adding two dashes between the `npm run build` command and your parameters, e.g. `npm run build -- --colors`.
 


### PR DESCRIPTION
This addition would have helped me a lot:

Add `--display-error-details` for detailed error messages, .i.e. `npm run build --display-error-details`.
Without this flag development is a black box and painful