### PR TITLE
Enable horizontal scrolling for wide tables

### DIFF
--- a/src/components/Markdown/Markdown.scss
+++ b/src/components/Markdown/Markdown.scss
@@ -181,6 +181,7 @@
     margin: 1em 0;
 
     @include break {
+      display: block;
       overflow-x: auto;
       overflow-y: hidden;
     }


### PR DESCRIPTION
Currently, tables that are too wide aren't displayed completely. See https://webpack.js.org/comparison, for example.

The CSS already had overflow-x and overflow-y values in place, but they weren't doing much as the tables weren't rendered as a block.