### PR TITLE
Fix a bug in getting-started.md

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -167,7 +167,7 @@ __dist/index.html__
    </head>
    <body>
 -    <script src="./src/index.js"></script>
-+    <script src="dist/bundle.js"></script>
++    <script src="bundle.js"></script>
    </body>
   </html>
 ```


### PR DESCRIPTION
The path for including bundle.js is not correct. index.html is already inside /dist folder, the correct path should be 'bundle.js' or '../dist/bundle.js'

_describe your changes..._

[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
