### PR TITLE
Update mode.md

### DIFF
--- a/src/content/concepts/mode.md
+++ b/src/content/concepts/mode.md
@@ -90,13 +90,13 @@ var config = {
   //...
 };
 
-module.exports = (env, argv) => {
+module.exports = env => {
 
-  if (argv.mode === 'development') {
+  if (env.mode === 'development') {
     config.devtool = 'source-map';
   }
 
-  if (argv.mode === 'production') {
+  if (env.mode === 'production') {
     //...
   }
 


### PR DESCRIPTION
Update `mode` docs to be in line with current `module.exports` function signature.

At least for me a 4.8.3 → 4.12.0 upgrade removed the second parameter, so I'm guessing this should be reflected in the docs?