### PR TITLE
Grammar correction: Line 48 of /concepts/index.md

### DIFF
--- a/src/content/concepts/index.md
+++ b/src/content/concepts/index.md
@@ -45,7 +45,7 @@ For a better understanding of the ideas behind module bundlers and how they work
 
 ## Entry
 
-An __entry point__ indicates which module webpack should use to begin building out its internal [dependency graph](/concepts/dependency-graph/). webpack will figure out which other modules and libraries that entry point depends on (directly and indirectly).
+An __entry point__ indicates which module webpack should be used to begin building out its internal [dependency graph](/concepts/dependency-graph/). webpack will figure out which other modules and libraries that entry point depends on (directly and indirectly).
 
 By default its value is `./src/index.js`, but you can specify a different (or multiple entry points) by configuring the __entry__ property in the [webpack configuration](/configuration). For example:
 


### PR DESCRIPTION
Grammar correction: Line 48 of `/concepts/index.md`

Change `should use to` to `should be used to`.