### PR TITLE
Fix a broken markdown link in node.md

### DIFF
--- a/src/content/api/node.md
+++ b/src/content/api/node.md
@@ -73,8 +73,8 @@ lifecycle running. It delegates all the loading, bundling, and writing work to
 registered plugins.
 
 The `hooks` property on a `Compiler` instance is used to register a plugin to
-any hook event in the `Compiler`'s lifecycle. The [`WebpackOptionsDefaulter`]
-(https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsDefaulter.js)
+any hook event in the `Compiler`'s lifecycle. The 
+[`WebpackOptionsDefaulter`](https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsDefaulter.js)
 and [`WebpackOptionsApply`](https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsApply.js)
 utilities are used by webpack to configure its `Compiler` instance with all the
 built-in plugins.


### PR DESCRIPTION
Not the biggest PR, but I like to help out where I can :)

It looked like the link for `WebpackOptionsDefaulter` was chopped in half to keep to a line length of 80, but markdown doesn't preserve links across new lines. I couldn't find a line length policy on the website or this repo, but since the line below it goes to 102 characters, I'm assuming you're willing to make an exception for links.  This brings line 77 up to 106 characters, but it's still safely below 120.
