### PR TITLE
Removed the relative path of bundle and main

### DIFF
--- a/src/content/guides/asset-management.md
+++ b/src/content/guides/asset-management.md
@@ -31,8 +31,8 @@ __dist/index.html__
 +    <title>Asset Management</title>
     </head>
     <body>
--     <script src="./main.js"></script>
-+     <script src="./bundle.js"></script>
+-     <script src="main.js"></script>
++     <script src="bundle.js"></script>
     </body>
   </html>
 ```


### PR DESCRIPTION
In the Getting Started section **<script src="main.js"></script>** is written but in asset-management src is replaced with relative path which can be misleading/confusing for beginners. As both the relative path and filename will work fine, it is better to have it same across the documentation.
