### PR TITLE
prefecting -> prefetching

### DIFF
--- a/src/content/guides/code-splitting.md
+++ b/src/content/guides/code-splitting.md
@@ -24,6 +24,7 @@ contributors:
   - kcolton
   - efreitasn
   - EugeneHlushko
+  - vcarl
 related:
   - title: <link rel=”prefetch/preload”> in webpack
     url: https://medium.com/webpack/link-rel-prefetch-preload-in-webpack-51a52358f84c
@@ -302,7 +303,7 @@ __src/index.js__
 ```
 
 
-## Prefecting/Preloading modules
+## Prefetching/Preloading modules
 
 webpack 4.6.0+ adds support for prefetching and preloading.
 


### PR DESCRIPTION
Simple typo fix! One of the headings on the code splitting page read "Prefecting".