### PR TITLE
Remove 404 link for NamedModulesPlugin

### DIFF
--- a/src/content/guides/caching.md
+++ b/src/content/guides/caching.md
@@ -282,7 +282,7 @@ manifest.1400d5af64fc1b7b3a45.js    5.85 kB       2  [emitted]         manifest
 - The `vendor` bundle changed because its `module.id` was changed.
 - And, the `manifest` bundle changed because it now contains a reference to a new module.
 
-The first and last are expected -- it's the `vendor` hash we want to fix. Luckily, there are two plugins we can use to resolve this issue. The first is the [`NamedModulesPlugin`](/plugins/named-modules-plugin), which will use the path to the module rather than a numerical identifier. While this plugin is useful during development for more readable output, it does take a bit longer to run. The second option is the [`HashedModuleIdsPlugin`](/plugins/hashed-module-ids-plugin), which is recommended for production builds:
+The first and last are expected -- it's the `vendor` hash we want to fix. Luckily, there are two plugins we can use to resolve this issue. The first is the `NamedModulesPlugin`, which will use the path to the module rather than a numerical identifier. While this plugin is useful during development for more readable output, it does take a bit longer to run. The second option is the [`HashedModuleIdsPlugin`](/plugins/hashed-module-ids-plugin), which is recommended for production builds:
 
 __webpack.config.js__
 


### PR DESCRIPTION
I don't see any valid link for `NamedModulesPlugin`, so I removed it at all.