### PR TITLE
Update link to new Write a Loader doc

### DIFF
--- a/src/content/concepts/loaders.mdx
+++ b/src/content/concepts/loaders.mdx
@@ -148,4 +148,4 @@ functions (loaders). Users now have more flexibility to include fine-grained log
 
 Loaders follow the standard [module resolution](/concepts/module-resolution/). In most cases it will be loaded from the [module path](/concepts/module-resolution/#module-paths) (think `npm install`, `node_modules`).
 
-A loader module is expected to export a function and be written in Node.js compatible JavaScript. They are most commonly managed with npm, but you can also have custom loaders as files within your application. By convention, loaders are usually named `xxx-loader` (e.g. `json-loader`). See ["How to Write a Loader?"](/development/how-to-write-a-loader) for more information.
+A loader module is expected to export a function and be written in Node.js compatible JavaScript. They are most commonly managed with npm, but you can also have custom loaders as files within your application. By convention, loaders are usually named `xxx-loader` (e.g. `json-loader`). See ["Writing a Loader"](/contribute/writing-a-loader/) for more information.


### PR DESCRIPTION
Reading up on loaders, I noticed a broken link toward the bottom of https://webpack.js.org/concepts#loaders to an old "How to write a loader?" article. I think https://webpack.js.org/contribute/writing-a-loader is the most up to date doc on this. Updated href and link name.