### PR TITLE
docs(api) delete needAdditionalPass of compiler-hooks

### DIFF
--- a/src/content/api/compiler-hooks.md
+++ b/src/content/api/compiler-hooks.md
@@ -191,13 +191,6 @@ Can return true/false at this point
 Parameters: `compilation`
 
 
-### `needAdditionalPass`
-
-`SyncBailHook`
-
-...
-
-
 ### `emit`
 
 `AsyncSeriesHook`


### PR DESCRIPTION
Delete needAdditionalPass of compiler-hooks,because of Compiler don't have needAdditionalPass hook.