### PR TITLE
docs(compiler-hooks): fixes typo in afterEnvironment

### DIFF
--- a/src/content/api/compiler-hooks.md
+++ b/src/content/api/compiler-hooks.md
@@ -81,7 +81,7 @@ Runs a plugin before the environment is prepared.
 
 `SyncHook`
 
-Executes a plugin a environment setup is complete.
+Executes a plugin after the environment setup is complete.
 
 
 ### `beforeRun`


### PR DESCRIPTION
Fixes a typo in the `afterEnvironment` hook

