### PR TITLE
Move resolving of external README.md relative hrefs up

### DIFF
--- a/src/scripts/fetch_package_files.js
+++ b/src/scripts/fetch_package_files.js
@@ -83,18 +83,18 @@ function fetchPackageFiles(options, finalCb) {
             // Replace lone h1 formats
             .replace(/<h1.*?>.+?<\/h1>/, '')
             .replace(/# .+/, '')
-            // Modify links to keep them within the site
-            .replace(/https?:\/\/github.com\/(webpack|webpack-contrib)\/([-A-za-z0-9]+-loader\/?)([)"])/g, '/loaders/$2/$3')
-            .replace(/https?:\/\/github.com\/(webpack|webpack-contrib)\/([-A-za-z0-9]+-plugin\/?)([)"])/g, '/plugins/$2/$3')
-            // Replace any <h2> with `##`
-            .replace(/<h2[^>]*>/g, '## ')
-            .replace(/<\/h2>/g, '')
             // Resolve anchor hrefs to avoid broken relative references in the docs
             // Examples:
             // - [click here](LICENSE) --> [click here](https://raw.githubusercontent.com/user/repository/branch/LICENSE)
             // - [click here](./LICENSE) --> [click here](https://raw.githubusercontent.com/user/repository/branch/LICENSE)
             // - [click here](#LICENSE) --> [click here](https://raw.githubusercontent.com/user/repository/branch#LICENSE)
             .replace(/\[([^[\]]*)\]\(([^)]+)\)/g, (match, textContent, href) => `[${textContent}](${urlModule.resolve(url, href)})`)
+            // Modify links to keep them within the site
+            .replace(/https?:\/\/github.com\/(webpack|webpack-contrib)\/([-A-za-z0-9]+-loader\/?)([)"])/g, '/loaders/$2/$3')
+            .replace(/https?:\/\/github.com\/(webpack|webpack-contrib)\/([-A-za-z0-9]+-plugin\/?)([)"])/g, '/plugins/$2/$3')
+            // Replace any <h2> with `##`
+            .replace(/<h2[^>]*>/g, '## ')
+            .replace(/<\/h2>/g, '')
             // Drop any comments
             .replace(/<!--[\s\S]*?-->/g, '');
         }


### PR DESCRIPTION
The relative link resolution was accidentally reversing the work done a few lines up where absolute links to repositories with `webpack` or `webpack-contrib` where converted into relative hrefs

This was a regression from https://github.com/webpack/webpack.js.org/pull/2006/commits/462145063c68e5e1300a40d1ce0080e7936c4076 merged in https://github.com/webpack/webpack.js.org/commit/1489e7bfc28783e17b254f6b02597a43a62a37fe