### PR TITLE
Document the mode property in the loader context

### DIFF
--- a/src/content/api/loaders.md
+++ b/src/content/api/loaders.md
@@ -436,6 +436,13 @@ Emit a file. This is webpack-specific.
 Access to the `compilation`'s `inputFileSystem` property.
 
 
+### `this.mode`
+
+The [`mode` configuration](/configuration/mode/) for webpack.
+
+Example values: `"production"`, `"development"`, or `"none"`
+
+
 ## Deprecated context properties
 
 W> The usage of these properties is highly discouraged since we are planning to remove them from the context. They are still listed here for documentation purposes.

--- a/src/content/api/loaders.md
+++ b/src/content/api/loaders.md
@@ -438,9 +438,9 @@ Access to the `compilation`'s `inputFileSystem` property.
 
 ### `this.mode`
 
-The [`mode` configuration](/configuration/mode/) for webpack.
+Read in which [`mode`](/configuration/mode/) webpack is running.
 
-Example values: `"production"`, `"development"`, or `"none"`
+Possible values: `'production'`, `'development'`, `'none'`
 
 
 ## Deprecated context properties


### PR DESCRIPTION
This adds documentation for the `mode` property of the loader context (included in the [4.32.0 release](https://github.com/webpack/webpack/releases/tag/v4.32.0)).

See webpack/webpack#9140.
