### PR TITLE
Add boolean as possible type for lineToLine

### DIFF
--- a/src/content/plugins/source-map-dev-tool-plugin.md
+++ b/src/content/plugins/source-map-dev-tool-plugin.md
@@ -30,7 +30,7 @@ The following options are supported:
 - `fallbackModuleFilenameTemplate` (`string`): See link above.
 - `module` (`boolean`): Indicates whether loaders should generate source maps (defaults to `true`).
 - `columns` (`boolean`): Indicates whether column mappings should be used (defaults to `true`).
-- `lineToLine` (`object`): Simplify and speed up source mapping by using line to line source mappings for matched modules.
+- `lineToLine` (`boolean` or `object`): Simplify and speed up source mapping by using line to line source mappings for matched modules.
 - `noSources` (`boolean`): Prevents the source file content from being included in the source map (defaults to `false`).
 - `publicPath` (`string`): Emits absolute URLs with public path prefix, e.g. `https://example.com/project/`.
 - `fileContext` (`string`): Makes the `[file]` argument relative to this directory.


### PR DESCRIPTION
I noticed a discrepancy between the typescript definitions and this documentation, and assumed the definition to be correct.

This changes doc to show that a boolean is possible for the lineToLine option
