### PR TITLE
docs(cli): fix multiple-entry cli command

### DIFF
--- a/src/content/api/cli.md
+++ b/src/content/api/cli.md
@@ -82,7 +82,7 @@ This will bundle your source code with entry as `index.js`, and the output bundl
 ```
 
 ```bash
-webpack index=./src/index.js entry2=./src/index2.js dist/bundle.js
+webpack index=./src/index.js entry2=./src/index2.js -o dist/bundle.js
 ```
 
 This will form the bundle with both the files as separate entry points.


### PR DESCRIPTION
- The `-o` tag was missing in the multiple-entry CLI command
