### PR TITLE
Fix Sidebar order alphabetically

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "scripts": {
     "clean": "rimraf ./dist src/content/**/_*.md src/**/_*.json",
-    "prestart": "npm run clean",
     "start": "NODE_ENV=development webpack-dev-server --config webpack.dev.js --env.dev",
     "content": "node src/scripts/build-content-tree.js ./src/content ./src/_content.json",
     "fetch": "sh src/scripts/fetch.sh",

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -29,7 +29,7 @@ export default ({
           group = page.group;
 
           return (
-            <div key={`sidebar-item-${index}`}>
+            <React.Fragment key={`sidebar-item-${index}`}>
               {displayGroup ? <h4 className="sidebar__group">{group}</h4> : null}
 
               <SidebarItem
@@ -39,7 +39,7 @@ export default ({
                 anchors={page.anchors}
                 currentPage={currentPage}
               />
-            </div>
+            </React.Fragment>
           );
         })}
       </div>

--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -32,7 +32,7 @@ import Content from '../../_content.json';
 class Site extends React.Component {
   state = {
     mobileSidebarOpen: false
-  }
+  };
 
   render() {
     let { location } = this.props;
@@ -43,77 +43,67 @@ class Site extends React.Component {
 
     return (
       <div className="site">
-        <DocumentTitle title={ getPageTitle(Content, location.pathname) } />
+        <DocumentTitle title={getPageTitle(Content, location.pathname)} />
         <NotificationBar />
         <Navigation
-          pathname={ location.pathname }
-          toggleSidebar={ this._toggleSidebar }
+          pathname={location.pathname}
+          toggleSidebar={this._toggleSidebar}
           links={[
             {
               content: 'Documentation',
               url: '/concepts',
               isActive: url => /^\/(api|concepts|configuration|guides|loaders|plugins)/.test(url),
-              children: this._strip(
-                sections.filter(item => item.name !== 'contribute')
-              )
+              children: this._strip(sections.filter(item => item.name !== 'contribute'))
             },
             { content: 'Contribute', url: '/contribute' },
             { content: 'Vote', url: '/vote' },
             { content: 'Blog', url: 'https://medium.com/webpack' }
-          ]} />
+          ]}
+        />
 
-        { isClient ? (
-          <SidebarMobile
-            open={ mobileSidebarOpen }
-            sections={ this._strip(Content.children) } />
-        ) : null }
+        {isClient ? <SidebarMobile open={mobileSidebarOpen} sections={this._strip(Content.children)} /> : null}
 
-          <Switch>
-            <Route
-              path="/"
-              exact
-              component={ Splash } />
-            <Route
-              render={ props => (
-                <Container className="site__content">
-                  <Switch>
-                    { pages.map(page => (
-                      <Route
-                        key={ page.url }
-                        exact={ true }
-                        path={ page.url }
-                        render={ props => {
-                          let path = page.path.replace('src/content/', '');
-                          let content = this.props.import(path);
-
-                          return (
-                            <React.Fragment>
-                              <Sponsors />
-                              <Sidebar
-                                className="site__sidebar"
-                                currentPage={ location.pathname }
-                                pages={ this._strip(section ? section.children : Content.children.filter(item => (
-                                  item.type !== 'directory' &&
-                                  item.url !== '/'
-                                ))) } />
-                              <Page
-                                { ...page }
-                                content={ content } />
-                              <Gitter />
-                            </React.Fragment>
-                          );
-                        }} />
-                    ))}
+        <Switch>
+          <Route path="/" exact component={Splash} />
+          <Route
+            render={props => (
+              <Container className="site__content">
+                <Switch>
+                  {pages.map(page => (
                     <Route
-                      path="/vote"
-                      component={ Vote } />
-                    <Route render={ props => (
-                      '404 Not Found'
-                    )} />
-                  </Switch>
-                </Container>
-              )} />
-          </Switch>
+                      key={page.url}
+                      exact={true}
+                      path={page.url}
+                      render={props => {
+                        let path = page.path.replace('src/content/', '');
+                        let content = this.props.import(path);
+
+                        return (
+                          <React.Fragment>
+                            <Sponsors />
+                            <Sidebar
+                              className="site__sidebar"
+                              currentPage={location.pathname}
+                              pages={this._strip(
+                                section
+                                  ? section.children
+                                  : Content.children.filter(item => item.type !== 'directory' && item.url !== '/')
+                              )}
+                            />
+                            <Page {...page} content={content} />
+                            <Gitter />
+                          </React.Fragment>
+                        );
+                      }}
+                    />
+                  ))}
+                  <Route path="/vote" component={Vote} />
+                  <Route render={props => '404 Not Found'} />
+                </Switch>
+              </Container>
+            )}
+          />
+        </Switch>
         <Footer />
       </div>
     );
@@ -128,7 +118,7 @@ class Site extends React.Component {
     this.setState({
       mobileSidebarOpen: open
     });
-  }
+  };
 
   /**
    * Strip any non-applicable properties
@@ -137,6 +127,14 @@ class Site extends React.Component {
    * @return {array}       - ...
    */
   _strip = array => {
+    let anchorTitleIndex = array.findIndex(item => item.name === 'index.md');
+
+    if (anchorTitleIndex !== -1) {
+      array.unshift(array[anchorTitleIndex]);
+
+      array.splice(anchorTitleIndex + 1, 1);
+    }
+
     return array.map(({ title, name, url, group, sort, anchors, children }) => ({
       title: title || name,
       content: title || name,
@@ -146,7 +144,7 @@ class Site extends React.Component {
       anchors,
       children: children ? this._strip(children) : []
     }));
-  }
+  };
 }
 
 export default Hot(module)(Site);

