### PR TITLE
CleanWebpackPlugin | Requires a config object

### DIFF
--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -36,7 +36,7 @@ __webpack.config.js__
       print: './src/print.js'
     },
     plugins: [
-      new CleanWebpackPlugin(['dist']),
+      new CleanWebpackPlugin(),
       new HtmlWebpackPlugin({
         title: 'Development'
       })
@@ -73,7 +73,7 @@ __webpack.config.js__
     },
 +   devtool: 'inline-source-map',
     plugins: [
-      new CleanWebpackPlugin(['dist']),
+      new CleanWebpackPlugin(),
       new HtmlWebpackPlugin({
         title: 'Development'
       })
@@ -214,7 +214,7 @@ __webpack.config.js__
 +     contentBase: './dist'
 +   },
     plugins: [
-      new CleanWebpackPlugin(['dist']),
+      new CleanWebpackPlugin(),
       new HtmlWebpackPlugin({
         title: 'Development'
       })
@@ -299,7 +299,7 @@ __webpack.config.js__
       contentBase: './dist'
     },
     plugins: [
-      new CleanWebpackPlugin(['dist']),
+      new CleanWebpackPlugin(),
       new HtmlWebpackPlugin({
         title: 'Output Management'
       })


### PR DESCRIPTION
new CleanWebpackPlugin() | requires a config object than an array

_describe your changes..._

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [ ] Make sure your PR complies with the [writer's guide][2].
- [ ] Review the diff carefully as sometimes this can reveal issues.
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
