### PR TITLE
Convert finishModules hook to be an AsyncSeries

### DIFF
--- a/src/content/api/compilation-hooks.md
+++ b/src/content/api/compilation-hooks.md
@@ -64,7 +64,7 @@ Parameters: `module`
 
 ### `finishModules`
 
-`SyncHook`
+`AsyncSeriesHook`
 
 All modules have been built.
 


### PR DESCRIPTION
Change `finishModules` hook to be `AsyncSeries`.

Resolves #2924