### PR TITLE
Fix missing "main.js" renaming to "bundle.js"

### DIFF
--- a/src/content/guides/asset-management.md
+++ b/src/content/guides/asset-management.md
@@ -54,7 +54,7 @@ __webpack.config.js__
     entry: './src/index.js',
     output: {
 -     filename: 'main.js',
-+     filename: 'bundle.js'
++     filename: 'bundle.js',
       path: path.resolve(__dirname, 'dist')
     },
 +   module: {

--- a/src/content/guides/asset-management.md
+++ b/src/content/guides/asset-management.md
@@ -53,7 +53,8 @@ __webpack.config.js__
   module.exports = {
     entry: './src/index.js',
     output: {
-      filename: 'bundle.js',
+-     filename: 'main.js',
++     filename: 'bundle.js'
       path: path.resolve(__dirname, 'dist')
     },
 +   module: {


### PR DESCRIPTION
In previous block of tutorials ("Getting started") project was accomplished used "main.js" as for output webpack bundle. It's supposed that user will go through next guide ("Asset Management") with project that done before.  But when other parts is changed, somebody forgot to change "main.js" to "bundle.js".