### PR TITLE
Small Grammar Change (Added comma)

### DIFF
--- a/src/content/concepts/index.md
+++ b/src/content/concepts/index.md
@@ -16,7 +16,7 @@ At its core, *webpack* is a _static module bundler_ for modern JavaScript applic
 
 T> Learn more about JavaScript modules and webpack modules [here](/concepts/modules).
 
-Since v4.0.0 webpack does not require a configuration file. Nevertheless, it is [incredibly configurable](/configuration). To get started you only need to understand four **Core Concepts**:
+Since v4.0.0, webpack does not require a configuration file. Nevertheless, it is [incredibly configurable](/configuration). To get started you only need to understand four **Core Concepts**:
 
 - Entry
 - Output


### PR DESCRIPTION
Without an apostrophe after "Since v4.0.0" it implies that the clause "Since v4.0.0 Webpack..." is a reason that leads to some effect.  With the added comma, it gets the real point across that things have changed with v4.0.0.

_describe your changes..._

- [ ] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [ ] Make sure your PR complies with the [writer's guide][2].
- [ ] Review the diff carefully as sometimes this can reveal issues.
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
