### PR TITLE
lint(links) disable link linter on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ jobs:
         - yarn lint:markdown || travis_terminate 1
         - yarn lint:social || travis_terminate 1
         - yarn build || travis_terminate 1
-        - yarn lint:links || travis_terminate 1
 
     - stage: Build
       name: Proselint

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,3 @@ jobs:
       name: Deploy
       if: branch = master AND type = push
       script: bash ./src/scripts/deploy.sh
-
-    - stage: Post-build
-      name: External Link Check
-      script: yarn linkcheck


### PR DESCRIPTION
disable links linter on travis

```
ok 99 load dist/guides/public-path
ok 100 load dist/guides/integrations
ok 101 load dist/api/cli
ok 102 load dist/api/node
ok 103 load dist/api/module-methods
ok 104 load dist/loaders
ok 105 load dist/concepts/loaders
ok 106 load dist/api
ok 107 load dist/writers-guide/index.html
_http_client.js:114
      throw new ERR_UNESCAPED_CHARACTERS('Request path');
      ^

TypeError [ERR_UNESCAPED_CHARACTERS]: Request path contains unescaped characters
    at new ClientRequest (_http_client.js:114:13)
    at Object.request (https.js:280:10)
    at Immediate.dispatchRequest (webpack.js.org/node_modules/teepee/lib/Teepee.js:605:79)
    at runCallback (timers.js:694:18)
    at tryOnImmediate (timers.js:665:5)
    at processImmediate (timers.js:647:5)
error Command failed with exit code 1.
```