### PR TITLE
Update development.md

### DIFF
--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -269,6 +269,9 @@ __webpack.config.js__
       print: './src/print.js'
     },
     devtool: 'inline-source-map',
+    devServer: {
+      contentBase: './dist'
+    },
     plugins: [
       new CleanWebpackPlugin(['dist']),
       new HtmlWebpackPlugin({


### PR DESCRIPTION
The `devServer` part in `webpack.config.js` that was added in the previous section titled `Using webpack-dev-server` suddenly disappeared in this section titled titled `Using webpack-dev-middleware`.
I suggesting keeping the `devServer` part in `webpack.config.js` since the `package.json` still has `"start": "webpack-dev-server --open"` so that the decument looks more consistent.