### PR TITLE
Fix typo in the synchronous loader code example

### DIFF
--- a/src/content/api/loaders.md
+++ b/src/content/api/loaders.md
@@ -36,7 +36,7 @@ __sync-loader-with-multiple-results.js__
 
 ``` js
 module.exports = function(content, map, meta) {
-  this.callback(null, someSyncOperation(content), sourceMaps, meta);
+  this.callback(null, someSyncOperation(content), map, meta);
   return; // always return undefined when calling callback()
 };
 ```


### PR DESCRIPTION
`this.callback` is called with `sourceMaps` instead of `map`.
