### PR TITLE
docs(config): Describe maxAsyncSize and maxInitialSize

### DIFF
--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -160,7 +160,7 @@ When the chunk has a name already, each part will get a new name derived from th
 
 T> `maxSize` takes higher priority than `maxInitialRequest/maxAsyncRequests`. Actual priority is `maxInitialRequest/maxAsyncRequests < maxSize < minSize`.
 
-Note that setting the value for `maxSize` sets the value for both `maxAsyncSize` and `maxInitialSize`.
+T> Setting the value for `maxSize` sets the value for both `maxAsyncSize` and `maxInitialSize`.
 
 ### `splitChunks.maxAsyncSize`
 

--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -176,7 +176,7 @@ The difference between `maxAsyncSize` and `maxSize` is that `maxAsyncSize` will 
 
 Like `maxSize`, `maxInitialSize` can be applied globally (`splitChunks.maxInitialSize`), to cacheGroups (`splitChunks.cacheGroups.{cacheGroup}.maxInitialSize`), or to the fallback cache group (`splitChunks.fallbackCacheGroup.maxInitialSize`).
 
-The difference between `maxInitialSize` and `maxSize` is that `maxInitialSize` will only be applied to chunks that are used for the initial load.
+The difference between `maxInitialSize` and `maxSize` is that `maxInitialSize` will only affect initial load chunks.
 
 ### `splitChunks.name`
 

--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -174,7 +174,7 @@ The difference between `maxAsyncSize` and `maxSize` is that `maxAsyncSize` will 
 
 `number`
 
-Like `maxSize`, `maxInitialSize` can be applied globally (`optimization.splitChunks.maxInitialSize`), to cacheGroups (`optimization.splitChunks.cacheGroups[x].maxInitialSize`), or to the fallback cache group (`optimization.splitChunks.fallbackCacheGroup.maxInitialSize`).
+Like `maxSize`, `maxInitialSize` can be applied globally (`splitChunks.maxInitialSize`), to cacheGroups (`splitChunks.cacheGroups.{cacheGroup}.maxInitialSize`), or to the fallback cache group (`splitChunks.fallbackCacheGroup.maxInitialSize`).
 
 The difference between `maxInitialSize` and `maxSize` is that `maxInitialSize` will only be applied to chunks that are used for the initial load.
 

--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -166,7 +166,7 @@ Note that setting the value for `maxSize` sets the value for both `maxAsyncSize`
 
 `number`
 
-Like `maxSize`, `maxAsyncSize` can be applied globally (`optimization.splitChunks.maxAsyncSize`), to cacheGroups (`optimization.splitChunks.cacheGroups[x].maxAsyncSize`), or to the fallback cache group (`optimization.splitChunks.fallbackCacheGroup.maxAsyncSize`).
+Like `maxSize`, `maxAsyncSize` can be applied globally (`splitChunks.maxAsyncSize`), to cacheGroups (`splitChunks.cacheGroups.{cacheGroup}.maxAsyncSize`), or to the fallback cache group (`splitChunks.fallbackCacheGroup.maxAsyncSize`).
 
 The difference between `maxAsyncSize` and `maxSize` is that `maxAsyncSize` will only be applied to chunks that are loaded on-demand.
 

--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -10,6 +10,7 @@ contributors:
   - jacobangel
   - madhavarshney
   - sakhisheikh
+  - superburrito
 related:
   - title: webpack's automatic deduplication algorithm example
     url: https://github.com/webpack/webpack/blob/master/examples/many-pages/README.md
@@ -158,6 +159,24 @@ When the chunk has a name already, each part will get a new name derived from th
 `maxSize` options is intended to be used with HTTP/2 and long term caching. It increase the request count for better caching. It could also be used to decrease the file size for faster rebuilding.
 
 T> `maxSize` takes higher priority than `maxInitialRequest/maxAsyncRequests`. Actual priority is `maxInitialRequest/maxAsyncRequests < maxSize < minSize`.
+
+Note that setting the value for `maxSize` sets the value for both `maxAsyncSize` and `maxInitialSize`.
+
+### `splitChunks.maxAsyncSize`
+
+`number`
+
+Like `maxSize`, `maxAsyncSize` can be applied globally (`optimization.splitChunks.maxAsyncSize`), to cacheGroups (`optimization.splitChunks.cacheGroups[x].maxAsyncSize`), or to the fallback cache group (`optimization.splitChunks.fallbackCacheGroup.maxAsyncSize`).
+
+The difference between `maxAsyncSize` and `maxSize` is that `maxAsyncSize` will only be applied to chunks that are loaded on-demand.
+
+### `splitChunks.maxInitialSize`
+
+`number`
+
+Like `maxSize`, `maxInitialSize` can be applied globally (`optimization.splitChunks.maxInitialSize`), to cacheGroups (`optimization.splitChunks.cacheGroups[x].maxInitialSize`), or to the fallback cache group (`optimization.splitChunks.fallbackCacheGroup.maxInitialSize`).
+
+The difference between `maxInitialSize` and `maxSize` is that `maxInitialSize` will only be applied to chunks that are used for the initial load.
 
 ### `splitChunks.name`
 

--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -168,7 +168,7 @@ Note that setting the value for `maxSize` sets the value for both `maxAsyncSize`
 
 Like `maxSize`, `maxAsyncSize` can be applied globally (`splitChunks.maxAsyncSize`), to cacheGroups (`splitChunks.cacheGroups.{cacheGroup}.maxAsyncSize`), or to the fallback cache group (`splitChunks.fallbackCacheGroup.maxAsyncSize`).
 
-The difference between `maxAsyncSize` and `maxSize` is that `maxAsyncSize` will only be applied to chunks that are loaded on-demand.
+The difference between `maxAsyncSize` and `maxSize` is that `maxAsyncSize` will only affect on-demand loading chunks.
 
 ### `splitChunks.maxInitialSize`
 


### PR DESCRIPTION
Adding a description for `maxAsyncSize` and `maxInitialSize`, in response to https://github.com/webpack/webpack.js.org/issues/2723 (based on https://github.com/webpack/webpack/pull/8484).

EDIT: Fixes #2723