### PR TITLE
Update writing-a-plugin.md

### DIFF
--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -34,7 +34,8 @@ class MyExampleWebpackPlugin {
         console.log('Here’s the `compilation` object which represents a single build of assets:', compilation);
 
         // Manipulate the build using the plugin API provided by webpack
-        compilation.addModule(/* ... */);
+        console.log(`print assets`, Object.keys(compilation.assets))
+        
 
         callback();
       }


### PR DESCRIPTION
```compilation.addModule(/* ... */)``` will resulting in an error ```Unhandled rejection TypeError: module.identifier is not a function```
,It is a bad experience to a green hand.

_describe your changes..._

- [ ] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [ ] Make sure your PR complies with the [writer's guide][2].
- [ ] Review the diff carefully as sometimes this can reveal issues.
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
