### PR TITLE
Fix clipped header on homepage

### DIFF
--- a/src/content/index.md
+++ b/src/content/index.md
@@ -69,11 +69,10 @@ __page.html__
 ```
 
 </div>
+</div>
 
 Then run `webpack` on the command-line to create `bundle.js`.
 
 ## It's That Simple
 
 __[Get Started](/guides/getting-started)__ quickly in our __Guides__ section, or dig into the __[Concepts](/concepts)__ section for more high-level information on the core notions behind webpack.
-
-</div>


### PR DESCRIPTION
Fixes https://github.com/webpack/webpack.js.org/issues/2854

Before:

![Screen Shot 2019-03-28 at 9 53 44 PM](https://user-images.githubusercontent.com/16640310/55163028-00b72600-51a4-11e9-90a0-e57b46fc6e7f.png)

After:

![Screen Shot 2019-03-28 at 9 53 18 PM](https://user-images.githubusercontent.com/16640310/55163033-03b21680-51a4-11e9-8869-49fbc10b36a1.png)

cc @Ajacmac