### PR TITLE
docs(plugins): Refer to optimization configuration

### DIFF
--- a/src/content/plugins/module-concatenation-plugin.md
+++ b/src/content/plugins/module-concatenation-plugin.md
@@ -10,7 +10,7 @@ related:
 
 In the past, one of webpack’s trade-offs when bundling was that each module in your bundle would be wrapped in individual function closures. These wrapper functions made it slower for your JavaScript to execute in the browser. In comparison, tools like Closure Compiler and RollupJS ‘hoist’ or concatenate the scope of all your modules into one closure and allow for your code to have a faster execution time in the browser.
 
-This plugin will enable the same concatenation behavior in webpack. By default this plugin is already enabled in [production `mode`](/configuration/mode/#mode-production) and disabled otherwise. If you need to override the default production `mode` setting, refer to the [`concatenateModules` optimization configuration](/configuration/optimization/#optimizationconcatenatemodules). To enable in other modes, you can add it manually:
+This plugin will enable the same concatenation behavior in webpack. By default this plugin is already enabled in [production `mode`](/configuration/mode/#mode-production) and disabled otherwise. If you need to override the production `mode` optimization, set the [`optimization.concatenateModules` option](/configuration/optimization/#optimizationconcatenatemodules) to `false`. To enable concatenation behavior in other modes, you can add `ModuleConcatenationPlugin` manually or use the `optimization.concatenateModules` option:
 
 ```js
 new webpack.optimize.ModuleConcatenationPlugin();

--- a/src/content/plugins/module-concatenation-plugin.md
+++ b/src/content/plugins/module-concatenation-plugin.md
@@ -10,7 +10,7 @@ related:
 
 In the past, one of webpack’s trade-offs when bundling was that each module in your bundle would be wrapped in individual function closures. These wrapper functions made it slower for your JavaScript to execute in the browser. In comparison, tools like Closure Compiler and RollupJS ‘hoist’ or concatenate the scope of all your modules into one closure and allow for your code to have a faster execution time in the browser.
 
-This plugin will enable the same concatenation behavior in webpack. By default this plugin is already enabled in [production `mode`](/configuration/mode/#mode-production) and disabled otherwise. If you need it in other modes, you can add it manually:
+This plugin will enable the same concatenation behavior in webpack. By default this plugin is already enabled in [production `mode`](/configuration/mode/#mode-production) and disabled otherwise. If you need to override the default production `mode` setting, refer to the [`concatenateModules` optimization configuration](/configuration/optimization/#optimizationconcatenatemodules). To enable in other modes, you can add it manually:
 
 ```js
 new webpack.optimize.ModuleConcatenationPlugin();


### PR DESCRIPTION
I ran across a case where I wanted to disable the default `concatenateModules: true` in production mode, read these docs and came to the conclusion there wasn't an available option. Maybe it's obvious in retrospect, but figured it might be helpful for someone else to find the reference in the  module-concatenation-plugin docs here.
