### PR TITLE
Correct main entry in package.json

### DIFF
--- a/src/content/guides/production.md
+++ b/src/content/guides/production.md
@@ -118,7 +118,7 @@ __package.json__
     "name": "development",
     "version": "1.0.0",
     "description": "",
-    "main": "webpack.config.js",
+    "main": "src/index.js",
     "scripts": {
 -     "start": "webpack-dev-server --open",
 +     "start": "webpack-dev-server --open --config webpack.dev.js",


### PR DESCRIPTION
fix: The main entry in package.json has incorrect settings. As the previous sections of the tutorial, I think it should be point to "src/index.js" instead.

_describe your changes..._

- [ ] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [ ] Make sure your PR complies with the [writer's guide][2].
- [ ] Review the diff carefully as sometimes this can reveal issues.
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
