### PR TITLE
docs(guides): add bundle-stats link to code-splitting

### DIFF
--- a/src/content/guides/code-splitting.md
+++ b/src/content/guides/code-splitting.md
@@ -334,6 +334,7 @@ Once you start splitting your code, it can be useful to analyze the output to ch
 - [webpack-visualizer](https://chrisbateman.github.io/webpack-visualizer/): Visualize and analyze your bundles to see which modules are taking up space and which might be duplicates.
 - [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer): A plugin and CLI utility that represents bundle content as a convenient interactive zoomable treemap.
 - [webpack bundle optimize helper](https://webpack.jakoblind.no/optimize): This tool will analyze your bundle and give you actionable suggestions on what to improve to reduce your bundle size.
+- [bundle-stats](https://github.com/bundle-stats/bundle-stats): Generate a bundle report(bundle size, assets, modules) and compare the results between different builds.
 
 ## Next Steps
 


### PR DESCRIPTION
Added link to bundle-stats.

Webpack plugin source - https://github.com/bundle-stats/bundle-stats/blob/master/packages/bundle-stats/src/webpack-plugin.js