### PR TITLE
Add rel="noopener nofollow" for links to sponsor websites

### DIFF
--- a/src/components/Support/Support.jsx
+++ b/src/components/Support/Support.jsx
@@ -100,7 +100,7 @@ export default class Support extends React.Component {
                className="support__item"
                title={ `$${formatMoney(supporter.totalDonations / 100)} by ${supporter.name || supporter.slug}` }
                target="_blank"
-               rel="noopener"
+               rel="noopener nofollow"
                href={ supporter.website || `https://opencollective.com/${supporter.slug}` }>
               {<img
                 className={ `support__${rank}-avatar` }

--- a/src/components/Support/Support.jsx
+++ b/src/components/Support/Support.jsx
@@ -100,6 +100,7 @@ export default class Support extends React.Component {
                className="support__item"
                title={ `$${formatMoney(supporter.totalDonations / 100)} by ${supporter.name || supporter.slug}` }
                target="_blank"
+               rel="noopener"
                href={ supporter.website || `https://opencollective.com/${supporter.slug}` }>
               {<img
                 className={ `support__${rank}-avatar` }


### PR DESCRIPTION
Hello :wave:

When linking to external sites with `target='_blank'`, it's important to add `rel='noopener'` as a security measure. Otherwise the external site is able to navigate the original browser tab in the background, for example to a phishing site. 

More info here: https://mathiasbynens.github.io/rel-noopener/


~You've also got a bit of a spam problem at the moment - there are lots of $2 donations that seem to exist solely to build backlinks for spammy gambling websites.~
That seems to have been mostly taken care of in #2681. However, I've also added [`rel='nofollow'`](https://support.google.com/webmasters/answer/96569?hl=en), which should let search engines know it's an untrusted link and hopefully protect your own search ranking. Hopefully that takes away some of the incentive to spam.