### PR TITLE
Correct path to main.js in index.html

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -172,7 +172,7 @@ __dist/index.html__
    </head>
    <body>
 -    <script src="./src/index.js"></script>
-+    <script src="main.js"></script>
++    <script src="./dist/main.js"></script>
    </body>
   </html>
 ```


### PR DESCRIPTION
Corrected path to main.js in index.html. Initial instructions result in 404.