### PR TITLE
site(misc) simplify rendering logic, clean dist on dev, clean config

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
     "node": ">=8.9.4"
   },
   "scripts": {
-    "clean": "rimraf ./dist src/content/**/_*.md src/**/_*.json",
-    "start": "cross-env NODE_ENV=development webpack-dev-server --config webpack.dev.js --env.dev",
+    "clean-dist": "rimraf ./dist",
+    "clean": "npm run clean-dist && rimraf src/content/**/_*.md src/**/_*.json",
+    "start": "npm run clean-dist && cross-env NODE_ENV=development webpack-dev-server --config webpack.dev.js --env.dev",
     "update-repos": "node src/utilities/fetch-package-repos.js",
     "content": "node src/scripts/build-content-tree.js ./src/content ./src/_content.json",
     "build-test": "npm run build && http-server dist/",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -10,22 +10,11 @@ import Site from './components/Site/Site';
 // Import helpers
 import isClient from './utilities/is-client';
 
-// Import Utilities
-import { findInContent } from './utilities/content-utils';
-
-// Import Content Tree
-import Content from './_content.json';
-
 const Router = process.env.NODE_ENV === 'production' ? AnalyticsRouter : BrowserRouter;
 const render = process.env.NODE_ENV === 'production' ? ReactDOM.hydrate : ReactDOM.render;
 
 // Client Side Rendering
 if (isClient) {
-  let { pathname } = window.location;
-  let trimmed = pathname.replace(/(.+)\/$/, '$1');
-  let entryPage = findInContent(Content, item => item.url === trimmed);
-  let entryPath = entryPage && entryPage.path.replace('src/content/', '');
-
   render((
     <Router id="UA-46921629-2">
       <Route
@@ -33,15 +22,7 @@ if (isClient) {
         render={ props => (
           <Site
             { ...props }
-            import={ path => {
-              if (path === entryPath) {
-                return import(`./content/${path}`);
-              } else if (path === '/vote') {
-                return import(`./components/${path}`);
-              } else {
-                return import(`./content/${path}`);
-              }
-            }} />
+            import={ path => import(`./content/${path}`) } />
         )} />
     </Router>
   ), document.getElementById('root'));

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,7 +1,4 @@
-const fs = require('fs');
 const path = require('path');
-const webpack = require('webpack');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 const mdPlugins = [


### PR DESCRIPTION
- Fixed a case when`npm run start` command to possibly serve old `./dist/index.html` after working with `npm run build-test` command for example
- simplified rendering logic (tested, vote works)
- cleanup unused vars in config