### PR TITLE
docs(guides): Add "npm build" instruction on "Loading Data" section

### DIFF
--- a/src/content/guides/asset-management.md
+++ b/src/content/guides/asset-management.md
@@ -483,19 +483,7 @@ __src/index.js__
   document.body.appendChild(component());
 ```
 
-Now once again, run your build command:
-
-``` bash
-npm run build
-
-...
-    Asset      Size  Chunks             Chunk Names
-bundle.js  76.7 KiB       0  [emitted]  main
-Entrypoint main = bundle.js
-...
-```
-
-When you open `index.html` and look at your console in your developer tools, you should be able to see your imported data being logged to the console!
+Re-run the `npm run build` command and open `index.html`. If you look at the console in your developer tools, you should be able to see your imported data being logged to the console!
 
 T> This can be especially helpful when implementing some sort of data visualization using a tool like [d3](https://github.com/d3). Instead of making an ajax request and parsing the data at runtime you can load it into your module during the build process so that the parsed data is ready to go as soon as the module hits the browser.
 

--- a/src/content/guides/asset-management.md
+++ b/src/content/guides/asset-management.md
@@ -483,6 +483,18 @@ __src/index.js__
   document.body.appendChild(component());
 ```
 
+Now once again, run your build command:
+
+``` bash
+npm run build
+
+...
+    Asset      Size  Chunks             Chunk Names
+bundle.js  76.7 KiB       0  [emitted]  main
+Entrypoint main = bundle.js
+...
+```
+
 When you open `index.html` and look at your console in your developer tools, you should be able to see your imported data being logged to the console!
 
 T> This can be especially helpful when implementing some sort of data visualization using a tool like [d3](https://github.com/d3). Instead of making an ajax request and parsing the data at runtime you can load it into your module during the build process so that the parsed data is ready to go as soon as the module hits the browser.


### PR DESCRIPTION
Added instruction for `npm build` on the `guides/asset-management`.

This change would prevent reader from confusion if they forgot to build module before check upon `dist/index.html`.