### PR TITLE
Revert "Add ref-loader to loader's introduction page"

### DIFF
--- a/src/content/loaders/index.md
+++ b/src/content/loaders/index.md
@@ -19,7 +19,6 @@ Loaders are activated by using `loadername!` prefixes in `require()` statements,
 - [`val-loader`](/loaders/val-loader) Executes code as module and consider exports as JS code
 - [`url-loader`](/loaders/url-loader) Works like the file loader, but can return a [data URL](https://tools.ietf.org/html/rfc2397) if the file is smaller than a limit
 - [`file-loader`](/loaders/file-loader) Emits the file into the output folder and returns the (relative) URL
-- [`ref-loader`](https://www.npmjs.com/package/ref-loader) Create dependencies between any files manually
 
 
 ## JSON


### PR DESCRIPTION
Reverts webpack/webpack.js.org#2653

Reasons behind revert are:

- not readable source code on parse.js (https://github.com/leecjson/ref-loader/blob/master/parse.js)
- no auto tests
- no current usage statistics, potentially suspicious

@leecjson the functionality looks very useful! Can you please add auto tests and refactor your source code to make it easily readable before re-submitting this to webpack.js.org please.