### PR TITLE
Updated getting-started.md

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -99,8 +99,8 @@ __package.json__
     "author": "",
     "license": "ISC",
     "devDependencies": {
-      "webpack": "^4.0.1",
-      "webpack-cli": "^2.0.9"
+    "webpack": "^4.20.2",
+    "webpack-cli": "^3.1.2"
     },
     "dependencies": {}
   }


### PR DESCRIPTION
Incremented versions for webpack and webpack-cli as was initially was generating error when running 'npx webpack' - 'Cannot read property 'properties' of undefined'. Please refer https://github.com/plotly/dash-component-boilerplate/issues/12
