### PR TITLE
docs: add group prop in writer's guide

### DIFF
--- a/src/content/contribute/writers-guide.md
+++ b/src/content/contribute/writers-guide.md
@@ -20,6 +20,7 @@ Each article contains a small section at the top written in [YAML Frontmatter](h
 ``` yaml
 ---
 title: My Article
+group: My Sub-Section
 sort: 3
 contributors:
   - [github username]
@@ -32,7 +33,8 @@ related:
 Let's break these down:
 
 - `title`: The name of the article.
-- `sort`: The order of the article within its section.
+- `group`: The name of the sub-section
+- `sort`: The order of the article within its section (or) sub-section if it is present.
 - `contributors`: A list of GitHub usernames who have contributed to this article.
 - `related`: Any related reading or useful examples.
 


### PR DESCRIPTION
### What is a change?
Currently we are using sub-sections using group property for `MODULES` and `PLUGINS` on `/api/` page.
This PR adds information about how to add sub-section.