### PR TITLE
docs(plugins): rename OccurenceOrderPlugin to OccurrenceOrderPlugin

### DIFF
--- a/src/content/plugins/internal-plugins.md
+++ b/src/content/plugins/internal-plugins.md
@@ -1,6 +1,7 @@
 ---
 title: Internal webpack plugins
 contributors:
+  - iAziz786
   - EugeneHlushko
   - ooflorent
   - Legends
@@ -320,9 +321,9 @@ Minimizes the chunks with `uglify.js`.
 
 `options` are uglifyjs options.
 
-### OccurenceOrderPlugin
+### OccurrenceOrderPlugin
 
-`optimize/OccurenceOrderPlugin(preferEntry)`
+`optimize/OccurrenceOrderPlugin(preferEntry)`
 
 Order the modules and chunks by occurrence. This saves space, because often referenced modules and chunks get smaller ids.
 


### PR DESCRIPTION
After the arrival of webpack 2, `OccurenceOrderPlugin` has been [renamed](https://github.com/webpack/webpack/issues/1964#issuecomment-177661869) to `OccurrenceOrderPlugin`. This PR updates this to internal-plugin docs.