### PR TITLE
remove unnecessary diff in getting started guide

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -20,6 +20,7 @@ contributors:
   - ztomasze
   - Spiral90210
   - byzyk
+  - strongSoda
 ---
 
 Webpack is used to compile JavaScript modules. Once [installed](/guides/installation), you can interface with webpack either from its [CLI](/api/cli) or [API](/api/node). If you're still new to webpack, please read through the [core concepts](/concepts) and [this comparison](/comparison) to learn why you might use it over the other tools that are out in the community.
@@ -270,8 +271,7 @@ __package.json__
     "version": "1.0.0",
     "description": "",
     "scripts": {
--      "test": "echo \"Error: no test specified\" && exit 1" 
-+      "test": "echo \"Error: no test specified\" && exit 1",
+      "test": "echo \"Error: no test specified\" && exit 1",
 +      "build": "webpack"
     },
     "keywords": [],


### PR DESCRIPTION
The getting started guide has an unnecessary diff in the package.json file in the scripts as below:

![oldDiff](https://user-images.githubusercontent.com/30754328/54221623-e7627880-4519-11e9-95f0-7c6d5c37d724.PNG)

The test field is shown in diff unnecessarily.

I have updated it to 

![updatedDiff](https://user-images.githubusercontent.com/30754328/54221700-0b25be80-451a-11e9-94c9-7baf1f8bdee3.PNG)

Thanks for your time & reviewing this PR.