### PR TITLE
docs(config): Example 3 - custom vendor chunks using RegEx

### DIFF
--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -8,6 +8,7 @@ contributors:
   - EugeneHlushko
   - byzyk
   - madhavarshney
+  - sakhisheikh
 related:
   - title: webpack's automatic deduplication algorithm example
     url: https://github.com/webpack/webpack/blob/master/examples/many-pages/README.md
@@ -344,3 +345,27 @@ module.exports = {
 ```
 
 W> This might result in a large chunk containing all external packages. It is recommended to only include your core frameworks and utilities and dynamically load the rest of the dependencies.
+
+### Split Chunks: Example 3
+
+ Create a `custom vendors` chunk, which includes only those `node_modules` from the whole application which passes the RegEx Test
+ 
+ __webpack.config.js__
+
+```js
+module.exports = {
+  //...
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        vendor: {
+          test: /[\\/]node_modules[\\/](react|react-dom)[\\/]/,
+          name: 'vendor',
+          chunks: 'all',
+        }
+      }
+    }
+  }
+};
+```
+ T> This will result into a vendor chunk containing desired libraries provided in RegEx patter. A better understanding of chunks can be visualized by  [webpack-visualizer](https://chrisbateman.github.io/webpack-visualizer/).


### PR DESCRIPTION
**What kind of change does this PR introduce?**
An example added to SplitChunksPlugin in `split-chunks-plugin.md`

**Did you add tests for your changes?**

Not necessary.

**Does this PR introduce a breaking change?**

No breaking change.

**What needs to be documented once your changes are merged?**

No update required.

When we have to split chunks on vendor basis we write test function in `splitChunks.cacheGroups.test`. I have added an example which demonstrate how we can use RegEx pattern to extract custom **node_modules** in vendor chunk.

For this I have gone through `SplitChunksPlugin.js` from `webpack/lib/optimize/`. I have tried so many to times to extract only react and react-dom at the first place with exact string matching pattern. But I failed to do this as soon as I figured it out while printing `module.nameForCondition())` and got to know the how modules are added in vendor chunks with RegEx test. I added `'/' `in the end of library name just to make sure it extracts all code under hood of the library.
