### PR TITLE
Add 'name' field docs & minor fixes

### DIFF
--- a/src/content/configuration/other-options.md
+++ b/src/content/configuration/other-options.md
@@ -24,7 +24,9 @@ W> Help Wanted: This page is still a work in progress. If you are familiar with 
 
 Set the value of `require.amd` or `define.amd`:
 
-```js
+__webpack.config.js__
+
+```javascript
 module.exports = {
   //...
   amd: {
@@ -47,7 +49,9 @@ As it happens, the AMD support in webpack ignores the defined name anyways.
 
 Fail out on the first error instead of tolerating it. By default webpack will log these errors in red in the terminal, as well as the browser console when using HMR, but continue bundling. To enable it:
 
-```js
+__webpack.config.js__
+
+```javascript
 module.exports = {
   //...
   bail: true
@@ -63,7 +67,9 @@ This will force webpack to exit its bundling process.
 
 Cache the generated webpack modules and chunks to improve build speed. Caching is enabled by default while in watch mode. To disable caching simply pass:
 
-```js
+__webpack.config.js__
+
+```javascript
 module.exports = {
   //...
   cache: false
@@ -72,7 +78,9 @@ module.exports = {
 
 If an object is passed, webpack will use this object for caching. Keeping a reference to this object will allow one to share the same cache between compiler calls:
 
-```js
+__webpack.config.js__
+
+```javascript
 let SharedCache = {};
 
 module.exports = {
@@ -119,7 +127,9 @@ T> Combine with `parallelism: 1` for better results.
 
 Use this option to generate a JSON file containing webpack "records" -- pieces of data used to store module identifiers across multiple builds. You can use this file to track how modules change between builds. To generate one, simply specify a location:
 
-```js
+__webpack.config.js__
+
+```javascript
 module.exports = {
   //...
   recordsPath: path.join(__dirname, 'records.json')
@@ -146,7 +156,9 @@ Specify the file from which to read the last set of records. This can be used to
 
 Specify where the records should be written. The following example shows how you might use this option in combination with `recordsInputPath` to rename a records file:
 
-```js
+__webpack.config.js__
+
+```javascript
 module.exports = {
   //...
   recordsInputPath: path.join(__dirname, 'records.json'),
@@ -161,7 +173,9 @@ module.exports = {
 
 Name of the configuration. Used when loading multiple configurations.
 
-```js
+__webpack.config.js__
+
+```javascript
 module.exports = {
   //...
   name: 'admin-app'

--- a/src/content/configuration/other-options.md
+++ b/src/content/configuration/other-options.md
@@ -115,6 +115,8 @@ T> Combine with `parallelism: 1` for better results.
 
 ## `recordsPath`
 
+`string`
+
 Use this option to generate a JSON file containing webpack "records" -- pieces of data used to store module identifiers across multiple builds. You can use this file to track how modules change between builds. To generate one, simply specify a location:
 
 ```js
@@ -133,10 +135,14 @@ W> Setting `recordsPath` will essentially set `recordsInputPath` and `recordsOut
 
 ## `recordsInputPath`
 
+`string`
+
 Specify the file from which to read the last set of records. This can be used to rename a records file. See the example below.
 
 
 ## `recordsOutputPath`
+
+`string`
 
 Specify where the records should be written. The following example shows how you might use this option in combination with `recordsInputPath` to rename a records file:
 

--- a/src/content/configuration/other-options.md
+++ b/src/content/configuration/other-options.md
@@ -6,6 +6,7 @@ contributors:
   - skipjack
   - terinjokes
   - byzyk
+  - vansosnin
 related:
   - title: Using Records
     url: https://survivejs.com/webpack/optimizing/separating-manifest/#using-records
@@ -144,5 +145,19 @@ module.exports = {
   //...
   recordsInputPath: path.join(__dirname, 'records.json'),
   recordsOutputPath: path.join(__dirname, 'newRecords.json')
+};
+```
+
+
+## `name`
+
+`string`
+
+Name of the configuration. Used when loading multiple configurations.
+
+```js
+module.exports = {
+  //...
+  name: 'admin-app'
 };
 ```


### PR DESCRIPTION
Added `name` field docs. I found it accidentally in the error message. And this is exactly what I needed in my work 🙂
Also added missing field types for sibling fields.