### PR TITLE
feat(docs): adds Gitter chat in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status][build-status]][build-status-url]
 [![Standard Version][release]][release-url]
+[![chat on gitter][chat]][chat-url]
 
 Guides, documentation, and all things webpack.
 
@@ -45,6 +46,8 @@ testing of the site at no cost...
 [build-status-url]: http://travis-ci.org/webpack/webpack.js.org
 [browserstack]: ./browserstack-logo.png
 [browserstack-url]: http://browserstack.com/
+[chat]: https://badges.gitter.im/webpack/webpack.svg
+[chat-url]: https://gitter.im/webpack/webpack
 [concepts-url]: https://github.com/webpack/webpack.js.org/issues/1386
 [contributing-url]: https://github.com/webpack/webpack.js.org/blob/master/.github/CONTRIBUTING.md
 [general-url]: https://github.com/webpack/webpack.js.org/issues/1525


### PR DESCRIPTION
Added Gitter chat img shield in README.md.

[![chat on gitter][chat]][chat-url]

[chat]: https://badges.gitter.im/webpack/webpack.svg
[chat-url]: https://gitter.im/webpack/webpack