### PR TITLE
Install webpack-cli as dev dependencies

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -25,7 +25,7 @@ First let's create a directory, initialize npm, and [install webpack locally](/g
 ``` bash
 mkdir webpack-demo && cd webpack-demo
 npm init -y
-npm install --save-dev webpack
+npm install --save-dev webpack webpack-cli
 ```
 
 Now we'll create the following directory structure and contents:


### PR DESCRIPTION
when i ran :
```
npx webpack src/index.js --output dist/bundle.js
```

I got the following output :
```
The CLI moved into a separate package: webpack-cli.
Please install 'webpack-cli' in addition to webpack itself to use the CLI.
-> When using npm: npm install webpack-cli -D
-> When using yarn: yarn add webpack-cli -D
```

So I guess the documentation needed to be updated :)