### PR TITLE
Fix typo in code-splitting.md

### DIFF
--- a/src/content/guides/code-splitting.md
+++ b/src/content/guides/code-splitting.md
@@ -302,7 +302,7 @@ __src/index.js__
 ```
 
 
-## Prefecting/Preloading modules
+## Prefetching/Preloading modules
 
 webpack 4.6.0+ adds support for prefetching and preloading.
 


### PR DESCRIPTION
Fixed a typo in the code splitting page.
