### PR TITLE
docs(plugins): clarify function provided to splitChunks.name

### DIFF
--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -11,6 +11,7 @@ contributors:
   - madhavarshney
   - sakhisheikh
   - superburrito
+  - ryandrew14
 related:
   - title: webpack's automatic deduplication algorithm example
     url: https://github.com/webpack/webpack/blob/master/examples/many-pages/README.md
@@ -168,6 +169,8 @@ T> `maxSize` takes higher priority than `maxInitialRequest/maxAsyncRequests`. Ac
 The name of the split chunk. Providing `true` will automatically generate a name based on chunks and cache group key.
 
 Providing a string or a function allows you to use a custom name. Specifying either a string or a function that always returns the same string will merge all common modules and vendors into a single chunk. This might lead to bigger initial downloads and slow down page loads.
+
+If you choose to specify a function, you may find the `chunk.name` and `chunk.hash` properties (where `chunk` is an element of the `chunks` array) particularly useful in choosing a name for your chunk.
 
 If the `splitChunks.name` matches an [entry point](/configuration/entry-context/#entry) name, the entry point will be removed.
 


### PR DESCRIPTION
This is a small update to the docs for the SplitChunksPlugin's name option. I found using this function to be really esoteric, and would love to clarify even more than I have here. The problem with that is that the `module` and `chunks` arguments provided are esoteric themselves, meaning that documenting the arguments would likely lead to more confusion than help.

The docs I'm sending helped me accomplish my goal with the function, and have helped [other people][3] who are confused as well. I believe it to be sufficient for most use cases for this function.

Quick edit: also takes part of #3116. I also just signed the CLA so that should be all set now.

[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://stackoverflow.com/questions/55717783/any-webpack-splitchunks-name-as-a-function-documentation-other-than-from-the-web/56570774