### PR TITLE
chore(rebuild): re-incorporate header links

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "yaml-frontmatter-loader": "^0.1.0"
   },
   "dependencies": {
+    "@rigor789/remark-autolink-headings": "^5.1.0",
     "ajv": "^5.5.2",
     "docsearch.js": "^2.5.2",
     "gitter-sidecar": "^1.2.3",

--- a/src/components/Markdown/Markdown.scss
+++ b/src/components/Markdown/Markdown.scss
@@ -13,13 +13,32 @@
   h6 { font-size: getFontSize(-1); }
 
   h1, h2, h3, h4, h5, h6 {
+    display: flex;
+    align-items: center;
     font-family: $font-stack-heading;
     font-weight:600;
     line-height:1.4;
     margin:1.5em 0 0.25em;
     color:getColor(fiord);
 
-    tt, code { font-size: 90%; color: inherit }
+    tt, code {
+      font-size: 90%;
+      color: inherit;
+    }
+
+    a {
+      margin-left: 8px;
+      font-size: 0.8em;
+      height: 1em;
+      opacity: 0;
+      visibility: hidden;
+      transition: all 250ms;
+    }
+
+    &:hover a {
+      opacity: 1;
+      visibility: visible;
+    }
   }
 
   h1:first-child {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -34,10 +34,11 @@ module.exports = (env = {}) => ({
           loader: 'remark-loader',
           options: {
             plugins: [
-              // TODO: Add necessary remark plugins
               require('remark-slug'),
-              require('remark-autolink-headings'),
-              require('remark-mermaid')
+              require('remark-mermaid'),
+              [require('remark-autolink-headings'), {
+                behaviour: 'append'
+              }]
             ]
           }
         }

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -36,7 +36,7 @@ module.exports = (env = {}) => ({
             plugins: [
               require('remark-slug'),
               require('remark-mermaid'),
-              [require('remark-autolink-headings'), {
+              [require('@rigor789/remark-autolink-headings'), {
                 behaviour: 'append'
               }]
             ]


### PR DESCRIPTION
Src code patched until
https://github.com/ben-eb/remark-autolink-headings/pull/41 is merged, if
ever, we should probably use a fork.