### PR TITLE
remove array example

### DIFF
--- a/src/content/configuration/externals.md
+++ b/src/content/configuration/externals.md
@@ -66,20 +66,6 @@ The following syntaxes are accepted...
 See the example above. The property name `jquery` indicates that the module `jquery` in `import $ from 'jquery'` should be excluded. In order to replace this module, the value `jQuery` will be used to retrieve a global `jQuery` variable. In other words, when a string is provided it will be treated as `root` (defined above and below).
 
 
-### array
-
-```js
-module.exports = {
-  //...
-  externals: {
-    subtract: ['./math', 'subtract']
-  }
-};
-```
-
-`subtract: ['./math', 'subtract']` converts to a parent child construct, where `./math` is the parent module and your bundle only requires the subset under `subtract` variable.
-
-
 ### object
 
 ```js


### PR DESCRIPTION
running 4.16.5, the example with the array returned the following error (using uuid in my project):

```
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.externals should be one of these:
   string | object { <key>: string | object | boolean } | function | RegExp | [string | object { <key>: string | object | boolean } | function | RegExp | [(recursive)]]
   -> Specify dependencies that shouldn't be resolved by webpack, but should become dependencies of the resulting bundle. The kind of the dependency depends on `output.libraryTarget`.
   Details:
    * configuration.externals should be a string.
      -> An exact matched dependency becomes external. The same string is used as external dependency.
    * configuration.externals['uuid'] should be a string.
    * configuration.externals['uuid'] should be an object.
    * configuration.externals['uuid'] should be a boolean.
    * configuration.externals should be an instance of function
      -> `function(context, request, callback(err, result))` The function is called on each dependency.
    * configuration.externals should be an instance of RegExp
      -> Every matched dependency becomes external.
    * configuration.externals should be an array:
      [string | object { <key>: string | object | boolean } | function | RegExp | [(recursive)]]
``` 

i'd actually prefer to keep `array` since it's less verbose, but having docs match the API is more important
