### PR TITLE
feat(pwa) use offline-plugin for service worker setup and offline sup…

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "modularscale-sass": "^3.0.3",
     "node-sass": "^4.5.3",
     "npm-run-all": "^4.1.1",
+    "offline-plugin": "^5.0.7",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "postcss-loader": "^2.1.3",
     "redirect-webpack-plugin": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "fetch:supporters": "node src/utilities/fetch-supporters.js",
     "fetch:starter-kits": "node src/utilities/fetch-starter-kits.js",
     "prebuild": "npm run clean",
-    "build": "run-s fetch content && cross-env NODE_ENV=production webpack --config webpack.prod.js",
+    "build": "run-s fetch content && cross-env NODE_ENV=production webpack --config webpack.ssg.js && cross-env NODE_ENV=production webpack --config webpack.prod.js",
     "postbuild": "npm run sitemap",
     "test": "npm run lint",
     "lint": "run-s lint:*",

--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -31,6 +31,11 @@ import './Site.scss';
 // Load Content Tree
 import Content from '../../_content.json';
 
+// call offline plugin so it can build
+if (isClient) {
+  require('offline-plugin/runtime').install();
+}
+
 class Site extends React.Component {
   state = {
     mobileSidebarOpen: false

--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -82,6 +82,7 @@ class Site extends React.Component {
                   <Route path="/vote" component={Vote} />
                   <Route path="/organization" component={Organization} />
                   <Route path="/starter-kits" component={StarterKits} />
+                  <Route path="/app-shell" component={() => <React.Fragment />} />
                   {pages.map(page => (
                     <Route
                       key={page.url}

--- a/src/utilities/find-files-in-dist.js
+++ b/src/utilities/find-files-in-dist.js
@@ -1,0 +1,9 @@
+// grab .css files from ssg run
+const fs = require('fs');
+
+module.exports = function (endsWith = false) {
+    const filesInDist = fs.readdirSync('./dist');
+    return endsWith
+        ? filesInDist.filter((item) => item.endsWith(endsWith))
+        : filesInDist;
+};

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -148,6 +148,7 @@ module.exports = (env = {}) => ({
   output: {
     path: path.resolve(__dirname, './dist'),
     publicPath: '/',
-    filename: '[name].bundle.js'
+    filename: '[name].bundle.js',
+    chunkFilename: '[name].[chunkhash].chunk.js'
   }
 });

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -23,7 +23,6 @@ module.exports = env => merge(common(env), {
     new OfflinePlugin({
       relativePaths: false,
       publicPath: '/',
-      appShell: '/',
       caches: {
         main: [':rest:', ...cssFiles],
         optional: ['*.chunk.js']

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -7,6 +7,7 @@ const flattenContentTree = require('./src/utilities/flatten-content-tree');
 const contentTree = require('./src/_content.json');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const TerserJSPlugin = require('terser-webpack-plugin');
+const OfflinePlugin = require('offline-plugin');
 
 // Load Common Configuration
 const common = require('./webpack.common.js');
@@ -43,7 +44,8 @@ const prod = {
         to: './assets/'
       },
       'CNAME'
-    ])
+    ]),
+    new OfflinePlugin()
   ]
 };
 

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -21,13 +21,10 @@ module.exports = env => merge(common(env), {
   },
   plugins: [
     new OfflinePlugin({
-      relativePaths: false,
-      publicPath: '/',
-      caches: {
-        main: [':rest:', ...cssFiles],
-        optional: ['*.chunk.js']
-      },
-      externals: ['/']
+      externals: ['/', ...cssFiles],
+      AppCache: {
+        FALLBACK: { '/': '/index.html' }
+      }
     })
   ]
 });

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -21,9 +21,13 @@ module.exports = env => merge(common(env), {
   },
   plugins: [
     new OfflinePlugin({
+      publicPath: '/',
       externals: ['/', ...cssFiles],
+      appShell: '/index.html',
+      excludes: [],
       AppCache: {
-        FALLBACK: { '/': '/index.html' }
+        publicPath: '/',
+        FALLBACK: { '/': './dist/index.html' }
       }
     })
   ]

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -27,9 +27,9 @@ module.exports = env => merge(common(env), {
     new OfflinePlugin({
       autoUpdate: true,
       publicPath: '/',
-      appShell: '/concepts/',
-      // make sure to cache homepage and concepts as app shell for the rest of the pages.
-      externals: ['/concepts/', '/', '/manifest.json', ...cssFiles, ...favicons],
+      appShell: '/app-shell/',
+      // make sure to cache homepage and app shell as app shell for the rest of the pages.
+      externals: ['/app-shell/', '/', '/manifest.json', ...cssFiles, ...favicons],
       excludes: [],
       AppCache: {
         publicPath: '/'

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -44,8 +44,7 @@ const prod = {
         to: './assets/'
       },
       'CNAME'
-    ]),
-    new OfflinePlugin()
+    ])
   ]
 };
 
@@ -108,6 +107,11 @@ module.exports = env => [
     }
   }),
   merge(common(env), prod, {
-    target: 'web'
+    target: 'web',
+    plugins: [
+      new OfflinePlugin({
+        externals: paths
+      })
+    ]
   })
 ];

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,10 +1,5 @@
 // Import External Dependencies
 const merge = require('webpack-merge');
-const SSGPlugin = require('static-site-generator-webpack-plugin');
-const RedirectWebpackPlugin = require('redirect-webpack-plugin');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
-const flattenContentTree = require('./src/utilities/flatten-content-tree');
-const contentTree = require('./src/_content.json');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const TerserJSPlugin = require('terser-webpack-plugin');
 const OfflinePlugin = require('offline-plugin');
@@ -12,17 +7,12 @@ const OfflinePlugin = require('offline-plugin');
 // Load Common Configuration
 const common = require('./webpack.common.js');
 
-// content tree to path array
-const paths = [
-  ...flattenContentTree(contentTree),
-  '/vote',
-  '/organization',
-  '/starter-kits'
-];
+// find css files for sw
+const cssFiles = require('./src/utilities/find-files-in-dist')('.css');
 
-// Prod only config
-const prod = {
+module.exports = env => merge(common(env), {
   mode: 'production',
+  target: 'web',
   optimization: {
     minimizer: [
       new TerserJSPlugin({}),
@@ -30,88 +20,15 @@ const prod = {
     ]
   },
   plugins: [
-    new CopyWebpackPlugin([
-      {
-        from: './assets/PWA',
-        to: './'
+    new OfflinePlugin({
+      relativePaths: false,
+      publicPath: '/',
+      appShell: '/',
+      caches: {
+        main: [':rest:', ...cssFiles],
+        optional: ['*.chunk.js']
       },
-      {
-        from: './assets/icon-square-small-slack.png',
-        to: './assets/'
-      },
-      {
-        from: './assets/icon-square-big.svg',
-        to: './assets/'
-      },
-      'CNAME'
-    ])
+      externals: ['/']
+    })
   ]
-};
-
-// Export both SSG and SPA configurations
-module.exports = env => [
-  merge(common(env), prod, {
-    target: 'node',
-    entry: {
-      index: './server.jsx'
-    },
-    plugins: [
-      new SSGPlugin({
-        globals: {
-          window: {}
-        },
-        paths,
-        locals: {
-          content: contentTree
-        }
-      }),
-      new RedirectWebpackPlugin({
-        redirects: {
-          'support': '/contribute/',
-          'writers-guide': '/contribute/writers-guide/',
-          'get-started': '/guides/getting-started/',
-          'get-started/install-webpack': '/guides/installation/',
-          'get-started/why-webpack': '/guides/why-webpack/',
-          'pluginsapi': '/api/plugins/',
-          'pluginsapi/compiler': '/api/compiler-hooks/',
-          'pluginsapi/template': '/api/template/',
-          'api/passing-a-config': '/configuration/configuration-types/',
-          'api/plugins/compiler': '/api/compiler-hooks/',
-          'api/plugins/compilation': '/api/compilation/',
-          'api/plugins/module-factories': '/api/module-methods/',
-          'api/plugins/parser': '/api/parser/',
-          'api/plugins/tapable': '/api/tapable/',
-          'api/plugins/template': '/api/template/',
-          'api/plugins/resolver': '/api/resolver/',
-          'development': '/contribute/',
-          'development/plugin-patterns': '/contribute/plugin-patterns/',
-          'development/release-process': '/contribute/release-process/',
-          'development/how-to-write-a-loader': '/contribute/writing-a-loader/',
-          'development/how-to-write-a-plugin': '/contribute/writing-a-plugin/',
-          'guides/code-splitting-import': '/guides/code-splitting/',
-          'guides/code-splitting-require': '/guides/code-splitting/',
-          'guides/code-splitting-async': '/guides/code-splitting/',
-          'guides/code-splitting-css': '/guides/code-splitting/',
-          'guides/code-splitting-libraries': '/guides/code-splitting/',
-          'guides/why-webpack': '/comparison/',
-          'guides/production-build': '/guides/production/',
-          'migrating': '/migrate/3/',
-          'plugins/no-emit-on-errors-plugin': '/configuration/optimization/#optimization-noemitonerrors',
-          'concepts/mode': '/configuration/mode'
-        }
-      })
-    ],
-    output: {
-      filename: 'server.[name].js',
-      libraryTarget: 'umd'
-    }
-  }),
-  merge(common(env), prod, {
-    target: 'web',
-    plugins: [
-      new OfflinePlugin({
-        externals: paths
-      })
-    ]
-  })
-];
+});

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -9,6 +9,10 @@ const common = require('./webpack.common.js');
 
 // find css files for sw
 const cssFiles = require('./src/utilities/find-files-in-dist')('.css');
+// find favicons
+const favicons = require('./src/utilities/find-files-in-dist')('.ico');
+
+// fall back all urls to app shell
 
 module.exports = env => merge(common(env), {
   mode: 'production',
@@ -21,13 +25,14 @@ module.exports = env => merge(common(env), {
   },
   plugins: [
     new OfflinePlugin({
+      autoUpdate: true,
       publicPath: '/',
-      externals: ['/', ...cssFiles],
-      appShell: '/index.html',
+      appShell: '/concepts/',
+      // make sure to cache homepage and concepts as app shell for the rest of the pages.
+      externals: ['/concepts/', '/', '/manifest.json', ...cssFiles, ...favicons],
       excludes: [],
       AppCache: {
-        publicPath: '/',
-        FALLBACK: { '/': './dist/index.html' }
+        publicPath: '/'
       }
     })
   ]

--- a/webpack.ssg.js
+++ b/webpack.ssg.js
@@ -1,0 +1,94 @@
+// Import External Dependencies
+const merge = require('webpack-merge');
+const SSGPlugin = require('static-site-generator-webpack-plugin');
+const RedirectWebpackPlugin = require('redirect-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const flattenContentTree = require('./src/utilities/flatten-content-tree');
+const contentTree = require('./src/_content.json');
+
+// Load Common Configuration
+const common = require('./webpack.common.js');
+
+// content tree to path array
+const paths = [
+  ...flattenContentTree(contentTree),
+  '/vote',
+  '/organization',
+  '/starter-kits'
+];
+
+module.exports = env => merge(common(env), {
+    mode: 'production',
+    target: 'node',
+    entry: {
+      index: './server.jsx'
+    },
+    output: {
+      filename: 'server.[name].js',
+      libraryTarget: 'umd'
+    },
+    optimization: {
+        splitChunks: false
+    },
+    plugins: [
+      new SSGPlugin({
+        globals: {
+          window: {}
+        },
+        paths,
+        locals: {
+          content: contentTree
+        }
+      }),
+      new RedirectWebpackPlugin({
+        redirects: {
+          'support': '/contribute/',
+          'writers-guide': '/contribute/writers-guide/',
+          'get-started': '/guides/getting-started/',
+          'get-started/install-webpack': '/guides/installation/',
+          'get-started/why-webpack': '/guides/why-webpack/',
+          'pluginsapi': '/api/plugins/',
+          'pluginsapi/compiler': '/api/compiler-hooks/',
+          'pluginsapi/template': '/api/template/',
+          'api/passing-a-config': '/configuration/configuration-types/',
+          'api/plugins/compiler': '/api/compiler-hooks/',
+          'api/plugins/compilation': '/api/compilation/',
+          'api/plugins/module-factories': '/api/module-methods/',
+          'api/plugins/parser': '/api/parser/',
+          'api/plugins/tapable': '/api/tapable/',
+          'api/plugins/template': '/api/template/',
+          'api/plugins/resolver': '/api/resolver/',
+          'development': '/contribute/',
+          'development/plugin-patterns': '/contribute/plugin-patterns/',
+          'development/release-process': '/contribute/release-process/',
+          'development/how-to-write-a-loader': '/contribute/writing-a-loader/',
+          'development/how-to-write-a-plugin': '/contribute/writing-a-plugin/',
+          'guides/code-splitting-import': '/guides/code-splitting/',
+          'guides/code-splitting-require': '/guides/code-splitting/',
+          'guides/code-splitting-async': '/guides/code-splitting/',
+          'guides/code-splitting-css': '/guides/code-splitting/',
+          'guides/code-splitting-libraries': '/guides/code-splitting/',
+          'guides/why-webpack': '/comparison/',
+          'guides/production-build': '/guides/production/',
+          'migrating': '/migrate/3/',
+          'plugins/no-emit-on-errors-plugin': '/configuration/optimization/#optimization-noemitonerrors',
+          'concepts/mode': '/configuration/mode'
+        }
+      }),
+      new CopyWebpackPlugin([
+        {
+          from: './assets/PWA',
+          to: './'
+        },
+        {
+          from: './assets/icon-square-small-slack.png',
+          to: './assets/'
+        },
+        {
+          from: './assets/icon-square-big.svg',
+          to: './assets/'
+        },
+        'CNAME'
+      ])
+    ]
+  });

--- a/webpack.ssg.js
+++ b/webpack.ssg.js
@@ -14,7 +14,8 @@ const paths = [
   ...flattenContentTree(contentTree),
   '/vote',
   '/organization',
-  '/starter-kits'
+  '/starter-kits',
+  '/app-shell'
 ];
 
 module.exports = env => merge(common(env), {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3057,15 +3057,15 @@ deep-equal@^1.0.0, deep-equal@^1.0.1:
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
   integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
 
+deep-extend@^0.5.1, deep-extend@~0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.5.1.tgz#b894a9dd90d3023fbf1c55a394fb858eb2066f1f"
+  integrity sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==
+
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
-
-deep-extend@~0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.5.1.tgz#b894a9dd90d3023fbf1c55a394fb858eb2066f1f"
-  integrity sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -3433,6 +3433,11 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
+
+ejs@^2.3.4:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
+  integrity sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==
 
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.124, electron-to-chromium@^1.3.30, electron-to-chromium@^1.3.47:
   version "1.3.125"
@@ -6374,7 +6379,7 @@ loader-runner@^2.3.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@^0.2.10, loader-utils@^0.2.16:
+loader-utils@0.2.x, loader-utils@^0.2.10, loader-utils@^0.2.16:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
   integrity sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=
@@ -7071,7 +7076,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-"minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.4, minimatch@~3.0.2, minimatch@~3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2, minimatch@~3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -7665,6 +7670,17 @@ obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
+
+offline-plugin@^5.0.7:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/offline-plugin/-/offline-plugin-5.0.7.tgz#26936ad1a7699f4d67e0a095a258972a4ccf1788"
+  integrity sha512-ArMFt4QFjK0wg8B5+R/6tt65u6Dk+Pkx4PAcW5O7mgIF3ywMepaQqFOQgfZD4ybanuGwuJihxUwMRgkzd+YGYw==
+  dependencies:
+    deep-extend "^0.5.1"
+    ejs "^2.3.4"
+    loader-utils "0.2.x"
+    minimatch "^3.0.3"
+    slash "^1.0.0"
 
 on-finished@~2.3.0:
   version "2.3.0"


### PR DESCRIPTION
- add offline plugin for utilizing SW and offline support
- takes one off #1400
- the whole website works offline thanks to our existing flatten content tree

Note:
- moved ssg config out as webpack was compiling both in a race (at least on my machine it seemed so.) to now run ssg and then run prod and include ssg run's css that was printed into html files.