### PR TITLE
docs(dev-server): Add documentation for `serveIndex` option

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -1111,9 +1111,9 @@ webpack-dev-server --quiet
 
 ## `devServer.serveIndex`
 
-`boolean`
+`boolean: true`
 
-This option Enables/Disables [`serveIndex`](https://github.com/expressjs/serve-index) middleware. It's enabled by default.
+Tells dev-server to use [`serveIndex`](https://github.com/expressjs/serve-index) middleware when enabled.
 
 [`serveIndex`](https://github.com/expressjs/serve-index) middleware generates directory listings on viewing directories that don't have an index.html file.
 

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -1108,6 +1108,7 @@ Usage via the CLI
 ```bash
 webpack-dev-server --quiet
 ```
+
 ## `devServer.serveIndex`
 
 `boolean`

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -12,6 +12,7 @@ contributors:
   - Yiidiir
   - Loonride
   - dmohns
+  - EslamHiko
 ---
 
 [webpack-dev-server](https://github.com/webpack/webpack-dev-server) can be used to quickly develop an application. See the [development guide](/guides/development/) to get started.
@@ -1107,7 +1108,22 @@ Usage via the CLI
 ```bash
 webpack-dev-server --quiet
 ```
+## `devServer.serveIndex`
 
+`boolean`
+
+This option Enables/Disables [`serveIndex`](https://github.com/expressjs/serve-index) middleware. It's enabled by default.
+
+[`serveIndex`](https://github.com/expressjs/serve-index) middleware generates directory listings on viewing directories that don't have an index.html file.
+
+```javascript
+module.exports = {
+  //...
+  devServer: {
+    serveIndex: true
+  }
+};
+```
 
 ## `devServer.setup`
 


### PR DESCRIPTION
add documentation for `serveIndex` option in this PR 

https://github.com/webpack/webpack-dev-server/pull/1752