### PR TITLE
docs(plugins) SCP idHint and removal of name and automaticNamePrefix

### DIFF
--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -61,7 +61,6 @@ module.exports = {
       maxAsyncRequests: 6,
       maxInitialRequests: 4,
       automaticNameDelimiter: '~',
-      name: true,
       cacheGroups: {
         vendors: {
           test: /[\\/]node_modules[\\/]/,
@@ -325,6 +324,29 @@ module.exports = {
       cacheGroups: {
         vendors: {
           enforce: true
+        }
+      }
+    }
+  }
+};
+```
+
+#### `splitChunks.cacheGroups.{cacheGroup}.idHint`
+
+`string`
+
+Sets the hint for chunk id. It will be added to chunk's filename.
+
+__webpack.config.js__
+
+```js
+module.exports = {
+  //...
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        vendors: {
+          idHint: 'vendors'
         }
       }
     }


### PR DESCRIPTION
Fixes #2705 partially, the rest is for migration guide

- remove name: true and automaticNamePrefix from splitChunks
- add idHint option to splitChunks to provide a hint for the named ids