### PR TITLE
docs(nodejs) Add information about nodejs version support

### DIFF
--- a/src/content/concepts/index.md
+++ b/src/content/concepts/index.md
@@ -166,3 +166,8 @@ Learn more about the [mode configuration here](/concepts/mode) and what optimiza
 ## Browser Compatibility
 
 webpack supports all browsers that are [ES5-compliant](https://kangax.github.io/compat-table/es5/) (IE8 and below are not supported). webpack needs `Promise` for `import()` and `require.ensure()`. If you want to support older browsers, you will need to [load a polyfill](/guides/shimming/) before using these expressions.
+
+
+## Environment
+
+webpack runs on Node.js version 8.x and higher.


### PR DESCRIPTION
Mention Node.js versions on which webpack can run.

Fixes #2305 