### PR TITLE
Update code-splitting.md

### DIFF
--- a/src/content/guides/code-splitting.md
+++ b/src/content/guides/code-splitting.md
@@ -265,7 +265,18 @@ Entrypoint index = index.bundle.js
     + 1 hidden module
 ```
 
-As `import()` returns a promise, it can be used with [`async` functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function). However, this requires using a pre-processor like Babel and the [Syntax Dynamic Import Babel Plugin](https://babeljs.io/docs/plugins/syntax-dynamic-import/#installation). Here's how it would simplify the code:
+As `import()` returns a promise, it can be used with [`async` functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function). However, this requires using a pre-processor like Babel and the [Syntax Dynamic Import Babel Plugin](https://babeljs.io/docs/plugins/syntax-dynamic-import/#installation). For `async await` `babel-polyfill` is required. Common usage can be found [here] https://babeljs.io/docs/en/babel-polyfill/. Or in case you are using mutiple entries. 
+
+Your webpack.config.js entry can look like: 
+
+```
+entry: {
+    app: ['babel-polyfill', './src/index.js'],
+    print: './print.js'
+}
+ ```
+
+Here's how it would simplify the code:
 
 __src/index.js__
 
@@ -292,7 +303,7 @@ __src/index.js__
     document.body.appendChild(component);
   });
 ```
-
+For more detailed setup please install refer this guide https://www.robinwieruch.de/minimal-react-webpack-babel-setup/
 
 ## Prefetching/Preloading modules
 


### PR DESCRIPTION
Docs missed the usage of `babel-polyfill` plugin required for async statements. Also added a minimal guide for setting up webpack and babel.

_describe your changes..._

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
