### PR TITLE
Prepend https:// to supporter website if it doesn't exist already

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8828,7 +8828,6 @@
       "dev": true,
       "requires": {
         "object-assign": "4.1.1",
-        "prepend-http": "1.0.4",
         "query-string": "4.3.4",
         "sort-keys": "1.1.2"
       }
@@ -11616,10 +11615,9 @@
       "dev": true
     },
     "prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
     "preserve": {
       "version": "0.2.0",
@@ -15067,10 +15065,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "dev": true,
-      "requires": {
-        "prepend-http": "1.0.4"
-      }
+      "dev": true
     },
     "urltools": {
       "version": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "ajv": "^5.5.2",
     "preact": "^8.2.7",
     "preact-compat": "3.17.0",
+    "prepend-http": "^2.0.0",
     "prop-types": "^15.5.10",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",

--- a/src/components/Support/Support.jsx
+++ b/src/components/Support/Support.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import prependHttp from 'prepend-http';
 import Backers from './support-backers.json';
 import Additional from './support-additional.js';
 import SmallIcon from '../../assets/icon-square-small-slack.png';
@@ -100,7 +101,7 @@ export default class Support extends React.Component {
                className="support__item"
                title={ `$${formatMoney(supporter.totalDonations / 100)} by ${supporter.name || supporter.slug}` }
                target="_blank"
-               href={ supporter.website || `https://opencollective.com/${supporter.slug}` }>
+               href={ prependHttp(supporter.website, { https: true }) || `https://opencollective.com/${supporter.slug}` }>
               {<img
                 className={ `support__${rank}-avatar` }
                 src={ supporter.avatar || SmallIcon }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5789,6 +5789,10 @@ prepend-http@^1.0.0, prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
 
+prepend-http@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
+
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"


### PR DESCRIPTION
The front page's supporters section has a lot of broken links where donors forgot to add a scheme in front of their domain of their website. All the links not containing schemes are broken.

This PR prepends a `https://` scheme in front of the website URL's that need it.
