### PR TITLE
fix(site) Dont remove files from gh-pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "start-only": "node ./antwar.bootstrap.js develop",
     "build": "npm run init:generated && npm run fetch && rm -rf build/ && node ./antwar.bootstrap.js build && npm run sitemap && echo webpack.js.org > build/CNAME",
     "build-test": "npm run build && http-server build/",
-    "deploy": "gh-pages -d build",
+    "deploy": "gh-pages -d build --add",
     "fetch": "sh src/scripts/fetch.sh",
     "init:generated": "mkdirp ./generated/loaders && mkdirp ./generated/plugins ",
     "lint": "run-s lint:*",


### PR DESCRIPTION
I manually tweaked our site source code (https://github.com/webpack/webpack.js.org/tree/feat/v3-docs) to generate a build that runs in a subfolder for webpack 3 docs, which I deployed to https://webpack.js.org/v3/ using `gh-pages` branch.

There is a daily cronjob that updates `gh-pages` branch with latest changes from master, it also deletes current files from that branch, which deletes previous `v3` build.

This PR adds a flag to `gh-pages` dependency to save previous files, I am afraid that it will also increment size of the branch, but I think it won't affect website performance.

This is a temporary solution until we develop a solution to support versioned docs, as lodash.com, hopefully this will be done in less than a month.