### PR TITLE
Update externals.md to include an example of more than one library

### DIFF
--- a/src/content/configuration/externals.md
+++ b/src/content/configuration/externals.md
@@ -76,7 +76,8 @@ externals: {
 
 ``` js
 externals : {
-  react: 'react'
+  react: 'React',
+  react-dom: 'ReactDOM'
 }
 
 // or


### PR DESCRIPTION
Give an example of where multiple libraries can be defined. I've used react because it typically requires multiple libraries to be included and there are no examples of multiple libraries being defined as external. Externals is a plural after all so implies multiple libraries can be excluded from the build.

I've capitalised react as the global object in the UMD build from unpkg is usually capitalised.