### PR TITLE
docs(guides): correct verb (3rd person singular -> plural)

### DIFF
--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -54,7 +54,7 @@ __webpack.config.js__
 
 When webpack bundles your source code, it can become difficult to track down errors and warnings to their original location. For example, if you bundle three source files (`a.js`, `b.js`, and `c.js`) into one bundle (`bundle.js`) and one of the source files contains an error, the stack trace will simply point to `bundle.js`. This isn't always helpful as you probably want to know exactly which source file the error came from.
 
-In order to make it easier to track down errors and warnings, JavaScript offers [source maps](http://blog.teamtreehouse.com/introduction-source-maps), which maps your compiled code back to your original source code. If an error originates from `b.js`, the source map will tell you exactly that.
+In order to make it easier to track down errors and warnings, JavaScript offers [source maps](http://blog.teamtreehouse.com/introduction-source-maps), which map your compiled code back to your original source code. If an error originates from `b.js`, the source map will tell you exactly that.
 
 There are a lot of [different options](/configuration/devtool) available when it comes to source maps. Be sure to check them out so you can configure them to your needs.
 


### PR DESCRIPTION
In ["Development" guide](https://webpack.js.org/guides/development/#using-source-maps):

**Was**: "...JavaScript offers source maps, which _maps_ compiled code back to..."
**Now**: "...JavaScript offers source maps, which _map_ compiled code back to..."

