### PR TITLE
feat(nav): allowing the / key to open the search 

### DIFF
--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -124,18 +124,21 @@ export default class Navigation extends React.Component {
       });
 
       // Keydown so we can "stop" the event if need be. 
-      window.addEventListener("keydown", e => {
+      window.addEventListener('keydown', e => {
         // Short circuit, as we only care about the "naked" key
         if (e.shiftKey || e.ctrlKey || e.metaKey) return;
       
         switch (e.which) {
           case 9: // `tab` key
-            if (e.target.classList.contains("navigation__search-input"))
+            if (e.target.classList.contains('navigation__search-input'))
               this._openSearch();
             break;
           case 191: // `/` key
-            !this._searchOpen && this._openSearch();
-            e.preventDefault(); // to block entering a `/` if the input is already in focus.
+            // We wrap this all in an if, so that the `/` key can still be used normally when the search is open.
+            if (!this._searchOpen) {
+              this._openSearch();
+              e.preventDefault(); // to block entering a `/` if the input is already in focus.
+            }
             break;
           case 27: // `esc` key
             this._searchOpen && this._closeSearch();

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -8,7 +8,7 @@ import Links from './Links.json';
 // TODO: Migrate to React Banner
 export default class Navigation extends React.Component {
 
-   // As this varaible is purly to track the state of the search,
+  // As this varaible is purly to track the state of the search,
   // and it's state doesn't affect the renders' output. And to
   // save react a re-render, we will not be storing this in the
   // components state object. 
@@ -127,7 +127,7 @@ export default class Navigation extends React.Component {
       window.addEventListener('keydown', e => {
         // Short circuit, as we only care about the "naked" key
         if (e.shiftKey || e.ctrlKey || e.metaKey) return;
-      
+
         switch (e.which) {
           case 9: // `tab` key
             if (e.target.classList.contains('navigation__search-input'))
@@ -145,7 +145,6 @@ export default class Navigation extends React.Component {
             break;
         }
       });
-      
 
     }
   }

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -119,9 +119,19 @@ export default class Navigation extends React.Component {
       });
 
       window.addEventListener('keyup', e => {
-        if (e.which === 9 && e.target.classList.contains('navigation__search-input')) {
-          this._openSearch();
+
+        switch(e.which) {
+          case 9: // `tab` key
+            if (e.target.classList.contains('navigation__search-input')) this._openSearch();
+            break;
+          case 191: // `/` key
+            this._openSearch(true);
+            break;
+          case 27: // `esc` key
+            this._closeSearch();
+            break;
         }
+
       });
     }
   }
@@ -168,8 +178,20 @@ export default class Navigation extends React.Component {
   /**
    * Expand the search input
    *
+   * 
+   * @param {boolean} andFocus - If this open should also focus the input
    */
-  _openSearch() {
+  _openSearch(andFocus = false) {
     this.container.classList.add('navigation--search-mode');
+
+    if ( andFocus === true ) this.searchInput.focus();
+  }
+
+  /**
+   * Closes the search input
+   *
+   */
+  _closeSearch() {
+    this.container.classList.remove('navigation--search-mode');
   }
 }

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -7,9 +7,14 @@ import Links from './Links.json';
 
 // TODO: Migrate to React Banner
 export default class Navigation extends React.Component {
-  render() {
-    let { pageUrl = '' } = this.props;
 
+   // As this varaible is purly to track the state of the search,
+  // and it's state doesn't affect the renders' output. And to
+  // save react a re-render, we will not be storing this in the
+  // components state object. 
+  _searchOpen = false;
+
+  render() {
     return (
       <header className="navigation" ref={ container => this.container = container }>
         <Container className="navigation__inner">
@@ -118,21 +123,27 @@ export default class Navigation extends React.Component {
         inputSelector: '.navigation__search-input'
       });
 
-      window.addEventListener('keyup', e => {
-
-        switch(e.which) {
+      // Keydown so we can "stop" the event if need be. 
+      window.addEventListener("keydown", e => {
+        // Short circuit, as we only care about the "naked" key
+        if (e.shiftKey || e.ctrlKey || e.metaKey) return;
+      
+        switch (e.which) {
           case 9: // `tab` key
-            if (e.target.classList.contains('navigation__search-input')) this._openSearch();
+            if (e.target.classList.contains("navigation__search-input"))
+              this._openSearch();
             break;
           case 191: // `/` key
-            this._openSearch(true);
+            !this._searchOpen && this._openSearch();
+            e.preventDefault(); // to block entering a `/` if the input is already in focus.
             break;
           case 27: // `esc` key
-            this._closeSearch();
+            this._searchOpen && this._closeSearch();
             break;
         }
-
       });
+      
+
     }
   }
 
@@ -170,21 +181,19 @@ export default class Navigation extends React.Component {
    *
    */
   _toggleSearch() {
-    let state = this.container.classList.toggle('navigation--search-mode');
-
-    if ( state === true ) this.searchInput.focus();
+    this._searchOpen
+      ? this._closeSearch()
+      : this._openSearch();
   }
 
   /**
    * Expand the search input
    *
-   * 
-   * @param {boolean} andFocus - If this open should also focus the input
    */
-  _openSearch(andFocus = false) {
+  _openSearch() {
     this.container.classList.add('navigation--search-mode');
-
-    if ( andFocus === true ) this.searchInput.focus();
+    this.searchInput.focus();
+    this._searchOpen = true;
   }
 
   /**
@@ -193,5 +202,6 @@ export default class Navigation extends React.Component {
    */
   _closeSearch() {
     this.container.classList.remove('navigation--search-mode');
+    this._searchOpen = false;
   }
 }


### PR DESCRIPTION
Adds the functionality to open the search window, similarly to how GitHub/vim does it with the `/` key.

Points to consider:
- the `/` key pops the search
- the `esc` key closes the search window
- added a new method `_closeSearch`
- added a defaulted argument to the `_openSearch` method
- _might be worth consolidating the `_toggleSearch` method to use the "open and close" methods?_

resolves: #2646 
