### PR TITLE
docs(plugins) link compiler and compilation from writing a plugin page

### DIFF
--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -75,7 +75,7 @@ module.exports = {
 
 ## Compiler and Compilation
 
-Among the two most important resources while developing plugins are the `compiler` and `compilation` objects. Understanding their roles is an important first step in extending the webpack engine.
+Among the two most important resources while developing plugins are the [`compiler`](/api/node/#compiler-instance) and [`compilation`](/api/compilation-hooks/) objects. Understanding their roles is an important first step in extending the webpack engine.
 
 ```javascript
 class HelloCompilationPlugin {


### PR DESCRIPTION
While looking at #3148 i noticed a very good point on missing linking to existing docs