### PR TITLE
import needs to be highlighted with '+' mark

### DIFF
--- a/src/content/guides/caching.md
+++ b/src/content/guides/caching.md
@@ -282,7 +282,7 @@ __webpack.config.js__
 
 ``` diff
   const path = require('path');
-  const webpack = require('webpack');
++ const webpack = require('webpack');
   const CleanWebpackPlugin = require('clean-webpack-plugin');
   const HtmlWebpackPlugin = require('html-webpack-plugin');
 


### PR DESCRIPTION
import webpack needs to be highlighted since we are adding webpack.HashedModuleIdsPlugin()

_describe your changes..._

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
