### PR TITLE
fix(guides) Use proper JSON in author-libraries

### DIFF
--- a/src/content/guides/author-libraries.md
+++ b/src/content/guides/author-libraries.md
@@ -38,26 +38,33 @@ npm install --save-dev webpack lodash
 
 __src/ref.json__
 
-```javascript
-[{
-  'num': 1,
-  'word': 'One'
-}, {
-  'num': 2,
-  'word': 'Two'
-}, {
-  'num': 3,
-  'word': 'Three'
-}, {
-  'num': 4,
-  'word': 'Four'
-}, {
-  'num': 5,
-  'word': 'Five'
-}, {
-  'num': 0,
-  'word': 'Zero'
-}];
+```json
+[
+  {
+    "num": 1,
+    "word": "One"
+  },
+  {
+    "num": 2,
+    "word": "Two"
+  },
+  {
+    "num": 3,
+    "word": "Three"
+  },
+  {
+    "num": 4,
+    "word": "Four"
+  },
+  {
+    "num": 5,
+    "word": "Five"
+  },
+  {
+    "num": 0,
+    "word": "Zero"
+  }
+]
 ```
 
 __src/index.js__


### PR DESCRIPTION
Proper JSON syntax should not use single quotes, see http://www.json.org/.

Changes in this commit:
* Use json instead of javascript for codeblock language.
* Change single quotes to double quotes.
* Remove semicolon.
* Apply default formatting with prettier.