### PR TITLE
Update API documentation about hooks

### DIFF
--- a/src/content/api/compilation-hooks.md
+++ b/src/content/api/compilation-hooks.md
@@ -526,7 +526,7 @@ Parameters: `chunks`
 Here's an example plugin from [@boopathi](https://github.com/boopathi) that outputs exactly what went into each chunk.
 
 ``` js
-compilation.hooks.afterOptimizeChunkAssets.tap(chunks => {
+compilation.hooks.afterOptimizeChunkAssets.tap('MyPlugin', chunks => {
   chunks.forEach(chunk => {
     console.log({
       id: chunk.id,

--- a/src/content/api/parser.md
+++ b/src/content/api/parser.md
@@ -13,8 +13,8 @@ The `parser` is found within [module factories](/api/compiler-hooks/#normalmodul
 more work to access:
 
 ``` js
-compiler.hooks.normalModuleFactory.tap(factory => {
-  factory.hooks.parser.tap((parser, options) => {
+compiler.hooks.normalModuleFactory.tap('MyPlugin', factory => {
+  factory.hooks.parser.tap('MyPlugin', (parser, options) => {
     parser.hooks.someHook.tap(...)
   })
 })

--- a/src/content/api/plugins.md
+++ b/src/content/api/plugins.md
@@ -68,6 +68,11 @@ compiler.hooks.run.tapPromise('MyPlugin', compiler => {
     console.log('Asynchronously tapping the run hook with a delay.')
   })
 })
+
+compiler.hooks.run.tapPromise('MyPlugin', async compiler => {
+  await new Promise(resolve => setTimeout(resolve, 1000))
+  console.log('Asynchronously tapping the run hook with a delay.')
+})
 ```
 
 The moral of the story is that there are a variety of ways to `hook` into the


### PR DESCRIPTION
- `tapName` was missing in several code examples
- add an example using `async`/`await`