### PR TITLE
Adding a note about splitChunks.name = false functionality

### DIFF
--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -164,7 +164,9 @@ T> `maxSize` takes higher priority than `maxInitialRequest/maxAsyncRequests`. Ac
 
 `boolean: true | function (module) | string`
 
-The name of the split chunk. Providing `true` will automatically generate a name based on chunks and cache group key, while `false` will use an id as the name (a good value for production so that it doesn't change unnecessarily). Providing a string or function will allow you to use a custom name. If the name matches an entry point name, the entry point will be removed.
+The name of the split chunk. Providing `true` will automatically generate a name based on chunks and cache group key. Providing a string or function will allow you to use a custom name. If the name matches an entry point name, the entry point will be removed.
+
+T> It is recommended to set `splitChunks.name` to `false` for production builds so that it doesn't change names unnecessarily.
 
 __webpack.config.js__
 

--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -164,7 +164,7 @@ T> `maxSize` takes higher priority than `maxInitialRequest/maxAsyncRequests`. Ac
 
 `boolean: true | function (module) | string`
 
-The name of the split chunk. Providing `true` will automatically generate a name based on chunks and cache group key. Providing a string or function will allow you to use a custom name. If the name matches an entry point name, the entry point will be removed.
+The name of the split chunk. Providing `true` will automatically generate a name based on chunks and cache group key, while `false` will use an id as the name (a good value for production so that it doesn't change unnecessarily). Providing a string or function will allow you to use a custom name. If the name matches an entry point name, the entry point will be removed.
 
 __webpack.config.js__
 


### PR DESCRIPTION
Hi people!

This adds a note about what `splitChunks.name = false` means and that it is probably a good setting for production. This (hopefully) is an easy win, as it was recommended by sokra: https://github.com/webpack/webpack/issues/8426#issuecomment-442375207

Thanks!