### PR TITLE
docs(config) Externals as object note about umd library target

### DIFF
--- a/src/content/configuration/externals.md
+++ b/src/content/configuration/externals.md
@@ -35,7 +35,7 @@ __index.html__
 
 __webpack.config.js__
 
-```js
+```javascript
 module.exports = {
   //...
   externals: {
@@ -46,7 +46,7 @@ module.exports = {
 
 This leaves any dependent modules unchanged, i.e. the code shown below will still work:
 
-```js
+```javascript
 import $ from 'jquery';
 
 $('.my-element').animate(/* ... */);
@@ -69,7 +69,7 @@ See the example above. The property name `jquery` indicates that the module `jqu
 
 ### array
 
-```js
+```javascript
 module.exports = {
   //...
   externals: {
@@ -83,7 +83,9 @@ module.exports = {
 
 ### object
 
-```js
+W> An object with `{ root, amd, commonjs, ... }` is only allowed for [`libraryTarget: 'umd'`](/configuration/output/#output-librarytarget). It's not allowed for other library targets.
+
+```javascript
 module.exports = {
   //...
   externals : {
@@ -119,7 +121,7 @@ It might be useful to define your own function to control the behavior of what y
 
 It basically comes down to this:
 
-```js
+```javascript
 module.exports = {
   //...
   externals: [
@@ -140,7 +142,7 @@ The `'commonjs ' + request` defines the type of module that needs to be external
 
 Every dependency that matches the given regular expression will be excluded from the output bundles.
 
-```js
+```javascript
 module.exports = {
   //...
   externals: /^(jquery|\$)$/i
@@ -153,7 +155,7 @@ In this case any dependency named `jQuery`, capitalized or not, or `$` would be 
 
 Sometimes you may want to use a combination of the above syntaxes. This can be done in the following manner:
 
-```js
+```javascript
 module.exports = {
   //...
   externals: [


### PR DESCRIPTION
- add a note about using object for externals
- use `javascript` for code example blocks to continue general `*.md` tidying and maintainability
- fixes #2668 