### PR TITLE
docs(config) resolve page tidy up and improvements

### DIFF
--- a/src/content/configuration/resolve.md
+++ b/src/content/configuration/resolve.md
@@ -11,7 +11,7 @@ contributors:
   - byzyk
   - numb86
   - jgravois
-  
+  - EugeneHlushko
 ---
 
 These options change how modules are resolved. webpack provides reasonable defaults, but it is possible to change the resolving in detail. Have a look at [Module Resolution](/concepts/module-resolution) for more explanation of how the resolver works.
@@ -21,7 +21,18 @@ These options change how modules are resolved. webpack provides reasonable defau
 
 `object`
 
-Configure how modules are resolved. For example, when calling `import "lodash"` in ES2015, the `resolve` options can change where webpack goes to look for `"lodash"` (see [`modules`](#resolve-modules)).
+Configure how modules are resolved. For example, when calling `import 'lodash'` in ES2015, the `resolve` options can change where webpack goes to look for `'lodash'` (see [`modules`](#resolve-modules)).
+
+__webpack.config.js__
+
+```js
+module.exports = {
+  //...
+  resolve: {
+    // configuration options
+  }
+};
+```
 
 
 ### `resolve.alias`
@@ -29,6 +40,8 @@ Configure how modules are resolved. For example, when calling `import "lodash"` 
 `object`
 
 Create aliases to `import` or `require` certain modules more easily. For example, to alias a bunch of commonly used `src/` folders:
+
+__webpack.config.js__
 
 ```js
 module.exports = {
@@ -56,6 +69,8 @@ import Utility from 'Utilities/utility';
 
 A trailing `$` can also be added to the given object's keys to signify an exact match:
 
+__webpack.config.js__
+
 ```js
 module.exports = {
   //...
@@ -76,22 +91,22 @@ import Test2 from 'xyz/file.js'; // Not an exact match, normal resolution takes 
 
 The following table explains other cases:
 
-| `alias:`                            | `import "xyz"`                        | `import "xyz/file.js"`              |
+| `alias:`                            | `import 'xyz'`                        | `import 'xyz/file.js'`              |
 | ----------------------------------- | ------------------------------------- | ----------------------------------- |
 | `{}`                                | `/abc/node_modules/xyz/index.js`      | `/abc/node_modules/xyz/file.js`     |
-| `{ xyz: "/abs/path/to/file.js" }`   | `/abs/path/to/file.js`                | error                               |
-| `{ xyz$: "/abs/path/to/file.js" }`  | `/abs/path/to/file.js`                | `/abc/node_modules/xyz/file.js`     |
-| `{ xyz: "./dir/file.js" }`          | `/abc/dir/file.js`                    | error                               |
-| `{ xyz$: "./dir/file.js" }`         | `/abc/dir/file.js`                    | `/abc/node_modules/xyz/file.js`     |
-| `{ xyz: "/some/dir" }`              | `/some/dir/index.js`                  | `/some/dir/file.js`                 |
-| `{ xyz$: "/some/dir" }`             | `/some/dir/index.js`                  | `/abc/node_modules/xyz/file.js`     |
-| `{ xyz: "./dir" }`                  | `/abc/dir/index.js`                   | `/abc/dir/file.js`                  |
-| `{ xyz: "modu" }`                   | `/abc/node_modules/modu/index.js`     | `/abc/node_modules/modu/file.js`    |
-| `{ xyz$: "modu" }`                  | `/abc/node_modules/modu/index.js`     | `/abc/node_modules/xyz/file.js`     |
-| `{ xyz: "modu/some/file.js" }`      | `/abc/node_modules/modu/some/file.js` | error                               |
-| `{ xyz: "modu/dir" }`               | `/abc/node_modules/modu/dir/index.js` | `/abc/node_modules/dir/file.js`     |
-| `{ xyz: "xyz/dir" }`                | `/abc/node_modules/xyz/dir/index.js`  | `/abc/node_modules/xyz/dir/file.js` |
-| `{ xyz$: "xyz/dir" }`               | `/abc/node_modules/xyz/dir/index.js`  | `/abc/node_modules/xyz/file.js`     |
+| `{ xyz: '/abs/path/to/file.js' }`   | `/abs/path/to/file.js`                | error                               |
+| `{ xyz$: '/abs/path/to/file.js' }`  | `/abs/path/to/file.js`                | `/abc/node_modules/xyz/file.js`     |
+| `{ xyz: './dir/file.js' }`          | `/abc/dir/file.js`                    | error                               |
+| `{ xyz$: './dir/file.js' }`         | `/abc/dir/file.js`                    | `/abc/node_modules/xyz/file.js`     |
+| `{ xyz: '/some/dir' }`              | `/some/dir/index.js`                  | `/some/dir/file.js`                 |
+| `{ xyz$: '/some/dir' }`             | `/some/dir/index.js`                  | `/abc/node_modules/xyz/file.js`     |
+| `{ xyz: './dir' }`                  | `/abc/dir/index.js`                   | `/abc/dir/file.js`                  |
+| `{ xyz: 'modu' }`                   | `/abc/node_modules/modu/index.js`     | `/abc/node_modules/modu/file.js`    |
+| `{ xyz$: 'modu' }`                  | `/abc/node_modules/modu/index.js`     | `/abc/node_modules/xyz/file.js`     |
+| `{ xyz: 'modu/some/file.js' }`      | `/abc/node_modules/modu/some/file.js` | error                               |
+| `{ xyz: 'modu/dir' }`               | `/abc/node_modules/modu/dir/index.js` | `/abc/node_modules/dir/file.js`     |
+| `{ xyz: 'xyz/dir' }`                | `/abc/node_modules/xyz/dir/index.js`  | `/abc/node_modules/xyz/dir/file.js` |
+| `{ xyz$: 'xyz/dir' }`               | `/abc/node_modules/xyz/dir/index.js`  | `/abc/node_modules/xyz/file.js`     |
 
 `index.js` may resolve to another file if defined in the `package.json`.
 
@@ -100,9 +115,11 @@ The following table explains other cases:
 
 ### `resolve.aliasFields`
 
-`array`
+`[string]: ['browser']`
 
-Specify a field, such as `browser`, to be parsed according to [this specification](https://github.com/defunctzombie/package-browser-field-spec). Default:
+Specify a field, such as `browser`, to be parsed according to [this specification](https://github.com/defunctzombie/package-browser-field-spec).
+
+__webpack.config.js__
 
 ```js
 module.exports = {
@@ -123,9 +140,11 @@ If unsafe cache is enabled, includes `request.context` in the cache key. This op
 
 ### `resolve.descriptionFiles`
 
-`array`
+`[string]: ['package.json']`
 
-The JSON files to use for descriptions. Default:
+The JSON files to use for descriptions.
+
+__webpack.config.js__
 
 ```js
 module.exports = {
@@ -139,9 +158,11 @@ module.exports = {
 
 ### `resolve.enforceExtension`
 
-`boolean`
+`boolean: false`
 
-If `true`, it will not allow extension-less files. So by default `require('./foo')` works if `./foo` has a `.js` extension, but with this enabled only `require('./foo.js')` will work. Default:
+If `true`, it will not allow extension-less files. So by default `require('./foo')` works if `./foo` has a `.js` extension, but with this enabled only `require('./foo.js')` will work.
+
+__webpack.config.js__
 
 ```js
 module.exports = {
@@ -155,9 +176,11 @@ module.exports = {
 
 ### `resolve.enforceModuleExtension`
 
-`boolean`
+`boolean: false`
 
-Whether to require to use an extension for modules (e.g. loaders). Default:
+Tells webpack whether to require to use an extension for modules (e.g. loaders).
+
+__webpack.config.js__
 
 ```js
 module.exports = {
@@ -171,9 +194,11 @@ module.exports = {
 
 ### `resolve.extensions`
 
-`array`
+`[string]: ['.wasm', '.mjs', '.js', '.json']`
 
-Automatically resolve certain extensions. This defaults to:
+Automatically resolve certain extensions.
+
+__webpack.config.js__
 
 ```js
 module.exports = {
@@ -190,17 +215,18 @@ which is what enables users to leave off the extension when importing:
 import File from '../path/to/file';
 ```
 
-W> Using this will __override the default array__, meaning that webpack will no longer try to resolve modules using the default extensions. For modules that are imported with their extension, e.g. `import SomeFile from "./somefile.ext"`, to be properly resolved, a string containing "\*" must be included in the array.
+W> Using this will __override the default array__, meaning that webpack will no longer try to resolve modules using the default extensions. For modules that are imported with their extension, e.g. `import SomeFile from './somefile.ext'`, to be properly resolved, a string containing "\*" must be included in the array.
 
 
 ### `resolve.mainFields`
 
-`array`
+`[string]`
 
-When importing from an npm package, e.g. `import * as D3 from "d3"`, this option will determine which fields in its `package.json` are checked. The default values will vary based upon the [`target`](/concepts/targets) specified in your webpack configuration.
+When importing from an npm package, e.g. `import * as D3 from 'd3'`, this option will determine which fields in its `package.json` are checked. The default values will vary based upon the [`target`](/concepts/targets) specified in your webpack configuration.
 
 When the `target` property is set to `webworker`, `web`, or left unspecified:
 
+__webpack.config.js__
 
 ```js
 module.exports = {
@@ -212,6 +238,8 @@ module.exports = {
 ```
 
 For any other target (including `node`):
+
+__webpack.config.js__
 
 ```js
 module.exports = {
@@ -231,14 +259,16 @@ For example, consider an arbitrary library called `upstream` with a `package.jso
 }
 ```
 
-When we `import * as Upstream from "upstream"` this will actually resolve to the file in the `browser` property. The `browser` property takes precedence because it's the first item in `mainFields`. Meanwhile, a Node.js application bundled by webpack will first try to resolve using the file in the `module` field.
+When we `import * as Upstream from 'upstream'` this will actually resolve to the file in the `browser` property. The `browser` property takes precedence because it's the first item in `mainFields`. Meanwhile, a Node.js application bundled by webpack will first try to resolve using the file in the `module` field.
 
 
 ### `resolve.mainFiles`
 
-`array`
+`[string]: ['index']`
 
-The filename to be used while resolving directories. Default:
+The filename to be used while resolving directories.
+
+__webpack.config.js__
 
 ```js
 module.exports = {
@@ -252,7 +282,7 @@ module.exports = {
 
 ### `resolve.modules`
 
-`array`
+`[string]: ['node_modules']`
 
 Tell webpack what directories should be searched when resolving modules.
 
@@ -262,7 +292,7 @@ A relative path will be scanned similarly to how Node scans for `node_modules`, 
 
 With an absolute path, it will only search in the given directory.
 
-`resolve.modules` defaults to:
+__webpack.config.js__
 
 ```js
 module.exports = {
@@ -274,6 +304,8 @@ module.exports = {
 ```
 
 If you want to add a directory to search in that takes precedence over `node_modules/`:
+
+__webpack.config.js__
 
 ```js
 module.exports = {
@@ -287,9 +319,11 @@ module.exports = {
 
 ### `resolve.unsafeCache`
 
-`regex` `array` `boolean`
+`regex` `array` `boolean: true`
 
-Enable aggressive, but __unsafe__, caching of modules. Passing `true` will cache everything. Default:
+Enable aggressive, but __unsafe__, caching of modules. Passing `true` will cache everything.
+
+__webpack.config.js__
 
 ```js
 module.exports = {
@@ -301,6 +335,8 @@ module.exports = {
 ```
 
 A regular expression, or an array of regular expressions, can be used to test file paths and only cache certain modules. For example, to only cache utilities:
+
+__webpack.config.js__
 
 ```js
 module.exports = {
@@ -316,7 +352,11 @@ W> Changes to cached paths may cause failure in rare cases.
 
 ### `resolve.plugins`
 
+`[Plugin]`
+
 A list of additional resolve plugins which should be applied. It allows plugins such as [`DirectoryNamedWebpackPlugin`](https://www.npmjs.com/package/directory-named-webpack-plugin).
+
+__webpack.config.js__
 
 ```js
 module.exports = {
@@ -332,13 +372,13 @@ module.exports = {
 
 ### `resolve.symlinks`
 
-`boolean`
+`boolean: true`
 
 Whether to resolve symlinks to their symlinked location.
 
 When enabled, symlinked resources are resolved to their _real_ path, not their symlinked location. Note that this may cause module resolution to fail when using tools that symlink packages (like `npm link`).
 
-`resolve.symlinks` defaults to:
+__webpack.config.js__
 
 ```js
 module.exports = {
@@ -352,15 +392,20 @@ module.exports = {
 
 ### `resolve.cachePredicate`
 
-`function`
+`function: function (module) { return true; }`
 
-A function which decides whether a request should be cached or not. An object is passed to the function with `path` and `request` properties. Default:
+A function which decides whether a request should be cached or not. An object is passed to the function with `path` and `request` properties. It must return a boolean.
+
+__webpack.config.js__
 
 ```js
 module.exports = {
   //...
   resolve: {
-    cachePredicate: function() { return true; }
+    cachePredicate: (module) => {
+      // additional logic
+      return true;
+    }
   }
 };
 ```
@@ -372,13 +417,15 @@ module.exports = {
 
 This set of options is identical to the `resolve` property set above, but is used only to resolve webpack's [loader](/concepts/loaders) packages. Default:
 
+__webpack.config.js__
+
 ```js
 module.exports = {
   //...
   resolveLoader: {
-    modules: [ 'node_modules' ],
-    extensions: [ '.js', '.json' ],
-    mainFields: [ 'loader', 'main' ]
+    modules: ['node_modules'],
+    extensions: ['.js', '.json'],
+    mainFields: ['loader', 'main']
   }
 };
 ```
@@ -388,15 +435,17 @@ T> Note that you can use alias here and other features familiar from resolve. Fo
 
 ### `resolveLoader.moduleExtensions`
 
-`array`
+`[string]`
 
 The extensions/suffixes that are used when resolving loaders. Since version two, we [strongly recommend](/migrate/3/#automatic-loader-module-name-extension-removed) using the full name, e.g. `example-loader`, as much as possible for clarity. However, if you really wanted to exclude the `-loader` bit, i.e. just use `example`, you can use this option to do so:
+
+__webpack.config.js__
 
 ```js
 module.exports = {
   //...
   resolveLoader: {
-    moduleExtensions: [ '-loader' ]
+    moduleExtensions: ['-loader']
   }
 };
 ```

--- a/src/content/configuration/resolve.md
+++ b/src/content/configuration/resolve.md
@@ -352,7 +352,7 @@ W> Changes to cached paths may cause failure in rare cases.
 
 ### `resolve.plugins`
 
-`[Plugin]`
+[`[Plugin]`](/plugins/)
 
 A list of additional resolve plugins which should be applied. It allows plugins such as [`DirectoryNamedWebpackPlugin`](https://www.npmjs.com/package/directory-named-webpack-plugin).
 


### PR DESCRIPTION
- add correct function signature
- move types and their defaults to the right place
- format configs accordingly to docs style
- remove redundant default texts
