### PR TITLE
Minor wording change

### DIFF
--- a/src/content/guides/typescript.md
+++ b/src/content/guides/typescript.md
@@ -119,7 +119,7 @@ __tsconfig.json__
   }
 ```
 
-Now we need to tell webpack to extract these source maps and into our final bundle:
+Now we need to tell webpack to extract these source maps and include in our final bundle:
 
 __webpack.config.js__
 


### PR DESCRIPTION
Readability improvement in a sentence:

Before
   "Now we tell webpack to extract these source maps and into our final bundle:"

After
   "Now we tell webpack to extract these source maps and include in our final bundle:"
