### PR TITLE
emove hooks that have been removed in webpack5

### DIFF
--- a/src/content/api/compilation-hooks.md
+++ b/src/content/api/compilation-hooks.md
@@ -5,6 +5,7 @@ sort: 2
 contributors:
   - byzyk
   - madhavarshney
+  - fadysamirsadek
 ---
 
 The `Compilation` module is used by the `Compiler` to create new compilations
@@ -93,29 +94,11 @@ Fired when the compilation stops accepting new modules.
 Fired when a compilation begins accepting new modules.
 
 
-### `optimizeDependenciesBasic`
-
-`SyncBailHook`
-
-...
-
-Parameters: `modules`
-
-
 ### `optimizeDependencies`
 
 `SyncBailHook`
 
 Fired at the beginning of dependency optimization.
-
-Parameters: `modules`
-
-
-### `optimizeDependenciesAdvanced`
-
-`SyncBailHook`
-
-...
 
 Parameters: `modules`
 
@@ -136,25 +119,7 @@ Parameters: `modules`
 Triggered at the beginning of the optimization phase.
 
 
-### `optimizeModulesBasic`
-
-`SyncBailHook`
-
-...
-
-Parameters: `modules`
-
-
 ### `optimizeModules`
-
-`SyncBailHook`
-
-...
-
-Parameters: `modules`
-
-
-### `optimizeModulesAdvanced`
 
 `SyncBailHook`
 
@@ -172,29 +137,11 @@ Parameters: `modules`
 Parameters: `modules`
 
 
-### `optimizeChunksBasic`
-
-`SyncBailHook`
-
-...
-
-Parameters: `chunks`
-
-
 ### `optimizeChunks`
 
 `SyncBailHook`
 
 Optimize the chunks.
-
-Parameters: `chunks`
-
-
-### `optimizeChunksAdvanced`
-
-`SyncBailHook`
-
-...
 
 Parameters: `chunks`
 
@@ -226,25 +173,7 @@ Parameters: `chunks` `modules`
 Parameters: `chunks` `modules`
 
 
-### `optimizeChunkModulesBasic`
-
-`SyncBailHook`
-
-...
-
-Parameters: `chunks` `modules`
-
-
 ### `optimizeChunkModules`
-
-`SyncBailHook`
-
-...
-
-Parameters: `chunks` `modules`
-
-
-### `optimizeChunkModulesAdvanced`
 
 `SyncBailHook`
 


### PR DESCRIPTION
_describe your changes..._

- [ ] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [ ] Make sure your PR complies with the [writer's guide][2].
- [ ] Review the diff carefully as sometimes this can reveal issues.
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
