### PR TITLE
 docs(api) document infrastructureLog and log compiler hooks 

### DIFF
--- a/src/content/api/compiler-hooks.md
+++ b/src/content/api/compiler-hooks.md
@@ -295,6 +295,6 @@ Allows to use infrastructure logging when enabled in the configuration via [`inf
 
 `SyncBailHook`
 
-Allows to log into [stats](/configuration/stats/) when enabled, see [`stats.logging`, `stats.loggingDebug` and `stats.loggingTrace` options](/configuration/other-options/#infrastructurelogging).
+Allows to log into [stats](/configuration/stats/) when enabled, see [`stats.logging`, `stats.loggingDebug` and `stats.loggingTrace` options](/configuration/stats/#stats).
 
 - Callback Parameters: `origin`, `logEntry`

--- a/src/content/api/compiler-hooks.md
+++ b/src/content/api/compiler-hooks.md
@@ -7,6 +7,7 @@ contributors:
   - byzyk
   - madhavarshney
   - misterdev
+  - EugeneHlushko
 ---
 
 The `Compiler` module is the main engine that creates a compilation instance
@@ -280,3 +281,20 @@ Executed when a watching compilation has been invalidated.
 `SyncHook`
 
 Called when a watching compilation has stopped.
+
+### `infrastructureLog`
+
+`SyncBailHook`
+
+Allows to use infrastructure logging when enabled in the configuration via [`infrastructureLogging` option](/configuration/other-options/#infrastructurelogging).
+
+- Callback Parameters: `name`, `type`, `args`
+
+
+### `log`
+
+`SyncBailHook`
+
+Allows to log into [stats](/configuration/stats/) when enabled, see [`stats.logging`, `stats.loggingDebug` and `stats.loggingTrace` options](/configuration/other-options/#infrastructurelogging).
+
+- Callback Parameters: `origin`, `logEntry`


### PR DESCRIPTION
Continuing to work towards documenting bunch of changes from #3205

Taken care of __Plugins__ task from the list which is around documenting `Compiler.hooks.infrastructureLog` and` Compilation.hooks.log` hooks