### PR TITLE
docs(plugins) split chunks cache group filename option

### DIFF
--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -265,7 +265,7 @@ module.exports = {
 Allows to override the filename when and only when it's an initial chunk.
 All placeholders available in [`output.filename`](/configuration/output/#output-filename) are also available here.
 
-W> This option can also be set globally in `splitChunks.filename`, but this isn't recommended and will very likely lead to an error if [`splitChunks.chunks`](#splitchunks-chunks) is not set to `'initial'`. Avoid setting it globally.
+W> This option can also be set globally in `splitChunks.filename`, but this isn't recommended and will likely lead to an error if [`splitChunks.chunks`](#splitchunks-chunks) is not set to `'initial'`. Avoid setting it globally.
 
 __webpack.config.js__
 

--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -258,6 +258,32 @@ module.exports = {
 };
 ```
 
+#### `splitChunks.cacheGroups.{cacheGroup}.filename`
+
+`string`
+
+Allows to override the filename when and only when it's an initial chunk.
+All placeholders available in [`output.filename`](/configuration/output/#output-filename) are also available here.
+
+W> This option can also be set globally in `splitChunks.filename`, but this isn't recommended and will very likely lead to an error if [`splitChunks.chunks`](#splitchunks-chunks) is not set to `'initial'`. Avoid setting it globally.
+
+__webpack.config.js__
+
+```js
+module.exports = {
+  //...
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        vendors: {
+          filename: '[name].bundle.js'
+        }
+      }
+    }
+  }
+};
+```
+
 ## Examples
 
 ### Defaults: Example 1


### PR DESCRIPTION
- document `splitChunks.cacheGroups.{cacheGroup}.filename` configuration option
- Fixes #2611
