### PR TITLE
docs(plugins) Relate SourceMapPlugins to default devtool config.

### DIFF
--- a/src/content/concepts/mode.md
+++ b/src/content/concepts/mode.md
@@ -49,6 +49,7 @@ T> Please remember that setting `NODE_ENV` doesn't automatically set `mode`.
 // webpack.development.config.js
 module.exports = {
 + mode: 'development'
+- devtool: 'eval',
 - plugins: [
 -   new webpack.NamedModulesPlugin(),
 -   new webpack.NamedChunksPlugin(),

--- a/src/content/plugins/eval-source-map-dev-tool-plugin.md
+++ b/src/content/plugins/eval-source-map-dev-tool-plugin.md
@@ -35,6 +35,8 @@ The following options are supported:
 
 T> Setting `module` and/or `columns` to `false` will yield less accurate source maps but will also improve compilation performance significantly.
 
+T> When using this plugin in [development mode](/concepts/mode/#mode-development), you must manually set `devTools: false`.
+
 
 ## Examples
 

--- a/src/content/plugins/source-map-dev-tool-plugin.md
+++ b/src/content/plugins/source-map-dev-tool-plugin.md
@@ -41,6 +41,8 @@ The `fileContext` option is useful when you want to store source maps in an uppe
 
 T> Setting `module` and/or `columns` to `false` will yield less accurate source maps but will also improve compilation performance significantly.
 
+T> When using this plugin in [development mode](/concepts/mode/#mode-development), you must manually set `devTools: false`.
+
 W> Remember that when using the [`UglifyJSPlugin`](/plugins/uglifyjs-webpack-plugin), you must utilize the `sourceMap` option.
 
 ## Examples


### PR DESCRIPTION
In development mode `devtool: eval` [is added automatically](https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsDefaulter.js#L39) to the Webpack config. In particular it must be manually deactivated if one wants to use `SourceMapDevToolPlugin` or `EvalSourceMapDevToolPlugin`.

This PR documents this behavior, both when describing development mode, and - more importantly to me - when describing how to use the two relevant plugins.