### PR TITLE
Adding minor getting started clarifications

### DIFF
--- a/src/content/guides/build-performance.md
+++ b/src/content/guides/build-performance.md
@@ -227,7 +227,7 @@ Note: the `ts-loader` documentation suggests the use of `cache-loader`, but this
 
 To gain typechecking again, use the [`ForkTsCheckerWebpackPlugin`](https://www.npmjs.com/package/fork-ts-checker-webpack-plugin).
 
-There is a [full example](https://github.com/TypeStrong/ts-loader/tree/master/examples/fast-incremental-builds) on the ts-loader github repository.
+There is a [full example](https://github.com/TypeStrong/ts-loader/tree/master/examples/fork-ts-checker-webpack-plugin) on the ts-loader github repository.
 
 ---
 

--- a/src/content/guides/environment-variables.md
+++ b/src/content/guides/environment-variables.md
@@ -13,7 +13,9 @@ related:
     url: https://blog.flennik.com/the-fine-art-of-the-webpack-2-config-dc4d19d7f172#d60a
 ---
 
-To disambiguate in your `webpack.config.js` between [development](/guides/development) and [production builds](/guides/production) you may use webpack "environment variables" (not to be confused with the [environment variables](https://en.wikipedia.org/wiki/Environment_variable) of the shell where you're running webpack).
+To disambiguate in your `webpack.config.js` between [development](/guides/development) and [production builds](/guides/production) you may use webpack "environment variables".
+
+T> webpack's environment variables are different from the [environment variables](https://en.wikipedia.org/wiki/Environment_variable) of the shell where you're running webpack
 
 The webpack command line [environment option](/api/cli/#environment-options) `--env` allows you to pass in as many environment variables as you like. Environment variables will be made accessible in your `webpack.config.js`. For example, `--env.production` or `--env.NODE_ENV=local` (`NODE_ENV` is conventionally used to define the environment type, see [here](https://dzone.com/articles/what-you-should-know-about-node-env).)
 

--- a/src/content/guides/environment-variables.md
+++ b/src/content/guides/environment-variables.md
@@ -7,12 +7,13 @@ contributors:
   - tbroadley
   - legalcodes
   - byzyk
+  - jceipek
 related:
   - title: The Fine Art of the webpack 3 Config
     url: https://blog.flennik.com/the-fine-art-of-the-webpack-2-config-dc4d19d7f172#d60a
 ---
 
-To disambiguate in your `webpack.config.js` between [development](/guides/development) and [production builds](/guides/production) you may use environment variables.
+To disambiguate in your `webpack.config.js` between [development](/guides/development) and [production builds](/guides/production) you may use webpack "environment variables" (not to be confused with the [environment variables](https://en.wikipedia.org/wiki/Environment_variable) of the shell where you're running webpack).
 
 The webpack command line [environment option](/api/cli/#environment-options) `--env` allows you to pass in as many environment variables as you like. Environment variables will be made accessible in your `webpack.config.js`. For example, `--env.production` or `--env.NODE_ENV=local` (`NODE_ENV` is conventionally used to define the environment type, see [here](https://dzone.com/articles/what-you-should-know-about-node-env).)
 

--- a/src/content/guides/environment-variables.md
+++ b/src/content/guides/environment-variables.md
@@ -13,9 +13,9 @@ related:
     url: https://blog.flennik.com/the-fine-art-of-the-webpack-2-config-dc4d19d7f172#d60a
 ---
 
-To disambiguate in your `webpack.config.js` between [development](/guides/development) and [production builds](/guides/production) you may use webpack "environment variables".
+To disambiguate in your `webpack.config.js` between [development](/guides/development) and [production builds](/guides/production) you may use "environment variables".
 
-T> webpack's environment variables are different from the [environment variables](https://en.wikipedia.org/wiki/Environment_variable) of the shell where you're running webpack
+T> webpack's environment variables are different from the [environment variables](https://en.wikipedia.org/wiki/Environment_variable) you might be used to from the shell where you're running webpack
 
 The webpack command line [environment option](/api/cli/#environment-options) `--env` allows you to pass in as many environment variables as you like. Environment variables will be made accessible in your `webpack.config.js`. For example, `--env.production` or `--env.NODE_ENV=local` (`NODE_ENV` is conventionally used to define the environment type, see [here](https://dzone.com/articles/what-you-should-know-about-node-env).)
 

--- a/src/content/guides/environment-variables.md
+++ b/src/content/guides/environment-variables.md
@@ -15,7 +15,7 @@ related:
 
 To disambiguate in your `webpack.config.js` between [development](/guides/development) and [production builds](/guides/production) you may use environment variables.
 
-T> webpack's environment variables are different from the [environment variables](https://en.wikipedia.org/wiki/Environment_variable) you might be used to from the shell where you're running webpack
+T> webpack's environment variables are different from the [environment variables](https://en.wikipedia.org/wiki/Environment_variable) of operating system shells like `bash` and `CMD.exe`
 
 The webpack command line [environment option](/api/cli/#environment-options) `--env` allows you to pass in as many environment variables as you like. Environment variables will be made accessible in your `webpack.config.js`. For example, `--env.production` or `--env.NODE_ENV=local` (`NODE_ENV` is conventionally used to define the environment type, see [here](https://dzone.com/articles/what-you-should-know-about-node-env).)
 

--- a/src/content/guides/environment-variables.md
+++ b/src/content/guides/environment-variables.md
@@ -13,7 +13,7 @@ related:
     url: https://blog.flennik.com/the-fine-art-of-the-webpack-2-config-dc4d19d7f172#d60a
 ---
 
-To disambiguate in your `webpack.config.js` between [development](/guides/development) and [production builds](/guides/production) you may use "environment variables".
+To disambiguate in your `webpack.config.js` between [development](/guides/development) and [production builds](/guides/production) you may use environment variables.
 
 T> webpack's environment variables are different from the [environment variables](https://en.wikipedia.org/wiki/Environment_variable) you might be used to from the shell where you're running webpack
 


### PR DESCRIPTION
I'm just trying out webpack and the installation and environment variables sections threw me off a bit. Hopefully these minor changes will help others avoid my confusion.

1. The installation section explains that you need to install the cli for webpack 4 but could be clearer that this is in addition to the `webpack` package. I added "also".

2. The environment variables section does not make clear that webpack's environment variables are separate from the environment variables I might set in `bash`, `fish`, `zsh`, etc... I added a tip to that effect.