### PR TITLE
docs: update CommonsChunkPlugin example links

### DIFF
--- a/src/content/plugins/commons-chunk-plugin.md
+++ b/src/content/plugins/commons-chunk-plugin.md
@@ -255,5 +255,5 @@ Since the `vendor` and `manifest` chunk use a different definition for `minChunk
 ## More Examples
 
 - [Common and Vendor Chunks](https://github.com/webpack/webpack/tree/master/examples/common-chunk-and-vendor-chunk)
-- [Multiple Common Chunks](https://github.com/webpack/webpack/tree/master/examples/multiple-commons-chunks)
-- [Multiple Entry Points with Commons Chunk](https://github.com/webpack/webpack/tree/master/examples/multiple-entry-points-commons-chunk-css-bundle)
+- [Multiple Common Chunks](https://github.com/webpack/webpack/tree/8b888fedfaeaac6bd39168c0952cc19e6c34280a/examples/multiple-commons-chunks)
+- [Multiple Entry Points with Commons Chunk](https://github.com/webpack/webpack/tree/8b888fedfaeaac6bd39168c0952cc19e6c34280a/examples/multiple-entry-points-commons-chunk-css-bundle)


### PR DESCRIPTION
Updated CommonsChunkPlugin examples links to point to latest available versions of the examples.

Fixes #1834