### PR TITLE
fix a little typo

### DIFF
--- a/src/content/guides/hot-module-replacement.md
+++ b/src/content/guides/hot-module-replacement.md
@@ -104,7 +104,7 @@ __index.js__
 + }
 ```
 
-Start changing the `console.log` statement in `print.js`, and you should see the following output in the browser console (don't worry about that `button.onclick = printMe()` output for now, we will also update that part later).
+Start changing the `console.log` statement in `print.js`, and you should see the following output in the browser console (don't worry about that `button.onclick = printMe` output for now, we will also update that part later).
 
 __print.js__
 


### PR DESCRIPTION
fixing a typo removing function's parenthesis, as we are assigning the function reference rather than its call return value
