### PR TITLE
docs(configuration): add electron-preload as available target

### DIFF
--- a/src/content/configuration/target.md
+++ b/src/content/configuration/target.md
@@ -30,6 +30,7 @@ Option                | Description
 `async-node`          | Compile for usage in a Node.js-like environment (uses `fs` and `vm` to load chunks asynchronously)
 `electron-main`       | Compile for [Electron](https://electronjs.org/) for main process.
 `electron-renderer`   | Compile for [Electron](https://electronjs.org/) for renderer process, providing a target using `JsonpTemplatePlugin`, `FunctionModulePlugin` for browser environments and `NodeTargetPlugin` and `ExternalsPlugin` for CommonJS and Electron built-in modules.
+`electron-preload`    | Compile for [Electron](https://electronjs.org/) for renderer process, providing a target using `NodeTemplatePlugin` with `asyncChunkLoading` set to `true`, `FunctionModulePlugin` for browser environments and `NodeTargetPlugin` and `ExternalsPlugin` for CommonJS and Electron built-in modules.
 `node`                | Compile for usage in a Node.js-like environment (uses Node.js `require` to load chunks)
 `node-webkit`         | Compile for usage in WebKit and uses JSONP for chunk loading. Allows importing of built-in Node.js modules and [`nw.gui`](http://docs.nwjs.io/en/latest/) (experimental)
 `web`                 | Compile for usage in a browser-like environment __(default)__


### PR DESCRIPTION
This PR adds the `electron-preload` target option to the configuration/target page.

See https://github.com/webpack/webpack/pull/9188