### PR TITLE
Update build-performance.md

### DIFF
--- a/src/content/guides/build-performance.md
+++ b/src/content/guides/build-performance.md
@@ -199,10 +199,6 @@ module.exports = {
 };
 ```
 
-### Node.js Version
-
-There has been a [performance regression](https://github.com/nodejs/node/issues/19769) in the latest stable versions of Node.js and its ES2015 `Map` and `Set` implementations. A fix has been merged into master, but a release has yet to be made. In the meantime, to get the most out of incremental build speeds, try to stick with version 8.9.x (the problem exists between 8.9.10 - 9.11.1). webpack has moved to using those ES2015 data structures liberally, and it will improve the initial build times as well.
-
 ### TypeScript Loader
 
 Recently, `ts-loader` has started to consume the internal TypeScript watch mode APIs which dramatically decreases the number of modules to be rebuilt on each iteration. This `experimentalWatchApi` shares the same logic as the normal TypeScript watch mode itself and is quite stable for development use. Turn on `transpileOnly`, as well, for even faster incremental builds.


### PR DESCRIPTION
This removes the note about performance regression in Node.js version, as it has been fixed and included in a Node.js release about a year ago: https://github.com/nodejs/node/issues/19769#issuecomment-388047423.
