### PR TITLE
Documentation: Fix error in Getting Started Guide

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -144,7 +144,7 @@ In this setup, `index.js` explicitly requires `lodash` to be present, and binds 
 With that said, let's run `npx webpack` with our script as the [entry point](/concepts/entry-points) and `bundle.js` as the [output](/concepts/output). The `npx` command, which ships with Node 8.2 or higher, runs the webpack binary (`./node_modules/.bin/webpack`) of the webpack package we installed in the beginning:
 
 ``` bash
-npx webpack src/index.js dist/bundle.js
+npx webpack src/index.js --output dist/bundle.js
 
 Hash: 857f878815ce63ad5b4f
 Version: webpack 3.9.1


### PR DESCRIPTION
One of the commands wasn't working properly as I was going through the Getting Started Guide.  I checked the `--help` and found that, without configuration, the `--output` or `-o` flag was required.  Without it, I was getting:

```
▶ npx webpack ./src/index.js ./dist/bundle.js
Hash: 4f8eb0312946d804aad5
Version: webpack 4.0.0
Time: 3564ms
Built at: 2/25/2018 8:57:00 AM
 1 asset
Entrypoint main = main.js
   [1] (webpack)/buildin/module.js 519 bytes {0} [built]
   [2] (webpack)/buildin/global.js 509 bytes {0} [built]
   [3] ./src/index.js 215 bytes {0} [built]
   [4] multi ./src/index.js ./dist/bundle.js 40 bytes {0} [built]
    + 1 hidden module

WARNING in configuration
The 'mode' option has not been set. Set 'mode' option to 'development' or 'production' to enable defaults for this environment.

ERROR in multi ./src/index.js ./dist/bundle.js
Module not found: Error: Can't resolve './dist/bundle.js' in '/Users/ryanpalo/Documents/Programming/JavaScript/Odin/webpack-demo'
 @ multi ./src/index.js ./dist/bundle.js
```