### PR TITLE
Update production.md

### DIFF
--- a/src/content/guides/production.md
+++ b/src/content/guides/production.md
@@ -160,7 +160,6 @@ __webpack.prod.js__
 
   module.exports = merge(common, {
     mode: 'production',
-    devtool: 'source-map'
   });
 ```
 


### PR DESCRIPTION
The `devtool: 'source-map'` line is later added in the Source Mapping section of the guide. The Source Mapping section also explains why that line is added to `webpack.prod.js` file and shows the diff too.