### PR TITLE
ui(search) fix mobile auto zoom on search input

### DIFF
--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -4,7 +4,6 @@ import Banner from 'react-banner';
 
 // Import Components
 import Link from '../Link/Link';
-import Container from '../Container/Container';
 import Logo from '../Logo/Logo';
 import Dropdown from '../Dropdown/Dropdown';
 

--- a/src/components/Navigation/Navigation.scss
+++ b/src/components/Navigation/Navigation.scss
@@ -107,7 +107,7 @@
 }
 
 .navigation-search__input {
-  font-size: 14px;
+  font-size: 16px;
   width: 0;
   max-width: calc(100vw - 8.5em);
   padding: 0;


### PR DESCRIPTION
Fixes the auto zoom when user focuses on search input. IOS zooms on any input which has font size < 16px;

To reproduce, open https://webpack.js.org/ and use search input, screen will zoom in
To test the fix, go to preview and repeat steps