### PR TITLE
docs(api) rename parser page into JavascriptParser

### DIFF
--- a/src/content/api/parser.md
+++ b/src/content/api/parser.md
@@ -1,9 +1,10 @@
 ---
-title: Parser
+title: JavascriptParser
 group: Plugins
 sort: 4
 contributors:
   - byzyk
+  - EugeneHlushko
 ---
 
 The `parser` instance, found in the `compiler`, is used to parse each module


### PR DESCRIPTION
* Rename `Parser` page into `JavascriptParser` 
* Fixes #2332 

P.S. i did not change the URL intentionally, it is not clear if we are getting any new parsers just yet.