### PR TITLE
docs(plugins) More info on HashedModuleIdsPlugin#hashDigestLength

### DIFF
--- a/src/content/plugins/hashed-module-ids-plugin.md
+++ b/src/content/plugins/hashed-module-ids-plugin.md
@@ -20,7 +20,7 @@ This plugin supports the following options:
 
 - `hashFunction`: The hashing algorithm to use, defaults to `'md4'`. All functions from Node.JS' [`crypto.createHash`](https://nodejs.org/api/crypto.html#crypto_crypto_createhash_algorithm_options) are supported.
 - `hashDigest`: The encoding to use when generating the hash, defaults to `'base64'`. All encodings from Node.JS' [`hash.digest`](https://nodejs.org/api/crypto.html#crypto_hash_digest_encoding) are supported.
-- `hashDigestLength`: The prefix length of the hash digest to use, defaults to `4`.
+- `hashDigestLength`: The prefix length of the hash digest to use, defaults to `4`. Note that some generated ids might be longer than specified here, to avoid module id collisions.
 
 
 ## Usage


### PR DESCRIPTION
I was wondering what is the behavior in case of potential collisions, I think it's worth documenting.

See https://github.com/webpack/webpack/blob/91e9dd77062797e3e716485f295d32a5cab57042/lib/HashedModuleIdsPlugin.js#L50

(This doesn't handle the potential collisions of the hashing algorithm itself, only the collisions due to truncating the hash -- though the first type should virtually never happen in case of the input type being a module name / path string, so I think that's fine).