### PR TITLE
docs(config) node config boolean only false allowed

### DIFF
--- a/src/content/configuration/node.md
+++ b/src/content/configuration/node.md
@@ -7,6 +7,7 @@ contributors:
   - oneforwonder
   - Rob--W
   - byzyk
+  - EugeneHlushko
 ---
 
 These options configure whether to polyfill or mock certain [Node.js globals](https://nodejs.org/docs/latest/api/globals.html) and modules. This allows code originally written for the Node.js environment to run in other environments like the browser.
@@ -16,7 +17,7 @@ This feature is provided by webpack's internal [`NodeStuffPlugin`](https://githu
 
 ## `node`
 
-`boolean | object`
+`boolean: false | object`
 
 This is an object where each property is the name of a Node global or module and each value may be one of the following...
 


### PR DESCRIPTION
- only false is allowed via schema, clarifying it here.

ref: https://github.com/webpack/webpack/blob/master/schemas/WebpackOptions.json#L2005