### PR TITLE
Updates plugins.md

### DIFF
--- a/src/content/api/plugins.md
+++ b/src/content/api/plugins.md
@@ -60,18 +60,18 @@ However, for `run` which utilizes the `AsyncHook`, we can utilize `tapAsync`
 or `tapPromise` (as well as `tap`):
 
 ``` js
-compiler.hooks.run.tapAsync('MyPlugin', (compiler, callback) => {
+compiler.hooks.run.tapAsync('MyPlugin', (source, target, routesList, callback) => {
   console.log('Asynchronously tapping the run hook.');
   callback();
 });
 
-compiler.hooks.run.tapPromise('MyPlugin', compiler => {
+compiler.hooks.run.tapPromise('MyPlugin', (source, target, routesList) => {
   return new Promise(resolve => setTimeout(resolve, 1000)).then(() => {
     console.log('Asynchronously tapping the run hook with a delay.');
   });
 });
 
-compiler.hooks.run.tapPromise('MyPlugin', async compiler => {
+compiler.hooks.run.tapPromise('MyPlugin', async (source, target, routesList) => {
   await new Promise(resolve => setTimeout(resolve, 1000));
   console.log('Asynchronously tapping the run hook with a delay.');
 });


### PR DESCRIPTION
Matches documented parameters with [`webpack/tapable` docs](https://github.com/webpack/tapable#usage):

```javascript
myCar.hooks.calculateRoutes.tapPromise("GoogleMapsPlugin", (source, target, routesList) => {
	// return a promise
	return google.maps.findRoute(source, target).then(route => {
		routesList.add(route);
	});
});
myCar.hooks.calculateRoutes.tapAsync("BingMapsPlugin", (source, target, routesList, callback) => {
	bing.findRoute(source, target, (err, route) => {
		if(err) return callback(err);
		routesList.add(route);
		// call the callback
		callback();
	});
});

// You can still use sync plugins
myCar.hooks.calculateRoutes.tap("CachedRoutesPlugin", (source, target, routesList) => {
	const cachedRoute = cache.get(source, target);
	if(cachedRoute)
		routesList.add(cachedRoute);
})
``` 