### PR TITLE
docs(license) fix up markup to not render sort attribute in the menu

### DIFF
--- a/src/content/license.md
+++ b/src/content/license.md
@@ -1,6 +1,8 @@
 ---
 title: License
 sort: 4
+contributors:
+  - EugeneHlushko
 ---
 
 ## webpack


### PR DESCRIPTION
Found another occurrence where sort was in menu, i hope i didnt miss any other this time.