### PR TITLE
Fix import in typescript files

### DIFF
--- a/src/content/configuration/configuration-languages.md
+++ b/src/content/configuration/configuration-languages.md
@@ -27,8 +27,8 @@ and then proceed to write your configuration:
 __webpack.config.ts__
 
 ```typescript
-import path from 'path';
-import webpack from 'webpack';
+import * as path from 'path';
+import * as webpack from 'webpack';
 
 const config: webpack.Configuration = {
   mode: 'production',


### PR DESCRIPTION
Since there is no default export in path and webpack definitions, we need to import modules this way.
