### PR TITLE
fix(guides): update production guide, fix #2387

### DIFF
--- a/src/content/guides/production.md
+++ b/src/content/guides/production.md
@@ -184,16 +184,13 @@ __webpack.prod.js__
 T> Avoid `inline-***` and `eval-***` use in production as they can increase bundle size and reduce the overall performance.
 
 
-## Specify the Environment
+## Specify the Mode
 
-T> Since webpack v4, you no longer need to manually specify the environment if you already have [`mode`](https://webpack.js.org/concepts/mode/) set correctly.
-
-Many libraries will key off the `process.env.NODE_ENV` variable to determine what should be included in the library. For example, when not in _production_ some libraries may add additional logging and testing to make debugging easier. However, with `process.env.NODE_ENV === 'production'` they might drop or add significant portions of code to optimize how things run for your actual users. We can use webpack's built in [`DefinePlugin`](/plugins/define-plugin) to define this variable for all our dependencies:
+Many libraries will key off the `process.env.NODE_ENV` variable to determine what should be included in the library. For example, when not in _production_ some libraries may add additional logging and testing to make debugging easier. However, with `process.env.NODE_ENV === 'production'` they might drop or add significant portions of code to optimize how things run for your actual users. Since webpack v4, specifying [`mode`](/concepts/mode/) automatically configures [`DefinePlugin`](/plugins/define-plugin) for you:
 
 __webpack.prod.js__
 
 ``` diff
-+ const webpack = require('webpack');
   const merge = require('webpack-merge');
   const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
   const common = require('./webpack.common.js');
@@ -204,11 +201,7 @@ __webpack.prod.js__
     plugins: [
       new UglifyJSPlugin({
         sourceMap: true
--     })
-+     }),
-+     new webpack.DefinePlugin({
-+       'process.env.NODE_ENV': JSON.stringify('production')
-+     })
+      })
     ]
   });
 ```

--- a/src/content/guides/production.md
+++ b/src/content/guides/production.md
@@ -16,6 +16,7 @@ contributors:
   - kelset
   - xgirma
   - mehrdaad
+  - SevenOutman
 ---
 
 In this guide we'll dive into some of the best practices and utilities for building a production site or application.
@@ -184,6 +185,8 @@ T> Avoid `inline-***` and `eval-***` use in production as they can increase bund
 
 
 ## Specify the Environment
+
+T> Since webpack v4, you no longer need to manually specify the environment if you already have [`mode`](https://webpack.js.org/concepts/mode/) set correctly.
 
 Many libraries will key off the `process.env.NODE_ENV` variable to determine what should be included in the library. For example, when not in _production_ some libraries may add additional logging and testing to make debugging easier. However, with `process.env.NODE_ENV === 'production'` they might drop or add significant portions of code to optimize how things run for your actual users. We can use webpack's built in [`DefinePlugin`](/plugins/define-plugin) to define this variable for all our dependencies:
 


### PR DESCRIPTION
Add explanation to [Specify the Environment](https://webpack.js.org/guides/production/#specify-the-environment) section in production guide, which is no longer effective with webpack v4. See advice here https://github.com/webpack/webpack.js.org/issues/2387.

P.S. I think it's better adding an instruction than removing the whole section, for there're users of previous major versions. If there's a separate branch and url for v3 docs, I'll add changes and remove the whole section in master.