### PR TITLE
Note possible confusion with DefinePlugin name

### DIFF
--- a/src/content/plugins/define-plugin.md
+++ b/src/content/plugins/define-plugin.md
@@ -17,6 +17,7 @@ new webpack.DefinePlugin({
 });
 ```
 
+T> `DefinePlugin` is not an API to define a webpack plugin; instead, it is a plugin that defines variables in a webpack build.
 
 ## Usage
 


### PR DESCRIPTION
It’s possible I’m just slow on the uptake, but when I was reading I was under the impression this was Webpack’s API for defining new plugins until about halfway through the article.