### PR TITLE
Update docs for module resolution

### DIFF
--- a/src/content/concepts/module-resolution.md
+++ b/src/content/concepts/module-resolution.md
@@ -65,7 +65,7 @@ Once the path is resolved based on the above rule, the resolver checks to see if
 
 If the path points to a folder, then the following steps are taken to find the right file with the right extension:
 
-- If the folder contains a `package.json` file, then fields specified in [`resolve.mainFields`](/configuration/resolve/#resolve-mainfields) configuration option are looked up in order, and the first such field in `package.json` determines the file path.
+- If the folder contains a `package.json` file, then fields specified in [`resolve.mainFiles`](/configuration/resolve/#resolve-mainfiles) configuration option are looked up in order, and the first such field in `package.json` determines the file path.
 - If there is no `package.json` or if the main fields do not return a valid path, file names specified in the [`resolve.mainFiles`](/configuration/resolve/#resolve-mainfiles) configuration option are looked for in order, to see if a matching filename exists in the imported/required directory .
 - The file extension is then resolved in a similar way using the `resolve.extensions` option.
 


### PR DESCRIPTION
This PR suggests to changing to document from `resolve.mainFields` to  `resolve.mainFiles` when resolving a module directory

Hello, I am new to webpack and I found that module resolution document might pointing wrong link.
In the resolve.mainFiles section, resolve.mainFiles is set for
> The filename to be used while resolving directories.

So I thought when resolving a module directory, webpack will refer `resolve.mainFiles` instead of `resolve.mainFields`