### PR TITLE
docs(concepts) Clarification about NODE_ENV and mode

### DIFF
--- a/src/content/concepts/index.md
+++ b/src/content/concepts/index.md
@@ -49,7 +49,7 @@ T> You can configure the `entry` property in various ways depending the needs of
 
 ## Output
 
-The **output** property tells webpack where to emit the *bundles* it creates and how to name these files and defaults to `./dist`. You can configure this part of the process by specifying an `output` field in your configuration:
+The **output** property tells webpack where to emit the *bundles* it creates and how to name these files, it defaults to `./dist`. You can configure this part of the process by specifying an `output` field in your configuration:
 
 __webpack.config.js__
 

--- a/src/content/concepts/mode.md
+++ b/src/content/concepts/mode.md
@@ -19,8 +19,8 @@ module.exports = {
 };
 ```
 
- 
-or pass it as a cli argument:
+
+or pass it as a [CLI](/api/cli/) argument:
 
 ```bash
 webpack --mode=production
@@ -32,6 +32,8 @@ Option                | Description
 --------------------- | -----------------------
 `development`         | Provides `process.env.NODE_ENV` with value `development`. Enables `NamedModulesPlugin`.
 `production`          | Provides `process.env.NODE_ENV` with value `production`. Enables `UglifyJsPlugin`, `ModuleConcatenationPlugin` and `NoEmitOnErrorsPlugin`.
+
+T> Please remember that setting `NODE_ENV` doesn't automatically set `mode`.
 
 
 ### Mode: development


### PR DESCRIPTION
- Added a small note regarding `NODE_ENV` and `mode`
- Uppercased cli to be consistent with the rest of the docs, also added a link to it.
- Worded `output` description.