### PR TITLE
Fixes `console.log` typo

### DIFF
--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -60,7 +60,7 @@ __src/print.js__
 ``` diff
   export default function printMe() {
 -   console.log('I get called from print.js!');
-+   cosnole.log('I get called from print.js!');
++   console.log('I get called from print.js!');
   }
 ```
 


### PR DESCRIPTION
Just fixes a simple typo in `console.log` statement