### PR TITLE
Add GitHub token to GitHub API calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,7 @@ sudo: required
 install:
   - yarn
   - sudo pip install proselint
+before_script:
+  - source ./src/scripts/env.sh
 script:
   - bash ./src/scripts/deploy.sh

--- a/src/scripts/env.sh
+++ b/src/scripts/env.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e # Exit with nonzero exit code if anything fails
+
+export GITHUB_TOKEN=$GITHUB_TOKEN
+

--- a/src/scripts/fetch.sh
+++ b/src/scripts/fetch.sh
@@ -8,14 +8,17 @@ mkdir -p ./generated/plugins
 cp -rf ./src/content/plugins/ ./generated/plugins
 
 # Fetch webpack-contrib (and various other) loader repositories
-node ./src/scripts/fetch_package_names.js "webpack-contrib" "-loader"
+node ./src/scripts/fetch_package_names.js "webpack-contrib" "-loader" | node ./src/scripts/fetch_package_files.js "README.md" "./generated/loaders"
+node ./src/scripts/fetch_package_names.js "babel" "babel-loader" | node ./src/scripts/fetch_package_files.js "README.md" "./generated/loaders"
+node ./src/scripts/fetch_package_names.js "postcss" "postcss-loader" | node ./src/scripts/fetch_package_files.js "README.md" "./generated/loaders"
+node ./src/scripts/fetch_package_names.js "peerigon" "extract-loader" | node ./src/scripts/fetch_package_files.js "README.md" "./generated/loaders"
 
 # Fetch webpack-contrib (and various other) plugin repositories
-# node ./src/scripts/fetch_package_names.js "webpack-contrib" "-webpack-plugin" | node ./src/scripts/fetch_package_files.js "README.md" "./generated/plugins"
-# node ./src/scripts/fetch_package_names.js "webpack-contrib" "-extract-plugin" | node ./src/scripts/fetch_package_files.js "README.md" "./generated/plugins"
+node ./src/scripts/fetch_package_names.js "webpack-contrib" "-webpack-plugin" | node ./src/scripts/fetch_package_files.js "README.md" "./generated/plugins"
+node ./src/scripts/fetch_package_names.js "webpack-contrib" "-extract-plugin" | node ./src/scripts/fetch_package_files.js "README.md" "./generated/plugins"
 
 # Remove deprecated or archived plugins repositories
-# rm ./generated/plugins/component-webpack-plugin.json ./generated/plugins/component-webpack-plugin.md
+rm ./generated/plugins/component-webpack-plugin.json ./generated/plugins/component-webpack-plugin.md
 
 # Fetch sponsors and backers from opencollective
 node ./src/scripts/fetch_supporters.js

--- a/src/scripts/fetch.sh
+++ b/src/scripts/fetch.sh
@@ -7,20 +7,17 @@ cp -rf ./src/content/loaders/ ./generated/loaders
 mkdir -p ./generated/plugins
 cp -rf ./src/content/plugins/ ./generated/plugins
 
-export GITHUB_TOKEN = $GITHUB_TOKEN
+source $(dirname $0)/env.sh
 
 # Fetch webpack-contrib (and various other) loader repositories
-node ./src/scripts/fetch_package_names.js "webpack-contrib" "-loader" | node ./src/scripts/fetch_package_files.js "README.md" "./generated/loaders"
-node ./src/scripts/fetch_package_names.js "babel" "babel-loader" | node ./src/scripts/fetch_package_files.js "README.md" "./generated/loaders"
-node ./src/scripts/fetch_package_names.js "postcss" "postcss-loader" | node ./src/scripts/fetch_package_files.js "README.md" "./generated/loaders"
-node ./src/scripts/fetch_package_names.js "peerigon" "extract-loader" | node ./src/scripts/fetch_package_files.js "README.md" "./generated/loaders"
+node ./src/scripts/fetch_package_names.js "webpack-contrib" "-loader"
 
 # Fetch webpack-contrib (and various other) plugin repositories
