### PR TITLE
Update define-plugin.md

### DIFF
--- a/src/content/plugins/define-plugin.md
+++ b/src/content/plugins/define-plugin.md
@@ -13,7 +13,7 @@ The `DefinePlugin` allows you to create global constants which can be configured
 
 ``` javascript
 new webpack.DefinePlugin({
-  // Definitions...
+  BUILT_AT: webpack.DefinePlugin.runtimeValue(Date.now, [fileDep, fileDep])
 });
 ```
 


### PR DESCRIPTION
This adds the following API to DefinePlugin:

```js
new webpack.DefinePlugin({
  BUILT_AT: webpack.DefinePlugin.runtimeValue(Date.now, [fileDep, fileDep])
})
``` #2314 added to docs:)

_describe your changes..._

- [ ] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [ ] Make sure your PR complies with the [writer's guide][2].
- [ ] Review the diff carefully as sometimes this can reveal issues.
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
