### PR TITLE
Update split-chunks-plugin.md

### DIFF
--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -112,7 +112,7 @@ module.exports = {
   //...
   optimization: {
     splitChunks: {
-      chunks (chunk) {
+      chunks: (chunk) => {
         // exclude `my-excluded-chunk`
         return chunk.name !== 'my-excluded-chunk';
       }


### PR DESCRIPTION
splitChunks.chunks is a key within object so example should have it point to a function not be a function

The documentation has a function within the `splitChunks` object definition but as it is within an object, it needs to be `chunks` key that references the function -- it cannot be an inline function.