### PR TITLE
 docs(config) add new stats option is off by default

### DIFF
--- a/src/content/configuration/stats.md
+++ b/src/content/configuration/stats.md
@@ -85,7 +85,7 @@ module.exports = {
     chunkOrigins: true,
 
     // Displays chunk parents, children and siblings
-    chunkRelations: true,
+    chunkRelations: false,
 
     // Sort the chunks by a field
     // You can reverse the sort with `!field`. Default is `id`.

--- a/src/content/configuration/stats.md
+++ b/src/content/configuration/stats.md
@@ -84,6 +84,9 @@ module.exports = {
     // Add the origins of chunks and chunk merging info
     chunkOrigins: true,
 
+    // Displays chunk parents, children and siblings
+    chunkRelations: true,
+
     // Sort the chunks by a field
     // You can reverse the sort with `!field`. Default is `id`.
     // Some other possible values: 'name', 'size', 'chunks', 'failed', 'issuer'


### PR DESCRIPTION
Fixes #2734 

Document new stats option which is off by default.