### PR TITLE
Removed deprecated setting of CleanupWebpackPlugin

### DIFF
--- a/src/content/guides/output-management.md
+++ b/src/content/guides/output-management.md
@@ -194,7 +194,7 @@ __webpack.config.js__
       print: './src/print.js'
     },
     plugins: [
-+     new CleanWebpackPlugin(['dist/*']),
++     new CleanWebpackPlugin(),
       new HtmlWebpackPlugin({
         title: 'Output Management'
       })


### PR DESCRIPTION
With the new release of version (v2.0.0) of CleanupWebpackPlugin, it started to look into output.path. Therefore, no need to specify cleanup path explicitly.

See details: https://github.com/johnagan/clean-webpack-plugin/releases