### PR TITLE
Update docs to explain what I assume "Dll" means

### DIFF
--- a/src/content/plugins/dll-plugin.md
+++ b/src/content/plugins/dll-plugin.md
@@ -13,7 +13,7 @@ related:
     url: https://github.com/webpack/webpack/blob/master/examples/explicit-vendor-chunk/README.md
 ---
 
-The `DllPlugin` and `DllReferencePlugin` provide means to split bundles in a way that can drastically improve build time performance. The term "DLL" abbreviates Dynamic Link Library (taken from Microsoft's implementation linking binary code after it is compiled).
+The `DllPlugin` and `DllReferencePlugin` provide means to split bundles in a way that can drastically improve build time performance. The term "DLL" stands for Dynamic-link library which was originally introduced by Microsoft.
 
 
 ## `DllPlugin`

--- a/src/content/plugins/dll-plugin.md
+++ b/src/content/plugins/dll-plugin.md
@@ -13,7 +13,7 @@ related:
     url: https://github.com/webpack/webpack/blob/master/examples/explicit-vendor-chunk/README.md
 ---
 
-The `DllPlugin` and `DllReferencePlugin` provide means to split bundles in a way that can drastically improve build time performance.
+The `DllPlugin` and `DllReferencePlugin` provide means to split bundles in a way that can drastically improve build time performance. The term "DLL" abbreviates Dynamic Link Library (taken from Microsoft's implementation linking binary code after it is compiled).
 
 
 ## `DllPlugin`


### PR DESCRIPTION
I'm just assuming this definition. I just discovered Webpack DLL, and find this terminology a little awkward. DLLs are traditionally binary files linked at run time, not build time (or maybe both, I can't remember). In any case, when I discovered Webpack DLL I couldn't find a definition for "Dll."