### PR TITLE
Includes installing webpack-cli

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -202,6 +202,11 @@ module.exports = {
   }
 };
 ```
+If you haven't already, install the new webpack-cli:
+
+```bash
+ npm install --save webpack-cli
+```
 
 Now, let's run the build again but instead using our new configuration:
 


### PR DESCRIPTION
This is now needed before running the `npx webpack` command.
