### PR TITLE
docs(config): fix broken link

### DIFF
--- a/src/content/configuration/index.md
+++ b/src/content/configuration/index.md
@@ -14,6 +14,7 @@ contributors:
   - jeremenichelli
   - dasarianudeep
   - byzyk
+  - kennetvu
 ---
 
 Out of the box, webpack won't require you to use a configuration file. However, it will assume the entry point of your project is `src/index` and will output the result in `dist/main.js` minified and optimized for production.
@@ -144,7 +145,7 @@ module.exports = {
         [loader](/configuration/module#rule-loader): "babel-loader",
         // the loader which should be applied, it'll be resolved relative to the context
         // -loader suffix is no longer optional in webpack2 for clarity reasons
-        // see [webpack 1 upgrade guide](/guides/migrating)
+        // see [webpack 1 upgrade guide](/migrate/3/#automatic-loader-module-name-extension-removed)
         [options](/configuration/module#rule-options-rule-query): {
           presets: ["es2015"]
         },


### PR DESCRIPTION
The link `https://webpack.js.org/guides/migrating` described in [https://webpack.js.org/configuration/#options](https://webpack.js.org/configuration/#options) is broken. Changed link to [migrate/3/#automatic-loader-module-name-extension-removed](migrate/3/#automatic-loader-module-name-extension-removed).

