### PR TITLE
style(sidebar): fix vertical spacing when option has an icon

### DIFF
--- a/src/components/SidebarItem/SidebarItem.scss
+++ b/src/components/SidebarItem/SidebarItem.scss
@@ -38,6 +38,7 @@
     padding-left: 1.5em;
     overflow: hidden;
     list-style: none;
+    line-height: 19px;
 
     &:before {
       content: '';


### PR DESCRIPTION
Ensure that sidebar items has proper height even when emoticon is used.

<img width="552" alt="screen shot 2018-03-08 at 07 56 54" src="https://user-images.githubusercontent.com/719641/37137531-71050072-22a6-11e8-8121-8a31955ec93b.png">

