### PR TITLE
guide example config - add missing require('path')

### DIFF
--- a/src/content/guides/environment-variables.md
+++ b/src/content/guides/environment-variables.md
@@ -27,6 +27,8 @@ There is one change that you will have to make to your webpack config. Typically
 __webpack.config.js__
 
 ``` js
+const path = require('path');
+
 module.exports = env => {
   // Use env.<YOUR VARIABLE> here:
   console.log('NODE_ENV: ', env.NODE_ENV); // 'local'


### PR DESCRIPTION
environment-variables.md - added missing `require('path')`

config was not usable as given without this line.