### PR TITLE
docs(plugins) Correct tag

### DIFF
--- a/src/content/plugins/html-webpack-plugin.md
+++ b/src/content/plugins/html-webpack-plugin.md
@@ -54,7 +54,7 @@ This will generate a file `dist/index.html` containing the following:
 
 If you have multiple webpack entry points, they will all be included with `<script>` tags in the generated HTML.
 
-If you have any CSS assets in webpack's output (for example, CSS extracted with the [MiniCssExtractPlugin](/plugins/mini-css-extract-plugin/)) then these will be included with `<link>` tags in the HTML head.
+If you have any CSS assets in webpack's output (for example, CSS extracted with the [MiniCssExtractPlugin](/plugins/mini-css-extract-plugin/)) then these will be included with `<link>` tags in the `<head>` element of generated HTML.
 
 
 ## Configuration

--- a/src/content/plugins/html-webpack-plugin.md
+++ b/src/content/plugins/html-webpack-plugin.md
@@ -4,6 +4,7 @@ contributors:
   - ampedandwired
   - simon04
   - Sibiraj-S
+  - EugeneHlushko
 ---
 
 The [`HtmlWebpackPlugin`](https://github.com/jantimon/html-webpack-plugin) simplifies creation of HTML files to serve your webpack bundles. This is especially useful for webpack bundles that include a hash in the filename which changes every compilation. You can either let the plugin generate an HTML file for you, supply your own template using [lodash templates](https://lodash.com/docs#template), or use your own [loader](/loaders).
@@ -51,12 +52,9 @@ This will generate a file `dist/index.html` containing the following:
 </html>
 ```
 
-If you have multiple webpack entry points, they will all be included with `script`
-tags in the generated HTML.
+If you have multiple webpack entry points, they will all be included with `<script>` tags in the generated HTML.
 
-If you have any CSS assets in webpack's output (for example, CSS extracted
-with the [MiniCssExtractPlugin](/plugins/mini-css-extract-plugin/))
-then these will be included with `<link>` tags in the HTML head.
+If you have any CSS assets in webpack's output (for example, CSS extracted with the [MiniCssExtractPlugin](/plugins/mini-css-extract-plugin/)) then these will be included with `<link>` tags in the HTML head.
 
 
 ## Configuration


### PR DESCRIPTION
Use real tag as opposed to the next similar reference to `<link>` tag...