### PR TITLE
fix(fetch-packages): remove only titles from loaders and plugins docs

### DIFF
--- a/src/utilities/process-readme.js
+++ b/src/utilities/process-readme.js
@@ -10,7 +10,7 @@ module.exports = function processREADME(body, options = {}) {
     })
     // Replace lone h1 formats
     .replace(/<h1.*?>.+?<\/h1>/, '')
-    .replace(/# .+/, '')
+    .replace(/^# .+/m, '')
     .replace(/.*\n=+/, '')
     // Replace local github links with absolute links to the github location
     // EXAMPLE: [Contributing](./.github/CONTRIBUTING.md)


### PR DESCRIPTION
Implements https://github.com/webpack/webpack.js.org/pull/2693 to `rebuild` branch.