### PR TITLE
Fix unencoded ✭ character in img src

### DIFF
--- a/src/components/Organization/Organization.jsx
+++ b/src/components/Organization/Organization.jsx
@@ -26,7 +26,7 @@ const Organization = props => {
               <h6>Downloads and Stars</h6>
               <Shield content={ `npm/dm/${org.npm}`} label="npm" />
               &nbsp;
-              <Shield content={ `github/stars/${org.repo}` } label="&#10029;" />
+              <Shield content={ `github/stars/${org.repo}` } label="%E2%9C%AD" />
 
               <h6>Activity</h6>
               <Shield


### PR DESCRIPTION
Fix unencoded star character in img src url (`https://img.shields.io/github/stars/webpack/memory-fs.svg?label=✭&style=flat-square&maxAge=3600`)

Caused `npm run linkcheck` to break.

This is a hopefully nicer alternative to disabling the link check: https://github.com/webpack/webpack.js.org/pull/2759

We'll look into making `hyperlink` either tolerate this kind of invalid url (if browsers tolerate it), or throw a specific error message instead of an internal error.