### PR TITLE
misc(phrasing) drop "its that simple" from homepage

### DIFF
--- a/src/content/index.md
+++ b/src/content/index.md
@@ -73,6 +73,6 @@ __page.html__
 
 Then run `webpack` on the command-line to create `bundle.js`.
 
-## It's That Simple
+## Awesome isn't it? Let's dive in!
 
 __[Get Started](/guides/getting-started)__ quickly in our __Guides__ section, or dig into the __[Concepts](/concepts)__ section for more high-level information on the core notions behind webpack.


### PR DESCRIPTION
Fixes #2378 