### PR TITLE
Update TypeScript configuration for Webpack config

### DIFF
--- a/src/content/configuration/configuration-languages.md
+++ b/src/content/configuration/configuration-languages.md
@@ -67,7 +67,8 @@ __tsconfig-for-webpack-config.json__
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es5"
+    "target": "es5",
+    "esModuleInterop": true
   }
 }
 ```


### PR DESCRIPTION
This changes the content of sample `tsconfig-for-webpack-config.json` configuration file to include
settings for  '--allowSyntheticDefaultImports' for better typesystem compatibility
fixing issues like:
` error TS1192: Module '"path"' has no default export.`

Thanks!

Full output of error fixed by configuration update:
```bash
/Users/piotrblazejewicz/git/angularjs-typescript-webpack/node_modules/ts-node/src/index.ts:250
    return new TSError(diagnosticText, diagnosticCodes)
           ^
TSError: ⨯ Unable to compile TypeScript:
webpack.config.ts(1,8): error TS1192: Module '"path"' has no default export.
webpack.config.ts(2,8): error TS1192: Module '"/Users/piotrblazejewicz/git/angularjs-typescript-webpack/node_modules/@types/webpack/index"' has no default export.
```