### PR TITLE
docs(guides) update tree shaking guide

### DIFF
--- a/src/content/guides/tree-shaking.md
+++ b/src/content/guides/tree-shaking.md
@@ -14,6 +14,7 @@ contributors:
   - byzyk
   - pnevares
   - EugeneHlushko
+  - torifat
 related:
   - title: "webpack 4 beta — try it today!"
     url: https://medium.com/webpack/webpack-4-beta-try-it-today-6b1d27d7d7e2#9a67
@@ -75,7 +76,10 @@ module.exports = {
     path: path.resolve(__dirname, 'dist')
 - }
 + },
-+ mode: 'development'
++ mode: 'development',
++ optimization: {
++   usedExports: true
++ }
 };
 ```
 
@@ -186,7 +190,10 @@ module.exports = {
     filename: 'bundle.js',
     path: path.resolve(__dirname, 'dist')
   },
-- mode: 'development'
+- mode: 'development',
+- optimization: {
+-   usedExports: true
+- }
 + mode: 'production'
 };
 ```


### PR DESCRIPTION
In last PR #2426 the `mode` was changed from `production` to `development` and it broke the tree shaking behavior because [`usedExports`](https://webpack.js.org/configuration/optimization/#optimization-usedexports) is `false` in `development` mode.