### PR TITLE
Update output-management.md (Minor)

### DIFF
--- a/src/content/guides/output-management.md
+++ b/src/content/guides/output-management.md
@@ -194,7 +194,7 @@ In general it's good practice to clean the `/dist` folder before each build, so 
 A popular plugin to manage this is the [`clean-webpack-plugin`](https://www.npmjs.com/package/clean-webpack-plugin) so let's install and configure it.
 
 ``` bash
-npm install clean-webpack-plugin --save-dev
+npm install --save-dev clean-webpack-plugin
 ```
 
 __webpack.config.js__


### PR DESCRIPTION
I see the pattern of `npm install <option> <package_name>` being used across the guides, but this npm command has the option part at the end.
It would look more consistent if this line kept the same pattern although the result is the same.