### PR TITLE
Use consistent plugin name in code snippet

### DIFF
--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -5,6 +5,7 @@ contributors:
   - tbroadley
   - iamakulov
   - byzyk
+  - franjohn21
 ---
 
 Plugins expose the full potential of the webpack engine to third-party developers. Using staged build callbacks, developers can introduce their own behaviors into the webpack build process. Building plugins is a bit more advanced than building loaders, because you'll need to understand some of the webpack low-level internals to hook into them. Be prepared to read some source code!
@@ -23,7 +24,7 @@ class MyExampleWebpackPlugin {
   apply(compiler) {
     // Specify the event hook to attach to
     compiler.hooks.compile.tapAsync(
-      'afterCompile',
+      'MyExampleWebpackPlugin',
       (compilation, callback) => {
         console.log('This is an example plugin!');
         console.log('Here’s the `compilation` object which represents a single build of assets:', compilation);


### PR DESCRIPTION
This PR resolves https://github.com/webpack/webpack.js.org/issues/2494 - the plugin name used in the initial code snippet is an event name and is confusing whether it's of significance or not. This PR uses the plugin's name which is consistent with the other code snippets on the page. https://webpack.js.org/contribute/writing-a-plugin/

<!--
- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.



[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
-->
/review @iamakulov @jeremenichelli @montogeek 