### PR TITLE
fix(links): fix anchor links to /configuration/output

### DIFF
--- a/src/content/configuration/configuration-types.md
+++ b/src/content/configuration/configuration-types.md
@@ -62,7 +62,7 @@ module.exports = () => {
 
 ## Exporting multiple configurations
 
-Instead of exporting a single configuration object/function, you may export multiple configurations (multiple functions are supported since webpack 3.1.0). When running webpack, all configurations are built. For instance, this is useful for [bundling a library](/guides/author-libraries) for multiple [targets](/configuration/output#output-librarytarget) such as AMD and CommonJS:
+Instead of exporting a single configuration object/function, you may export multiple configurations (multiple functions are supported since webpack 3.1.0). When running webpack, all configurations are built. For instance, this is useful for [bundling a library](/guides/author-libraries) for multiple [targets](/configuration/output#outputlibrarytarget) such as AMD and CommonJS:
 
 ```js
 module.exports = [{

--- a/src/content/configuration/entry-context.md
+++ b/src/content/configuration/entry-context.md
@@ -91,4 +91,4 @@ module.exports = {
 };
 ```
 
-When combining with the [`output.library`](/configuration/output#output-library) option: If an array is passed only the last item is exported.
+When combining with the [`output.library`](/configuration/output#outputlibrary) option: If an array is passed only the last item is exported.

--- a/src/content/configuration/externals.md
+++ b/src/content/configuration/externals.md
@@ -83,7 +83,7 @@ module.exports = {
 
 ### object
 
-W> An object with `{ root, amd, commonjs, ... }` is only allowed for [`libraryTarget: 'umd'`](/configuration/output/#output-librarytarget). It's not allowed for other library targets.
+W> An object with `{ root, amd, commonjs, ... }` is only allowed for [`libraryTarget: 'umd'`](/configuration/output/#outputlibrarytarget). It's not allowed for other library targets.
 
 ```javascript
 module.exports = {

--- a/src/content/guides/author-libraries.md
+++ b/src/content/guides/author-libraries.md
@@ -297,7 +297,7 @@ You can expose the library in the following ways:
 - Window: available trough the `window` object, in the browser (`libraryTarget:'window'`).
 - UMD: available after AMD or CommonJS `require` (`libraryTarget:'umd'`).
 
-If `library` is set and `libraryTarget` is not, `libraryTarget` defaults to `var` as specified in the [output configuration documentation](/configuration/output). See [`output.libraryTarget`](/configuration/output#output-librarytarget) there for a detailed list of all available options.
+If `library` is set and `libraryTarget` is not, `libraryTarget` defaults to `var` as specified in the [output configuration documentation](/configuration/output). See [`output.libraryTarget`](/configuration/output#outputlibrarytarget) there for a detailed list of all available options.
 
 W> With webpack 3.5.5, using `libraryTarget: { root:'_' }` doesn't work properly (as stated in [issue 4824](https://github.com/webpack/webpack/issues/4824)). However, you can set `libraryTarget: { var: '_' }` to expect the library as a global variable.
 

--- a/src/content/plugins/dll-plugin.md
+++ b/src/content/plugins/dll-plugin.md
@@ -30,7 +30,7 @@ new webpack.DllPlugin(options);
 
 Creates a `manifest.json` which is written to the given `path`. It contains mappings from require and import requests, to module ids. It is used by the `DllReferencePlugin`.
 
-Combine this plugin with [`output.library`](/configuration/output/#output-library) option to expose (aka, put into the global scope) the dll function.
+Combine this plugin with [`output.library`](/configuration/output/#outputlibrary) option to expose (aka, put into the global scope) the dll function.
 
 
 ## `DllReferencePlugin`
@@ -42,7 +42,7 @@ This plugin is used in the primary webpack config, it references the dll-only-bu
 - `content` (optional): the mappings from request to module id (defaults to `manifest.content`)
 - `name` (optional): the name where the dll is exposed (defaults to `manifest.name`) (see also [`externals`](/configuration/externals/))
 - `scope` (optional): prefix which is used for accessing the content of the dll
-- `sourceType` (optional): how the dll is exposed ([libraryTarget](/configuration/output/#output-librarytarget))
+- `sourceType` (optional): how the dll is exposed ([libraryTarget](/configuration/output/#outputlibrarytarget))
 
 ```javascript
 new webpack.DllReferencePlugin(options);
@@ -50,7 +50,7 @@ new webpack.DllReferencePlugin(options);
 
 References a dll manifest file to map dependency names to module ids, then requires them as needed using the internal `__webpack_require__` function.
 
-W> Keep the `name` consistent with [`output.library`](/configuration/output/#output-library).
+W> Keep the `name` consistent with [`output.library`](/configuration/output/#outputlibrary).
 
 
 ### Modes


### PR DESCRIPTION
fix(links): fix anchor links to `/configuration/output`

related to #2929

Fixed broken anchor links:
* `/configuration/output#output-librarytarget` -> `/configuration/output#outputlibrarytarget`
* `/configuration/output#output-library` -> `/configuration/output#outputlibrary`

Some takeaways (also answering @montogeek 's [question](https://github.com/webpack/webpack.js.org/pull/2929#issuecomment-482023800))
> Why this wasn't catch by the link checker?

* on travis only `lint:links` runs, which executes `hyperlink` with `-i` flag. Looks like in this case fragment links are not checked at all
* `hyperlink` [does not correctly check fragment links](https://github.com/Munter/hyperlink/issues/150) pointing to folders having `index.html` inside.