--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -127,7 +127,7 @@ class Site extends React.Component {
    * @return {array}       - ...
    */
   _strip = array => {
-    let anchorTitleIndex = array.findIndex(item => item.name === 'index.md');
+    let anchorTitleIndex = array.findIndex(item => item.name.toLowerCase() === 'index.md');
 
     if (anchorTitleIndex !== -1) {
       array.unshift(array[anchorTitleIndex]);

--- a/src/utilities/content-tree-enhancers.js
+++ b/src/utilities/content-tree-enhancers.js
@@ -34,7 +34,7 @@ const enhance = (tree, options) => {
     remark()
       .use(slug)
       .use(extractAnchors, { anchors })
-      .process(content, (err) => {
+      .process(content, err => {
         if (err) {
           throw err;
         }
@@ -46,7 +46,7 @@ const enhance = (tree, options) => {
   }
 };
 
-const filter = (item) => true;
+const filter = item => true;
 
 const sort = (a, b) => {
   let group1 = (a.group || '').toLowerCase();
@@ -56,20 +56,25 @@ const sort = (a, b) => {
   if (group1 > group2) return 1;
   if (a.sort && b.sort) return a.sort - b.sort;
 
-  else return 0;
+  let aTitle = (a.title || '').toLowerCase();
+  let bTitle = (b.title || '').toLowerCase();
+  if (aTitle < bTitle) return -1;
+  if (aTitle > bTitle) return 1;
+
+  return 0;
 };
 
 function restructure(item, options) {
-    enhance(item, options);
+  enhance(item, options);
 
-   if (item.children) {
-     item.children.forEach(child => restructure(child, options));
+  if (item.children) {
+    item.children.forEach(child => restructure(child, options));
 
-     item.children.filter(filter);
-     item.children.sort(sort);
-   }
+    item.children.filter(filter);
+    item.children.sort(sort);
+  }
 
-   return item;
+  return item;
 }
 
 module.exports = {


### PR DESCRIPTION
Pages sidebar order was incorrect in all pages, this PR fixes it.

We are using `directory-tree` to get a JS Object representation of our content, at this moment it returns `index.md` files as any other page, but we have to use it as our main anchor in the sidebar.

I tried to change how `sort` function works on  `content-tree-enhancers.js`, without success, as last resort I manually moved the item to the beginning of the array. It works but it is a hack.

We should think in a better structure for our content, or at least create a different representation between system files and site content structure and navigation (sidebar).