### PR TITLE
chore(rebuild): don't load gitter twice

### DIFF
--- a/src/components/Gitter/Gitter.jsx
+++ b/src/components/Gitter/Gitter.jsx
@@ -7,32 +7,34 @@ import isClient from '../../utilities/is-client';
 // Load Styling
 import '../Gitter/Gitter.scss';
 
+let sidecar = false;
+
 // Create and export component
 export default class Gitter extends React.Component {
-  _sidecar = null
-
-  render() {
-    return (
-      <div className="gitter">
-        <div
-          className="gitter__button"
-          onClick={() => window.gitterSidecar && window.gitterSidecar.toggleChat(true)}>
-          <i className="gitter__icon icon-gitter" />
-        </div>
-      </div>
-    );
-  }
-
   componentDidMount() {
     if (isClient) {
       import('gitter-sidecar').then(Sidecar => {
-        if (!window.gitterSidecar) {
-          window.gitterSidecar = new Sidecar({
+        if (!sidecar) {
+          sidecar = new Sidecar({
             room: 'webpack/webpack',
             activationElement: false
           });
         }
       });
     }
+  }
+
+  handleIconClick = () => sidecar && sidecar.toggleChat(true);
+
+  render() {
+    return (
+      <div className="gitter">
+        <div
+          className="gitter__button"
+          onClick={this.handleIconClick}>
+          <i className="gitter__icon icon-gitter" />
+        </div>
+      </div>
+    );
   }
 }

--- a/src/components/Gitter/Gitter.jsx
+++ b/src/components/Gitter/Gitter.jsx
@@ -7,10 +7,10 @@ import isClient from '../../utilities/is-client';
 // Load Styling
 import '../Gitter/Gitter.scss';
 
-let sidecar = false;
+let sidecar = null;
 
 // Create and export component
-export default class Gitter extends React.Component {\
+export default class Gitter extends React.Component {
   render() {
     return (
       <div className="gitter">
@@ -37,6 +37,6 @@ export default class Gitter extends React.Component {\
   }
 
   _handleIconClick = () => {
-    sidecar && sidecar.toggleChat(true)
+    sidecar && sidecar.toggleChat(true);
   }
 }

--- a/src/components/Gitter/Gitter.jsx
+++ b/src/components/Gitter/Gitter.jsx
@@ -22,13 +22,16 @@ export default class Gitter extends React.Component {
   }
 
   componentDidMount() {
-    if (isClient) {
-      import('gitter-sidecar').then(Sidecar => {
-        this._sidecar = new Sidecar({
-          room: 'webpack/webpack',
-          activationElement: false
+    if ( window.document !== undefined ) {
+      if (!window.gitterLoadTriggered) {
+        window.gitterLoadTriggered = true;
+        import('gitter-sidecar').then(Sidecar => {
+          this._sidecar = new Sidecar({
+            room: 'webpack/webpack',
+            activationElement: false
+          });
         });
-      });
+      }
     }
   }
 }

--- a/src/components/Gitter/Gitter.jsx
+++ b/src/components/Gitter/Gitter.jsx
@@ -14,7 +14,9 @@ export default class Gitter extends React.Component {
   render() {
     return (
       <div className="gitter">
-        <div className="gitter__button js-gitter-toggle-chat-button">
+        <div
+          className="gitter__button"
+          onClick={() => window.gitterSidecar && window.gitterSidecar.toggleChat(true)}>
           <i className="gitter__icon icon-gitter" />
         </div>
       </div>
@@ -26,7 +28,7 @@ export default class Gitter extends React.Component {
       if (!window.gitterLoadTriggered) {
         window.gitterLoadTriggered = true;
         import('gitter-sidecar').then(Sidecar => {
-          this._sidecar = new Sidecar({
+          window.gitterSidecar = new Sidecar({
             room: 'webpack/webpack',
             activationElement: false
           });

--- a/src/components/Gitter/Gitter.jsx
+++ b/src/components/Gitter/Gitter.jsx
@@ -10,7 +10,19 @@ import '../Gitter/Gitter.scss';
 let sidecar = false;
 
 // Create and export component
-export default class Gitter extends React.Component {
+export default class Gitter extends React.Component {\
+  render() {
+    return (
+      <div className="gitter">
+        <div
+          className="gitter__button"
+          onClick={this._handleIconClick}>
+          <i className="gitter__icon icon-gitter" />
+        </div>
+      </div>
+    );
+  }
+
   componentDidMount() {
     if (isClient) {
       import('gitter-sidecar').then(Sidecar => {
@@ -24,17 +36,7 @@ export default class Gitter extends React.Component {
     }
   }
 
-  handleIconClick = () => sidecar && sidecar.toggleChat(true);
-
-  render() {
-    return (
-      <div className="gitter">
-        <div
-          className="gitter__button"
-          onClick={this.handleIconClick}>
-          <i className="gitter__icon icon-gitter" />
-        </div>
-      </div>
-    );
+  _handleIconClick = () => {
+    sidecar && sidecar.toggleChat(true)
   }
 }

--- a/src/components/Gitter/Gitter.jsx
+++ b/src/components/Gitter/Gitter.jsx
@@ -24,16 +24,15 @@ export default class Gitter extends React.Component {
   }
 
   componentDidMount() {
-    if ( window.document !== undefined ) {
-      if (!window.gitterLoadTriggered) {
-        window.gitterLoadTriggered = true;
-        import('gitter-sidecar').then(Sidecar => {
+    if (isClient) {
+      import('gitter-sidecar').then(Sidecar => {
+        if (!window.gitterSidecar) {
           window.gitterSidecar = new Sidecar({
             room: 'webpack/webpack',
             activationElement: false
           });
-        });
-      }
+        }
+      });
     }
   }
 }


### PR DESCRIPTION
Fixes #2131 

Open for discussion:

We could move gitter to `Site.jsx` to have cleaner implementation and stop worrying about hiding and showing the chat toggle button but that would result in gitter widget on all pages of the website vs what we currently have only on documentation pages (`Page.jsx`)