### PR TITLE
Escape backslashes in mdx files

### DIFF
--- a/src/content/api/node.mdx
+++ b/src/content/api/node.mdx
@@ -7,6 +7,7 @@ contributors:
   - byzyk
   - wizardofhogwarts
   - EugeneHlushko
+  - lukasgeiter
 ---
 
 webpack provides a Node.js API which can be used directly in Node.js runtime.
@@ -274,7 +275,7 @@ webpack([
   { entry: './index1.js', output: { filename: 'bundle1.js' } },
   { entry: './index2.js', output: { filename: 'bundle2.js' } }
 ], (err, [stats](#stats-object)) => {
-  process.stdout.write(stats.toString() + '\n');
+  process.stdout.write(stats.toString() + '\\n');
 })
 ```
 

--- a/src/content/concepts/loaders.mdx
+++ b/src/content/concepts/loaders.mdx
@@ -13,6 +13,7 @@ contributors:
   - debs-obrien
   - EugeneHlushko
   - wizardofhogwarts
+  - lukasgeiter
 ---
 
 Loaders are transformations that are applied on the source code of a module. They allow you to pre-process files as you `import` or “load” them. Thus, loaders are kind of like “tasks” in other build tools and provide a powerful way to handle front-end build steps. Loaders can transform files from a different language (like TypeScript) to JavaScript or inline images as data URLs. Loaders even allow you to do things like `import` CSS files directly from your JavaScript modules!
@@ -35,8 +36,8 @@ __webpack.config.js__
 module.exports = {
   module: {
     rules: [
-      { test: /\.css$/, use: 'css-loader' },
-      { test: /\.ts$/, use: 'ts-loader' }
+      { test: /\\.css$/, use: 'css-loader' },
+      { test: /\\.ts$/, use: 'ts-loader' }
     ]
   }
 };
@@ -64,7 +65,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.css$/,
+        test: /\\.css$/,
         use: [
           // [style-loader](/loaders/style-loader)
           { loader: 'style-loader' },

--- a/src/content/configuration/index.mdx
+++ b/src/content/configuration/index.mdx
@@ -13,6 +13,7 @@ contributors:
   - sterlingvix
   - jeremenichelli
   - dasarianudeep
+  - lukasgeiter
 ---
 
 Out of the box, webpack won't require you to use a configuration file. However, it will assume the entry point of your project is `src/index` and will output the result in `dist/main.js` minified and optimized for production.
@@ -144,14 +145,14 @@ module.exports = {
         /* Expert output configuration (on own risk) */
       </default>
       devtoolLineToLine: {
-        test: /\.jsx$/
+        test: /\\.jsx$/
       },
       // use a simple 1:1 mapped SourceMaps for these modules (faster)
       hotUpdateMainFilename: "[hash].hot-update.json", // string
       // filename template for HMR manifest
       hotUpdateChunkFilename: "[id].[hash].hot-update.js", // string
       // filename template for HMR chunks
-      sourcePrefix: "\t", // string
+      sourcePrefix: "\\t", // string
       // prefix module sources in bundle for better readablitity
     </expert>
   },
@@ -160,7 +161,7 @@ module.exports = {
     rules: [
       // rules for modules (configure loaders, parser options, etc.)
       {
-        test: /\.jsx?$/,
+        test: /\\.jsx?$/,
         include: [
           path.resolve(__dirname, "app")
         ],
@@ -189,7 +190,7 @@ module.exports = {
         // options for the loader
       },
       {
-        test: /\.html$/,
+        test: /\\.html$/,
         use: [
           // apply multiple loaders and options
           "htmllint-loader",
@@ -218,15 +219,15 @@ module.exports = {
         /* Advanced module configuration (click to show) */
       </default>
       noParse: [
-        /special-library\.js$/
+        /special-library\\.js$/
       ],
       // do not parse this module
       unknownContextRequest: ".",
       unknownContextRecursive: true,
-      unknownContextRegExp: /^\.\/.*$/,
+      unknownContextRegExp: /^\\.\\/.*$/,
       unknownContextCritical: true,
       exprContextRequest: ".",
-      exprContextRegExp: /^\.\/.*$/,
+      exprContextRegExp: /^\\.\\/.*$/,
       exprContextRecursive: true,
       exprContextCritical: true,
       wrappedContextRegExp: /.*/,
@@ -355,7 +356,7 @@ module.exports = {
       externals: ["react", /^@angular/],
     </default>
     externals: "react", // string (exact match)
-    externals: /^[a-z\-]+($|\/)/, // Regex
+    externals: /^[a-z\\-]+($|\\/)/, // Regex
     externals: { // object
       angular: "this angular", // this["angular"]
       react: { // UMD

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -13,6 +13,7 @@ contributors:
   - nerdkid93
   - EugeneHlushko
   - superburrito
+  - lukasgeiter
 ---
 
 These options determine how the [different types of modules](/concepts/modules) within a project will be treated.
@@ -183,7 +184,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.css$/,
+        test: /\\.css$/,
         oneOf: [
           {
             resourceQuery: /inline/, // foo.css?inline
@@ -264,7 +265,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.css$/,
+        test: /\\.css$/,
         resourceQuery: /inline/,
         use: 'url-loader'
       }
@@ -308,7 +309,7 @@ module.exports = {
     rules: [
       //...
       {
-        test: /\.json$/,
+        test: /\\.json$/,
         type: 'javascript/auto',
         loader: 'custom-json-loader'
       }
@@ -433,7 +434,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.css$/,
+        test: /\\.css$/,
         include: [
           path.resolve(__dirname, 'app/styles'),
           path.resolve(__dirname, 'vendor/styles')
@@ -558,6 +559,6 @@ T> You can use the `ContextReplacementPlugin` to modify these values for individ
 A few use cases:
 
 - Warn for dynamic dependencies: `wrappedContextCritical: true`.
-- `require(expr)` should include the whole directory: `exprContextRegExp: /^\.\//`
+- `require(expr)` should include the whole directory: `exprContextRegExp: /^\\.\\//`
 - `require('./templates/' + expr)` should not include subdirectories by default: `wrappedContextRecursive: false`
 - `strictExportPresence` makes missing exports an error instead of warning


### PR DESCRIPTION
This PR fixes several not escaped backslashes in `.mdx` files. Without a second escaping backslash they are either not visible or interpreted as special character (e.g. `\n`)