### PR TITLE
[WIP/Discussion] docs: merging webpack-cli documentation

### DIFF
--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -54,7 +54,7 @@ class Site extends React.Component {
             {
               content: 'Documentation',
               url: '/concepts',
-              isActive: url => /^\/(api|concepts|configuration|guides|loaders|migrate|plugins)/.test(url),
+              isActive: url => /^\/(api|cli|concepts|configuration|guides|loaders|migrate|plugins)/.test(url),
               children: this._strip(sections.filter(item => item.name !== 'contribute'))
             },
             { content: 'Contribute', url: '/contribute' },

--- a/src/content/cli/add.md
+++ b/src/content/cli/add.md
@@ -1,0 +1,40 @@
+---
+title: add
+group: packages
+sort: 1
+contributors:
+  - misterdev
+---
+
+## Description
+
+This package contains the logic to add new properties in a webpack configuration file. It will run a generator that prompts the user for questions of which property to add to their webpack configuration file.
+
+## Installation
+
+```bash
+npm i -D webpack-cli @webpack-cli/add
+```
+
+or
+
+```bash
+yarn add --dev  webpack-cli @webpack-cli/add
+```
+
+## Usage
+
+To run the scaffolding instance programmatically, install it as a dependency. When using the package programmatically, one does not have to install webpack-cli.
+
+### Node
+
+```js
+const add = require('@webpack-cli/add').default;
+add();
+```
+
+### CLI (via webpack-cli)
+
+```bash
+npx webpack-cli add
+```

--- a/src/content/cli/generate-loader.md
+++ b/src/content/cli/generate-loader.md
@@ -1,0 +1,34 @@
+---
+title: generate-loader
+group: packages
+sort: 2
+contributors:
+  - misterdev
+---
+
+## Description
+
+This package contains the logic to initiate new loader projects.
+
+## Installation
+
+```bash
+npm i -D webpack-cli @webpack-cli/generate-loader
+```
+
+## Usage
+
+To run the package programmatically, install it as a dependency. When using the package programmatically, one does not have to install webpack-cli.
+
+### Node
+
+```js
+const generateLoader = require('@webpack-cli/generate-loader').default;
+generateLoader();
+```
+
+### CLI (via webpack-cli)
+
+```bash
+npx webpack-cli generate-loader
+```

--- a/src/content/cli/generate-plugin.md
+++ b/src/content/cli/generate-plugin.md
@@ -1,0 +1,34 @@
+---
+title: generate-plugin
+group: packages
+sort: 3
+contributors:
+  - misterdev
+---
+
+## Description
+
+This package contains the logic to initiate new plugin projects.
+
+## Installation
+
+```bash
+npm i -D webpack-cli @webpack-cli/generate-plugin
+```
+
+## Usage
+
+To run the package programmatically, install it as a dependency. When using the package programmatically, one does not have to install webpack-cli.
+
+### Node
+
+```js
+const generatePlugin = require('@webpack-cli/generate-plugin').default;
+generatePlugin();
+```
+
+### CLI (via webpack-cli)
+
+```bash
+npx webpack-cli generate-plugin
+```

--- a/src/content/cli/generators.md
+++ b/src/content/cli/generators.md
@@ -1,0 +1,28 @@
+---
+title: generators
+group: packages
+sort: 4
+contributors:
+  - misterdev
+---
+
+## Description
+
+This package contains all webpack-cli related yeoman generators. 
+
+## Installation
+
+```bash
+npm i -D webpack-cli @webpack-cli/generators
+```
+
+## Usage
+
+To run the package programmatically, install it as a dependency. When using the package programmatically, one does not have to install webpack-cli.
+
+### Node
+
+```js
+const { addGenerator, addonGenerator, initGenerator, loaderGenerator, pluginGenerator, removeGenerator, updateGenerator } = require('@webpack-cli/generators');
+// ... compose with yeoman env or add a generator to your own yeoman project
+```

--- a/src/content/cli/index.md
+++ b/src/content/cli/index.md
@@ -1,0 +1,43 @@
+---
+title: webpack-cli
+sort: 1
+contributors:
+  - misterdev
+---
+
+W> This section refers to the `webpack-cli` package, if you are looking for webpack's command line API check the [API](../api/cli) section.
+
+## Description
+
+webpack CLI has several standalone packages apart from the main package that focuses on the solving respective smaller use cases.
+This folder is the collection of those packages.
+
+## Packages
+
+1. [add](/cli/add)
+2. [generate-loader](/cli/generate-loader)
+3. [generate-plugin](/cli/generate-plugin)
+4. [generators](/cli/generators)
+5. [info](/cli/info)
+6. [init](/cli/init)
+7. [make](/cli/make)
+8. [migrate](/cli/migrate)
+9. [remove](/cli/remove)
+10. [serve](/cli/serve)
+11. [update](/cli/update)
+12. [utils](/cli/utils)
+13. [webpack-scaffold](/cli/webpack-scaffold)
+
+## Generic Installation
+
+Standalone installation of packages
+
+```shell
+npm install @webpack-cli/<package>
+```
+
+Installation of respective `package` with `webpack-cli` [Recommended]
+
+```shell
+npm install webpack-cli @webpack-cli/<package>
+```

--- a/src/content/cli/info.md
+++ b/src/content/cli/info.md
@@ -1,0 +1,32 @@
+---
+title: info
+group: packages
+sort: 5
+contributors:
+  - misterdev
+---
+
+## Description
+
+This pacakge returns a set of information related to the local enviroment.
+
+## Installation
+
+```bash
+npm i -D @webpack-cli/info
+```
+
+## Usage
+
+### Node
+
+```js
+const envinfo = require('@webpack-cli/info').default;
+envinfo();
+```
+
+### CLI (via webpack-cli)
+
+```bash
+npx webpack-cli info
+```

--- a/src/content/cli/init.md
+++ b/src/content/cli/init.md
@@ -1,0 +1,55 @@
+---
+title: init
+group: packages
+sort: 6
+contributors:
+  - misterdev
+---
+
+## Description
+
+This package contains the logic to create a new webpack configuration.
+
+## Installation
+
+```bash
+npm i -D webpack-cli @webpack-cli/init
+```
+
+## Usage
+
+To run the package programmatically, install it as a dependency. When using the package programmatically, one does not have to install webpack-cli.
+
+### Node
+
+```js
+const init = require('@webpack-cli/init').default;
+
+// this will run the default init instance
+init();
+
+// we're slicing node.process, ...myPacakges is a webpack-scaffold name/path
+init([null, null, ...myPacakges]);
+```
+
+### CLI (via `webpack-cli`)
+
+Via defaults
+
+```bash
+npx webpack-cli init
+```
+
+Via custom scaffold
+
+Using package on `npm`
+
+```bash
+npx webpack-cli init webpack-scaffold-[name]
+```
+
+Using path to local directory
+
+```bash
+npx webpack-cli init [path]
+```

--- a/src/content/cli/make.md
+++ b/src/content/cli/make.md
@@ -1,0 +1,12 @@
+---
+title: make
+group: packages
+sort: 7
+contributors:
+  - misterdev
+---
+
+
+## Description
+
+This package needs a description

--- a/src/content/cli/migrate.md
+++ b/src/content/cli/migrate.md
@@ -1,0 +1,36 @@
+---
+title: migrate
+group: packages
+sort: 8
+contributors:
+  - misterdev
+---
+
+## Description
+
+This package contains the logic to migrate a project from one version to the other.
+
+## Installation
+
+```bash
+npm i -D webpack-cli @webpack-cli/migrate
+```
+
+## Usage
+
+To run the package programmatically, install it as a dependency. When using the package programmatically, one does not have to install webpack-cli.
+
+### Node
+
+```js
+const migrate = require('@webpack-cli/migrate').default;
+
+// add null to mock process.env
+migrate(null, null, inputPath, outputPath);
+```
+
+### CLI (via webpack-cli)
+
+```bash
+npx webpack-cli migrate
+```

--- a/src/content/cli/remove.md
+++ b/src/content/cli/remove.md
@@ -1,0 +1,34 @@
+---
+title: remove
+group: packages
+sort: 8
+contributors:
+  - misterdev
+---
+
+## Description
+
+This package contains the logic to remove  properties of a webpack configuration file. It will run a generator that prompts the user for questions of which property to remove in their webpack configuration file.
+
+## Installation
+
+```bash
+npm i -D webpack-cli @webpack-cli/remove
+```
+
+## Usage
+
+To run the scaffolding instance programmatically, install it as a dependency. When using the package programmatically, one does not have to install webpack-cli.
+
+### Node
+
+```js
+const remove = require('@webpack-cli/remove').default;
+remove();
+```
+
+### CLI (via webpack-cli)
+
+```bash
+npx webpack-cli remove
+```

--- a/src/content/cli/serve.md
+++ b/src/content/cli/serve.md
@@ -1,0 +1,34 @@
+---
+title: serve
+group: packages
+sort: 10
+contributors:
+  - misterdev
+---
+
+## Description
+
+This package contains the logic to run webpack-serve without using webpack-serve directly.
+
+## Installation
+
+```bash
+npm i -D webpack-cli @webpack-cli/serve
+```
+
+## Usage
+
+To run the scaffolding instance programmatically, install it as a dependency. When using the package programmatically, one does not have to install webpack-cli.
+
+### Node
+
+```js
+const serve = require('@webpack-cli/serve').serve;
+serve();
+```
+
+### CLI (via webpack-cli)
+
+```bash
+npx webpack-cli serve
+```

--- a/src/content/cli/ui.md
+++ b/src/content/cli/ui.md
@@ -1,0 +1,11 @@
+---
+title: UI
+group: UI
+sort: 1
+contributors:
+  - misterdev
+---
+
+## Description
+
+Webpack UI is a WIP aimed at developing a graphic interface to webpack

--- a/src/content/cli/update.md
+++ b/src/content/cli/update.md
@@ -1,0 +1,34 @@
+---
+title: update
+group: packages
+sort: 11
+contributors:
+  - misterdev
+---
+
+## Description
+
+This package contains the logic to update properties in a webpack configuration file. It will run a generator that prompts the user for questions of which property to update in their webpack configuration file.
+
+## Installation
+
+```bash
+npm i -D webpack-cli @webpack-cli/update
+```
+
+## Usage
+
+To run the scaffolding instance programmatically, install it as a dependency. When using the package programmatically, one does not have to install webpack-cli.
+
+### Node
+
+```js
+const update = require('@webpack-cli/update').default;
+update();
+```
+
+### CLI (via webpack-cli)
+
+```bash
+npx webpack-cli update
+```

--- a/src/content/cli/utils.md
+++ b/src/content/cli/utils.md
@@ -1,0 +1,38 @@
+---
+title: utils
+group: packages
+sort: 12
+contributors:
+  - misterdev
+---
+
+w> (WIP, not yet published)
+
+## Description
+
+This package contains the utilities used across the webpack-cli repositories.
+
+## Installation
+
+```bash
+npm i -D webpack-cli @webpack-cli/utils
+```
+
+## Contents
+
+- AST transformations
+- Checking NPM registry
+- A Recursive AST parser
+- Checking Local Configurations
+- Yeoman Generator Adapter
+- Package Resolver
+- Test Utilities for Jest
+
+## Usage
+
+### Node
+
+```js
+const utils = require('@webpack-cli/utils');
+// API yet to be exposed
+```

--- a/src/content/cli/webpack-scaffold.md
+++ b/src/content/cli/webpack-scaffold.md
@@ -1,0 +1,209 @@
+---
+title: webpack scaffold
+group: packages
+sort: 13
+contributors:
+  - misterdev
+---
+
+This is the utility suite for creating a webpack `scaffold`, it contains utility functions to help you work with [Inquirer](https://github.com/SBoudrias/Inquirer.js/) prompting and scaffolding.
+
+## Installation
+
+```bash
+npm i -D webpack-cli @webpack-cli/webpack-scaffold
+```
+
+# API
+
+1. [parseValue()](#parsevalue)
+2. [createArrowFunction()](#createarrowfunction)
+3. [createRegularFunction()](#createregularfunction)
+4. [createDynamicPromise()](#createdynamicpromise)
+5. [createAssetFilterFunction()](#createassetfilterfunction)
+6. [createExternalFunction()](#createexternalfunction)
+7. [createRequire()](#createrequire)
+8. Inquirer: [List](#list), [RawList](#rawlist), [CheckList](#checklist), [Input](#input), [InputValidate](#inputvalidate), [Confirm](#confirm)
+
+## parseValue
+
+Param: `String`
+
+Used when you cannot use regular conventions. Handy for examples like `RegExp` or `output.sourcePrefix`
+
+```js
+const parseValue = require('@webpack-cli/webpack-scaffold').parseValue;
+
+this.configuration.myScaffold.webpackOptions.output.sourcePrefix = parseValue('\t');
+// sourcePrefix: '\t'
+```
+
+## createArrowFunction
+
+Param: `String`
+
+Generally used when dealing with an entry point as an arrow function
+
+```js
+const createArrowFunction = require('@webpack-cli/webpack-scaffold').createArrowFunction;
+
+this.configuration.myScaffold.webpackOptions.entry = createArrowFunction('app.js');
+// entry: () => 'app.js'
+```
+
+## createRegularFunction
+
+Param: `String`
+
+Used when creating a function that returns a single value
+
+```js
+const createRegularFunction = require('@webpack-cli/webpack-scaffold').createRegularFunction;
+
+this.configuration.myScaffold.webpackOptions.entry = createRegularFunction('app.js');
+// entry: function() { return 'app.js' }
+```
+
+## createDynamicPromise
+
+Param: `Array` | `String`
+
+Used to create a dynamic entry point
+
+```js
+const createDynamicPromise = require('@webpack-cli/webpack-scaffold').createDynamicPromise;
+
+this.confguration.myScaffold.webpackOptions.entry = createDynamicPromise('app.js');
+// entry: () => new Promise((resolve) => resolve('app.js'))
+
+this.configuration.myScaffold.webpackOptions.entry = createDynamicPromise(['app.js', 'index.js']);
+// entry: () => new Promise((resolve) => resolve(['app.js','index.js']))
+```
+
+## createAssetFilterFunction
+
+Param: `String`
+
+Used to create an [assetFilterFunction](https://webpack.js.org/configuration/performance/#performance-assetfilter)
+
+```js
+const createAssetFilterFunction = require('@webpack-cli/webpack-scaffold').createAssetFilterFunction;
+
+this.configuration.myScaffold.webpackOptions.performance.assetFilter = createAssetFilterFunction('js');
+// assetFilter: function (assetFilename) { return assetFilename.endsWith('.js'); }
+```
+
+## createExternalFunction
+
+Param: `String`
+
+Used to create an [general function from Externals](https://webpack.js.org/configuration/externals/#function);
+
+```js
+const createExternalFunction = require('@webpack-cli/webpack-scaffold').createExternalFunction;
+
+this.configuration.myScaffold.webpackOptions.externals = [createExternalFunction('^yourregex$')];
+/*
+externals: [
+  function(context, request, callback) {
+    if (/^yourregex$/.test(request)){
+      return callback(null, 'commonjs ' + request);
+    }
+    callback();
+  }
+*/
+```
+
+## createRequire
+
+Param: `String`
+
+Used to create a module in `topScope`
+
+```js
+const createRequire = require('@webpack-cli/webpack-scaffold').createRequire;
+
+this.configuration.myScaffold.topScope = [createRequire('webpack')];
+// const webpack = require('webpack')
+```
+
+## [Inquirer](https://github.com/SBoudrias/Inquirer.js/#prompt-types)
+
+### List
+
+Param: `name<String>, message<String>, choices<Array>`
+
+Creates a List from Inquirer
+
+```js
+const List = require('@webpack-cli/webpack-scaffold').List;
+
+List('entry', 'what kind of entry do you want?', ['Array', 'Function']);
+```
+
+### RawList 
+
+Param: `name<String>, message<String>, choices<Array>`
+
+Creates a RawList from Inquirer
+
+```js
+const RawList = require('@webpack-cli/webpack-scaffold').RawList;
+
+RawList('entry', 'what kind of entry do you want?', ['Array', 'Function']);
+```
+
+### CheckList
+
+Param: `name<String>, message<String>, choices<Array>`
+
+Creates a CheckList(`checkbox`) from Inquirer
+
+```js
+const CheckList = require('@webpack-cli/webpack-scaffold').CheckList;
+
+CheckList('entry', 'what kind of entry do you want?', ['Array', 'Function']);
+```
+
+### Input 
+
+Param: `name<String>, message<String>`
+
+Creates an Input from Inquirer
+
+```js
+const Input = require('@webpack-cli/webpack-scaffold').Input;
+
+Input('entry', 'what is your entry point?');
+```
+
+### InputValidate
+
+Param: `name<String>, message<String>, validate<Function>`
+
+Creates an Input from Inquirer
+
+```js
+const InputValidate = require('@webpack-cli/webpack-scaffold').InputValidate;
+
+const validation = (value) => {
+  if(value.length > 4) {
+    return true;
+  } else {
+    return 'Wow, that was short!';
+  }
+};
+InputValidate('entry', 'what is your entry point?', validation);
+```
+
+### Confirm
+
+Param: `name<String>, message<String>, default<?Boolean>`
+
+Creates an Input from Inquirer
+
+```js
+const Confirm = require('@webpack-cli/webpack-scaffold').Confirm;
+
+Confirm('contextConfirm', 'Is this your context?');
+```


### PR DESCRIPTION
At the moment `webpack-cli` documentation consists of many markdown files inside the [repository](https://github.com/webpack/webpack-cli), to make it more accessible it needs to be improved and hosted in a website, for this reason I'm importing ` webpack-cli` documentation into a new section of `webpack.js.org`.

I've created a section named `cli` with a temporary disclaimer to disambiguate the webpack command line API from webpack-cli:

![cli1](https://user-images.githubusercontent.com/11232797/54856724-3d92a100-4cfc-11e9-847e-02124ba5a76d.png)

I've also imported most of the `webpack-cli` documentation:

![cli2](https://user-images.githubusercontent.com/11232797/54856726-3ec3ce00-4cfc-11e9-8137-17f1b5506517.png)

I'm opening this PR to get feedback, if this is the right approach I will keep working on completing this work by importing and improving the current documentation.

@evenstensberg & @fokusferit