### PR TITLE
fix(plugins): Fix SplitChunksPlugin cacheGroup priority option

### DIFF
--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -210,7 +210,7 @@ module.exports = {
 };
 ```
 
-#### `splitChunks.cacheGroups.priority`
+#### `splitChunks.cacheGroups.{cacheGroup}.priority`
 
 `number`
 


### PR DESCRIPTION
`priority` option should belong to `cacheGroups.{cacheGroup}`, should not belong to `cacheGroups`

