### PR TITLE
Updating with new babel-present-env modules link

### DIFF
--- a/src/content/plugins/module-concatenation-plugin.md
+++ b/src/content/plugins/module-concatenation-plugin.md
@@ -21,7 +21,7 @@ new webpack.optimize.ModuleConcatenationPlugin();
 >
 > Scope hoisting is specifically a feature made possible by ECMAScript Module syntax. Because of this webpack may fallback to normal bundling based on what kind of modules you are using, and [other conditions](https://medium.com/webpack/webpack-freelancing-log-book-week-5-7-4764be3266f5).
 
-W> Keep in mind that this plugin will only be applied to [ES6 modules](/api/module-methods/#es6-recommended-) processed directly by webpack. When using a transpiler, you'll need to disable module processing (e.g. the [`modules`](https://babeljs.io/docs/plugins/preset-es2015/#optionsmodules) option in Babel).
+W> Keep in mind that this plugin will only be applied to [ES6 modules](/api/module-methods/#es6-recommended-) processed directly by webpack. When using a transpiler, you'll need to disable module processing (e.g. the [`modules`](https://babeljs.io/docs/en/babel-preset-env#modules) option in Babel).
 
 
 ## Optimization Bailouts


### PR DESCRIPTION
I wanted to read something about the ModuleConcatenationPlugin and realized that the URL to the Babel modules configuration is leading to the old 2015 preset.

Just Updating this with the new https://babeljs.io/docs/en/babel-preset-env#modules.

This PR is only updating the modules Url for the Babel reference.