-node ./src/scripts/fetch_package_names.js "webpack-contrib" "-webpack-plugin" | node ./src/scripts/fetch_package_files.js "README.md" "./generated/plugins"
-node ./src/scripts/fetch_package_names.js "webpack-contrib" "-extract-plugin" | node ./src/scripts/fetch_package_files.js "README.md" "./generated/plugins"
+# node ./src/scripts/fetch_package_names.js "webpack-contrib" "-webpack-plugin" | node ./src/scripts/fetch_package_files.js "README.md" "./generated/plugins"
+# node ./src/scripts/fetch_package_names.js "webpack-contrib" "-extract-plugin" | node ./src/scripts/fetch_package_files.js "README.md" "./generated/plugins"
 
 # Remove deprecated or archived plugins repositories
-rm ./generated/plugins/component-webpack-plugin.json ./generated/plugins/component-webpack-plugin.md
+# rm ./generated/plugins/component-webpack-plugin.json ./generated/plugins/component-webpack-plugin.md
 
 # Fetch sponsors and backers from opencollective
 node ./src/scripts/fetch_supporters.js

--- a/src/scripts/fetch.sh
+++ b/src/scripts/fetch.sh
@@ -7,8 +7,6 @@ cp -rf ./src/content/loaders/ ./generated/loaders
 mkdir -p ./generated/plugins
 cp -rf ./src/content/plugins/ ./generated/plugins
 
-source $(dirname $0)/env.sh
-
 # Fetch webpack-contrib (and various other) loader repositories
 node ./src/scripts/fetch_package_names.js "webpack-contrib" "-loader"
 

--- a/src/scripts/fetch.sh
+++ b/src/scripts/fetch.sh
@@ -7,6 +7,8 @@ cp -rf ./src/content/loaders/ ./generated/loaders
 mkdir -p ./generated/plugins
 cp -rf ./src/content/plugins/ ./generated/plugins
 
+export GITHUB_TOKEN = $GITHUB_TOKEN
+
 # Fetch webpack-contrib (and various other) loader repositories
 node ./src/scripts/fetch_package_names.js "webpack-contrib" "-loader" | node ./src/scripts/fetch_package_files.js "README.md" "./generated/loaders"
 node ./src/scripts/fetch_package_names.js "babel" "babel-loader" | node ./src/scripts/fetch_package_files.js "README.md" "./generated/loaders"

