### PR TITLE
Fixed typo in parser.md

### DIFF
--- a/src/content/api/parser.md
+++ b/src/content/api/parser.md
@@ -461,7 +461,7 @@ Triggered when parsing the `typeof` of an identifier
 
 Called when parsing a function call.
 
-- Hook Paramaeters: `identifier`
+- Hook Parameters: `identifier`
 - Callback Parameters: `expression`
 
 ```js


### PR DESCRIPTION
Fixed a typo: Paramaeters -> Parameters
