### PR TITLE
Add chunkGroups option to stats config docs

### DIFF
--- a/src/content/configuration/stats.md
+++ b/src/content/configuration/stats.md
@@ -69,6 +69,9 @@ module.exports = {
 
     // Add chunk information (setting this to `false` allows for a less verbose output)
     chunks: true,
+    
+    // Add namedChunkGroups information
+    chunkGroups: true,
 
     // Add built modules information to chunk information
     chunkModules: true,


### PR DESCRIPTION
This option is picked up here:

  https://github.com/webpack/webpack/blob/4de3ce05/lib/Stats.js#L145-L148

And used here:

  https://github.com/webpack/webpack/blob/4de3ce05/lib/Stats.js#L474-L476

This controls the addition of `namedChunkGroups` in the stats output.