--- a/src/scripts/fetch_package_names.js
+++ b/src/scripts/fetch_package_names.js
@@ -36,8 +36,8 @@ function fetchPackageNames(options, cb) {
   console.log("fetchPackageNames");
   const github = new GitHubApi();
 
-  console.log(process.env);
-  console.log(process.env.GITHUB_TOKEN);
+  console.log("processEnv", process.env);
+  console.log("GH token", process.env.GITHUB_TOKEN);
 
   if(process.env.GITHUB_TOKEN) {
     github.authenticate({

--- a/src/scripts/fetch_package_names.js
+++ b/src/scripts/fetch_package_names.js
@@ -33,11 +33,7 @@ function main() {
 }
 
 function fetchPackageNames(options, cb) {
-  console.log("fetchPackageNames");
   const github = new GitHubApi();
-
-  console.log("processEnv", process.env);
-  console.log("GH token", process.env.GITHUB_TOKEN);
 
   if(process.env.GITHUB_TOKEN) {
     github.authenticate({
@@ -45,6 +41,10 @@ function fetchPackageNames(options, cb) {
       token: process.env.GITHUB_TOKEN
     });
   }
+
+  github.misc.getRateLimit({}, (err, data) => {
+    console.log(JSON.stringify(data, null, 4))
+  })
 
   // XXX: weak since this handles only one page
   github.repos.getForOrg({

--- a/src/scripts/fetch_package_names.js
+++ b/src/scripts/fetch_package_names.js
@@ -43,8 +43,8 @@ function fetchPackageNames(options, cb) {
   }
 
   github.misc.getRateLimit({}, (err, data) => {
-    console.log(JSON.stringify(data, null, 4))
-  })
+    console.log(JSON.stringify(data, null, 4));
+  });
 
   // XXX: weak since this handles only one page
   github.repos.getForOrg({

--- a/src/scripts/fetch_package_names.js
+++ b/src/scripts/fetch_package_names.js
@@ -33,7 +33,11 @@ function main() {
 }
 
 function fetchPackageNames(options, cb) {
+  console.log("fetchPackageNames")
   const github = new GitHubApi();
+
+  console.log(process.env)
+  console.log(process.env.GITHUB_TOKEN)
 
   if(process.env.GITHUB_TOKEN) {
     github.authenticate({

--- a/src/scripts/fetch_package_names.js
+++ b/src/scripts/fetch_package_names.js
@@ -33,11 +33,11 @@ function main() {
 }
 
 function fetchPackageNames(options, cb) {
-  console.log("fetchPackageNames")
+  console.log("fetchPackageNames");
   const github = new GitHubApi();
 
-  console.log(process.env)
-  console.log(process.env.GITHUB_TOKEN)
+  console.log(process.env);
+  console.log(process.env.GITHUB_TOKEN);
 
   if(process.env.GITHUB_TOKEN) {
     github.authenticate({

--- a/src/scripts/fetch_package_names.js
+++ b/src/scripts/fetch_package_names.js
@@ -43,13 +43,6 @@ function fetchPackageNames(options, cb) {
       type: 'token',
       token: process.env.GITHUB_TOKEN
     });
-
-    github.misc.getRateLimit({}, (err, data) => {
-      if (err) {
-        console.log(JSON.stringify(err, null, 4));
-      }
-      console.log(JSON.stringify(data, null, 4));
-    });
   }
 
   // XXX: weak since this handles only one page

--- a/src/scripts/fetch_package_names.js
+++ b/src/scripts/fetch_package_names.js
@@ -1,62 +1,74 @@
 #!/usr/bin/env node
 // ./fetch_package_names <suffix> > output
 // ./fetch_package_names "-loader" > output.json
-const GitHubApi = require("github");
+const GitHubApi = require('github');
 
 if (require.main === module) {
-    main();
+  main();
 } else {
-    module.exports = fetchPackageNames;
+  module.exports = fetchPackageNames;
 }
 
 function main() {
   const organization = process.argv[2];
   const suffix = process.argv[3];
 
-  if(!organization) {
+  if (!organization) {
     return console.error('Missing organization!');
   }
-  if(!suffix) {
+  if (!suffix) {
     return console.error('Missing suffix!');
   }
 
-  fetchPackageNames({
-    organization: organization,
-    suffix: suffix
-  }, function(err, d) {
-    if (err) {
-      return console.error(err);
-    }
+  fetchPackageNames(
+    {
+      organization: organization,
+      suffix: suffix
+    },
+    function(err, d) {
+      if (err) {
+        return console.error(err);
+      }
 
-    console.log(JSON.stringify(d, null, 4));
-  });
+      console.log(JSON.stringify(d, null, 4));
+    }
+  );
 }
 
 function fetchPackageNames(options, cb) {
   const github = new GitHubApi();
 
-  if(process.env.GITHUB_TOKEN) {
+  if (process.env.GITHUB_TOKEN) {
     github.authenticate({
       type: 'token',
       token: process.env.GITHUB_TOKEN
     });
+
+    github.misc.getRateLimit({}, (err, data) => {
+      if (err) {
+        console.log(JSON.stringify(err, null, 4));
+      }
+      console.log(JSON.stringify(data, null, 4));
+    });
   }
 
-  github.misc.getRateLimit({}, (err, data) => {
-    console.log(JSON.stringify(data, null, 4));
-  });
-
   // XXX: weak since this handles only one page
-  github.repos.getForOrg({
-    org: options.organization,
-    per_page: 100
-  }, function (err, d) {
-    if (err) {
-      return cb(err);
-    }
+  github.repos.getForOrg(
+    {
+      org: options.organization,
+      per_page: 100
+    },
+    function(err, d) {
+      if (err) {
+        return cb(err);
+      }
 
-    return cb(null, d.data.filter(function(o) {
-      return o.name.endsWith(options.suffix);
-    }));
-  });
+      return cb(
+        null,
+        d.data.filter(function(o) {
+          return o.name.endsWith(options.suffix);
+        })
+      );
+    }
+  );
 }


### PR DESCRIPTION
Follow up of https://github.com/webpack/webpack.js.org/pull/1963 that actually works.
Travis scripts runs in a child process which doesn't inherit environment variables, so you have to re export them.

See https://travis-ci.org/webpack/webpack.js.org/builds/392673634?utm_source=github_status&utm_medium=notification for logs regarding rate limits, it says 5000 instead of 60. I hope this will solve our constant failed builds.