### PR TITLE
ui(mobile) fix headings being cut off screen

### DIFF
--- a/src/components/Markdown/Markdown.scss
+++ b/src/components/Markdown/Markdown.scss
@@ -37,6 +37,7 @@
     line-height: 1.4;
     margin: 1.5em 0 0.25em;
     color: getColor(fiord);
+    word-break: break-all;
 
     tt,
     code {


### PR DESCRIPTION
It has been reported on twitter that headings are invisible for mobile resolutions when heading is long enough.

We can break words for such headings. It looks like this now:
<img width="375" alt="Screen Shot 2019-05-24 at 11 47 29 PM" src="https://user-images.githubusercontent.com/10549495/58356038-d40b4c00-7e7e-11e9-852f-982645e6e7a6.png">


Or we can allow horizontal scroll for such headings so that user can scroll them (as we do for code blocks):
<img width="366" alt="Screen Shot 2019-05-24 at 11 49 14 PM" src="https://user-images.githubusercontent.com/10549495/58356053-de2d4a80-7e7e-11e9-9ca1-c80b734d8f22.png">
