### PR TITLE
docs(guides) updates due to recent plugin update

### DIFF
--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -155,7 +155,7 @@ __package.json__
     "author": "",
     "license": "ISC",
     "devDependencies": {
-      "clean-webpack-plugin": "^0.1.16",
+      "clean-webpack-plugin": "^2.0.0",
       "css-loader": "^0.28.4",
       "csv-loader": "^2.1.1",
       "file-loader": "^0.11.2",
@@ -250,7 +250,7 @@ __package.json__
     "author": "",
     "license": "ISC",
     "devDependencies": {
-      "clean-webpack-plugin": "^0.1.16",
+      "clean-webpack-plugin": "^2.0.1",
       "css-loader": "^0.28.4",
       "csv-loader": "^2.1.1",
       "file-loader": "^0.11.2",
@@ -372,7 +372,7 @@ __package.json__
     "author": "",
     "license": "ISC",
     "devDependencies": {
-      "clean-webpack-plugin": "^0.1.16",
+      "clean-webpack-plugin": "^2.0.0",
       "css-loader": "^0.28.4",
       "csv-loader": "^2.1.1",
       "express": "^4.15.3",

--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -250,7 +250,7 @@ __package.json__
     "author": "",
     "license": "ISC",
     "devDependencies": {
-      "clean-webpack-plugin": "^2.0.1",
+      "clean-webpack-plugin": "^2.0.0",
       "css-loader": "^0.28.4",
       "csv-loader": "^2.1.1",
       "file-loader": "^0.11.2",

--- a/src/content/guides/output-management.md
+++ b/src/content/guides/output-management.md
@@ -194,7 +194,6 @@ __webpack.config.js__
       print: './src/print.js'
     },
     plugins: [
-+     // new CleanWebpackPlugin(['dist/*']) for < v2 versions of CleanWebpackPlugin
 +     new CleanWebpackPlugin(),
       new HtmlWebpackPlugin({
         title: 'Output Management'


### PR DESCRIPTION
As a follow up to recent clean-webpack-plugin 's update, we want to reflect all the necessary changes

Related to #2884