### PR TITLE
docs(config) add comments and values for rule.type

### DIFF
--- a/src/content/configuration/module.md
+++ b/src/content/configuration/module.md
@@ -264,6 +264,29 @@ Indicate what parts of the module contain side effects. See [Tree Shaking](/guid
 `Rule.test` is a shortcut to `Rule.resource.test`. If you supply a `Rule.test` option, you cannot also supply a `Rule.resource`. See [`Rule.resource`](#rule-resource) and [`Condition.test`](#condition) for details.
 
 
+## `Rule.type`
+
+Possible values: `"javascript/auto" | "javascript/dynamic" | "javascript/esm" | "json" | "webassembly/experimental"`
+
+`Rule.type` sets the type for a matching module. This prevents defaultRules and their default importing behaviors from occuring. For example, if you want to load a `.json` file through a custom loader, you'd need to set the `type` to `javascript/auto` to bypass webpack's built-in json importing. (See [v4.0 changelog](https://github.com/webpack/webpack/releases/tag/v4.0.0) for more details)
+
+```javascript
+module.exports = {
+  //...
+  module: {
+    rules: [
+      //...
+      {
+        test: /\.json$/,
+        type: 'javascript/auto',
+        loader: 'custom-json-loader'
+      }
+    ]
+  }
+};
+```
+
+
 ## `Rule.use`
 
 A list of [UseEntries](#useentry) which are applied to modules. Each entry specifies a loader to be used.

--- a/src/content/configuration/module.md
+++ b/src/content/configuration/module.md
@@ -10,6 +10,7 @@ contributors:
   - byzyk
   - pnevares
   - fadysamirsadek
+  - nerdkid93
 ---
 
 These options determine how the [different types of modules](/concepts/modules) within a project will be treated.

--- a/src/content/configuration/module.md
+++ b/src/content/configuration/module.md
@@ -269,7 +269,7 @@ Indicate what parts of the module contain side effects. See [Tree Shaking](/guid
 
 Possible values: `"javascript/auto" | "javascript/dynamic" | "javascript/esm" | "json" | "webassembly/experimental"`
 
-`Rule.type` sets the type for a matching module. This prevents defaultRules and their default importing behaviors from occuring. For example, if you want to load a `.json` file through a custom loader, you'd need to set the `type` to `javascript/auto` to bypass webpack's built-in json importing. (See [v4.0 changelog](https://github.com/webpack/webpack/releases/tag/v4.0.0) for more details)
+`Rule.type` sets the type for a matching module. This prevents defaultRules and their default importing behaviors from occurring. For example, if you want to load a `.json` file through a custom loader, you'd need to set the `type` to `javascript/auto` to bypass webpack's built-in json importing. (See [v4.0 changelog](https://github.com/webpack/webpack/releases/tag/v4.0.0) for more details)
 
 ```javascript
 module.exports = {


### PR DESCRIPTION
Added documentation and an example around a Module's `Rule.type` configuration property. Fixes #1994 