### PR TITLE
docs(all): add doctype for valid HTML in all documentation

### DIFF
--- a/src/content/guides/asset-management.md
+++ b/src/content/guides/asset-management.md
@@ -21,6 +21,7 @@ Let's make a minor change to our project before we get started:
 __dist/index.html__
 
 ``` diff
+  <!doctype html>
   <html>
     <head>
 -    <title>Getting Started</title>

--- a/src/content/guides/author-libraries.md
+++ b/src/content/guides/author-libraries.md
@@ -101,17 +101,18 @@ require(['webpackNumbers'], function ( webpackNumbers) {
 The consumer also can use the library by loading it via a script tag:
 
 ``` html
+<!doctype html>
 <html>
-...
-<script src="https://unpkg.com/webpack-numbers"></script>
-<script>
-  // ...
-  // Global variable
-  webpackNumbers.wordToNum('Five')
-  // Property in the window object
-  window.webpackNumbers.wordToNum('Five')
-  // ...
-</script>
+  ...
+  <script src="https://unpkg.com/webpack-numbers"></script>
+  <script>
+    // ...
+    // Global variable
+    webpackNumbers.wordToNum('Five')
+    // Property in the window object
+    window.webpackNumbers.wordToNum('Five')
+    // ...
+  </script>
 </html>
 ```
 

--- a/src/content/guides/development-vagrant.md
+++ b/src/content/guides/development-vagrant.md
@@ -36,7 +36,7 @@ module.exports = {
 And create a `index.html` file. The script tag should point to your bundle. If `output.filename` is not specified in the config, this will be `bundle.js`.
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <script src="/bundle.js" charset="utf-8"></script>

--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -58,6 +58,7 @@ document.body.appendChild(component());
 __index.html__
 
 ``` html
+<!doctype html>
 <html>
   <head>
     <title>Getting Started</title>
@@ -127,6 +128,7 @@ Now, since we'll be bundling our scripts, we have to update our `index.html` fil
 __dist/index.html__
 
 ``` diff
+  <!doctype html>
   <html>
    <head>
      <title>Getting Started</title>

--- a/src/content/guides/output-management.md
+++ b/src/content/guides/output-management.md
@@ -69,6 +69,7 @@ Let's also update our `dist/index.html` file, in preparation for webpack to spli
 __dist/index.html__
 
 ``` diff
+  <!doctype html>
   <html>
     <head>
 -     <title>Asset Management</title>

--- a/src/content/guides/shimming.md
+++ b/src/content/guides/shimming.md
@@ -374,6 +374,7 @@ With that in place, we can add the logic to conditionally load our new `polyfill
 __dist/index.html__
 
 ``` diff
+  <!doctype html>
   <html>
     <head>
       <title>Getting Started</title>

--- a/src/content/index.md
+++ b/src/content/index.md
@@ -45,6 +45,7 @@ module.exports = {
 __page.html__
 
 ```html
+<!doctype html>
 <html>
   <head>
     ...


### PR DESCRIPTION
As pointed out in Issue #1866, this should be added for valid HTML.