### PR TITLE
docs(configuration): add a missing option

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lint:markdown": "markdownlint --rules markdownlint-rule-emphasis-style --config ./.markdownlint.json *.md ./src/content/**/*.md --ignore './src/content/**/_*.md'",
     "lint:social": "alex . -q",
     "lint:prose": "cp .proselintrc ~/ && proselint src/content",
-    "lint:links": "hyperlink -r dist/index.html --canonicalroot https://webpack.js.org/ -i --todo https://img.shields.io --todo https://codecov.io/gh --todo 'content-type-mismatch https://travis-ci.org' | tee internal-links.tap | tap-spot",
+    "lint:links": "hyperlink -r dist/index.html --canonicalroot https://webpack.js.org/ -i --todo https://img.shields.io --todo https://codecov.io/gh --todo 'content-type-mismatch https://travis-ci.org' --todo 'Asset is used as both Html and Image' | tee internal-links.tap | tap-spot",
     "linkcheck": "hyperlink -r dist/index.html --canonicalroot https://webpack.js.org/ --skip support__ --skip sidecar.gitter.im --skip vimdoc.sourceforge.net --skip img.shields.io --skip npmjs.com/package/ --skip opencollective.com/webpack --todo external-redirect | tee external-links.tap | tap-spot",
     "sitemap": "cd dist && sitemap-static --prefix=https://webpack.js.org/ > sitemap.xml",
     "serve": "npm run build && sirv start ./dist --port 4000",

--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -16,6 +16,7 @@ contributors:
   - harshwardhansingh
   - eemeli
   - EugeneHlushko
+  - g-plane
 ---
 
 The top-level `output` key contains set of options instructing webpack on how and where it should output your bundles, assets and anything else you bundle or load with webpack.
@@ -338,6 +339,11 @@ The lengths of `[hash]` and `[chunkhash]` can be specified using `[hash:16]` (de
 If using a function for this option, the function will be passed an object containing the substitutions in the table above.
 
 T> When using the [`ExtractTextWebpackPlugin`](/plugins/extract-text-webpack-plugin), use `[contenthash]` to obtain a hash of the extracted file (neither `[hash]` nor `[chunkhash]` work).
+
+
+## `output.globalObject`
+
+When targeting a library, especially the `libraryTarget` is `'umd'`, this option indicates what global object will be used to mount the library. Default value is `'window'`. If you want to make your UMD build available on both browsers and Node.js, you should set this option to `'this'`.
 
 
 ## `output.hashDigest`

--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -342,6 +342,7 @@ T> When using the [`ExtractTextWebpackPlugin`](/plugins/extract-text-webpack-plu
 
 
 ## `output.globalObject`
+`string: 'window'`
 
 When targeting a library, especially the `libraryTarget` is `'umd'`, this option indicates what global object will be used to mount the library. To make UMD build available on both browsers and Node.js, set `output.globalObject` option to `'this'`.
 

--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -342,6 +342,7 @@ T> When using the [`ExtractTextWebpackPlugin`](/plugins/extract-text-webpack-plu
 
 
 ## `output.globalObject`
+
 `string: 'window'`
 
 When targeting a library, especially the `libraryTarget` is `'umd'`, this option indicates what global object will be used to mount the library. To make UMD build available on both browsers and Node.js, set `output.globalObject` option to `'this'`.

--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -343,7 +343,7 @@ T> When using the [`ExtractTextWebpackPlugin`](/plugins/extract-text-webpack-plu
 
 ## `output.globalObject`
 
-When targeting a library, especially the `libraryTarget` is `'umd'`, this option indicates what global object will be used to mount the library. Default value is `'window'`. If you want to make your UMD build available on both browsers and Node.js, you should set this option to `'this'`.
+When targeting a library, especially the `libraryTarget` is `'umd'`, this option indicates what global object will be used to mount the library. To make UMD build available on both browsers and Node.js, set `output.globalObject` option to `'this'`.
 
 
 ## `output.hashDigest`

--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -346,6 +346,22 @@ T> When using the [`ExtractTextWebpackPlugin`](/plugins/extract-text-webpack-plu
 
 When targeting a library, especially the `libraryTarget` is `'umd'`, this option indicates what global object will be used to mount the library. To make UMD build available on both browsers and Node.js, set `output.globalObject` option to `'this'`.
 
+For example:
+
+__webpack.config.js__
+
+```javascript
+module.exports = {
+  // ...
+  output: {
+    library: 'myLib',
+    libraryTarget: 'umd',
+    filename: 'myLib.js',
+    globalObject: 'this'
+  }
+};
+```
+
 
 ## `output.hashDigest`
 


### PR DESCRIPTION
The `output.globalObject` is useful for UMD build, which should be documented.

Ref: https://github.com/webpack/webpack/issues/6522