### PR TITLE
Update the “Writing a plugin” docs for the new plugin API

### DIFF
--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -14,7 +14,7 @@ A plugin for `webpack` consists of a named JavaScript class that:
 
 - Defines the `apply` method.
 - Specifies an [event hook](/api/compiler-hooks/) on which to bind itself.
-- Tunes the build using the plugin API provided by webpack.
+- Manipulates the build using the plugin API provided by webpack.
 
 ```javascript
 class MyExampleWebpackPlugin {
@@ -27,7 +27,7 @@ class MyExampleWebpackPlugin {
         console.log('This is an example plugin!');
         console.log('Here’s the `compilation` object which represents a single build of assets:', compilation);
 
-        // Tune the build using the plugin API provided by webpack
+        // Manipulate the build using the plugin API provided by webpack
         compilation.addModule(/* ... */);
 
         callback();
@@ -58,7 +58,7 @@ class HelloWorldPlugin {
 module.exports = HelloWorldPlugin;
 ```
 
-Then to use the plugin, just include an instance in your webpack config `plugins` array:
+Then to use the plugin, include an instance in your webpack config `plugins` array:
 
 ```javascript
 // webpack.config.js

--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -3,31 +3,30 @@ title: Writing a Plugin
 sort: 4
 contributors:
   - tbroadley
+  - iamakulov
 ---
 
 Plugins expose the full potential of the webpack engine to third-party developers. Using staged build callbacks, developers can introduce their own behaviors into the webpack build process. Building plugins is a bit more advanced than building loaders, because you'll need to understand some of the webpack low-level internals to hook into them. Be prepared to read some source code!
 
 ## Creating a Plugin
 
-A plugin for `webpack` consists of
+A plugin for `webpack` consists of a named JavaScript function that:
 
-- A named JavaScript function.
 - Defines `apply` method in its prototype.
 - Specifies an [event hook](/api/compiler-hooks/) on which to bind itself.
 - Manipulates webpack internal instance specific data.
-- Invokes webpack provided callback after functionality is complete.
 
 ```javascript
 // A named JavaScript function.
 function MyExampleWebpackPlugin() {
 
-};
+}
 
