### PR TITLE
fix(fetch) done add two underscores for supporters.json

### DIFF
--- a/src/utilities/fetchSupporters.js
+++ b/src/utilities/fetchSupporters.js
@@ -26,7 +26,7 @@ request(url)
     }
 
     // Write the file
-    return asyncWriteFile(`./src/components/Support/_${filename}`, body);
+    return asyncWriteFile(`./src/components/Support/${filename}`, body);
   })
   .catch(error => {
     console.error('utilities/fetchSupporters:', error);


### PR DESCRIPTION
Currently fetch command creates `__supporters.json` instead of `_supporters.json` because an underscore was added in both filename and file path string literal.

This patch fixes it, if you do a git clean and fetch currently dev server errors on trying to read non existent `_supporters.json` because it was fetched with two underscores.