### PR TITLE
Fix typo in Under-the-Hood example

### DIFF
--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -197,7 +197,7 @@ class SomeWebpackInternalClass {
 
   someMethod() {
     // Call a hook:
-    this.hooks.run.call();
+    this.hooks.compilation.call();
 
     // Call another hook:
     // (This is an async one, so webpack passes a callback into it)


### PR DESCRIPTION
I guess the first call to the hook in the example was supposed to demonstrate how a call to the SyncHook would look like. Therefore, it should reference the `this.hooks.compilation`.

Greetings,
Georg