### PR TITLE
Edited example code snippet to throw error

### DIFF
--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -59,7 +59,7 @@ __src/print.js__
 ``` diff
   export default function printMe() {
 -   console.log('I get called from print.js!');
-+   console.log('I get called from print.js!');
++   cosnole.log('I get called from print.js!');
   }
 ```
 


### PR DESCRIPTION
In the example snippet, the word 'console' has been changed to say 'cosnole' to throw the error in the example.