### PR TITLE
Add a warning note for common errors when specifying rules

### DIFF
--- a/src/content/concepts/index.md
+++ b/src/content/concepts/index.md
@@ -114,7 +114,7 @@ The configuration above has defined a `rules` property for a single module with 
 
 W> It is important to remember that when defining rules in your webpack config, you are defining them under `module.rules` and not `rules`. For your benefit, webpack will warn you if this is done incorrectly.
 
-W> Keep in mind that when using regex to match files, you may not qoute it. i.e `/\.txt$/` is not the same as `'/\.txt$/'`/ `"/\.txt$/"`. The former instructs webpack to match any file that ends with .txt and the later instructs webpack to match a single file with an absolute path '.txt'; this is likely not your intention. 
+W> Keep in mind that when using regex to match files, you may not quote it. i.e `/\.txt$/` is not the same as `'/\.txt$/'`/ `"/\.txt$/"`. The former instructs webpack to match any file that ends with .txt and the later instructs webpack to match a single file with an absolute path '.txt'; this is likely not your intention. 
 
 You can check further customization when including loaders in the [loaders section](/concepts/loaders).
 

--- a/src/content/concepts/index.md
+++ b/src/content/concepts/index.md
@@ -114,6 +114,8 @@ The configuration above has defined a `rules` property for a single module with 
 
 W> It is important to remember that when defining rules in your webpack config, you are defining them under `module.rules` and not `rules`. For your benefit, webpack will warn you if this is done incorrectly.
 
+W> Keep in mind that when using regex to match files, you may not qoute it. i.e `\/.txt$/` is not the same as `'\/.txt$'`/ `"/\.txt$/"`. The former instructs webpack to match any file that ends with .txt and the later instructs webpack to match a single file with an absolute path '.txt'; this is likely not your intention. 
+
 You can check further customization when including loaders in the [loaders section](/concepts/loaders).
 
 

--- a/src/content/concepts/index.md
+++ b/src/content/concepts/index.md
@@ -114,7 +114,7 @@ The configuration above has defined a `rules` property for a single module with 
 
 W> It is important to remember that when defining rules in your webpack config, you are defining them under `module.rules` and not `rules`. For your benefit, webpack will warn you if this is done incorrectly.
 
-W> Keep in mind that when using regex to match files, you may not qoute it. i.e `\/.txt$/` is not the same as `'\/.txt$'`/ `"/\.txt$/"`. The former instructs webpack to match any file that ends with .txt and the later instructs webpack to match a single file with an absolute path '.txt'; this is likely not your intention. 
+W> Keep in mind that when using regex to match files, you may not qoute it. i.e `/\.txt$/` is not the same as `'/\.txt$/'`/ `"/\.txt$/"`. The former instructs webpack to match any file that ends with .txt and the later instructs webpack to match a single file with an absolute path '.txt'; this is likely not your intention. 
 
 You can check further customization when including loaders in the [loaders section](/concepts/loaders).
 


### PR DESCRIPTION
When specifying a test in `module.rules`, webpack accepts either a regex or string. However it's easy to mistakenly qoute the regex which will cause webpack to not use the specified loader. I added this warning to help newcomers like me who might  stumbled into this situation save themselves frustrations and wasted time.

