### PR TITLE
docs(config) target updates to current webpack state

### DIFF
--- a/src/content/configuration/target.md
+++ b/src/content/configuration/target.md
@@ -9,13 +9,14 @@ contributors:
   - pastelsky
   - tbroadley
   - byzyk
+  - EugeneHlushko
 ---
 
-webpack can compile for multiple environments or _targets_. To understand what a `target` is in detail, read through [the targets concept page](/concepts/targets).
+webpack can compile for multiple environments or _targets_. To understand what a `target` is in detail, read through [the targets concept page](/concepts/targets/).
 
 ## `target`
 
-`string | function(compiler)`
+`string | function (compiler)`
 
 Instructs webpack to target a specific environment.
 
@@ -27,8 +28,6 @@ The following string values are supported via [`WebpackOptionsApply`](https://gi
 Option                | Description
 --------------------- | -----------------------
 `async-node`          | Compile for usage in a Node.js-like environment (uses `fs` and `vm` to load chunks asynchronously)
-~~`atom`~~            | Alias for `electron-main`
-~~`electron`~~        | Alias for `electron-main`
 `electron-main`       | Compile for [Electron](https://electronjs.org/) for main process.
 `electron-renderer`   | Compile for [Electron](https://electronjs.org/) for renderer process, providing a target using `JsonpTemplatePlugin`, `FunctionModulePlugin` for browser environments and `NodeTargetPlugin` and `ExternalsPlugin` for CommonJS and Electron built-in modules.
 `node`                | Compile for usage in a Node.js-like environment (uses Node.js `require` to load chunks)
@@ -36,7 +35,7 @@ Option                | Description
 `web`                 | Compile for usage in a browser-like environment **(default)**
 `webworker`           | Compile as WebWorker
 
-For example, when the `target` is set to `"electron"`, webpack includes multiple electron specific variables. For more information on which templates and externals are used, you can refer to webpack's [source code](https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsApply.js#L70-L185).
+For example, when the `target` is set to `"electron-main"`, webpack includes multiple electron specific variables. For more information on which templates and externals are used, you can refer to webpack's [source code](https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsApply.js#L148-L183).
 
 
 ### `function`


### PR DESCRIPTION
- atom and electron no longer allowed via schema
- outdated link and example