### PR TITLE
(NotificationBar) Removed link to unixstickers

### DIFF
--- a/src/components/NotificationBar/NotificationBar.jsx
+++ b/src/components/NotificationBar/NotificationBar.jsx
@@ -13,8 +13,8 @@ export default class NotificationBar extends React.Component {
       <div className={ `notification-bar ${dismissedMod}` }>
         <Container className="notification-bar__inner">
           <p>
-            Sponsor webpack and get apparel from the <a href="https://webpack.threadless.com">official shop</a>{' '}
-            or get stickers <a href="http://www.unixstickers.com/tag/webpack">here</a>! All proceeds go to our{' '}
+            Sponsor webpack and get apparel from the <a href="https://webpack.threadless.com">official shop</a>!{' '}
+            All proceeds go to our{' '}
             <a href="https://opencollective.com/webpack">open collective</a>!
           </p>
           { localStorageIsEnabled ?


### PR DESCRIPTION
Removed link to unixstrickers, since it's not possible to buy webpack stickers anymore after they changed to only selling sticker packs.