### PR TITLE
Fix reference to default

### DIFF
--- a/src/content/guides/code-splitting.md
+++ b/src/content/guides/code-splitting.md
@@ -235,7 +235,6 @@ __src/index.js__
 -   element.innerHTML = _.join(['Hello', 'webpack'], ' ');
 +   return import(/* webpackChunkName: "lodash" */ 'lodash').then(({ default: _ }) => {
 +     var element = document.createElement('div');
-+     var _ = _.default;
 +
 +     element.innerHTML = _.join(['Hello', 'webpack'], ' ');
 +


### PR DESCRIPTION
Just noticed this error in the documentation. The callback function already destructures the default from the parameter so `_` is already the lodash we expect.