### PR TITLE
docs(guides): change bundle filename

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -13,6 +13,7 @@ contributors:
   - TheDutchCoder
   - sudarsangp
   - Vanguard90
+  - ayvarot
 ---
 
 Webpack is used to compile JavaScript modules. Once [installed](/guides/installation), you can interface with webpack either from its [CLI](/api/cli) or [API](/api/node). If you're still new to webpack, please read through the [core concepts](/concepts) and [this comparison](/comparison) to learn why you might use it over the other tools that are out in the community.
@@ -167,14 +168,14 @@ __dist/index.html__
    </head>
    <body>
 -    <script src="./src/index.js"></script>
-+    <script src="main.js"></script>
++    <script src="bundle.js"></script>
    </body>
   </html>
 ```
 
 In this setup, `index.js` explicitly requires `lodash` to be present, and binds it as `_` (no global scope pollution). By stating what dependencies a module needs, webpack can use this information to build a dependency graph. It then uses the graph to generate an optimized bundle where scripts will be executed in the correct order.
 
-With that said, let's run `npx webpack` with our script as the [entry point](/concepts/entry-points) and `main.js` as the [output](/concepts/output). The `npx` command, which ships with Node 8.2 or higher, runs the webpack binary (`./node_modules/.bin/webpack`) of the webpack package we installed in the beginning:
+With that said, let's run `npx webpack` with our script as the [entry point](/concepts/entry-points) and `bundle.js` as the [output](/concepts/output). The `npx` command, which ships with Node 8.2 or higher, runs the webpack binary (`./node_modules/.bin/webpack`) of the webpack package we installed in the beginning:
 
 ``` bash
 npx webpack
@@ -184,8 +185,8 @@ Version: webpack 4.0.1
 Time: 3003ms
 Built at: 2018-2-26 22:42:11
     Asset      Size  Chunks             Chunk Names
-main.js  69.6 KiB       0  [emitted]  main
-Entrypoint main = main.js
+bundle.js  69.6 KiB       0  [emitted]  main
+Entrypoint main = bundle.js
    [1] (webpack)/buildin/module.js 519 bytes {0} [built]
    [2] (webpack)/buildin/global.js 509 bytes {0} [built]
    [3] ./src/index.js 256 bytes {0} [built]


### PR DESCRIPTION
Replace `main.js` by `bundle.js` to make sense with the text used in the second paragraph of section `Modules`.