### PR TITLE
Change Heading Level of "Magic Comments" Section

### DIFF
--- a/src/content/api/module-methods.md
+++ b/src/content/api/module-methods.md
@@ -74,7 +74,7 @@ if ( module.hot ) {
 
 W> This feature relies on [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) internally. If you use `import()` with older browsers, remember to shim `Promise` using a polyfill such as [es6-promise](https://github.com/stefanpenner/es6-promise) or [promise-polyfill](https://github.com/taylorhakes/promise-polyfill).
 
-## Magic Comments
+#### Magic Comments
 
 Inline comments to make features work. By adding comments to the import we can do things such as name our chunk or select different modes. For a full list of these magic comments see the code below followed by an explanation of what these comments do. 
 


### PR DESCRIPTION
The "Magic Comments" section applies to the `import()` (level-3) sub-section of the `ES6` (level: 2) section.
Changing to level-4 will make it clear that the magic comments apply to `ES6` > `import()`.
