### PR TITLE
Recast this sentence about `externals`

### DIFF
--- a/src/content/guides/author-libraries.md
+++ b/src/content/guides/author-libraries.md
@@ -144,7 +144,7 @@ For full library configuration and code please refer to [webpack-library-example
 
 Now let's bundle this library in a way that will achieve the following goals:
 
-- Without bundling `lodash`, but requiring it to be loaded by the consumer using `externals`.
+- Using `externals` to avoid bundling `lodash`, so the consumer is required to load it.
 - Setting the library name as `webpack-numbers`.
 - Exposing the library as a variable called `webpackNumbers`.
 - Being able to access the library inside Node.js.


### PR DESCRIPTION
I really tripped over the original version because I read it as if the *consumer* was required to use `externals`. Obvious in hindsight but maybe this change will spare someone else a few minutes of confusion 😊
