### PR TITLE
feat(site) Improve heading display when buttons overlap headings…

### DIFF
--- a/src/components/Page/Page.jsx
+++ b/src/components/Page/Page.jsx
@@ -77,7 +77,7 @@ class Page extends React.Component {
           {contentRender}
 
           {loadRelated && (
-            <div>
+            <div className="related__section">
               <hr />
               <h3>Further Reading</h3>
               <ul>

--- a/src/components/Page/Page.scss
+++ b/src/components/Page/Page.scss
@@ -9,6 +9,13 @@
 
   @include break {
     flex: 3;
-    padding: 1.5em;
+    // page links not fitting in 768+ resolutions with long headings
+    padding: 2em 1.5em 1.5em;
+  }
+
+  .related__section {
+    @media print {
+      display: none;
+    }
   }
 }

--- a/src/components/PageLinks/PageLinks.scss
+++ b/src/components/PageLinks/PageLinks.scss
@@ -4,14 +4,17 @@
 .page-links {
   position: absolute;
   display: none;
-  top: 1.5em;
+  top: 0.5em;
   right: 1.5em;
   font-weight: 600;
   text-transform: uppercase;
 
   @media print {
-    display: flex;
-    align-items: center;
+    display: none;
+  }
+
+  @include break {
+    display: block;
   }
 
   &__gap {
@@ -36,9 +39,5 @@
       height: 17px;
       margin-left: 3px;
     }
-  }
-
-  @include break {
-    display: block;
   }
 }


### PR DESCRIPTION
Headings on our pages are overlapping with edit link and print link, apparently this issue existed even before adding print button to page links but now i noticed it.

<img width="880" alt="Screen Shot 2019-06-07 at 10 50 35 AM" src="https://user-images.githubusercontent.com/10549495/59089346-9264b180-8912-11e9-83eb-9f15a7b89580.png">

Also hide page links and related reading section from printing.