### PR TITLE
Use webpack bundle default path in example code

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -171,7 +171,7 @@ __dist/index.html__
    </head>
    <body>
 -    <script src="./src/index.js"></script>
-+    <script src="main.js"></script>
++    <script src="./dist/main.js"></script>
    </body>
   </html>
 ```


### PR DESCRIPTION
Changed the script source in example code from ``main.js`` to ``./dist/main.js``, which is the default path without a configuration file.