### PR TITLE
Bring back linting of internal links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ jobs:
         - yarn lint:markdown || travis_terminate 1
         - yarn lint:social || travis_terminate 1
         - yarn build || travis_terminate 1
+        - yarn lint:links || travis_terminate 1
 
     - stage: Build
       name: Proselint


### PR DESCRIPTION
https://github.com/webpack/webpack.js.org/pull/2806 disabled **all** link checking.

The slowest task we wanted to avoid was the external link check, which was allowed to fail anyway. But not the internal link check, which ensures we don't have any broken links internal to the documentation page.

This change brings back the internal checks. This is also the faster of the two link checks