### PR TITLE
docs(guides): change CleanWebpackPlugin arguments usage

### DIFF
--- a/src/content/guides/output-management.md
+++ b/src/content/guides/output-management.md
@@ -194,7 +194,7 @@ __webpack.config.js__
       print: './src/print.js'
     },
     plugins: [
-+     new CleanWebpackPlugin(['dist/*']),
++     new CleanWebpackPlugin(),
       new HtmlWebpackPlugin({
         title: 'Output Management'
       })

--- a/src/content/guides/output-management.md
+++ b/src/content/guides/output-management.md
@@ -194,7 +194,7 @@ __webpack.config.js__
       print: './src/print.js'
     },
     plugins: [
-      // new CleanWebpackPlugin(['dist/*']) for < v2 versions of CleanWebpackPlugin
++     // new CleanWebpackPlugin(['dist/*']) for < v2 versions of CleanWebpackPlugin
 +     new CleanWebpackPlugin(),
       new HtmlWebpackPlugin({
         title: 'Output Management'

--- a/src/content/guides/output-management.md
+++ b/src/content/guides/output-management.md
@@ -194,7 +194,7 @@ __webpack.config.js__
       print: './src/print.js'
     },
     plugins: [
-       // new CleanWebpackPlugin(['dist/*']) for < v2 versions of CleanWebpackPlugin
+      // new CleanWebpackPlugin(['dist/*']) for < v2 versions of CleanWebpackPlugin
 +     new CleanWebpackPlugin(),
       new HtmlWebpackPlugin({
         title: 'Output Management'

--- a/src/content/guides/output-management.md
+++ b/src/content/guides/output-management.md
@@ -194,6 +194,7 @@ __webpack.config.js__
       print: './src/print.js'
     },
     plugins: [
+       // new CleanWebpackPlugin(['dist/*']) for < v2 versions of CleanWebpackPlugin
 +     new CleanWebpackPlugin(),
       new HtmlWebpackPlugin({
         title: 'Output Management'


### PR DESCRIPTION
CleanWebpackPlugin released  v2.0.0 and the API has a breaking change: No configuration is needed for standard usage (cleans webpack's output.path).

`new CleanWebpackPlugin(['dist/*'])` with the new version clean-webpack-plugin installed above will cause an error:
"Error: clean-webpack-plugin only accepts an options object. See: https://github.com/johnagan/clean-webpack-plugin#options-and-defaults-optional "