### PR TITLE
fix(fetch-packages): remove only titles from loaders and plugins docs

### DIFF
--- a/src/scripts/fetch_packages.js
+++ b/src/scripts/fetch_packages.js
@@ -130,7 +130,7 @@ function fetchPackageFiles(options, finalCb) {
             })
             // Replace lone h1 formats
             .replace(/<h1.*?>.+?<\/h1>/, '')
-            .replace(/# .+/, '')
+            .replace(/^# .+/m, '')
             // Resolve anchor hrefs to avoid broken relative references in the docs
             // Examples:
             // - [click here](LICENSE) --> [click here](https://raw.githubusercontent.com/user/repository/branch/LICENSE)


### PR DESCRIPTION
When fetching packages title is removed by a regular expressions, but in `README.md` files like the one from [`style-loader`](https://github.com/webpack-contrib/style-loader/blob/master/README.md), there's no a title heading using the pattern `# ...`. Instead, its first line that matches this pattern is a sub-header. Since the purpose is only to replace a title, this PR changes the RegExp to match this kind of issues and maintaining other docs working as usual.

Fixes #2692 