### PR TITLE
Update dev-server.md

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -53,7 +53,7 @@ Content not from webpack is served from /path/to/dist/
 
 that will give some background on where the server is located and what it's serving.
 
-If you're using dev-server through the Node.js API, the options in `devServer` will be ignored. Pass the options as a second parameter instead: `new WebpackDevServer(compiler, {...})`. [See here](https://github.com/webpack/webpack-dev-server/tree/master/examples/api/simple) for an example of how to use webpack-dev-server through the Node.js API.
+If you're using dev-server through the Node.js API, the options in `devServer` will be ignored. Pass the options as a second parameter instead: `new WebpackDevServer(compiler, {...})`. [See here](https://github.com/webpack/webpack-dev-server/tree/master/examples/api/simple) for an example of how to use webpack-dev-server through the Node.js API. **Note:** You cannot use the second compiler argument (a callback) when using `WebpackDevServer`.
 
 W> Be aware that when [exporting multiple configurations](/configuration/configuration-types/#exporting-multiple-configurations) only the `devServer` options for the first configuration will be taken into account and used for all the configurations in the array.
 


### PR DESCRIPTION
This gave me a cryptic error, and I spent a long time trying to figure out why it was happening. I'm sure this would affect others as well.

When passing in the second argument to `webpack(config, callback)`, it will return a different object then when called with just the config. This causes problems when using webpack-dev-server because it's expecting a compiler, not the webpack config with a `compiler` prop.

You would see the error `TypeError: Cannot read property 'plugins' of undefined` when the callback is added to `webpack()`.

