### PR TITLE
ux(splash) fix splash overlapping with links on low heights

### DIFF
--- a/src/components/Splash/Splash.scss
+++ b/src/components/Splash/Splash.scss
@@ -2,6 +2,9 @@
 @import 'mixins';
 
 .splash {
+  position: relative;
+  overflow: hidden;
+  
   &__section {
     position:relative;
     text-align:center;


### PR DESCRIPTION
Dont let splash's content overlap links.

Fixes #2637 