### PR TITLE
Revert "docs(config) optimization moduleIds"

### DIFF
--- a/src/content/configuration/optimization.md
+++ b/src/content/configuration/optimization.md
@@ -177,33 +177,6 @@ module.exports = {
 };
 ```
 
-## `optimization.moduleIds`
-
-`bool: false` `string: natural, named, hashed, size, total-size`
-
-Tells webpack which algorithm to use when choosing module ids. Setting `optimization.moduleIds` to `false` tells webpack that none of built-in algorithms should be used, as custom one can be provided via plugin.
-
-The following string values are supported:
-
-Option                | Description
---------------------- | -----------------------
-`natural`             | Numeric ids in order of usage.
-`named`               | Readable ids for better debugging.
-`hashed`              | short hashes as ids for better long term caching.
-`size`                | Numeric ids focused on minimal initial download size.
-`total-size`          | numeric ids focused on minimal total download size.
-
-__webpack.config.js__
-
-```js
-module.exports = {
-  //...
-  optimization: {
-    moduleIds: 'hashed'
-  }
-};
-```
-
 ## `optimization.nodeEnv`
 
 `string` `bool: false`


### PR DESCRIPTION
Reverts webpack/webpack.js.org#2533

UPD: because it belongs to `master`