### PR TITLE
normalModuleLoader will not be removed but moved

### DIFF
--- a/src/content/api/compilation-hooks.md
+++ b/src/content/api/compilation-hooks.md
@@ -697,7 +697,7 @@ Executed after setting up a child compiler.
 
 `SyncHook`
 
-W> This hook will be moved in v5.0.0
+W> This hook will be moved in v5.0.0 to `NormalModule.getCompilationHooks(compilation).loader`
 
 The normal module loader is the function that actually loads all the modules
 

--- a/src/content/api/compilation-hooks.md
+++ b/src/content/api/compilation-hooks.md
@@ -697,7 +697,7 @@ Executed after setting up a child compiler.
 
 `SyncHook`
 
-W> This hook will be removed in v5.0.0
+W> This hook will be moved in v5.0.0
 
 The normal module loader is the function that actually loads all the modules
 


### PR DESCRIPTION
https://github.com/webpack/webpack/blob/v5.0.0-alpha.11/lib/Compilation.js#L152

```
"Compilation.hooks.normalModuleLoader was moved to NormalModule.getCompilationHooks(compilation).loader"
```