### PR TITLE
docs(code-splitting): update webpack configuration

### DIFF
--- a/src/content/guides/code-splitting.md
+++ b/src/content/guides/code-splitting.md
@@ -185,6 +185,7 @@ __webpack.config.js__
     output: {
       filename: '[name].bundle.js',
 +     chunkFilename: '[name].bundle.js',
++     publicPath: 'dist/',
       path: path.resolve(__dirname, 'dist')
     },
 -   optimization: {


### PR DESCRIPTION
Missing publicPath in the configuration of webpack.config.js. Occurs as an error when running in the browser