### PR TITLE
Update output-management.md

### DIFF
--- a/src/content/guides/output-management.md
+++ b/src/content/guides/output-management.md
@@ -187,7 +187,7 @@ __webpack.config.js__
 ``` diff
   const path = require('path');
   const HtmlWebpackPlugin = require('html-webpack-plugin');
-+ const CleanWebpackPlugin = require('clean-webpack-plugin');
++ const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
   module.exports = {
     entry: {


### PR DESCRIPTION
clean-webpack-plugin has released 3.0.0
https://github.com/johnagan/clean-webpack-plugin/releases
“Replaced default export with named export CleanWebpackPlugin”
`const { CleanWebpackPlugin } = require('clean-webpack-plugin')
`


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
