### PR TITLE
change bundle.js to main.js

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -180,11 +180,11 @@ With that said, let's run `npx webpack` with our script as the [entry point](/co
 npx webpack
 
 Hash: dabab1bac2b940c1462b
-Version: webpack 4.0.1
+Version: webpack 4.5.0
 Time: 3003ms
 Built at: 2018-2-26 22:42:11
     Asset      Size  Chunks             Chunk Names
-bundle.js  69.6 KiB       0  [emitted]  main
+main.js  69.6 KiB       0  [emitted]  main
 Entrypoint main = main.js
    [1] (webpack)/buildin/module.js 519 bytes {0} [built]
    [2] (webpack)/buildin/global.js 509 bytes {0} [built]
@@ -204,7 +204,7 @@ Open `index.html` in your browser and, if everything went right, you should see 
 
 The [`import`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) and [`export`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) statements have been standardized in [ES2015](https://babeljs.io/learn-es2015/). Although they are not supported in most browsers yet, webpack does support them out of the box.
 
-Behind the scenes, webpack actually "transpiles" the code so that older browsers can also run it. If you inspect `dist/bundle.js`, you might be able to see how webpack does this, it's quite ingenious! Besides `import` and `export`, webpack supports various other module syntaxes as well, see [Module API](/api/module-methods) for more information.
+Behind the scenes, webpack actually "transpiles" the code so that older browsers can also run it. If you inspect `dist/main.js`, you might be able to see how webpack does this, it's quite ingenious! Besides `import` and `export`, webpack supports various other module syntaxes as well, see [Module API](/api/module-methods) for more information.
 
 Note that webpack will not alter any code other than `import` and `export` statements. If you are using other [ES2015 features](http://es6-features.org/), make sure to [use a transpiler](/loaders/#transpiling) such as [Babel](https://babeljs.io/) or [Bublé](https://buble.surge.sh/guide/) via webpack's [loader system](/concepts/loaders/).
 
@@ -233,7 +233,7 @@ const path = require('path');
 module.exports = {
   entry: './src/index.js',
   output: {
-    filename: 'bundle.js',
+    filename: 'main.js',
     path: path.resolve(__dirname, 'dist')
   }
 };
@@ -249,8 +249,8 @@ Version: webpack 4.0.1
 Time: 328ms
 Built at: 2018-2-26 22:47:43
     Asset      Size  Chunks             Chunk Names
-bundle.js  69.6 KiB       0  [emitted]  main
-Entrypoint main = bundle.js
+main.js  69.6 KiB       0  [emitted]  main
+Entrypoint main = main.js
    [1] (webpack)/buildin/module.js 519 bytes {0} [built]
    [2] (webpack)/buildin/global.js 509 bytes {0} [built]
    [3] ./src/index.js 256 bytes {0} [built]
@@ -307,8 +307,8 @@ Version: webpack 4.0.1
 Time: 323ms
 Built at: 2018-2-26 22:50:25
     Asset      Size  Chunks             Chunk Names
-bundle.js  69.6 KiB       0  [emitted]  main
-Entrypoint main = bundle.js
+main.js  69.6 KiB       0  [emitted]  main
+Entrypoint main = main.js
    [1] (webpack)/buildin/module.js 519 bytes {0} [built]
    [2] (webpack)/buildin/global.js 509 bytes {0} [built]
    [3] ./src/index.js 256 bytes {0} [built]
@@ -332,7 +332,7 @@ webpack-demo
 |- package.json
 |- webpack.config.js
 |- /dist
-  |- bundle.js
+  |- main.js
   |- index.html
 |- /src
   |- index.js


### PR DESCRIPTION
In recent versions of webpack, the default name for output file is 'main.js'.
Users might be confused as they wouldn't be able to locate 'bundle.js'.