### PR TITLE
chore(rebuild): exclude external urls from ssg process

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "request": "^2.81.0",
     "sass-loader": "^6.0.6",
     "sitemap-static": "^0.4.2",
-    "static-site-generator-webpack-plugin": "^3.4.1",
+    "static-site-generator-webpack-plugin": "git://github.com/EugeneHlushko/static-site-generator-webpack-plugin.git#957984e4fe7592f534b1949736bef7251b6e832c",
     "style-loader": "^0.18.2",
     "tap-min": "^1.2.1",
     "tap-parser": "^6.0.1",

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -30,7 +30,8 @@ module.exports = env => [
         crawl: true,
         globals: {
           window: {}
-        }
+        },
+        disallowDomains: true
       })
     ],
     output: {


### PR DESCRIPTION
* prevents urls like `website.com` getting fetched and built into ./dist

Filed up a PR against master of SSGWP markdalgleish/static-site-generator-webpack-plugin#128 to remove fork ref from package.json if gets accepted