### PR TITLE
Making resolve extension for ts as well

### DIFF
--- a/src/content/guides/typescript.md
+++ b/src/content/guides/typescript.md
@@ -78,8 +78,8 @@ module.exports = {
       }
     ]
   },
-  resolve: {
-    extensions: [ '.tsx', '.ts', '.js' ]
++  resolve: {
++    extensions: [ '.tsx', '.ts', '.js' ]
   },
   output: {
     filename: 'bundle.js',


### PR DESCRIPTION
Generally, before migration, the package should not resolve .ts or .tsx files so I think it is a good idea to highlight the resolve extensions as well.

_describe your changes..._

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
