### PR TITLE
ui(homepage) fix heading alignment

### DIFF
--- a/src/components/Splash/Splash.scss
+++ b/src/components/Splash/Splash.scss
@@ -4,6 +4,11 @@
 .splash {
   position: relative;
   overflow: hidden;
+
+  h1,
+  h2 {
+    justify-content: center;
+  }
   
   &__section {
     position:relative;


### PR DESCRIPTION
Heading were all aligned left on homepage splashes, probably we broke it when merged rebuild.