### PR TITLE
Clarify array syntax of externals

### DIFF
--- a/src/content/configuration/externals.md
+++ b/src/content/configuration/externals.md
@@ -78,8 +78,7 @@ module.exports = {
 };
 ```
 
-`subtract: ['./math', 'subtract']` converts to a parent child construct, where `./math` is the parent module and your bundle only requires the subset under `subtract` variable.
-
+`subtract: ['./math', 'subtract']` allows you select part of a commonjs module, where `./math` is the module and your bundle only requires the subset under the `subtract` variable. This example would translate to `require('./math').subtract;`
 
 ### object
 


### PR DESCRIPTION
I changed the description of the array syntax for `externals` and added an example. I just spent 1 hour digging through the source code to find out what exactly this does. The result being that a) this doesn't do what I thought when I read "parent child construct" and b) I actually have no clue at all what this would be useful for. It seems to me to be a leftover from commonjs days? If someone could give me an example how this is useful, maybe adding another sentence here would be nice.

As an aside, what I first thought this would allow me to do is that when I have 
```
a.js
– c.js
b.js
– c.js
```
that I could specify that c.js shall be bundled only when imported by a.js, but not in b.js, like `{'c.js': ['a.js', 'c.js']}` (parent a, child c)