### PR TITLE
Added notification for webpack 4 beta availability w/links to articles

### DIFF
--- a/src/components/NotificationBar/NotificationBar.jsx
+++ b/src/components/NotificationBar/NotificationBar.jsx
@@ -15,7 +15,7 @@ export default class NotificationBar extends React.Component {
           <p>
             WEBPACK 4 IS RELEASED, TRY IT TODAY, SEE THE CHANGELOG AND THESE ARTICLES: <br />
             <a target="_blank" href="https://github.com/webpack/webpack/releases/tag/v4.0.0">* Change Log</a><br />
-            <a target="_blank" href="https://medium.com/webpack/webpack-4-beta-try-it-today-6b1d27d7d7e2">* Install and setup Webpack 4</a><br />
+            <a target="_blank" href="https://medium.com/webpack/webpack-4-released-today-6cdb994702d4">* Install and setup Webpack 4</a><br />
             <a target="_blank" href="https://medium.com/webpack/webpack-4-mode-and-optimization-5423a6bc597a">* New configuration options in Webpack 4</a><br />
           </p>
           <br />

--- a/src/components/NotificationBar/NotificationBar.jsx
+++ b/src/components/NotificationBar/NotificationBar.jsx
@@ -13,7 +13,8 @@ export default class NotificationBar extends React.Component {
       <div className={ `notification-bar ${dismissedMod}` }>
         <Container className="notification-bar__inner">
           <p>
-            WEBPACK 4 IS IN BETA, TRY IT TODAY, SEE THESE ARTICLES: <br />
+            WEBPACK 4 IS RELEASED, TRY IT TODAY, SEE THE CHANGELOG AND THESE ARTICLES: <br />
+            <a target="_blank" href="https://github.com/webpack/webpack/releases/tag/v4.0.0">* Change Log</a><br />
             <a target="_blank" href="https://medium.com/webpack/webpack-4-beta-try-it-today-6b1d27d7d7e2">* Install and setup Webpack 4</a><br />
             <a target="_blank" href="https://medium.com/webpack/webpack-4-mode-and-optimization-5423a6bc597a">* New configuration options in Webpack 4</a><br />
           </p>

--- a/src/components/NotificationBar/NotificationBar.jsx
+++ b/src/components/NotificationBar/NotificationBar.jsx
@@ -13,6 +13,12 @@ export default class NotificationBar extends React.Component {
       <div className={ `notification-bar ${dismissedMod}` }>
         <Container className="notification-bar__inner">
           <p>
+            WEBPACK 4 IS IN BETA, TRY IT TODAY, SEE THESE ARTICLES: <br />
+            <a target="_blank" href="https://medium.com/webpack/webpack-4-beta-try-it-today-6b1d27d7d7e2">* Install and setup Webpack 4</a><br />
+            <a target="_blank" href="https://medium.com/webpack/webpack-4-mode-and-optimization-5423a6bc597a">* New configuration options in Webpack 4</a><br />
+          </p>
+          <br />
+          <p>
             Sponsor webpack and get apparel from the <a href="https://webpack.threadless.com">official shop</a>{' '}
             or get stickers <a href="http://www.unixstickers.com/tag/webpack">here</a>! All proceeds go to our{' '}
             <a href="https://opencollective.com/webpack">open collective</a>!

--- a/src/components/NotificationBar/NotificationBar.jsx
+++ b/src/components/NotificationBar/NotificationBar.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Container from '../Container/Container';
 import testLocalStorage from '../../utilities/test-local-storage';
 
-const version = '2';
+const version = '3';
 const localStorageIsEnabled = testLocalStorage() !== false;
 
 export default class NotificationBar extends React.Component {

--- a/src/content/api/cli.md
+++ b/src/content/api/cli.md
@@ -109,12 +109,6 @@ Specifies a different [configuration](/configuration) file to pick up. Use this 
 webpack --config example.config.js
 ```
 
-**Suppress output of webpack**
-
-```bash
-webpack --silent
-```
-
 **Print result of webpack as a JSON**
 
 ```bash


### PR DESCRIPTION
Modified the NotificationBar to add an additional note about webpack 4 being in beta and some helpful links. 

Please let me know if the formatting/wording can be improved and I'll make the necessary changes.

Also, is there a possibility that if someone had previously dismissed the notification bar that it will then not show with this new information in it? Should I add a second NotificationBar instead?