### PR TITLE
Updated invalid devServer.proxy example code

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -827,10 +827,10 @@ module.exports = {
     index: '', // specify to enable root proxying
     host: '...',
     contentBase: '...',
-    proxy: {
+    proxy: [{
       context: () => true,
       target: 'http://localhost:1234'
-    }
+    }]
   }
 };
 ```


### PR DESCRIPTION
It seems the last proxy example omitted the array format used in the example before it. Initial example did not work with webpack 4.13.0 and webpack-dev-server 3.1.4. The updated version worked fine.
