### PR TITLE
Fix typo in print.js diff

### DIFF
--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -152,7 +152,7 @@ __src/print.js__
 
 ``` diff
   export default function printMe() {
--   cosnole.log('I get called from print.js!');
+-   console.log('I get called from print.js!');
 +   console.log('I get called from print.js!');
   }
 ```


### PR DESCRIPTION
Fixed typo for console command in the diff snippet for the documentation on the dev server