### PR TITLE
docs(dev): remove devtool from mode section

### DIFF
--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -11,6 +11,7 @@ contributors:
   - GAumala
   - EugeneHlushko
   - byzyk
+  - trivikr
 ---
 
 T> This guide extends on code examples found in the [Output Management](/guides/output-management) guide.
@@ -34,7 +35,6 @@ __webpack.config.js__
       app: './src/index.js',
       print: './src/print.js'
     },
-    devtool: 'inline-source-map',
     plugins: [
       new CleanWebpackPlugin(['dist']),
       new HtmlWebpackPlugin({


### PR DESCRIPTION
devtool: 'inline-source-map' is added in "Using source maps" section
which comes after the "Development" section

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.

[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
