### PR TITLE
Added explanation for splitChunks.minSize

### DIFF
--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -136,7 +136,7 @@ Minimum number of chunks that must share a module before splitting.
 
 `number`
 
-Minimum size for a chunk to be generated.
+Minimum size, in bytes, for a chunk to be generated.
 
 ### `splitChunks.name`
 


### PR DESCRIPTION
First of all, I wanted to congratulate everyone on the great job of maintaining docs! Really useful.

For the splitChunks page, it took me a while to figure out what does the size represent (unit of measurement). I didn't find any reference on it, but hopefully I got this right since the rules are based on 30kb and the default value is 30000.

Cheers!
Alex