### PR TITLE
docs(guide): Remove redundant hint

### DIFF
--- a/src/content/guides/tree-shaking.md
+++ b/src/content/guides/tree-shaking.md
@@ -9,6 +9,7 @@ contributors:
   - MijaelWatts
   - dmitriid
   - probablyup
+  - gish
 related:
   - title: "webpack 4 beta — try it today!"
     url: https://medium.com/webpack/webpack-4-beta-try-it-today-6b1d27d7d7e2#9a67
@@ -171,8 +172,6 @@ module.exports = {
 + mode: "production"
 };
 ```
-
-T> Note that the `--optimize-minimize` flag can be used to insert the `UglifyJSPlugin` as well.
 
 With that squared away, we can run another `npm run build` and see if anything has changed.
 


### PR DESCRIPTION
The hint for --optimize-minimize is appearing twice in [the guide to tree shaking][1]. This change will keep the one added in [6c2ab16][2].

[1]: https://webpack.js.org/guides/tree-shaking/#minify-the-output
[2]: https://github.com/webpack/webpack.js.org/commit/6c2ab166853738fbd09993d99b72d1f11381bc63#diff-8152e1597fc1acfff8849d4b494f4915R155