### PR TITLE
docs(concepts) Remove redundant word in configuration.md

### DIFF
--- a/src/content/concepts/configuration.md
+++ b/src/content/concepts/configuration.md
@@ -28,7 +28,7 @@ While they are technically feasible, __the following practices should be avoided
 
 T> The most important part to take away from this document is that there are many different ways to format and style your webpack configuration. The key is to stick with something consistent that you and your team can understand and maintain.
 
-The following examples below describe how webpack's configuration can be both expressive and configurable because _it is code_:
+The examples below describe how webpack's configuration can be both expressive and configurable because _it is code_:
 
 ## Simple Configuration
 


### PR DESCRIPTION
Removed 'following' from 'The following examples below' as it kind of seems redundant.