### PR TITLE
Small clarification in Tables section of writers-guide.md

### DIFF
--- a/src/content/contribute/writers-guide.md
+++ b/src/content/contribute/writers-guide.md
@@ -86,7 +86,7 @@ Parameter   | Explanation                                      | Input Type | De
 --devtool   | Define source map type for the bundled resources | string     | -
 --progress  | Print compilation progress in percentage         | boolean    | false
 
-Same goes for tables.
+Tables should also be ordered alphabetically.
 
 ### Configuration Properties
 


### PR DESCRIPTION
When I first read the writers guide, it took me a while to realize that the "Same goes for tables" was referring to the fact that they must be in alphabetical order (or at least... I'm pretty sure that's what it is referring to 😅)

<img width="790" alt="screen shot 2018-10-26 at 13 58 06" src="https://user-images.githubusercontent.com/26869552/47572517-7429e280-d93b-11e8-8cfc-21fce072adf0.png">

In my opinion, it would be better to give it its own context, especially because people can link directly to the Tables section. 