### PR TITLE
Update loader testing docs to catch compiler errors

### DIFF
--- a/src/content/contribute/writing-a-loader.md
+++ b/src/content/contribute/writing-a-loader.md
@@ -289,7 +289,7 @@ export default (fixture, options = {}) => {
 
   return new Promise((resolve, reject) => {
     compiler.run((err, stats) => {
-      if (err) reject(err);
+      if (err || stats.hasErrors()) reject(err);
 
       resolve(stats);
     });


### PR DESCRIPTION
Update the loader testing example to check for runtime errors as mentioned [earlier in the docs](https://webpack.js.org/api/node/#webpack-).

> The err object will not include compilation errors and those must be handled separately using stats.hasErrors()
