### PR TITLE
Update getting-started.md

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -167,7 +167,7 @@ __dist/index.html__
    </head>
    <body>
 -    <script src="./src/index.js"></script>
-+    <script src="bundle.js"></script>
++    <script src="main.js"></script>
    </body>
   </html>
 ```


### PR DESCRIPTION
The initial example does not work. Running `npx webpack` creates the file `dist/main.js` so the `<script src="">` attribute needs to point to main.js