### PR TITLE
fix(ux) Set max width to sidebar to avoid overflow text

### DIFF
--- a/src/components/Sidebar/Sidebar.scss
+++ b/src/components/Sidebar/Sidebar.scss
@@ -5,6 +5,7 @@
 .sidebar {
   display: none;
   width: 100%;
+  max-width: 280px;
   max-height: 100%;
   will-change: transform;
 


### PR DESCRIPTION
Fixes 
![image](https://user-images.githubusercontent.com/1002461/44270499-fdd07c00-a237-11e8-84d2-ab6b5b567959.png)
