### PR TITLE
fix(homepage): Fix a homepage animation bug.

### DIFF
--- a/src/components/Cube/Cube.jsx
+++ b/src/components/Cube/Cube.jsx
@@ -93,7 +93,7 @@ export default class Cube extends React.Component {
         let nowTime = performance.now();
         let deltaTime = nowTime - lastTime;
 
-        if (repeatDelay <= deltaTime) {
+        if (repeatDelay <= deltaTime && !document.hidden) {
           let obj = {};
           obj[axis] = degrees += 90;
 


### PR DESCRIPTION
Add a condition to the homepage animation.

Reproduction:
When you come back after leave the homepage for a long time , the cube will spin quickly and then become normal.