### PR TITLE
Mistake in Mode Doc corrected

### DIFF
--- a/src/content/concepts/mode.md
+++ b/src/content/concepts/mode.md
@@ -5,6 +5,7 @@ contributors:
   - EugeneHlushko
   - byzyk
   - mrichmond
+  - Fental
 related:
   - title: 'webpack default options (source code)'
     url: https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsDefaulter.js

--- a/src/content/concepts/mode.md
+++ b/src/content/concepts/mode.md
@@ -115,7 +115,7 @@ module.exports = {
 -     hidePathInfo: true,
 -     minSize: 30000,
 -     maxAsyncRequests: 5,
--     maxAsyncRequests: 3,
+-     maxInitialRequests: 3,
 -   },
 -   noEmitOnErrors: true,
 -   checkWasmTypes: true,


### PR DESCRIPTION
_One of maxAsyncRequests properties in webpack.development.config.js should be maxInitialRequests._

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
