### PR TITLE
Add documentation for `Rule.use` as a function

### DIFF
--- a/src/content/configuration/module.md
+++ b/src/content/configuration/module.md
@@ -308,15 +308,13 @@ module.exports = {
 
 ## `Rule.use`
 
-`[UseEntry]` `function`
+`[UseEntry] | function`
 
 `Rule.use` can be an array of [UseEntry](#useentry) which are applied to modules. Each entry specifies a loader to be used.
 
 Passing a string (i.e. `use: [ 'style-loader' ]`) is a shortcut to the loader property (i.e. `use: [ { loader: 'style-loader '} ]`).
 
 Loaders can be chained by passing multiple loaders, which will be applied from right to left (last to first configured).
-
-`Function`
 
 `Rule.use` can be a function which receives the object argument describing the module being loaded, and must return an array of `UseEntry`.
 
@@ -326,7 +324,7 @@ The object parameter has the following fields:
 - `resource`: The path to the module being loaded
 - `realResource`: The path to the module being loaded
 - `resourceQuery`: ??
-- `compiler`: ?? (can be undefined)
+- `compiler`: The current webpack compiler (can be undefined)
 - `issuer`: The path to the module that is importing the module being loaded
 
 __webpack.config.js__

--- a/src/content/configuration/module.md
+++ b/src/content/configuration/module.md
@@ -308,9 +308,9 @@ module.exports = {
 
 ## `Rule.use`
 
-`array`
+`[UseEntry]` `function`
 
-An array of [UseEntry](#useentry) which are applied to modules. Each entry specifies a loader to be used.
+`Rule.use` can be an array of [UseEntry](#useentry) which are applied to modules. Each entry specifies a loader to be used.
 
 Passing a string (i.e. `use: [ 'style-loader' ]`) is a shortcut to the loader property (i.e. `use: [ { loader: 'style-loader '} ]`).
 
@@ -318,9 +318,9 @@ Loaders can be chained by passing multiple loaders, which will be applied from r
 
 `Function`
 
-A function which takes an object describing the module being loaded, and must return an array of `UseEntry`.
+`Rule.use` can be a function which receives the object argument describing the module being loaded, and must return an array of `UseEntry`.
 
-The same shortcut as as an array can be used for the return value (i.e. `use: [ 'style-loader' ]`).
+The same shortcut as an array can be used for the return value (i.e. `use: [ 'style-loader' ]`).
 
 The object parameter has the following fields:
 - `resource`: The path to the module being loaded

--- a/src/content/configuration/module.md
+++ b/src/content/configuration/module.md
@@ -322,9 +322,8 @@ The object parameter has the following fields:
 
 - `compiler`: The current webpack compiler (can be undefined)
 - `issuer`: The path to the module that is importing the module being loaded
-- `resource`: The path to the module being loaded
-- `realResource`: The path to the module being loaded
-- `resourceQuery`
+- `realResource`: Always the path to the module being loaded
+- `resource`: The path to the module being loaded, it is usually equal to `realResource` except when the resource name is overwritten via `!=!` in request string
 
 The same shortcut as an array can be used for the return value (i.e. `use: [ 'style-loader' ]`).
 

--- a/src/content/configuration/module.md
+++ b/src/content/configuration/module.md
@@ -318,14 +318,15 @@ Loaders can be chained by passing multiple loaders, which will be applied from r
 
 `Rule.use` can be a function which receives the object argument describing the module being loaded, and must return an array of `UseEntry`.
 
-The same shortcut as an array can be used for the return value (i.e. `use: [ 'style-loader' ]`).
-
 The object parameter has the following fields:
-- `resource`: The path to the module being loaded
-- `realResource`: The path to the module being loaded
-- `resourceQuery`: ??
+
 - `compiler`: The current webpack compiler (can be undefined)
 - `issuer`: The path to the module that is importing the module being loaded
+- `resource`: The path to the module being loaded
+- `realResource`: The path to the module being loaded
+- `resourceQuery`
+
+The same shortcut as an array can be used for the return value (i.e. `use: [ 'style-loader' ]`).
 
 __webpack.config.js__
 

--- a/src/content/configuration/module.md
+++ b/src/content/configuration/module.md
@@ -308,11 +308,26 @@ module.exports = {
 
 ## `Rule.use`
 
-A list of [UseEntries](#useentry) which are applied to modules. Each entry specifies a loader to be used.
+`array`
+
+An array of [UseEntry](#useentry) which are applied to modules. Each entry specifies a loader to be used.
 
 Passing a string (i.e. `use: [ 'style-loader' ]`) is a shortcut to the loader property (i.e. `use: [ { loader: 'style-loader '} ]`).
 
 Loaders can be chained by passing multiple loaders, which will be applied from right to left (last to first configured).
+
+`Function`
+
+A function which takes an object describing the module being loaded, and must return an array of `UseEntry`.
+
+The same shortcut as as an array can be used for the return value (i.e. `use: [ 'style-loader' ]`).
+
+The object parameter has the following fields:
+- `resource`: The path to the module being loaded
+- `realResource`: The path to the module being loaded
+- `resourceQuery`: ??
+- `compiler`: ?? (can be undefined)
+- `issuer`: The path to the module that is importing the module being loaded
 
 __webpack.config.js__
 


### PR DESCRIPTION
Adds some documentation for using a function for `Rule.use` configuration.

For the object passed to the function, I'm not surewhat `realResource`, `compiler` & `resourceQuery` are for, and I'd appreciate some help to explain them succinctly , thank you

Fixes #2691 