### PR TITLE
webpack-dev-middleware options

### DIFF
--- a/src/content/configuration/stats.md
+++ b/src/content/configuration/stats.md
@@ -15,6 +15,8 @@ The `stats` option lets you precisely control what bundle information gets displ
 
 T> For webpack-dev-server, this property needs to be in the `devServer` object.
 
+T> For webpack-dev-middleware, this property needs to be in the `webpack-dev-middleware options` object.
+
 W> This option does not have any effect when using the Node.js API.
 
 ## `stats`

--- a/src/content/configuration/stats.md
+++ b/src/content/configuration/stats.md
@@ -15,7 +15,7 @@ The `stats` option lets you precisely control what bundle information gets displ
 
 T> For webpack-dev-server, this property needs to be in the `devServer` object.
 
-T> For webpack-dev-middleware, this property needs to be in the `webpack-dev-middleware options` object.
+T> For webpack-dev-middleware, this property needs to be in the webpack-dev-middleware's `options` object.
 
 W> This option does not have any effect when using the Node.js API.
 


### PR DESCRIPTION
Just added a info screen to add that the stats should be in the webpack-dev-middleware options when using webpack-dev-middleware.

