### PR TITLE
docs(various) removed output.devtoolLineToLine, lineToLine of SourceM…

### DIFF
--- a/src/content/api/compilation-hooks.md
+++ b/src/content/api/compilation-hooks.md
@@ -627,12 +627,7 @@ Parameters: `childCompiler` `compilerName` `compilerIndex`
 
 ### `normalModuleLoader`
 
-`SyncHook`
-
-The normal module loader is the function that actually loads all the modules
-in the module graph (one-by-one).
-
-Parameters: `loaderContext` `module`
+Since webpack v5 `normalModuleLoader` hook was removed. Now to access the loader use `NormalModule.getCompilationHooks(compilation).loader` instead.
 
 ### `dependencyReference`
 

--- a/src/content/api/compilation-hooks.md
+++ b/src/content/api/compilation-hooks.md
@@ -5,6 +5,7 @@ sort: 2
 contributors:
   - byzyk
   - madhavarshney
+  - EugeneHlushko
 ---
 
 The `Compilation` module is used by the `Compiler` to create new compilations

--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -136,28 +136,6 @@ A fallback used when the template string or function above yields duplicates.
 See [`output.devtoolModuleFilenameTemplate`](#output-devtoolmodulefilenametemplate).
 
 
-## `output.devtoolLineToLine`
-
-`boolean | object`
-
-> Avoid using this option as it is __deprecated__ and will soon be removed.
-
-Enables line to line mapping for all or some modules. This produces a simple source map where each line of the generated source is mapped to the same line of the original source. This is a performance optimization and should only be used if all input lines match generated lines.
-
-Pass a boolean to enable or disable this feature for all modules (defaults to `false`). An object with `test`, `include`, `exclude` is also allowed. For example, to enable this feature for all javascript files within a certain directory:
-
-__webpack.config.js__
-
-```javascript
-module.exports = {
-  //...
-  output: {
-    devtoolLineToLine: { test: /\.js$/, include: 'src/utilities' }
-  }
-};
-```
-
-
 ## `output.devtoolModuleFilenameTemplate`
 
 `string | function(info)`

--- a/src/content/plugins/source-map-dev-tool-plugin.md
+++ b/src/content/plugins/source-map-dev-tool-plugin.md
@@ -5,6 +5,7 @@ contributors:
   - simon04
   - neilkennedy
   - byzyk
+  - EugeneHlushko
 related:
   - title: Building Source Maps
     url: https://survivejs.com/webpack/building/source-maps/#-sourcemapdevtoolplugin-and-evalsourcemapdevtoolplugin-

--- a/src/content/plugins/source-map-dev-tool-plugin.md
+++ b/src/content/plugins/source-map-dev-tool-plugin.md
@@ -30,12 +30,9 @@ The following options are supported:
 - `fallbackModuleFilenameTemplate` (`string`): See link above.
 - `module` (`boolean`): Indicates whether loaders should generate source maps (defaults to `true`).
 - `columns` (`boolean`): Indicates whether column mappings should be used (defaults to `true`).
-- `lineToLine` (`boolean` or `object`): Simplify and speed up source mapping by using line to line source mappings for matched modules.
 - `noSources` (`boolean`): Prevents the source file content from being included in the source map (defaults to `false`).
 - `publicPath` (`string`): Emits absolute URLs with public path prefix, e.g. `https://example.com/project/`.
 - `fileContext` (`string`): Makes the `[file]` argument relative to this directory.
-
-The `lineToLine` object allows for the same `test`, `include`, and `exclude` options described above.
 
 The `fileContext` option is useful when you want to store source maps in an upper level directory to avoid `../../` appearing in the absolute `[url]`.
 


### PR DESCRIPTION
- Removed option output.devtoolLineToLine
- Removed option lineToLine for SourceMapDevToolPlugin
- Replaced `compilation.hooks.normalModuleLoader` by `NormalModule.getCompilationHooks(compilation).loader`

Fixes #2647 