### PR TITLE
Replace whitespaces with tabs in split-chunks-plugin.md

### DIFF
--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -181,7 +181,7 @@ splitChunks: {
 			test: /[\\/]node_modules[\\/]/,
 			priority: -10
 		},
-    default: {
+		default: {
 			minChunks: 2,
 			priority: -20,
 			reuseExistingChunk: true


### PR DESCRIPTION
This fixes incorrect indentation in code example in <https://webpack.js.org/plugins/split-chunks-plugin/>.

![image](https://user-images.githubusercontent.com/473530/39997189-fea5a800-57bc-11e8-9343-1226d570669a.png)
