### PR TITLE
ui(search) improve mobile search ux/ui; close button on notification

### DIFF
--- a/src/components/Navigation/Search.scss
+++ b/src/components/Navigation/Search.scss
@@ -1,13 +1,35 @@
 @import 'functions';
 
+// use full width for search results
+.navigation-search .algolia-autocomplete .ds-dropdown-menu {
+  @media (max-width: 600px) {
+    position: fixed !important;
+    left: 0 !important;
+    right: 0 !important;
+    top: 54px !important;
+    min-width: 0 !important;
+  }
+}
+
+// when notification is shown
+.notification-bar + header .navigation-search .algolia-autocomplete .ds-dropdown-menu {
+  @media (max-width: 600px) {
+    top: 110px !important;
+  }
+}
+
 .algolia-autocomplete {
   display: flex !important;
   position: relative;
 
   .ds-dropdown-menu {
     box-shadow: none;
-    margin-top: 19px;
-    margin-right: -37px;
+    margin-top: 0;
+
+    @media (min-width: 601px) {
+      margin-top: 19px;
+      margin-right: -37px;
+    }
 
     &:before {
       content: none;
@@ -32,7 +54,7 @@
 
   .algolia-docsearch-suggestion--wrapper {
     display: flex;
-    padding: 0;
+    padding: 0 0.5em;
   }
 
   .algolia-docsearch-suggestion--text {

--- a/src/components/NotificationBar/NotificationBar.scss
+++ b/src/components/NotificationBar/NotificationBar.scss
@@ -4,6 +4,7 @@
 .notification-bar {
   color: getColor(white);
   background: getColor(emperor);
+  min-height: 56px;
 
   @media print {
     display: none;
@@ -20,7 +21,7 @@
 
 .notification-bar__inner {
   position: relative;
-  padding: 0.5em 1em;
+  padding: 0.5em 36px 0.5em 1em;
 
   @include break {
     padding: 0.5em 1.5em;


### PR DESCRIPTION
Search feels terrible on mobile right now... So i took a shot on trying to not create our own docsearch.css but to add a few overrides, most of them are to inline style therefore hold the !important flag. If we'd get rid of this would mean to clone and compile our own docsearch.css.

- Make sure search box fits screen
- Use full width for screens under docsearch's max-width of search box (600px;)
- Different offset for case with notification and without.
- Fix notification's close button, it is covered with text now :(

Search before:
<img width="373" alt="Screen Shot 2019-07-09 at 8 37 51 PM" src="https://user-images.githubusercontent.com/10549495/60911246-6c248f80-a28b-11e9-85b9-250c3049324b.png">

Search after: (notice how it now fits the screen, try more on preview)
<img width="374" alt="Screen Shot 2019-07-09 at 8 38 30 PM" src="https://user-images.githubusercontent.com/10549495/60911265-78a8e800-a28b-11e9-8049-b3e248d78d5f.png">

And notification bar, close button.
Before:
<img width="382" alt="Screen Shot 2019-07-09 at 8 39 46 PM" src="https://user-images.githubusercontent.com/10549495/60911292-83637d00-a28b-11e9-9ed2-31cb9bb488e4.png">

After:
<img width="371" alt="Screen Shot 2019-07-09 at 8 39 57 PM" src="https://user-images.githubusercontent.com/10549495/60911306-878f9a80-a28b-11e9-9e03-d46b383cee8d.png">

Might actually close #3052 but not sure