### PR TITLE
Fix Wikipedia polyfill link

### DIFF
--- a/src/content/guides/shimming.md
+++ b/src/content/guides/shimming.md
@@ -10,6 +10,7 @@ contributors:
   - byzyk
   - EugeneHlushko
   - dhurlburtusa
+  - plr108
 related:
   - title: Reward modern browser users script
     url: https://hackernoon.com/10-things-i-learned-making-the-fastest-site-in-the-world-18a0e1cdf4a7#c665
@@ -21,7 +22,7 @@ The `webpack` compiler can understand modules written as ES2015 modules, CommonJ
 
 W> __We don't recommend using globals!__ The whole concept behind webpack is to allow more modular front-end development. This means writing isolated modules that are well contained and do not rely on hidden dependencies (e.g. globals). Please use these features only when necessary.
 
-Another instance where _shimming_ can be useful is when you want to [polyfill](https://en.wikipedia.org/wiki/Polyfill_(programming)) browser functionality to support more users. In this case, you may only want to deliver those polyfills to the browsers that need patching (i.e. load them on demand).
+Another instance where _shimming_ can be useful is when you want to [polyfill](https://en.wikipedia.org/wiki/Polyfill_%28programming%29) browser functionality to support more users. In this case, you may only want to deliver those polyfills to the browsers that need patching (i.e. load them on demand).
 
 The following article will walk through both of these use cases.
 


### PR DESCRIPTION
URL encode Wikipedia polyfill link.  Closing parenthesis in previous link was dropped in most browsers.