### PR TITLE
Update getting-started.md

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -13,6 +13,7 @@ contributors:
   - TheDutchCoder
   - sudarsangp
   - Vanguard90
+  - seungha-kim
 ---
 
 Webpack is used to compile JavaScript modules. Once [installed](/guides/installation), you can interface with webpack either from its [CLI](/api/cli) or [API](/api/node). If you're still new to webpack, please read through the [core concepts](/concepts) and [this comparison](/comparison) to learn why you might use it over the other tools that are out in the community.
@@ -25,7 +26,7 @@ First let's create a directory, initialize npm, and [install webpack locally](/g
 ``` bash
 mkdir webpack-demo && cd webpack-demo
 npm init -y
-npm install --save-dev webpack
+npm install --save-dev webpack webpack-cli
 ```
 
 Now we'll create the following directory structure and contents:


### PR DESCRIPTION
Without `webpack-cli`, cannot proceed this guide.
The `npx webpack ...` command emits error: 'The CLI moved into a separate package: webpack-cli.'