### PR TITLE
Fix error with filename + npm package.

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -26,6 +26,7 @@ First let's create a directory, initialize npm, and [install webpack locally](/g
 mkdir webpack-demo && cd webpack-demo
 npm init -y
 npm install --save-dev webpack
+npm install webpack-cli -D
 ```
 
 Now we'll create the following directory structure and contents:
@@ -136,7 +137,7 @@ __dist/index.html__
    </head>
    <body>
 -    <script src="./src/index.js"></script>
-+    <script src="bundle.js"></script>
++    <script src="main.js"></script>
    </body>
   </html>
 ```


### PR DESCRIPTION
1) Webpack as default build to file main.js , not on bundle.js. 
2) Add npm install webpack-cli -D to npm install, If you do not do this console throw next: 
======================================================
The CLI moved into a separate package: webpack-cli.
Please install 'webpack-cli' in addition to webpack itself to use the CLI.
-> When using npm: npm install webpack-cli -D
-> When using yarn: yarn add webpack-cli -D
======================================================
So pls fix this, thank`s.

_describe your changes..._

- [ ] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [ ] Make sure your PR complies with the [writer's guide][2].
- [ ] Review the diff carefully as sometimes this can reveal issues.
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
