### PR TITLE
Add example of nested object value support in DefinePlugin docs

### DIFF
--- a/src/content/plugins/define-plugin.md
+++ b/src/content/plugins/define-plugin.md
@@ -32,7 +32,10 @@ new webpack.DefinePlugin({
   VERSION: JSON.stringify('5fa3b9'),
   BROWSER_SUPPORTS_HTML5: true,
   TWO: '1+1',
-  'typeof window': JSON.stringify('object')
+  'typeof window': JSON.stringify('object'),
+  'process.env': {
+    NODE_ENV: JSON.stringify(process.env.NODE_ENV)
+  }
 });
 ```
 


### PR DESCRIPTION
The only example of this is under a warning towards the bottom of the document. I think adding it to the top would help bring attention to the feature.

