### PR TITLE
feat(rebuild): improve font loading strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "@rigor789/remark-autolink-headings": "^5.1.0",
     "ajv": "^5.5.2",
     "docsearch.js": "^2.5.2",
+    "fontfaceobserver": "^2.0.13",
     "gitter-sidecar": "^1.2.3",
     "prop-types": "^15.5.10",
     "react": "^16.2.0",

--- a/src/components/Markdown/Markdown.scss
+++ b/src/components/Markdown/Markdown.scss
@@ -3,7 +3,7 @@
 @import 'prism-theme';
 
 .markdown {
-  line-height:1.5em;
+  line-height: 1.5em;
 
   h1 { font-size: getFontSize(4); }
   h2 { font-size: getFontSize(3); }
@@ -15,11 +15,15 @@
   h1, h2, h3, h4, h5, h6 {
     display: flex;
     align-items: center;
-    font-family: $font-stack-heading;
+    font-family: $font-system-heading;
     font-weight:600;
     line-height:1.4;
     margin:1.5em 0 0.25em;
     color:getColor(fiord);
+
+    .geomanist-ready & {
+      font-family: $font-stack-heading;
+    }
 
     tt, code {
       font-size: 90%;
@@ -274,8 +278,7 @@
   }
 
   code, tt {
-    font-family: $font-stack-code;
-    font-size: 90%;
+    font-family: $font-system-code;
     margin: 0 2px;
     padding: 2px 6px;
     white-space: normal;

--- a/src/components/Navigation/Navigation.scss
+++ b/src/components/Navigation/Navigation.scss
@@ -59,16 +59,19 @@
 }
 
 .navigation__item {
-  position: relative;
-  display: inline-block;
-  font-size: getFontSize(-1);
-  padding-bottom: 0.1em;
-  margin-right: 18px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
   color: getColor(white);
-  transition: all 250ms;
+  display: inline-block;
+  font-size: getFontSize(-2);
+  letter-spacing: 0.5px;
+  margin-right: 18px;
+  padding-bottom: 0.1em;
+  position: relative;
+  text-transform: uppercase;
   @include fontantialias(false);
+
+  .source-sans-ready & {
+    font-size: getFontSize(-1);
+  }
 
   &:hover {
     color: getColor(malibu);
@@ -87,7 +90,7 @@
       content: '';
       position: absolute;
       width: 100%;
-      height: 3px;
+      height: 2px;
       top: 100%;
       left: 0;
       background: getColor(malibu);
@@ -189,12 +192,16 @@
 
 .navigation-sub__link {
   display: inline-block;
-  font-size: 0.8em;
+  font-size: 0.75em;
+  line-height: 25px;
   margin-left: 1.5em;
-  padding: 0.4em 0;
   color: $text-color-highlight;
   text-transform: uppercase;
   @include fontantialias(false);
+
+  .source-sans-ready & {
+    font-size: 0.8em;
+  }
 
   &:hover {
     color: getColor(malibu);

--- a/src/components/NotificationBar/NotificationBar.scss
+++ b/src/components/NotificationBar/NotificationBar.scss
@@ -4,6 +4,7 @@
 .notification-bar {
   color: getColor(white);
   background: getColor(emperor);
+  height: 37px;
 
   a {
     color: getColor(malibu);
@@ -19,11 +20,17 @@
 }
 
 .notification-bar__inner {
+  font-size: 15px;
+  line-height: 37px;
   position: relative;
-  padding: 0.5em 1em;
+  padding: 0 1em;
 
   @include break {
-    padding: 0.5em 1.5em;
+    padding: 0 1.5em;
+  }
+
+  .source-sans-ready & {
+    font-size: 16px;
   }
 }
 

--- a/src/components/Shield/Shield.jsx
+++ b/src/components/Shield/Shield.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export default props => (
-  <img src={
+  <img height="20" src={
     `https://img.shields.io/${props.content}.svg?label=${props.label}&style=flat-square&maxAge=3600`
   } />
 );

--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -35,6 +35,13 @@ class Site extends React.Component {
     mobileSidebarOpen: false
   }
 
+  componentDidMount() {
+    if (isClient) {
+      // dynamically load font bundle on client
+      import('../../fonts.js');
+    }
+  }
+
   render() {
     let { location } = this.props;
     let { mobileSidebarOpen } = this.state;
@@ -45,9 +52,7 @@ class Site extends React.Component {
     return (
       <div className="site">
         <DocumentTitle title={ GetPageTitle(Content, location.pathname) } />
-
         <NotificationBar />
-
         <Navigation
           pathname={ location.pathname }
           toggleSidebar={ this._toggleSidebar }

--- a/src/components/Splash/Splash.scss
+++ b/src/components/Splash/Splash.scss
@@ -2,6 +2,8 @@
 @import 'mixins';
 
 .splash {
+  overflow: hidden;
+
   &__section {
     position:relative;
     text-align:center;

--- a/src/components/Vote/Vote.scss
+++ b/src/components/Vote/Vote.scss
@@ -4,8 +4,12 @@
 
 .vote {
   h1, h2, h3, h4, h5, h6 {
-    font-family: $font-stack-heading;
+    font-family: $font-system-heading;
     font-weight: 600;
     color: getColor(fiord);
+
+    .geomanist-ready & {
+      font-family: $font-stack-heading;
+    }
   }
 }

--- a/src/fonts.js
+++ b/src/fonts.js
@@ -1,0 +1,30 @@
+// Import Dependencies
+import FontFaceObserver from 'fontfaceobserver';
+
+// Import Styling
+import('./styles/fonts.scss');
+
+const bodyStackNormal = new FontFaceObserver('Source Sans Pro', {
+  weight: 400
+});
+
+const bodyStackNormalItalic = new FontFaceObserver('Source Sans Pro', {
+  weight: 400,
+  style: 'italic'
+});
+
+const bodyStackMedium = new FontFaceObserver('Source Sans Pro', {
+  weight: 600
+});
+
+const bodyStack = Promise
+  .all([ bodyStackNormal.load(), bodyStackNormalItalic.load(), bodyStackMedium.load() ])
+  .then(() => {
+    document.documentElement.classList.add('source-sans-ready');
+  });
+
+const headingStack = new FontFaceObserver('Geomanist', { weight: 600 })
+  .load()
+  .then(() => {
+    document.documentElement.classList.add('geomanist-ready');
+  });

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -9,7 +9,7 @@ import Site from './components/Site/Site';
 
 // Import helpers
 import isClient from './utilities/is-client';
-        
+
 // Import Utilities
 import { FindInContent } from './utilities/content-utils';
 

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -1,7 +1,9 @@
+@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,600');
+
 @font-face {
   font-family: 'Geomanist';
+  font-weight: 600;
   src: url('../assets/geomanist-medium.woff2') format('woff2'),
   url('../assets/geomanist-medium.woff') format('woff');
-  font-weight: 600;
   font-style: normal;
 }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,7 +1,4 @@
-@import url('https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,600');
-
 @import 'vars';
-@import 'fonts';
 @import 'functions';
 @import 'mixins';
 
@@ -16,8 +13,19 @@ html {
 }
 
 body {
-  font: 400 getFontSize(0) $font-stack-body;
+  font-family: $font-system-body;
+  font-weight: 400;
   color: getColor(elephant);
+
+  // styles to decrease font glitch
+  font-size: 15.5px;
+  letter-spacing: -0.01em;
+
+  .source-sans-ready & {
+    font-size: getFontSize(0);
+    font-family: $font-stack-body;
+    letter-spacing: 0;
+  }
 }
 
 a {

--- a/src/styles/partials/_vars.scss
+++ b/src/styles/partials/_vars.scss
@@ -18,9 +18,11 @@ $screens: (
   medium: 768px
 );
 
-$font-stack-body: 'Source Sans Pro', -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+$font-system-body: Helvetica, Arial, sans-serif;
+$font-system-heading: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+$font-system-code: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+
+$font-stack-body: 'Source Sans Pro', sans-serif;
 $font-stack-heading: Geomanist, sans-serif;
-$font-stack-code: 'Source Code Pro', Consolas, "Liberation Mono", Menlo, Courier, monospace;
 
 $text-color-highlight: lighten(map-get($colors, denim), 5%);
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,12 @@
     node-fetch "^2.1.1"
     url-template "^2.0.8"
 
+"@rigor789/remark-autolink-headings@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@rigor789/remark-autolink-headings/-/remark-autolink-headings-5.1.0.tgz#cb692df8b1914d88b2a957c949bed13fcbdc1a23"
+  dependencies:
+    unist-util-visit "^1.0.1"
+
 JSONStream@^1.0.4:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.2.tgz#c102371b6ec3a7cf3b847ca00c20bb0fce4c6dea"
@@ -1577,6 +1583,14 @@ cli-cursor@^2.1.0:
 cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
+
+clipboard@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-1.7.1.tgz#360d6d6946e99a7a1fef395e42ba92b5e9b5a16b"
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
 
 clipboard@^2.0.0:
   version "2.0.0"
@@ -3244,6 +3258,10 @@ fn-name@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
 
+fontfaceobserver@^2.0.13:
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/fontfaceobserver/-/fontfaceobserver-2.0.13.tgz#47adbb343261eda98cb44db2152196ff124d3221"
+
 fontgen-loader@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fontgen-loader/-/fontgen-loader-0.2.1.tgz#b8ed6d9a798d5b055b80f1e21db4b04170b6f051"
@@ -3813,6 +3831,10 @@ hast-util-is-element@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hast-util-is-element/-/hast-util-is-element-1.0.0.tgz#3f7216978b2ae14d98749878782675f33be3ce00"
 
+hast-util-parse-selector@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.1.0.tgz#b55c0f4bb7bb2040c889c325ef87ab29c38102b4"
+
 hast-util-sanitize@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/hast-util-sanitize/-/hast-util-sanitize-1.1.2.tgz#d10bd6757a21e59c13abc8ae3530dd3b6d7d679e"
@@ -3838,6 +3860,16 @@ hast-util-to-html@^3.0.0:
 hast-util-whitespace@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-1.0.0.tgz#bd096919625d2936e1ff17bc4df7fd727f17ece9"
+
+hastscript@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-3.1.0.tgz#66628ba6d7f1ad07d9277dd09028aba7f4934599"
+  dependencies:
+    camelcase "^3.0.0"
+    comma-separated-tokens "^1.0.0"
+    hast-util-parse-selector "^2.0.0"
+    property-information "^3.0.0"
+    space-separated-tokens "^1.0.0"
 
 hawk@3.1.3, hawk@~3.1.3:
   version "3.1.3"
@@ -6649,6 +6681,12 @@ prismjs@^1.9.0:
   optionalDependencies:
     clipboard "^2.0.0"
 
+prismjs@~1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.10.0.tgz#77e5187c2ae6b3253fcc313029cf25fe53778721"
+  optionalDependencies:
+    clipboard "^1.7.1"
+
 private@^0.1.6, private@^0.1.7, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -7163,6 +7201,13 @@ redux@^3.3.0:
     lodash-es "^4.2.1"
     loose-envify "^1.1.0"
     symbol-observable "^1.0.3"
+
+refractor@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/refractor/-/refractor-2.3.0.tgz#b8cade8f88020f8836ca3622c6ef87fd2444d76a"
+  dependencies:
+    hastscript "^3.1.0"
+    prismjs "~1.10.0"
 
 regenerate@^1.2.1:
   version "1.3.3"


### PR DESCRIPTION
This is my first try on trying to improve loading times on the rebuild branch. What I'm doing is applying what is consider best practice on font loading.

The new observer module doesn't affect the initial bundle since it's dynamically loaded when the site component mounts. I also removed the code web font since is pretty much the same as the system one in Mac and saves as tons of KiBs.

This should eliminate the flash of invisible content that we have on the site right now.

An example here on how it looks when the fonts kicks off:

![kapture 2018-05-13 at 14 35 21](https://user-images.githubusercontent.com/3856481/39967465-dcd00ef2-56bb-11e8-87a9-46b6f9bf940e.gif)

I've introduced some small css changes to prevent the stacking effect to be huge, but the loading times on the site should improve drastically. Also, once the SPA bundle kicks off, there's no stacking anymore since we are not reloading the site.

TODO:
 - Fix recalculation on TextRotater component for homepage.
 - Fix banner styles on mobile.

