### PR TITLE
preset-es2015 is deprecated, please use preset-env

### DIFF
--- a/src/content/configuration/configuration-languages.md
+++ b/src/content/configuration/configuration-languages.md
@@ -135,14 +135,14 @@ In the example below JSX (React JavaScript Markup) and Babel are used to create 
 First install the necessary dependencies:
 
 ``` bash
-npm install --save-dev babel-register jsxobj babel-preset-es2015
+npm install --save-dev babel-register jsxobj @babel/preset-env
 ```
 
 __.babelrc__
 
 ``` json
 {
-  "presets": [ "es2015" ]
+  "presets": [ "env" ]
 }
 ```
 

--- a/src/content/configuration/index.md
+++ b/src/content/configuration/index.md
@@ -159,7 +159,7 @@ module.exports = {
         // -loader suffix is no longer optional in webpack2 for clarity reasons
         // see [webpack 1 upgrade guide](/guides/migrating)
         [options](/configuration/module#rule-options-rule-query): {
-          presets: ["es2015"]
+          presets: ["env"]
         },
         // options for the loader
       },


### PR DESCRIPTION
`preset-es2015` is deprecated and should not be used. It is encouraged by babel to use `preset-env` instead.