### PR TITLE
fix: various fixes on concepts for v4 and some rephrasing

### DIFF
--- a/src/content/concepts/index.md
+++ b/src/content/concepts/index.md
@@ -68,7 +68,7 @@ module.exports = {
 
 In the example above, we use the `output.filename` and the `output.path` properties to tell webpack the name of our bundle and where we want it to be emitted to. In case you're wondering about the path module being imported at the top, it is a core [Node.js module](https://nodejs.org/api/modules.html) that gets used to manipulate file paths.
 
-T> The `output` property has [many more configurable features](/configuration/output) and if you like to know more about the concepts behind it, you can [read more in the ouput section](/concepts/output).
+T> The `output` property has [many more configurable features](/configuration/output) and if you like to know more about the concepts behind it, you can [read more in the output section](/concepts/output).
 
 
 ## Loaders

--- a/src/content/concepts/index.md
+++ b/src/content/concepts/index.md
@@ -10,13 +10,16 @@ contributors:
   - TheDutchCoder
   - adambraimbridge
   - EugeneHlushko
+  - jeremenichelli
 ---
 
-At its core, *webpack* is a _static module bundler_ for modern JavaScript applications. When webpack processes your application, it recursively builds a _dependency graph_ that includes every module your application needs, then packages all of those modules into one or more _bundles_.
+At its core, **webpack** is a _static module bundler_ for modern JavaScript applications. When webpack processes your application, it internally builds a _dependency graph_ which maps every module your project needs, then it generates one or more _bundles_.
 
 T> Learn more about JavaScript modules and webpack modules [here](/concepts/modules).
 
-Since v4.0.0 webpack does not require a configuration file. Nevertheless, it is [incredibly configurable](/configuration). To get started you only need to understand four **Core Concepts**:
+Since version 4, **webpack does not require a configuration file** to bundle your project, nevertheless it is [incredibly configurable](/configuration) to better fit your needs.
+
+To get started you only need to understand its **Core Concepts**:
 
 - Entry
 - Output
@@ -28,13 +31,9 @@ This document is intended to give a **high-level** overview of these concepts, w
 
 ## Entry
 
-An **entry point** indicates which module webpack should use to begin building out its internal *dependency graph*. After entering the entry point, webpack will figure out which other modules and libraries that entry point depends on (directly and indirectly).
+An **entry point** indicates which module webpack should use to begin building out its internal *dependency graph*, webpack will figure out which other modules and libraries that entry point depends on (directly and indirectly).
 
-Every dependency is then processed and outputted into files called *bundles*, which we'll discuss more in the next section.
-
-You can specify an entry point (or multiple entry points) by configuring the `entry` property in the [webpack configuration](/configuration). It defaults to `./src`.
-
-Here's the simplest example of an `entry` configuration:
+By default its value is `./src/index.js`, but you can specify a different (or multiple entry points) by configuring the **entry** property in the [webpack configuration](/configuration). For example:
 
 __webpack.config.js__
 
@@ -44,12 +43,14 @@ module.exports = {
 };
 ```
 
-T> You can configure the `entry` property in various ways depending the needs of your application. Learn more in the [entry points](/concepts/entry-points) section.
+T> Learn more in the [entry points](/concepts/entry-points) section.
 
 
 ## Output
 
-The **output** property tells webpack where to emit the *bundles* it creates and how to name these files, it defaults to `./dist`. Basically, the entire app structure will get compiled into the folder that you specify in the output path. You can configure this part of the process by specifying an `output` field in your configuration:
+The **output** property tells webpack where to emit the *bundles* it creates and how to name these files, it defaults to `./dist/bundle.js` for the main output file and to the `./dist` folder for any other generated file.
+
+You can configure this part of the process by specifying an `output` field in your configuration:
 
 __webpack.config.js__
 
@@ -67,20 +68,16 @@ module.exports = {
 
 In the example above, we use the `output.filename` and the `output.path` properties to tell webpack the name of our bundle and where we want it to be emitted to. In case you're wondering about the path module being imported at the top, it is a core [Node.js module](https://nodejs.org/api/modules.html) that gets used to manipulate file paths.
 
-T> You may see the term **emitted** or **emit** used throughout our documentation and [plugin API](/api/plugins). This is a fancy term for 'produced' or 'discharged'.
-
-T> The `output` property has [many more configurable features](/configuration/output) and if you like to know more about the concepts behind the `output` property, you can [read more in the concepts section](/concepts/output).
+T> The `output` property has [many more configurable features](/configuration/output) and if you like to know more about the concepts behind it, you can [read more in the ouput section](/concepts/output).
 
 
 ## Loaders
 
-*Loaders* enable webpack to process more than just JavaScript files (webpack itself only understands JavaScript). They give you the ability to leverage webpack's bundling capabilities for all kinds of files by converting them to valid [modules](/concepts/modules) that webpack can process.
-
-Essentially, webpack loaders transform all types of files into modules that can be included in your application's dependency graph (and eventually a bundle).
+Out of the box, webpack only understands JavaScript files. **Loaders** allow webpack to process other types of files and converting them into valid [modules](/concepts/modules) that can be consumed by your application and added to the dependency graph.
 
 W> Note that the ability to `import` any type of module, e.g. `.css` files, is a feature specific to webpack and may not be supported by other bundlers or task runners. We feel this extension of the language is warranted as it allows developers to build a more accurate dependency graph.
 
-At a high level, __loaders__ have two purposes in your webpack configuration:
+At a high level, **loaders** have two purposes in your webpack configuration:
 
 1. The `test` property identifies which file or files should be transformed.
 2. The `use` property indicates which loader should be used to do the transforming.
@@ -108,16 +105,16 @@ The configuration above has defined a `rules` property for a single module with 
 
 > "Hey webpack compiler, when you come across a path that resolves to a '.txt' file inside of a `require()`/`import` statement, **use** the `raw-loader` to transform it before you add it to the bundle."
 
-W> It is important to remember that **when defining rules in your webpack config, you are defining them under `module.rules` and not `rules`**. For your benefit, webpack will 'yell at you' if this is done incorrectly.
+W> It is important to remember that when defining rules in your webpack config, you are defining them under `module.rules` and not `rules`. For your benefit, webpack will warn you if this is done incorrectly.
 
-There are other, more specific properties to define on loaders that we haven't yet covered.
-
-[Learn more!](/concepts/loaders)
+You can check further customization when including loaders in the [loaders section](/concepts/loaders).
 
 
 ## Plugins
 
-While loaders are used to transform certain types of modules, plugins can be leveraged to perform a wider range of tasks. Plugins range from bundle optimization and minification all the way to defining environment-like variables. The [plugin interface](/api/plugins) is extremely powerful and can be used to tackle a wide variety of tasks.
+While loaders are used to transform certain types of modules, plugins can be leveraged to perform a wider range of tasks, from bundle optimization, assets management or inject environment variables.
+
+T> Check out the [plugin interface](/api/plugins) and how to use it to extend webpacks capabilities.
 
 In order to use a plugin, you need to `require()` it and add it to the `plugins` array. Most plugins are customizable through options. Since you can use a plugin multiple times in a config for different purposes, you need to create an instance of it by calling it with the `new` operator.
 
@@ -134,7 +131,6 @@ const config = {
     ]
   },
   plugins: [
-    new webpack.optimize.UglifyJsPlugin(),
     new HtmlWebpackPlugin({template: './src/index.html'})
   ]
 };
@@ -142,16 +138,18 @@ const config = {
 module.exports = config;
 ```
 
-There are many plugins that webpack provides out of the box! Check out our [list of plugins](/plugins) for more information.
+In the example above, the `html-webpack-plugin` generates an html file for your application injecting automatically all your generated bundles.
 
-Using plugins in your webpack config is straightforward - however, there are many use cases that are worth further exploration.
+T> There are many plugins that webpack provides out of the box! Check out the [list of plugins](/plugins).
 
-[Learn more!](/concepts/plugins)
+Using plugins in your webpack config is straightforward - however, there are many use cases that are worth further exploration, [learn more about them here](/concepts/plugins).
 
 
 ## Mode
 
-By setting the `mode` parameter to either `development` or `production`, you can enable webpack's built-in optimizations that correspond with the selected mode.
+By setting the `mode` property to either `development` or `production`, you can enable webpack's built-in optimizations that correspond with the selected mode.
+
+By default its value is `production`.
 
 ```javascript
 module.exports = {
@@ -159,4 +157,4 @@ module.exports = {
 };
 ```
 
-[Learn more!](/concepts/mode)
+Learn more about the [mode configuration here](/concepts/mode) and what optimizations take place on each value.

--- a/src/content/concepts/index.md
+++ b/src/content/concepts/index.md
@@ -13,7 +13,7 @@ contributors:
   - jeremenichelli
 ---
 
-At its core, **webpack** is a _static module bundler_ for modern JavaScript applications. When webpack processes your application, it internally builds a _dependency graph_ which maps every module your project needs, then it generates one or more _bundles_.
+At its core, **webpack** is a _static module bundler_ for modern JavaScript applications. When webpack processes your application, it internally builds a _dependency graph_ which maps every module your project needs and generates one or more _bundles_.
 
 T> Learn more about JavaScript modules and webpack modules [here](/concepts/modules).
 


### PR DESCRIPTION
Initially this PR solves https://github.com/webpack/webpack.js.org/issues/2035 issue.

I also change some parts and code snippets that are not valid with v4 release.

FInally, I encounter a lot of issues with code snippets and content in each section. There were lots of sentences saying exactly the same thing over and over, probably tangling more the understanding an entry user needs on what each concept means in webpack.

Would your words on my changes, the intention was to summarize and simplify the content to be a little more consumable.

You can check the formatted version of the concepts page [here](https://github.com/webpack/webpack.js.org/blob/762a338f28e361d70ae494d1ff12b330441b4a1b/src/content/concepts/index.md) which might help review the content.
