### PR TITLE
Fix syntax mistake in loaders.md

### DIFF
--- a/src/content/concepts/loaders.md
+++ b/src/content/concepts/loaders.md
@@ -12,6 +12,7 @@ contributors:
   - byzyk
   - debs-obrien
   - EugeneHlushko
+  - scriptype
 ---
 
 Loaders are transformations that are applied on the source code of a module. They allow you to pre-process files as you `import` or “load” them. Thus, loaders are kind of like “tasks” in other build tools and provide a powerful way to handle front-end build steps. Loaders can transform files from a different language (like TypeScript) to JavaScript or inline images as data URLs. Loaders even allow you to do things like `import` CSS files directly from your JavaScript modules!
@@ -65,14 +66,14 @@ module.exports = {
       {
         test: /\.css$/,
         use: [
-          { loader: ['style-loader'](/loaders/style-loader) },
+          { loader: 'style-loader' },
           {
-            loader: ['css-loader'](/loaders/css-loader),
+            loader: 'css-loader',
             options: {
               modules: true
             }
           },
-          { loader: ['sass-loader'](/loaders/sass-loader) }
+          { loader: 'sass-loader' }
         ]
       }
     ]


### PR DESCRIPTION
Loader links removed from sample configuration. They were appearing as literal markdown statements. And since the pages they were linking to don't seem to exist, I just removed them.