### PR TITLE
Add info about loader overrides

### DIFF
--- a/src/content/api/loaders.md
+++ b/src/content/api/loaders.md
@@ -17,7 +17,6 @@ The first loader is passed one argument: the content of the resource file. The c
 
 A single result can be returned in __sync mode__. For multiple results the `this.callback()` must be called. In __async mode__ `this.async()` must be called to indicate that the [loader runner](https://github.com/webpack/loader-runner) should wait for an asynchronous result. It returns `this.callback()`. Then the loader must return `undefined` and call that callback.
 
-TODO: Add info about loader overrides
 
 ## Examples
 
@@ -96,7 +95,11 @@ module.exports.raw = true;
 
 ### Pitching Loader
 
-Loaders are __always__ called from right to left. There are some instances where the loader only cares about the __metadata__ behind a request and can ignore the results of the previous loader. The `pitch` method on loaders is called from __left to right__ before the loaders are actually executed (from right to left). For the following [`use`](/configuration/module#rule-use) configuration:
+Loaders are __always__ called from right to left. There are some instances where the loader only cares about the __metadata__ behind a request and can ignore the results of the previous loader. The `pitch` method on loaders is called from __left to right__ before the loaders are actually executed (from right to left). 
+
+Note that loaders may be added inline in requests and disabled via inline prefixes, which will impact the order in which they are "pitched" and executed. See the section on [`use`](/configuration/module#rule-use) for more details.
+
+For the following configuration of [`use`](/configuration/module#rule-use):
 
 ``` javascript
 module.exports = {

--- a/src/content/api/loaders.md
+++ b/src/content/api/loaders.md
@@ -98,7 +98,7 @@ module.exports.raw = true;
 
 Loaders are __always__ called from right to left. There are some instances where the loader only cares about the __metadata__ behind a request and can ignore the results of the previous loader. The `pitch` method on loaders is called from __left to right__ before the loaders are actually executed (from right to left). 
 
-Note that loaders may be added inline in requests and disabled via inline prefixes, which will impact the order in which they are "pitched" and executed. See the section on [`enforce`](/configuration/module#ruleenforce) for more details.
+T> Loaders may be added inline in requests and disabled via inline prefixes, which will impact the order in which they are "pitched" and executed. See [`Rule.enforce`](/configuration/module#ruleenforce) for more details.
 
 For the following configuration of [`use`](/configuration/module#rule-use):
 

--- a/src/content/api/loaders.md
+++ b/src/content/api/loaders.md
@@ -17,6 +17,7 @@ The first loader is passed one argument: the content of the resource file. The c
 
 A single result can be returned in __sync mode__. For multiple results the `this.callback()` must be called. In __async mode__ `this.async()` must be called to indicate that the [loader runner](https://github.com/webpack/loader-runner) should wait for an asynchronous result. It returns `this.callback()`. Then the loader must return `undefined` and call that callback.
 
+TODO: Add info about loader overrides
 
 ## Examples
 

--- a/src/content/api/loaders.md
+++ b/src/content/api/loaders.md
@@ -9,6 +9,7 @@ contributors:
   - sokra
   - EugeneHlushko
   - jantimon
+  - superburrito
 ---
 
 A loader is just a JavaScript module that exports a function. The [loader runner](https://github.com/webpack/loader-runner) calls this function and passes the result of the previous loader or the resource file into it. The `this` context of the function is filled-in by webpack and the [loader runner](https://github.com/webpack/loader-runner) with some useful methods that allow the loader (among other things) to change its invocation style to async, or get query parameters.

--- a/src/content/api/loaders.md
+++ b/src/content/api/loaders.md
@@ -97,7 +97,7 @@ module.exports.raw = true;
 
 Loaders are __always__ called from right to left. There are some instances where the loader only cares about the __metadata__ behind a request and can ignore the results of the previous loader. The `pitch` method on loaders is called from __left to right__ before the loaders are actually executed (from right to left). 
 
-Note that loaders may be added inline in requests and disabled via inline prefixes, which will impact the order in which they are "pitched" and executed. See the section on [`use`](/configuration/module#rule-use) for more details.
+Note that loaders may be added inline in requests and disabled via inline prefixes, which will impact the order in which they are "pitched" and executed. See the section on [`enforce`](/configuration/module#ruleenforce) for more details.
 
 For the following configuration of [`use`](/configuration/module#rule-use):
 

--- a/src/content/configuration/module.md
+++ b/src/content/configuration/module.md
@@ -121,6 +121,17 @@ All normal and pre loaders can be omitted (overridden) by prefixing `-!` in the 
 
 All normal, post and pre loaders can be omitted (overridden) by prefixing `!!` in the request.
 
+``` javascript
+// Disable preloaders
+import { a } from '!./file1.js';
+
+// Disable preloaders and normal loaders
+import { b } from  '-!./file2.js';
+
+// Disable all loaders
+import { c } from  '!!./file3.js';
+```
+
 Inline loaders and `!` prefixes should not be used as they are non-standard. They may be use by loader generated code.
 
 

--- a/src/content/configuration/module.md
+++ b/src/content/configuration/module.md
@@ -12,6 +12,7 @@ contributors:
   - fadysamirsadek
   - nerdkid93
   - EugeneHlushko
+  - superburrito
 ---
 
 These options determine how the [different types of modules](/concepts/modules) within a project will be treated.


### PR DESCRIPTION
Fixes https://github.com/webpack/webpack.js.org/issues/2804

Update: Turns out that the docs do already talk about the overrides [here](https://webpack.js.org/configuration/module#ruleenforce), but this PR attempts to make this information more obvious.

@EugeneHlushko If you find that it's not necessary, we can close this PR 