### PR TITLE
[DOCUMENTATION] update options argument: CleanWebpackPlugin

### DIFF
--- a/src/content/guides/caching.md
+++ b/src/content/guides/caching.md
@@ -53,7 +53,7 @@ __webpack.config.js__
     entry: './src/index.js',
     plugins: [
       // new CleanWebpackPlugin(['dist/*']) for < v2 versions of CleanWebpackPlugin
-      new CleanWebpackPlugin(['dist']),
+      new CleanWebpackPlugin(),
       new HtmlWebpackPlugin({
 -       title: 'Output Management'
 +       title: 'Caching'


### PR DESCRIPTION
https://github.com/johnagan/clean-webpack-plugin

It takes an options object. It looks like it cleans `dist` by default.


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
