### PR TITLE
Fix typo "promted" -> "prompted"

### DIFF
--- a/src/content/configuration/index.mdx
+++ b/src/content/configuration/index.mdx
@@ -459,7 +459,7 @@ Or use [webpack-cli's `init` command](https://github.com/webpack/webpack-cli/tre
 npx webpack-cli init
 ```
 
-W> You might be promted to install `@webpack-cli/init` if it is not yet installed in the project or globally.
+W> You might be prompted to install `@webpack-cli/init` if it is not yet installed in the project or globally.
 
 T> After running `npx webpack-cli init` you might get more packages installed to your project depending on the choices you've made during configuration generation.
 


### PR DESCRIPTION
Fixes a typo that I came across while reading docs for plugin configuration.