### PR TITLE
More link fixes

### DIFF
--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -250,7 +250,7 @@ The prefix length of the hash digest to use, defaults to `20`.
 
 `string|function`
 
-The hashing algorithm to use, defaults to `'md5'`. All functions from Node.JS' [`crypto.createHash`](https://nodejs.org/api/crypto.html#crypto_crypto_createhash_algorithm) are supported. Since `4.0.0-alpha2`, the `hashFunction` can now be a constructor to a custom hash function. You can provide a non-crypto hash function for performance reasons.
+The hashing algorithm to use, defaults to `'md5'`. All functions from Node.JS' [`crypto.createHash`](https://nodejs.org/api/crypto.html#crypto_crypto_createhash_algorithm_options) are supported. Since `4.0.0-alpha2`, the `hashFunction` can now be a constructor to a custom hash function. You can provide a non-crypto hash function for performance reasons.
 
 ``` js
 hashFunction: require('metrohash').MetroHash64
@@ -260,7 +260,7 @@ Make sure that the hashing function will have `update` and `digest` methods avai
 
 ## `output.hashSalt`
 
-An optional salt to update the hash via Node.JS' [`hash.update`](https://nodejs.org/api/crypto.html#crypto_hash_update_data_input_encoding).
+An optional salt to update the hash via Node.JS' [`hash.update`](https://nodejs.org/api/crypto.html#crypto_hash_update_data_inputencoding).
 
 
 ## `output.hotUpdateChunkFilename`

--- a/src/scripts/fetch_package_files.js
+++ b/src/scripts/fetch_package_files.js
@@ -87,8 +87,8 @@ function fetchPackageFiles(options, finalCb) {
             // Examples:
             // - [click here](LICENSE) --> [click here](https://raw.githubusercontent.com/user/repository/branch/LICENSE)
             // - [click here](./LICENSE) --> [click here](https://raw.githubusercontent.com/user/repository/branch/LICENSE)
-            // - [click here](#LICENSE) --> [click here](https://raw.githubusercontent.com/user/repository/branch#LICENSE)
-            .replace(/\[([^[\]]*)\]\(([^)]+)\)/g, (match, textContent, href) => `[${textContent}](${urlModule.resolve(url, href)})`)
+            // - [click here](#LICENSE) --> [click here](#LICENSE)
+            .replace(/\[([^[\]]*)\]\(([^)#]+)\)/g, (match, textContent, href) => `[${textContent}](${urlModule.resolve(url, href)})`)
             // Modify links to keep them within the site
             .replace(/https?:\/\/github.com\/(webpack|webpack-contrib)\/([-A-za-z0-9]+-loader\/?)([)"])/g, '/loaders/$2/$3')
             .replace(/https?:\/\/github.com\/(webpack|webpack-contrib)\/([-A-za-z0-9]+-plugin\/?)([)"])/g, '/plugins/$2/$3')


### PR DESCRIPTION
Fixes broken links to nodejs documentation (fragments were renamed).

Stops resolving local fragment anchors in imported plugin/loader README's to `https://raw.githubusercontent.com`

Closes #2023 