### PR TITLE
Update cli.md

### DIFF
--- a/src/content/api/cli.md
+++ b/src/content/api/cli.md
@@ -109,12 +109,6 @@ Specifies a different [configuration](/configuration) file to pick up. Use this 
 webpack --config example.config.js
 ```
 
-**Suppress output of webpack**
-
-```bash
-webpack --silent
-```
-
 **Print result of webpack as a JSON**
 
 ```bash


### PR DESCRIPTION
- revert `--silent` only available in `webpack@4.0.0` (via `webpack-cli@2.0.3`)

see [comment](https://github.com/webpack/webpack.js.org/pull/1781#issuecomment-367485130) in #1781
