### PR TITLE
feat(icons) add tocuh icons for saving docs to homescreens, tune SW

### DIFF
--- a/src/server.jsx
+++ b/src/server.jsx
@@ -56,6 +56,9 @@ export default locals => {
           ))}
           <link rel="manifest" href="/manifest.json" />
           <link rel="canonical" href={enforceTrailingSlash(locals.path)} />
+          <link rel="apple-touch-icon" href="/images/icons/icon-192x192.png" />
+          <link rel="apple-touch-icon" sizes="152x152" href="/images/icons/icon-152x152.png" />
+          <link rel="icon" sizes="192x192" href="/images/icons/icon-192x192.png" />
         </head>
         <body>
           <div id="root">

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -30,7 +30,7 @@ module.exports = env => merge(common(env), {
       appShell: '/app-shell/',
       // make sure to cache homepage and app shell as app shell for the rest of the pages.
       externals: ['/app-shell/', '/', '/manifest.json', ...cssFiles, ...favicons],
-      excludes: [],
+      excludes: ['/images/icons/**'],
       AppCache: {
         publicPath: '/'
       }


### PR DESCRIPTION
As pointed on twitter when doing `save to home screen` with our website, icon wasn't visible. This attempts to fix it