### PR TITLE
docs(dev-server): document serverMode

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -1166,7 +1166,7 @@ module.exports = {
 
 ## `devServer.serverMode`
 
-`string: 'sockjs' | require.resolve('path/to/implementation')` `function: class extending [BaseServer](https://github.com/webpack/webpack-dev-server/blob/master/lib/servers/BaseServer.js)`
+`string: 'sockjs' | require.resolve('path/to/implementation')` `function: class extending BaseServer`
 
 W> `serverMode` is an experimental option, meaning its usage could potentially change without warning.
 

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -1166,13 +1166,13 @@ module.exports = {
 
 ## `devServer.serverMode`
 
-`string: 'sockjs' | require.resolve('path/to/implementation')` `function: class extending BaseServer`
+`string: 'sockjs' | require.resolve('path/to/implementation')` `function: class extending <a href="https://github.com/webpack/webpack-dev-server/blob/master/lib/servers/BaseServer.js">BaseServer</a>`
 
 W> `serverMode` is an experimental option, meaning its usage could potentially change without warning.
 
 This option allows you to choose the current socket server implementation, or provide your own custom socket server implementation. The current default implementation is [`'sockjs'`](https://www.npmjs.com/package/sockjs). [`'ws'`](https://www.npmjs.com/package/ws) will soon be implemented as an alternative to `'sockjs'`, and will become the default implementation in the next major `devServer` version.
 
-To create a custom implementation, you must create a class that extends [`BaseClient`](https://github.com/webpack/webpack-dev-server/blob/master/lib/servers/BaseServer.js), found in the `lib/servers/` directory of the `webpack-dev-server` module. See the example below for full implementation details.
+To create a custom implementation, you must create a class that extends [`BaseServer`](https://github.com/webpack/webpack-dev-server/blob/master/lib/servers/BaseServer.js), found in the `lib/servers/` directory of the `webpack-dev-server` module. See the example below for full implementation details.
 
 Use the current default implementation:
 

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -1166,7 +1166,7 @@ module.exports = {
 
 ## `devServer.serverMode`
 
-`string: 'sockjs' | require.resolve('path/to/implementation')` `function: class extending <a href="https://github.com/webpack/webpack-dev-server/blob/master/lib/servers/BaseServer.js">BaseServer</a>`
+`string: 'sockjs' | require.resolve('path/to/implementation')` `function: class extending [BaseServer](https://github.com/webpack/webpack-dev-server/blob/master/lib/servers/BaseServer.js)`
 
 W> `serverMode` is an experimental option, meaning its usage could potentially change without warning.
 

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -1252,7 +1252,7 @@ module.exports = class CustomServer extends BaseServer {
   onConnection(f) {
     this.socket.on('connection', f);
   }
-}
+};
 ```
 
 Using `CustomServer.js` via path:


### PR DESCRIPTION
_describe your changes..._

Closes https://github.com/webpack/webpack.js.org/issues/3100

This will need to be updated once `'ws'` implementation is added.

As far as the full class implementation example, I see a few options:
- keep it as is, full class example using `sockjs`
- make it generic, not using `sockjs`, just omitting some parts
- remove completely, make an example in dev server and link to it instead