### PR TITLE
Fix wrong alignment of green outline on Open Collective backers

### DIFF
--- a/src/components/Support/Support.jsx
+++ b/src/components/Support/Support.jsx
@@ -137,7 +137,6 @@ export default class Support extends React.Component {
                 src={ supporter.avatar || SmallIcon }
                 alt={ supporter.name || supporter.slug ? `${supporter.name || supporter.slug}'s avatar` : 'avatar' }
                 onError={ this._handleImgError } />}
-              { rank === 'backer' ? <figure className="support__outline" /> : null }
             </a>
           ))
         }

--- a/src/components/Support/Support.scss
+++ b/src/components/Support/Support.scss
@@ -51,17 +51,8 @@
     height: 31px;
     border-radius: 50%;
     border: 1px solid white;
+    box-shadow: 0 0 0 1px rgb(112, 202, 10);
     overflow: hidden;
-  }
-
-  &__outline {
-    position: absolute;
-    top: 0;
-    margin: -1px;
-    width: calc(100% + 2px);
-    height: calc(100% - 4px);
-    border-radius: 50%;
-    border: 1px solid rgb(112, 202, 10);
   }
 
   &__bottom {


### PR DESCRIPTION
Changes method of creating green outline around Open Collective backers from an extra dom element with quirky positioning to a CSS box shadow.

**Before**
![webpack js org_](https://user-images.githubusercontent.com/331790/52675647-c2351700-2f27-11e9-8a6c-6abce6da0118.png)

**After**
![localhost_3000_](https://user-images.githubusercontent.com/331790/52675673-d4af5080-2f27-11e9-8fd8-994d7494dd53.png)


