### PR TITLE
docs(guides): remove extra spaces before parentheses

### DIFF
--- a/src/content/guides/author-libraries.md
+++ b/src/content/guides/author-libraries.md
@@ -109,7 +109,7 @@ webpackNumbers.wordToNum('Two');
 - __AMD module require:__
 
 ``` js
-require(['webpackNumbers'], function ( webpackNumbers) {
+require(['webpackNumbers'], function (webpackNumbers) {
   // ...
   webpackNumbers.wordToNum('Two');
 });


### PR DESCRIPTION
Remove extra spaces before parentheses on the `guides/author-libraries`.