-// Defines `apply` method in it's prototype.
+// Defines `apply` method in its prototype.
 MyExampleWebpackPlugin.prototype.apply = function(compiler) {
-  // Specifies webpack's event hook to attach itself.
-  compiler.plugin('webpacksEventHook', function(compilation /* Manipulates webpack internal instance specific data. */, callback) {
-    console.log("This is an example plugin!!!");
+  // Specifies webpack's event hook to attach itself
+  compiler.hooks.compile.tapAsync('afterCompile', function(compilation /* Manipulates webpack internal instance specific data. */, callback) {
+    console.log('This is an example plugin!!!');
 
     // Invokes webpack provided callback after functionality is complete.
     callback();
@@ -50,7 +49,6 @@ These two components are an integral part of any webpack plugin (especially a `c
 
 ## Basic plugin architecture
 
-
 Plugins are instantiated objects with an `apply` method on their prototype. This `apply` method is called once by the webpack compiler while installing the plugin. The `apply` method is given a reference to the underlying webpack compiler, which grants access to compiler callbacks. A simple plugin is structured as follows:
 
 ```javascript
@@ -59,7 +57,7 @@ function HelloWorldPlugin(options) {
 }
 
 HelloWorldPlugin.prototype.apply = function(compiler) {
-  compiler.plugin('done', function() {
+  compiler.hooks.done.tap('HelloWorldPlugin', function() {
     console.log('Hello World!');
   });
 };
@@ -67,7 +65,7 @@ HelloWorldPlugin.prototype.apply = function(compiler) {
 module.exports = HelloWorldPlugin;
 ```
 
-Then to install the plugin, just include an instance in your webpack config `plugins` array:
+Then to use the plugin, just include an instance in your webpack config `plugins` array:
 
 ```javascript
 var HelloWorldPlugin = require('hello-world');
@@ -82,18 +80,17 @@ var webpackConfig = {
 
 ## Accessing the compilation
 
-Using the compiler object, you may bind callbacks that provide a reference to each new compilation. These compilations provide callbacks for hooking into numerous steps within the build process.
+Using the compiler object, you may setup event hooks that provide a reference to each new compilation. These compilations provide additional event hooks for hooking into steps within the build process.
 
 ```javascript
 function HelloCompilationPlugin(options) {}
 
 HelloCompilationPlugin.prototype.apply = function(compiler) {
-
   // Setup callback for accessing a compilation:
-  compiler.plugin("compilation", function(compilation) {
+  compiler.hooks.compilation.tap("HelloCompilationPlugin", function(compilation) {
 
     // Now setup callbacks for accessing compilation steps:
-    compilation.plugin("optimize", function() {
+    compilation.hooks.optimize.tap("HelloCompilationPlugin", function() {
       console.log("Assets are being optimized.");
     });
   });
@@ -102,24 +99,38 @@ HelloCompilationPlugin.prototype.apply = function(compiler) {
 module.exports = HelloCompilationPlugin;
 ```
 
-For more information on what callbacks are available on the `compiler`, `compilation`, and other important objects, see the [plugins](/api/plugins/) doc.
+For more information on what hooks are available on the `compiler`, `compilation`, and other important objects, see the [plugins](/api/plugins/) doc.
 
-## Async compilation plugins
+## Async event hooks
 
-Some compilation plugin steps are asynchronous, and pass a callback function that _must_ be invoked when your plugin is finished running.
+Some event hooks are asynchronous. Apart from `tap`, they also have `tapAsync` and `tapPromise` methods. By tapping using these methods, you can do asynchronous actions inside hooks:
 
 ```javascript
 function HelloAsyncPlugin(options) {}
 
 HelloAsyncPlugin.prototype.apply = function(compiler) {
-  compiler.plugin("emit", function(compilation, callback) {
-
+  // tapAsync() is callback-based
+  compiler.hooks.emit.tapAsync('HelloAsyncPlugin', function(compilation, callback) {
     // Do something async...
     setTimeout(function() {
       console.log("Done with async work...");
       callback();
     }, 1000);
-
+  });
+  
+  // tapPromise() is promise-based
+  compiler.hooks.emit.tapPromise('HelloAsyncPlugin', function(compilation) {
+    // Do something async...
+    return doSomethingAsync()
+      .then(() => {
+        console.log("Done with async work...");
+      });
+  });
+  
+  // Plain old tap() is still here:
+  compiler.hooks.emit.tap('HelloAsyncPlugin', function() {
+    // No async work here
+    console.log("Done with sync work...");
   });
 };
 
@@ -136,7 +147,7 @@ Let's write a simple example plugin that generates a new build file called `file
 function FileListPlugin(options) {}
 
 FileListPlugin.prototype.apply = function(compiler) {
-  compiler.plugin('emit', function(compilation, callback) {
+  compiler.hooks.emit.tapAsync('FileListPlugin', function(compilation, callback) {
     // Create a header string for the generated file:
     var filelist = 'In this build:\n\n';
 
@@ -163,46 +174,33 @@ FileListPlugin.prototype.apply = function(compiler) {
 module.exports = FileListPlugin;
 ```
 
-## Different Plugin Shapes
+## Under the hood
 
-A plugin can be classified into types based on the event it is registered to. Every event hook decides how it is going to apply the plugins in its registry.
+Under the hood, webpack uses [Tapable](https://github.com/webpack/tapable) to create and run hooks. This is how it looks:
 
-- __synchronous__ The Tapable instance applies plugins using
+```javascript
+import { SyncHook, AsyncSeriesHook } from 'tapable';
 
-`applyPlugins(name: string, args: any...)`
+class SomeWebpackInternalClass {
+  constructor() {
+    this.hooks = {
+      // Create hooks:
+      compilation: new SyncHook(),
+      run: new AsyncSeriesHook(),
+    };
+  }
+  
+  someMethod() {
+    // Call a hook:
+    this.hooks.run.call();
+  
+    // Call another hook:
+    // (This is an async one, so webpack passes a callback into it)
+    this.hooks.run.callAsync(() => {
+      // The callback is called when all tapped functions finish executing
+    });
+  }
+}
+```
 
-`applyPluginsBailResult(name: string, args: any...)`
-
-This means that each of the plugin callbacks will be invoked one after the other with the specific `args`.
-This is the simplest format for a plugin. Many useful events like `"compile"`, `"this-compilation"` expect plugins to have synchronous execution.
-
-- __waterfall__ Plugins applied using
-
-`applyPluginsWaterfall(name: string, init: any, args: any...)`
-
-Here each of the plugins are called one after the other with the args from the return value of the previous plugin. The plugin must take the order of its execution into account.
-It must accept arguments from the previous plugin that was executed. The value for the first plugin is `init`. This pattern is used in the Tapable instances which are related to the `webpack` templates like `ModuleTemplate`, `ChunkTemplate` etc.
-
-- __asynchronous__ When all the plugins are applied asynchronously using
-
-`applyPluginsAsync(name: string, args: any..., callback: (err?: Error) -> void)`
-
-The plugin handler functions are called with all args and a callback function with the signature `(err?: Error) -> void`. The handler functions are called in order of registration. `callback` is called after all the handlers are called.
-This is also a commonly used pattern for events like `"emit"`, `"run"`.
-
-- __async waterfall__ The plugins will be applied asynchronously in the waterfall manner.
-
-`applyPluginsAsyncWaterfall(name: string, init: any, callback: (err: Error, result: any) -> void)`
-
-The plugin handler functions are called with the current value and a callback function with the signature `(err: Error, nextValue: any) -> void.` When called `nextValue` is the current value for the next handler. The current value for the first handler is `init`. After all handlers are applied, callback is called with the last value. If any handler passes a value for `err`, the callback is called with this error and no more handlers are called.
-This plugin pattern is expected for events like `"before-resolve"` and `"after-resolve"`.
-
-- __async series__ It is the same as asynchronous but if any of the plugins registered fails, then no more plugins are called.
-
-`applyPluginsAsyncSeries(name: string, args: any..., callback: (err: Error, result: any) -> void)`
-
--__parallel__ -
-
-`applyPluginsParallel(name: string, args: any..., callback: (err?: Error) -> void)`
-
-`applyPluginsParallelBailResult(name: string, args: any..., callback: (err: Error, result: any) -> void)`
+There’re multiple types of hooks which run tapped functions a bit differently. They are described [in the Tapable docs](https://github.com/webpack/tapable#hook-types).

--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -34,19 +34,6 @@ MyExampleWebpackPlugin.prototype.apply = function(compiler) {
 };
 ```
 
-## Compiler and Compilation
-
-Among the two most important resources while developing plugins are the `compiler` and `compilation` objects. Understanding their roles is an important first step in extending the webpack engine.
-
-- The `compiler` object represents the fully configured webpack environment. This object is built once upon starting webpack, and is configured with all operational settings including options, loaders, and plugins. When applying a plugin to the webpack environment, the plugin will receive a reference to this compiler. Use the compiler to access the main webpack environment.
-
-- A `compilation` object represents a single build of versioned assets. While running webpack development middleware, a new compilation will be created each time a file change is detected, thus generating a new set of compiled assets. A compilation surfaces information about the present state of module resources, compiled assets, changed files, and watched dependencies. The compilation also provides many callback points at which a plugin may choose to perform custom actions.
-
-These two components are an integral part of any webpack plugin (especially a `compilation`), so developers will benefit by familiarizing themselves with these source files:
-
-- [Compiler Source](https://github.com/webpack/webpack/blob/master/lib/Compiler.js)
-- [Compilation Source](https://github.com/webpack/webpack/blob/master/lib/Compilation.js)
-
 ## Basic plugin architecture
 
 Plugins are instantiated objects with an `apply` method on their prototype. This `apply` method is called once by the webpack compiler while installing the plugin. The `apply` method is given a reference to the underlying webpack compiler, which grants access to compiler callbacks. A simple plugin is structured as follows:
@@ -78,9 +65,22 @@ var webpackConfig = {
 };
 ```
 
-## Accessing the compilation
+## Compiler and Compilation
 
-Using the compiler object, you may setup event hooks that provide a reference to each new compilation. These compilations provide additional event hooks for hooking into steps within the build process.
+Among the two most important resources while developing plugins are the `compiler` and `compilation` objects. Understanding their roles is an important first step in extending the webpack engine.
+
+- The `compiler` object represents the fully configured webpack environment. This object is built once upon starting webpack, and is configured with all operational settings including options, loaders, and plugins. When applying a plugin to the webpack environment, the plugin will receive a reference to this compiler. Use the compiler to access the main webpack environment.
+
+- A `compilation` object represents a single build of versioned assets. While running webpack development middleware, a new compilation will be created each time a file change is detected, thus generating a new set of compiled assets. A compilation surfaces information about the present state of module resources, compiled assets, changed files, and watched dependencies. The compilation also provides many callback points at which a plugin may choose to perform custom actions.
+
+These two components are an integral part of any webpack plugin (especially a `compilation`), so developers will benefit by familiarizing themselves with these source files:
+
+- [Compiler Source](https://github.com/webpack/webpack/blob/master/lib/Compiler.js)
+- [Compilation Source](https://github.com/webpack/webpack/blob/master/lib/Compilation.js)
+
+## Accessing Compilation
+
+Compiler exposes a bunch of hooks that provide a reference to each new compilation. Compilations, in their turn, provide additional event hooks for tapping into steps within the build process.
 
 ```javascript
 function HelloCompilationPlugin(options) {}
@@ -99,7 +99,7 @@ HelloCompilationPlugin.prototype.apply = function(compiler) {
 module.exports = HelloCompilationPlugin;
 ```
 
-For more information on what hooks are available on the `compiler`, `compilation`, and other important objects, see the [plugins](/api/plugins/) doc.
+The list of hooks available on the `compiler`, `compilation`, and other important objects, see the [plugins API](/api/plugins/) docs.
 
 ## Async event hooks
 

--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -71,7 +71,7 @@ Among the two most important resources while developing plugins are the `compile
 
 - The `compiler` object represents the fully configured webpack environment. This object is built once upon starting webpack, and is configured with all operational settings including options, loaders, and plugins. When applying a plugin to the webpack environment, the plugin will receive a reference to this compiler. Use the compiler to access the main webpack environment.
 
-- A `compilation` object represents a single build of versioned assets. While running webpack development middleware, a new compilation will be created each time a file change is detected, thus generating a new set of compiled assets. A compilation surfaces information about the present state of module resources, compiled assets, changed files, and watched dependencies. The compilation also provides many callback points at which a plugin may choose to perform custom actions.
+- A `compilation` object represents a single build of versioned assets. While running webpack development middleware, a new compilation will be created each time a file change is detected, thus generating a new set of compiled assets. A compilation surfaces information about the present state of module resources, compiled assets, changed files, and watched dependencies. The compilation also provides many hooks at which a plugin can perform custom actions.
 
 These two components are an integral part of any webpack plugin (especially a `compilation`), so developers will benefit by familiarizing themselves with these source files:
 

--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -14,20 +14,21 @@ A plugin for `webpack` consists of a named JavaScript class that:
 
 - Defines the `apply` method.
 - Specifies an [event hook](/api/compiler-hooks/) on which to bind itself.
-- Manipulates webpack internal instance specific data.
+- Tunes the build using the plugin API provided by webpack.
 
 ```javascript
-// A named JavaScript class...
 class MyExampleWebpackPlugin {
-  // ...that defines `apply` method in its prototype...
+  // Define the `apply` method
   apply(compiler) {
-    // ...specifies webpack’s event hook to attach itself..
+    // Specify the event hook to attach to
     compiler.hooks.compile.tapAsync(
       'afterCompile',
       (compilation, callback) => {
-        // ...and manipulates webpack internal instance specific data.
-        console.log('This is an example plugin!!!');
-        console.log('Here’s the compilation object:', compilation);
+        console.log('This is an example plugin!');
+        console.log('Here’s the `compilation` object which represents a single build of assets:', compilation);
+
+        // Tune the build using the plugin API provided by webpack
+        compilation.addModule(/* ... */);
 
         callback();
       }
@@ -115,7 +116,6 @@ class HelloAsyncPlugin {
   apply(compiler) {
     // tapAsync() is callback-based
     compiler.hooks.emit.tapAsync('HelloAsyncPlugin', function(compilation, callback) {
-      // Do something async...
       setTimeout(function() {
         console.log("Done with async work...");
         callback();
@@ -124,7 +124,6 @@ class HelloAsyncPlugin {
 
     // tapPromise() is promise-based
     compiler.hooks.emit.tapPromise('HelloAsyncPlugin', (compilation) => {
-      // Do something async...
       return doSomethingAsync()
         .then(() => {
           console.log("Done with async work...");


### PR DESCRIPTION
* Update the docs to use the new Tapable API
* Add the “Under the hood” section
* Remove the “Hook types” section and link to the Tapable docs instead (depends on https://github.com/webpack/tapable/pull/63)
* Put sections talking about compiler and compilation next to each other
* Do some minor tuning

Depends on https://github.com/webpack/tapable/pull/63.


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
