### PR TITLE
docs(guides): fix config

### DIFF
--- a/src/content/guides/progressive-web-application.md
+++ b/src/content/guides/progressive-web-application.md
@@ -3,6 +3,7 @@ title: Progressive Web Application
 sort: 14
 contributors:
   - johnnyreilly
+  - chenxsan
 ---
 
 T> This guide extends on code examples found in the [Output Management](/guides/output-management) guide.
@@ -78,7 +79,7 @@ __webpack.config.js__
 +     title: 'Progressive Web Application'
 -   })
 +   }),
-+   new WorkboxPlugin({
++   new WorkboxPlugin.GenerateSW({
 +     // these options encourage the ServiceWorkers to get in there fast 
 +     // and not allow any straggling "old" SWs to hang around
 +     clientsClaim: true,


### PR DESCRIPTION
`workbox-webpack-plugin` [exports](https://github.com/GoogleChrome/workbox/blob/ed2a847baf34c17c0f019d11cdfb1464fe3a9e19/packages/workbox-webpack-plugin/src/index.js#L20) an `object` now:

```
module.exports = {
  GenerateSW,
  InjectManifest,
};
```
So this doc is updated according to https://github.com/google/WebFundamentals/blob/f64420d4fdb3a7dd8796577c7683e81e69d2305e/src/content/en/tools/workbox/guides/generate-service-worker/webpack.md#setup-your-webpack-config