### PR TITLE
remove duplicate warning

### DIFF
--- a/src/content/guides/code-splitting.md
+++ b/src/content/guides/code-splitting.md
@@ -122,8 +122,6 @@ W> The CommonsChunkPlugin has been removed in webpack v4 legato. To learn how ch
 
 The [`SplitChunks`](/plugins/split-chunks-plugin/) allows us to extract common dependencies into an existing entry chunk or an entirely new chunk. Let's use this to de-duplicate the `lodash` dependency from the previous example:
 
-W> The CommonsChunkPlugin has been removed in webpack v4 legato. To learn how chunks are treated in the latest version, check out the [SplitChunksPlugin](/plugins/split-chunks-plugin/).
-
 __webpack.config.js__
 
 ``` diff


### PR DESCRIPTION
This PR remove a duplicate warning on the code-splitting page

https://webpack.js.org/guides/code-splitting/#prevent-duplication