### PR TITLE
docs(config): clarify `stats.md` sort fields

### DIFF
--- a/src/content/configuration/stats.md
+++ b/src/content/configuration/stats.md
@@ -9,6 +9,7 @@ contributors:
   - jasonblanchard
   - byzyk
   - renjithvk
+  - Raiondesu
 ---
 
 The `stats` option lets you precisely control what bundle information gets displayed. This can be a nice middle ground if you don't want to use `quiet` or `noInfo` because you want some bundle information, but not all of it.
@@ -54,6 +55,8 @@ module.exports = {
 
     // Sort assets by a field
     // You can reverse the sort with `!field`.
+    // Some possible values: 'id' (default), 'name', 'size', 'chunks', 'failed', 'issuer'
+    // For a complete list of fields see the bottom of the page
     assetsSort: "field",
 
     // Add build date and time information
@@ -82,6 +85,8 @@ module.exports = {
 
     // Sort the chunks by a field
     // You can reverse the sort with `!field`. Default is `id`.
+    // Some other possible values: 'name', 'size', 'chunks', 'failed', 'issuer'
+    // For a complete list of fields see the bottom of the page
     chunksSort: "field",
 
     // Context directory for request shortening
@@ -132,6 +137,8 @@ module.exports = {
 
     // Sort the modules by a field
     // You can reverse the sort with `!field`. Default is `id`.
+    // Some other possible values: 'name', 'size', 'chunks', 'failed', 'issuer'
+    // For a complete list of fields see the bottom of the page
     modulesSort: "field",
 
     // Show dependencies and origin of warnings/errors (since webpack 2.5.0)
@@ -171,3 +178,27 @@ module.exports = {
   }
 }
 ```
+
+### Sorting fields
+
+For `assetsSort`, `chunksSort` and `moduleSort` there are several possible fields that you can sort items by:
+
+ - `id` is the item's id;
+ - `name` - a item's name that was assigned to it upon importing;
+ - `size` - a size of item in bytes;
+ - `chunks` - what chunks the item originates from (for example, if there are multiple subchunks for one chunk - the subchunks will be grouped together according to their main chunk);
+ - `errors` - amount of errors in items;
+ - `warnings` - amount of warnings in items;
+ - `failed` - whether the item has failed compilation;
+ - `cacheable` - whether the item is cacheable;
+ - `built` - whether the asset has been built;
+ - `prefetched` - whether the asset will be prefetched;
+ - `optional` - whether the asset is optional;
+ - `identifier` - identifier of the item;
+ - `index` - item's processing index;
+ - `index2`
+ - `profile`
+ - `issuer` - an identifier of the issuer;
+ - `issuerId` - an id of the issuer;
+ - `issuerName` - a name of the issuer;
+ - `issuerPath` - a full issuer object. There's no real need to sort by this field;

--- a/src/content/configuration/stats.md
+++ b/src/content/configuration/stats.md
@@ -183,22 +183,22 @@ module.exports = {
 
 For `assetsSort`, `chunksSort` and `moduleSort` there are several possible fields that you can sort items by:
 
-- `id` is the item's id;
-- `name` - a item's name that was assigned to it upon importing;
-- `size` - a size of item in bytes;
-- `chunks` - what chunks the item originates from (for example, if there are multiple subchunks for one chunk - the subchunks will be grouped together according to their main chunk);
-- `errors` - amount of errors in items;
-- `warnings` - amount of warnings in items;
-- `failed` - whether the item has failed compilation;
-- `cacheable` - whether the item is cacheable;
-- `built` - whether the asset has been built;
-- `prefetched` - whether the asset will be prefetched;
-- `optional` - whether the asset is optional;
-- `identifier` - identifier of the item;
-- `index` - item's processing index;
-- `index2`
-- `profile`
-- `issuer` - an identifier of the issuer;
-- `issuerId` - an id of the issuer;
-- `issuerName` - a name of the issuer;
-- `issuerPath` - a full issuer object. There's no real need to sort by this field;
+* `id` is the item's id;
+* `name` - a item's name that was assigned to it upon importing;
+* `size` - a size of item in bytes;
+* `chunks` - what chunks the item originates from (for example, if there are multiple subchunks for one chunk - the subchunks will be grouped together according to their main chunk);
+* `errors` - amount of errors in items;
+* `warnings` - amount of warnings in items;
+* `failed` - whether the item has failed compilation;
+* `cacheable` - whether the item is cacheable;
+* `built` - whether the asset has been built;
+* `prefetched` - whether the asset will be prefetched;
+* `optional` - whether the asset is optional;
+* `identifier` - identifier of the item;
+* `index` - item's processing index;
+* `index2`
+* `profile`
+* `issuer` - an identifier of the issuer;
+* `issuerId` - an id of the issuer;
+* `issuerName` - a name of the issuer;
+* `issuerPath` - a full issuer object. There's no real need to sort by this field;

--- a/src/content/configuration/stats.md
+++ b/src/content/configuration/stats.md
@@ -183,22 +183,22 @@ module.exports = {
 
 For `assetsSort`, `chunksSort` and `moduleSort` there are several possible fields that you can sort items by:
 
- - `id` is the item's id;
- - `name` - a item's name that was assigned to it upon importing;
- - `size` - a size of item in bytes;
- - `chunks` - what chunks the item originates from (for example, if there are multiple subchunks for one chunk - the subchunks will be grouped together according to their main chunk);
- - `errors` - amount of errors in items;
- - `warnings` - amount of warnings in items;
- - `failed` - whether the item has failed compilation;
- - `cacheable` - whether the item is cacheable;
- - `built` - whether the asset has been built;
- - `prefetched` - whether the asset will be prefetched;
- - `optional` - whether the asset is optional;
- - `identifier` - identifier of the item;
- - `index` - item's processing index;
- - `index2`
- - `profile`
- - `issuer` - an identifier of the issuer;
- - `issuerId` - an id of the issuer;
- - `issuerName` - a name of the issuer;
- - `issuerPath` - a full issuer object. There's no real need to sort by this field;
+- `id` is the item's id;
+- `name` - a item's name that was assigned to it upon importing;
+- `size` - a size of item in bytes;
+- `chunks` - what chunks the item originates from (for example, if there are multiple subchunks for one chunk - the subchunks will be grouped together according to their main chunk);
+- `errors` - amount of errors in items;
+- `warnings` - amount of warnings in items;
+- `failed` - whether the item has failed compilation;
+- `cacheable` - whether the item is cacheable;
+- `built` - whether the asset has been built;
+- `prefetched` - whether the asset will be prefetched;
+- `optional` - whether the asset is optional;
+- `identifier` - identifier of the item;
+- `index` - item's processing index;
+- `index2`
+- `profile`
+- `issuer` - an identifier of the issuer;
+- `issuerId` - an id of the issuer;
+- `issuerName` - a name of the issuer;
+- `issuerPath` - a full issuer object. There's no real need to sort by this field;


### PR DESCRIPTION
Added possible values for `assetsSort`, `chunksSort` and `moduleSort` according to the [sources](https://github.com/webpack/webpack/blob/cec5bfb01c025a28062646e18467293e4d6b93ab/lib/Stats.js#L489).

Before this change it was impossible to straight up guess all the possible sorting fields for statistics.

I see this as a critical drawback for projects with a large amount of chunks and assets (I work on one with ~100 chunks). Lack of relevant field sorting documentation means hours wasted on trying to align the records in console statistics.
Like it was for me.

After 2 hours of googling and rereading webpack documentation I had to dive into the source-code.

This PR is here to make webpack docs another tiny bit better and to ensure that nobody will have to forcefully scan the sources in order to do plain-simple things like proper sorting in console.