### PR TITLE
docs(config) removeAvailableModules are now disabled in mode development

### DIFF
--- a/src/content/configuration/mode.md
+++ b/src/content/configuration/mode.md
@@ -80,6 +80,7 @@ module.exports = {
 -   noEmitOnErrors: false,
 -   checkWasmTypes: false,
 -   minimize: false,
+-   removeAvailableModules: false
 - },
 - plugins: [
 -   new webpack.NamedModulesPlugin(),


### PR DESCRIPTION
`optimization.removeAvailableModules` is now disabled in `mode` `'development'`

See: https://github.com/webpack/webpack/releases/tag/v4.38.0