### PR TITLE
Extend documentation for require.context

### DIFF
--- a/src/content/api/module-methods.md
+++ b/src/content/api/module-methods.md
@@ -353,17 +353,28 @@ Aside from the module syntaxes described above, webpack also allows a few custom
 require.context(
   directory: String,
   includeSubdirs: Boolean /* optional, default true */,
-  filter: RegExp /* optional */
+  filter: RegExp /* optional, default /^\.\/.*$/, any file */,
+  mode: String  /* optional, 'sync' | 'eager' | 'weak' | 'lazy' | 'lazy-once', default 'sync' */
 )
 ```
 
-Specify a whole group of dependencies using a path to the `directory`, an option to `includeSubdirs`, and a `filter` for more fine grained control of the modules included. These can then be easily resolved later on:
+Specify a whole group of dependencies using a path to the `directory`, an option to `includeSubdirs`, a `filter` for more fine grained control of the modules included, and a `mode` to define the way how loading will work. Underlying modules can then be easily resolved later on:
 
 ```javascript
 var context = require.context('components', true, /\.html$/);
 var componentA = context.resolve('componentA');
 ```
 
+If `mode` is specified as "lazy", the underlying modules will be loaded asynchronously:
+
+```javascript
+var context = require.context('locales', true, /\.json$/, 'lazy');
+context('localeA').then(locale => {
+  // do something with locale
+});
+```
+
+The full list of available modes and its behavior is described in [`import()`](#import-) documentation.
 
 ### `require.include`
 


### PR DESCRIPTION
`require.context`, accepts an extra forth argument, but this is not described in documentation.

Information is based on replies from this issue https://github.com/webpack/webpack/issues/7283
