### PR TITLE
fixing invalid splitChunks example

### DIFF
--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -216,9 +216,13 @@ module.exports = {
   //...
   optimization: {
     splitChunks: {
-      test (chunks) {
-        //...
-        return true;
+      cacheGroups: {
+        vendors: {
+          test (chunks) {
+            //...
+            return true;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
From [this comment](https://github.com/webpack/webpack.js.org/issues/1956#issuecomment-417346913):

> The documentation (https://webpack.js.org/plugins/split-chunks-plugin/#splitchunks-cachegroups-test) shows a code example defining splitChunks.test (which I dont believe exists?) instead of splitChunks.cacheGroups[yourGroup].test.