### PR TITLE
Update for change in CleanWebpackPlugin

### DIFF
--- a/src/content/guides/output-management.md
+++ b/src/content/guides/output-management.md
@@ -194,7 +194,7 @@ __webpack.config.js__
       print: './src/print.js'
     },
     plugins: [
-+     new CleanWebpackPlugin(['dist/*']),
++     new CleanWebpackPlugin(),
       new HtmlWebpackPlugin({
         title: 'Output Management'
       })


### PR DESCRIPTION
CleanWebpackPlugin now requires an "options" object, or no args. For the tutorial, it is sufficient to pass in no arguments to achieve the same 'dist/*' functionality.

This change prevents an error from occurring while following the tutorial.