### PR TITLE
Update TypeScript configuration example to TS 2.7

### DIFF
--- a/src/content/configuration/configuration-languages.md
+++ b/src/content/configuration/configuration-languages.md
@@ -26,8 +26,8 @@ and then proceed to write your configuration:
 __webpack.config.ts__
 
 ```typescript
-import * as webpack from 'webpack';
-import * as path from 'path';
+import path from 'path';
+import webpack from 'webpack';
 
 const config: webpack.Configuration = {
   entry: './foo.js',
@@ -39,6 +39,8 @@ const config: webpack.Configuration = {
 
 export default config;
 ```
+
+Above sample assumes version >= 2.7 or newer of TypeScript is used with the new `esModuleInterop` and `allowSyntheticDefaultImports` compiler options in your `tsconfig.json` file.
 
 Note that you'll also need to check your `tsconfig.json` file. If the module in `compilerOptions` in `tsconfig.json` is `commonjs`, the setting is complete, else webpack will fail with an error. This occurs because `ts-node` does not support any module syntax other than `commonjs`.
 


### PR DESCRIPTION
This PR changes the TypeScript configuration sample slightly trying to simplify the code - and make it on the same level as any ES6/ES2015 module based code.
The TS 2.7 allows - with simple configuration change in `tsconfig.json` - to unify use of imports in vanilla JavaScript module and TypeScript module source code. This remove needs of using `* as` in source code.
The text of the note has been extended to add note about these compiler additional configuration properties - which should be helpful for users with some TypeScript background. The unfortunate outcome is that the entire length of the section is slightly increased.

Here is a quick demo project that was setup based on existing (and this one) configuration notes to show that it is working setup:

https://github.com/peterblazejewicz/webpack-guides-typescript

Thanks!

