### PR TITLE
docs(development): Add warning about dev server

### DIFF
--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -8,6 +8,7 @@ contributors:
   - TheDutchCoder
   - WojciechKo
   - Calinou
+  - GAumala
 ---
 
 T> This guide extends on code examples found in the [Output Management](/guides/output-management) guide.
@@ -204,6 +205,8 @@ __webpack.config.js__
 ```
 
 This tells `webpack-dev-server` to serve the files from the `dist` directory on `localhost:8080`.
+
+W> webpack-dev-server doesn't write any output files after compiling. Instead, it keeps bundle files in memory and serves them as if they were real files mounted at the server's root path. If your page expects to find the bundle files in different path, you can change this with the [`publicPath`](/configuration/dev-server/#devserver-publicpath-) option in the dev server's configuration.
 
 Let's add a script to easily run the dev server as well:
 


### PR DESCRIPTION
In the Development guide, add a warning about the dev server not writing any output files.

I was recently using webpack for a new project, and had a little trouble setting up the dev server because of some misunderstandings about how it works. If the dev server says that it compiles files, I'd expect an output to be written somewhere, just like when you run webpack from the terminal. 

However this is not the case and it left me puzzled for a while. It seems [a lot of people](https://github.com/webpack/webpack-dev-server/issues/24#issuecomment-44366325) also find this not so obvious so I decided to try help a little with this PR. Let me know what you think.
