### PR TITLE
Fix webpack 4 migration guide link to split chunks docs

### DIFF
--- a/src/content/migrate/4.md
+++ b/src/content/migrate/4.md
@@ -87,9 +87,9 @@ module.exports = {
 
 ## CommonsChunkPlugin
 
-The `CommonsChunkPlugin` was removed. Instead the [`optimization.splitChunks`](/configuration/optimization/#optimization-splitchunks/) options can be used.
+The `CommonsChunkPlugin` was removed. Instead the [`optimization.splitChunks`](/configuration/optimization/#optimization-splitchunks) options can be used.
 
-See documentation of the [`optimization.splitChunks`](/configuration/optimization/#optimization-splitchunks/) for more details. The default configuration may already suit your needs.
+See documentation of the [`optimization.splitChunks`](/configuration/optimization/#optimization-splitchunks) for more details. The default configuration may already suit your needs.
 
 T> When generating the HTML from the stats you can use `optimization.splitChunks.chunks: "all"` which is the optimal configuration in most cases.
 


### PR DESCRIPTION
The link to [optimization.splitChunks](https://webpack.js.org/configuration/optimization/#optimization-splitchunks) anchor was broken.