### PR TITLE
Update development.md

### DIFF
--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -162,7 +162,7 @@ __package.json__
       "file-loader": "^0.11.2",
       "html-webpack-plugin": "^2.29.0",
       "style-loader": "^0.18.2",
-      "webpack": "^3.0.0",
+      "webpack": "^4.30.0",
       "xml-loader": "^1.2.1"
     }
   }
@@ -258,7 +258,7 @@ __package.json__
       "file-loader": "^0.11.2",
       "html-webpack-plugin": "^2.29.0",
       "style-loader": "^0.18.2",
-      "webpack": "^3.0.0",
+      "webpack": "^4.30.0",
       "xml-loader": "^1.2.1"
     }
   }
@@ -381,7 +381,7 @@ __package.json__
       "file-loader": "^0.11.2",
       "html-webpack-plugin": "^2.29.0",
       "style-loader": "^0.18.2",
-      "webpack": "^3.0.0",
+      "webpack": "^4.30.0",
       "webpack-dev-middleware": "^1.12.0",
       "xml-loader": "^1.2.1"
     }


### PR DESCRIPTION
Since the article gives an example of usage `mode` property within `webpack.config.js`, but the `package.json` refers to the `"webpack": "^3.0.0"`, but to make the `mode` property works, it is needed to use webpack v4 major version at least.
