### PR TITLE
docs(plugins): adding CopyWebpackPlugin to table

### DIFF
--- a/src/content/plugins/index.md
+++ b/src/content/plugins/index.md
@@ -6,6 +6,7 @@ contributors:
   - rouzbeh84
   - aretecode
   - eko3alpha
+  - refactorized
 ---
 
 webpack has a rich plugin interface. Most of the features within webpack itself use this plugin interface. This makes webpack **flexible**.
@@ -18,6 +19,7 @@ Name                                                     | Description
 [`CommonsChunkPlugin`](/plugins/commons-chunk-plugin)    | Extract common modules shared between chunks
 [`CompressionWebpackPlugin`](/plugins/compression-webpack-plugin) | Prepare compressed versions of assets to serve them with Content-Encoding
 [`ContextReplacementPlugin`](/plugins/context-replacement-plugin) | Override the inferred context of a `require` expression
+[`CopyWebpackPlugin`](/plugins/copy-webpack-plugin) | Copies individual files or entire directories to the build directory
 [`DefinePlugin`](/plugins/define-plugin)           | Allow global constants configured at compile time
 [`DllPlugin`](/plugins/dll-plugin)                 | Split bundles in order to drastically improve build time
 [`EnvironmentPlugin`](/plugins/environment-plugin) | Shorthand for using the [`DefinePlugin`](./define-plugin) on `process.env` keys


### PR DESCRIPTION
it's in the plugins navigation menu already but absent from the table.