### PR TITLE
Update reference to SplitChunksPlugin

### DIFF
--- a/src/content/guides/build-performance.md
+++ b/src/content/guides/build-performance.md
@@ -86,8 +86,8 @@ Use the `DllPlugin` to move code that is changed less often into a separate comp
 Decrease the total size of the compilation to increase build performance. Try to keep chunks small.
 
 - Use fewer/smaller libraries.
-- Use the `CommonsChunkPlugin` in Multi-Page Applications.
-- Use the `CommonsChunkPlugin` in `async` mode in Multi-Page Applications.
+- Use the `SplitChunksPlugin` in Multi-Page Applications.
+- Use the `SplitChunksPlugin` in `async` mode in Multi-Page Applications.
 - Remove unused code.
 - Only compile the part of the code you are currently developing on.
 


### PR DESCRIPTION
Since webpack v4, the CommonsChunkPlugin was removed in favor of optimization.splitChunks
