### PR TITLE
docs(module-variables.md): add custom __webpack_chunk_load__ example

### DIFF
--- a/src/content/api/module-variables.md
+++ b/src/content/api/module-variables.md
@@ -158,7 +158,6 @@ __webpack_chunk_load__ = (id) => {
 ```
 
 T> You will not see `__webpack_chunk_load__` in output code because webpack converts it to a property on `__webpack_require__`.
-converts it to a property on `__webpack_require__`.
 
 ### `__webpack_modules__` (webpack-specific)
 

--- a/src/content/api/module-variables.md
+++ b/src/content/api/module-variables.md
@@ -157,7 +157,7 @@ __webpack_chunk_load__ = (id) => {
 }
 ```
 
-You will not see `__webpack_chunk_load__` in output code because webpack
+T> You will not see `__webpack_chunk_load__` in output code because webpack converts it to a property on `__webpack_require__`.
 converts it to a property on `__webpack_require__`.
 
 ### `__webpack_modules__` (webpack-specific)

--- a/src/content/api/module-variables.md
+++ b/src/content/api/module-variables.md
@@ -131,7 +131,7 @@ The internal chunk loading function. Takes two arguments:
 - `chunkId` The id for the chunk to load.
 - `callback(require)` A callback function called once the chunk is loaded.
 
-You can override this function to customize retry behavior.  For example:
+T> You can override this function to customize retry behavior.  For example:
 
 ```js
 const cdns = [

--- a/src/content/api/module-variables.md
+++ b/src/content/api/module-variables.md
@@ -131,7 +131,7 @@ The internal chunk loading function. Takes two arguments:
 - `chunkId` The id for the chunk to load.
 - `callback(require)` A callback function called once the chunk is loaded.
 
-T> You can override this function to customize retry behavior.  For example:
+T> You can override this function to customize retry behavior. For example:
 
 ```js
 const cdns = [


### PR DESCRIPTION
https://github.com/webpack/webpack/issues/5021
https://github.com/webpack/webpack.js.org/issues/3001

adds custom example from Tobias Koppers' comments to the documentation and explains what `__webpack_chunk_load__` gets compiled to