### PR TITLE
Mention @babel/preset-env transforming ES modules to CommonJS by default

### DIFF
--- a/src/content/guides/tree-shaking.md
+++ b/src/content/guides/tree-shaking.md
@@ -204,6 +204,7 @@ T> [ModuleConcatenationPlugin](/plugins/module-concatenation-plugin) is needed f
 So, what we've learned is that in order to take advantage of _tree shaking_, you must...
 
 - Use ES2015 module syntax (i.e. `import` and `export`).
+- Ensure no compilers transform your ES2015 module syntax into CommonJS modules (this is the default behavior of popular Babel preset @babel/preset-env - see [documentation](https://babeljs.io/docs/en/babel-preset-env#modules) for more details).
 - Add a `"sideEffects"` property to your project's `package.json` file.
 - Use [`production`](/concepts/mode/#mode-production) `mode` configuration option to enable [various optimizations](/concepts/mode/#usage) including minification and tree shaking.
 


### PR DESCRIPTION
@babel/preset-env is extremely popular, but unless an additional configuration was added to it, it will break Webpack's tree shaking. It's worth mentioning it in the docs, I think.