### PR TITLE
docs: update optimization.removeAvailableModules

### DIFF
--- a/src/content/configuration/optimization.md
+++ b/src/content/configuration/optimization.md
@@ -291,9 +291,9 @@ module.exports = {
 
 ## `optimization.removeAvailableModules`
 
-`bool: true`
+`bool`
 
-Tells webpack to detect and remove modules from chunks when these modules are already included in all parents. Setting `optimization.removeAvailableModules` to `false` will disable this optimization.
+Tells webpack to detect and remove modules from chunks when these modules are already included in all parents. Setting `optimization.removeAvailableModules` to `false` will disable this optimization. Disabled by default for [mode](/configuration/mode/) `development` and enabled for [mode](/configuration/mode/) `production`.
 
 __webpack.config.js__
 


### PR DESCRIPTION
## Motivation

#3216

update documentation for https://github.com/webpack/webpack/releases/tag/v4.38.0

> optimization.removeAvailableModules is now disabled in development mode by default