### PR TITLE
docs(getting-started): use var instead to match the rest of the guides

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -53,7 +53,7 @@ __src/index.js__
 
 ``` javascript
 function component() {
-  let element = document.createElement('div');
+  var element = document.createElement('div');
 
   // Lodash, currently included via a script, is required for this line to work
   element.innerHTML = _.join(['Hello', 'webpack'], ' ');

--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -148,7 +148,7 @@ __src/index.js__
 + import _ from 'lodash';
 +
   function component() {
-    let element = document.createElement('div');
+    var element = document.createElement('div');
 
 -   // Lodash, currently included via a script, is required for this line to work
     element.innerHTML = _.join(['Hello', 'webpack'], ' ');


### PR DESCRIPTION
I understand that there's a PR for this similar issue already https://github.com/webpack/webpack.js.org/pull/2614, but it's been 3 months and we haven't had any updates from the last PR regarding to the `const` reassignment fix.

A simpler fix will be only changing **docs(getting-started)** to replace it `let` with `var`, as that's the only part inconsistent with the others.



[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
