### PR TITLE
infra(site) Avoid fetching packages in PRs

### DIFF
--- a/src/scripts/fetch.sh
+++ b/src/scripts/fetch.sh
@@ -7,21 +7,30 @@ cp -rf ./src/content/loaders/ ./generated/loaders
 mkdir -p ./generated/plugins
 cp -rf ./src/content/plugins/ ./generated/plugins
 
-# Fetch webpack-contrib (and various other) loader repositories
-node ./src/scripts/fetch_packages.js "webpack-contrib" "-loader" "README.md" "./generated/loaders"
-node ./src/scripts/fetch_packages.js "babel" "babel-loader" "README.md" "./generated/loaders"
-node ./src/scripts/fetch_packages.js "postcss" "postcss-loader" "README.md" "./generated/loaders"
-node ./src/scripts/fetch_packages.js "peerigon" "extract-loader" "README.md" "./generated/loaders"
+function fetchPackages() {
+  # Fetch webpack-contrib (and various other) loader repositories
+  node ./src/scripts/fetch_packages.js "webpack-contrib" "-loader" "README.md" "./generated/loaders"
+  node ./src/scripts/fetch_packages.js "babel" "babel-loader" "README.md" "./generated/loaders"
+  node ./src/scripts/fetch_packages.js "postcss" "postcss-loader" "README.md" "./generated/loaders"
+  node ./src/scripts/fetch_packages.js "peerigon" "extract-loader" "README.md" "./generated/loaders"
 
-# Fetch webpack-contrib (and various other) plugin repositories
-node ./src/scripts/fetch_packages.js "webpack-contrib" "-webpack-plugin" "README.md" "./generated/plugins"
-node ./src/scripts/fetch_packages.js "webpack-contrib" "-extract-plugin" "README.md" "./generated/plugins"
+  # Fetch webpack-contrib (and various other) plugin repositories
+  node ./src/scripts/fetch_packages.js "webpack-contrib" "-webpack-plugin" "README.md" "./generated/plugins"
+  node ./src/scripts/fetch_packages.js "webpack-contrib" "-extract-plugin" "README.md" "./generated/plugins"
 
-# Remove deprecated or archived plugins repositories
-rm ./generated/plugins/component-webpack-plugin.json ./generated/plugins/component-webpack-plugin.md
+  # Remove deprecated or archived plugins repositories
+  rm ./generated/plugins/component-webpack-plugin.json ./generated/plugins/component-webpack-plugin.md
 
-# Fetch sponsors and backers from opencollective
-node ./src/scripts/fetch_supporters.js
+  # Fetch sponsors and backers from opencollective
+  node ./src/scripts/fetch_supporters.js
 
-# Fetch starter kits
-node ./src/scripts/fetch_starter_kits.js
+  # Fetch starter kits
+  node ./src/scripts/fetch_starter_kits.js
+}
+
+if [ "$TRAVIS_PULL_REQUEST" = "" ]
+then
+  fetchPackages
+else
+  echo "PR running, not fetching packages."
+fi


### PR DESCRIPTION
Currently we are fetching all webpack-contrib packages information in every PR to build our docs, but we don't really need to do it since we don't check for its content, we also don't have E2E test. This is a waste of time and resources, it is also consuming our GitHub API Limit rather quickly.

This PR removed fetching packages in PRs, this will reduce broken PRs builds and also make our build run faster.
