### PR TITLE
docs(api): fix cli example

### DIFF
--- a/src/content/api/cli.md
+++ b/src/content/api/cli.md
@@ -67,7 +67,7 @@ If your project structure is as follows -
 ```
 
 ```bash
-webpack src/index.js dist/bundle.js
+webpack ./src/index.js dist/bundle.js
 ```
 
 This will bundle your source code with entry as `index.js` and the output bundle file will have a path of `dist` and the filename will be `bundle.js`


### PR DESCRIPTION
`entry` should begin with `./`, or we'll get error:

> Entry module not found: Error: Can't resolve 'src/index.js' in ...

Because webpack will try to resolve it from `node_modules` directory.