### PR TITLE
docs(plugins/split-chunks-plugin): fix indentation

### DIFF
--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -181,7 +181,7 @@ splitChunks: {
 			test: /[\\/]node_modules[\\/]/,
 			priority: -10
 		},
-    default: {
+		default: {
 			minChunks: 2,
 			priority: -20,
 			reuseExistingChunk: true


### PR DESCRIPTION
fix optimization.splitChunks section config example cacheGroups.default indentation

<img width="361" alt="screen shot 2018-05-22 at 18 09 36" src="https://user-images.githubusercontent.com/1522846/40371762-db57b78c-5deb-11e8-99e4-c3bdf0b5e013.png">
