### PR TITLE
Fix default hashFunction for HashedModuleIdsPlugin

### DIFF
--- a/src/content/plugins/hashed-module-ids-plugin.md
+++ b/src/content/plugins/hashed-module-ids-plugin.md
@@ -18,7 +18,7 @@ new webpack.HashedModuleIdsPlugin({
 
 This plugin supports the following options:
 
-- `hashFunction`: The hashing algorithm to use, defaults to `'md5'`. All functions from Node.JS' [`crypto.createHash`](https://nodejs.org/api/crypto.html#crypto_crypto_createhash_algorithm_options) are supported.
+- `hashFunction`: The hashing algorithm to use, defaults to `'md4'`. All functions from Node.JS' [`crypto.createHash`](https://nodejs.org/api/crypto.html#crypto_crypto_createhash_algorithm_options) are supported.
 - `hashDigest`: The encoding to use when generating the hash, defaults to `'base64'`. All encodings from Node.JS' [`hash.digest`](https://nodejs.org/api/crypto.html#crypto_hash_digest_encoding) are supported.
 - `hashDigestLength`: The prefix length of the hash digest to use, defaults to `4`.
 


### PR DESCRIPTION
According to the code, the default hashFunction is md4, not md5.

https://github.com/webpack/webpack/blob/482ff200/lib/HashedModuleIdsPlugin.js#L18

