### PR TITLE
Update filelist.md plugin example in write-a-plugin.md

### DIFF
--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -151,7 +151,7 @@ Let's write a simple example plugin that generates a new build file called `file
 class FileListPlugin {
   apply(compiler) {
     // emit is asynchronous hook, tapping into it using tapAsync, you can use tapPromise/tap(synchronous) as well
-    compiler.hooks.emit.tapAsync('FileListPlugin', (compiler, callback) => {
+    compiler.hooks.emit.tapAsync('FileListPlugin', (compilation, callback) => {
       // Create a header string for the generated file:
       var filelist = 'In this build:\n\n';
 


### PR DESCRIPTION
In the filelist.md the callback parameter should be `compilation`, not `compiler`.