### PR TITLE
Update installation.md to reference `npm build` vs. `npm start`

### DIFF
--- a/src/content/guides/installation.md
+++ b/src/content/guides/installation.md
@@ -40,7 +40,7 @@ Installing locally is what we recommend for most projects. This makes it easier 
 
 ```json
 "scripts": {
-	"start": "webpack --config webpack.config.js"
+	"build": "webpack --config webpack.config.js"
 }
 ```
 


### PR DESCRIPTION
In the follow-up steps in the guide, `npm run build` is always referenced, not `npm run start`. It seems like in the initial installation section `build` should be the name of the npm task vs. `start`.

![screen shot 2019-01-04 at 09 29 33](https://user-images.githubusercontent.com/630449/50701879-5f895b00-100c-11e9-9035-3cecba232a37.png)
