### PR TITLE
Fix the order of loaders

### DIFF
--- a/src/content/configuration/module.md
+++ b/src/content/configuration/module.md
@@ -98,7 +98,7 @@ Specifies the category of the loader. No value means normal loader.
 
 There is also an additional category "inlined loader" which are loaders applied inline of the import/require.
 
-All loaders are sorted in the order `pre, inline, normal, post` and used in this order.
+All loaders are sorted in the order `pre, normal, inline, post` and used in this order.
 
 All normal loaders can be omitted (overridden) by prefixing `!` in the request.
 


### PR DESCRIPTION
The actual behavior is that "inline" loaders are invoked after "normal"

fixes https://github.com/webpack/webpack/issues/7576
