### PR TITLE
fix(docs) Document output.pathinfo default values

### DIFF
--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -616,7 +616,7 @@ Note that `[hash]` in this parameter will be replaced with an hash of the compil
 
 `boolean`
 
-Tell webpack to include comments in bundles with information about the contained modules. This option defaults to `true` in `development` and `false` in `production` mode respectively. Please note that `output.pathinfo` **should not** be used in production, but it's very useful in development when reading the generated code.
+Tell webpack to include comments in bundles with information about the contained modules. This option defaults to `true` in `development` and `false` in `production` [mode](/concepts/mode/) respectively. Please note that `output.pathinfo` **should not** be used in production, but it's very useful in development when reading the generated code.
 
 ``` js
 pathinfo: true

--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -616,7 +616,9 @@ Note that `[hash]` in this parameter will be replaced with an hash of the compil
 
 `boolean`
 
-Tell webpack to include comments in bundles with information about the contained modules. This option defaults to `true` in `development` and `false` in `production` [mode](/concepts/mode/) respectively. Please note that `output.pathinfo` **should not** be used in production, but it's very useful in development when reading the generated code.
+Tells webpack to include comments in bundles with information about the contained modules. This option defaults to `true` in `development` and `false` in `production` [mode](/concepts/mode/) respectively.
+
+W> While the data this comments can provide is very useful during development when reading the generated code, it **should not** be used in production.
 
 ``` js
 pathinfo: true

--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -616,7 +616,7 @@ Note that `[hash]` in this parameter will be replaced with an hash of the compil
 
 `boolean`
 
-Tell webpack to include comments in bundles with information about the contained modules. This option defaults to `false` and **should not** be used in production, but it's very useful in development when reading the generated code.
+Tell webpack to include comments in bundles with information about the contained modules. This option defaults to `true` in `development` and `false` in `production` mode respectively. Please note that `output.pathinfo` **should not** be used in production, but it's very useful in development when reading the generated code.
 
 ``` js
 pathinfo: true


### PR DESCRIPTION
* mention default values for `output.pathinfo`

Fixes #2014