### PR TITLE
docs(optimization): module initialization with multiple runtimes

### DIFF
--- a/src/content/configuration/optimization.md
+++ b/src/content/configuration/optimization.md
@@ -73,6 +73,10 @@ It is possible to use preset mode of the plugin by providing a string value:
 
 By setting `optimization.runtimeChunk` to `object` it is only possible to provide the `name` property which stands for the name or name factory for the runtime chunks.
 
+Default is `false`: each entry chunk embeds runtime.
+
+W> Imported modules are initialized for each runtime chunk separately, so if you include multiple entrypoints on a page, beware of this behavior. You will probably want to set it to `single` or use another configuration that allows you to only have one runtime instance.
+
 __webpack.config.js__
 
 


### PR DESCRIPTION
Document behavior when multiple runtimes are present on a page.

Discussion: https://github.com/webpack/webpack/issues/7375
