### PR TITLE
Fix inaccurate description of callback in MultiCompiler

### DIFF
--- a/src/content/api/node.mdx
+++ b/src/content/api/node.mdx
@@ -267,7 +267,7 @@ webpack({
 The `MultiCompiler` module allows webpack to run multiple configurations in
 separate compilers. If the `options` parameter in the webpack's NodeJS api is
 an array of options, webpack applies separate compilers and calls the
-`callback` method at the end of each compiler execution.
+`callback` after all compilers have been executed.
 
 ``` js-with-links
 var webpack = require('webpack');


### PR DESCRIPTION
The docs currently state that the callback passed to the `MultiCompiler` is executed after each configuration in the options array has been compiled.

This is not the case. The callback is executed once, after all compilations have finished.