### PR TITLE
misc(style) fix gitter right position for mobile breakpoint

### DIFF
--- a/src/components/Gitter/Gitter.scss
+++ b/src/components/Gitter/Gitter.scss
@@ -4,8 +4,12 @@
 
 .gitter {
   position: fixed;
-  right: 1.5em;
+  right: 1em;
   bottom: 3em;
+
+  @include break {
+    right: 1.5em;
+  }
 }
 
 .gitter__button {


### PR DESCRIPTION
Gitter spacing on right was off, fixed it to stay aligned to content on mobile as well

<img width="190" alt="scr" src="https://user-images.githubusercontent.com/10549495/57538123-658f9f80-7350-11e9-80e1-54902c3544aa.png">
