### PR TITLE
Add caveat for using http-proxy-middleware options

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -730,7 +730,7 @@ webpack-dev-server --port 8080
 
 Proxying some URLs can be useful when you have a separate API backend development server and you want to send API requests on the same domain.
 
-The dev-server makes use of the powerful [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware) package. Checkout its [documentation](https://github.com/chimurai/http-proxy-middleware#options) for more advanced usages.
+The dev-server makes use of the powerful [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware) package. Check out its [documentation](https://github.com/chimurai/http-proxy-middleware#options) for more advanced usages. Note that some of `http-proxy-middleware`'s features do not require a `target` key, e.g. its `router` feature, but you will still need to include a `target` key in your config here, otherwise `webpack-dev-server` won't pass it along to `http-proxy-middleware`).
 
 With a backend on `localhost:3000`, you can use this to enable proxying:
 


### PR DESCRIPTION
When trying to use the `router` feature in [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware) in our `webpack-dev-server` config, I was having trouble and couldn't find any documentation as to why it hadn't worked. I ended up looking in the source code and realized that I hadn't been including a `target` key. It hadn't been clear that that was required, since the `router` function overrides the `target` key. I figured others might run into the same issue and wanted to clarify.
