### PR TITLE
docs(dev-server): New http2 option

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -479,7 +479,9 @@ webpack-dev-server --hot-only
 
 Serve over HTTP/2 using [spdy](https://www.npmjs.com/package/spdy). This option is ignored for Node 10.0.0 and above, as spdy is broken for those versions. The dev server will migrate over to Node's built-in HTTP/2 once Express supports it.
 
-When this option is enabled but the server is unable to serve over HTTP/2, the server defaults to HTTPS. If this option is not explicitly set to `false`, it will default to `true` when using HTTPS.
+If this option is not explicitly set to `false`, it will default to `true` when using HTTPS. When this option is enabled but the server is unable to serve over HTTP/2, the server defaults to HTTPS.
+
+HTTP/2 with a self-signed certificate:
 
 __webpack.config.js__
 
@@ -492,7 +494,7 @@ module.exports = {
 };
 ```
 
-Provide your own certificate using the [https](#devserver-https) option:
+Provide your own certificate using the [https](#devserverhttps) option:
 
 __webpack.config.js__
 
@@ -514,6 +516,12 @@ Usage via the CLI
 
 ```bash
 webpack-dev-server --http2
+```
+
+To pass your own certificate via the CLI use the following options
+
+```bash
+webpack-dev-server --http2 --key /path/to/server.key --cert /path/to/server.crt --cacert /path/to/ca.pem
 ```
 
 

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -475,11 +475,11 @@ webpack-dev-server --hot-only
 
 ## `devServer.http2`
 
-`boolean`
+`boolean: false`
 
-Serve over HTTP/2 using [spdy](https://www.npmjs.com/package/spdy). This option is ignored for Node 10.0.0 and above, as spdy is broken for those versions. The dev server will migrate over to Node's built-in HTTP/2 once Express supports it.
+Serve over HTTP/2 using [spdy](https://www.npmjs.com/package/spdy). This option is ignored for Node 10.0.0 and above, as spdy is broken for those versions. The dev server will migrate over to Node's built-in HTTP/2 once [Express](https://expressjs.com/) supports it.
 
-If this option is not explicitly set to `false`, it will default to `true` when using HTTPS. When this option is enabled but the server is unable to serve over HTTP/2, the server defaults to HTTPS.
+If `devServer.http2` is not explicitly set to `false`, it will default to `true` when [`devServer.https`](#devserverhttps) is enabled. When `devServer.http2` is enabled but the server is unable to serve over HTTP/2, the server defaults to HTTPS.
 
 HTTP/2 with a self-signed certificate:
 
@@ -512,13 +512,13 @@ module.exports = {
 };
 ```
 
-Usage via the CLI
+Usage via CLI
 
 ```bash
 webpack-dev-server --http2
 ```
 
-To pass your own certificate via the CLI use the following options
+To pass your own certificate via CLI, use the following options
 
 ```bash
 webpack-dev-server --http2 --key /path/to/server.key --cert /path/to/server.crt --cacert /path/to/ca.pem

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -10,6 +10,7 @@ contributors:
   - byzyk
   - EugeneHlushko
   - Yiidiir
+  - Loonride
 ---
 
 [webpack-dev-server](https://github.com/webpack/webpack-dev-server) can be used to quickly develop an application. See the [development guide](/guides/development/) to get started.
@@ -469,6 +470,50 @@ Usage via the CLI
 
 ```bash
 webpack-dev-server --hot-only
+```
+
+
+## `devServer.http2`
+
+`boolean`
+
+Serve over HTTP/2 using [spdy](https://www.npmjs.com/package/spdy). This option is ignored for Node 10.0.0 and above, as spdy is broken for those versions. The dev server will migrate over to Node's built-in HTTP/2 once Express supports it.
+
+When this option is enabled but the server is unable to serve over HTTP/2, the server defaults to HTTPS. If this option is not explicitly set to `false`, it will default to `true` when using HTTPS.
+
+__webpack.config.js__
+
+```javascript
+module.exports = {
+  //...
+  devServer: {
+    http2: true
+  }
+};
+```
+
+Provide your own certificate using the [https](#devserver-https) option:
+
+__webpack.config.js__
+
+```javascript
+module.exports = {
+  //...
+  devServer: {
+    http2: true,
+    https: {
+      key: fs.readFileSync('/path/to/server.key'),
+      cert: fs.readFileSync('/path/to/server.crt'),
+      ca: fs.readFileSync('/path/to/ca.pem'),
+    }
+  }
+};
+```
+
+Usage via the CLI
+
+```bash
+webpack-dev-server --http2
 ```
 
 


### PR DESCRIPTION
_describe your changes..._

Issue: https://github.com/webpack/webpack.js.org/issues/2922

I documented the new `devServer.http2` option.
- Included API/CLI examples for self-signed and custom certificates
- Detailed relations of this with `https` option
