### PR TITLE
Update code-splitting.md

### DIFF
--- a/src/content/guides/code-splitting.md
+++ b/src/content/guides/code-splitting.md
@@ -237,7 +237,7 @@ __src/index.js__
 +   return import(/* webpackChunkName: "lodash" */ 'lodash').then(_ => {
 +     var element = document.createElement('div');
 +
-+     element.innerHTML = _.join(['Hello', 'webpack'], ' ');
++     element.innerHTML = _.default.join(['Hello', 'webpack'], ' ');
 +
 +     return element;
 +


### PR DESCRIPTION
In running this example as-is I kept coming across this error:

`index.bundle.js:1 Uncaught (in promise) TypeError: e.join is not a function at n.e.then.then.e (index.bundle.js:1)`

Upon inspecting `_` is `{default: ƒ}`
