### PR TITLE
gitignore: add yarn-error.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ starter-kits-data.json
 .vscode
 .idea
 .DS_Store
+yarn-error.log


### PR DESCRIPTION
Since we're using `yarn`, add `yarn-error.log` file to `.gitignore`. 