### PR TITLE
docs(guides) correct guides intro

### DIFF
--- a/src/content/guides/index.md
+++ b/src/content/guides/index.md
@@ -3,10 +3,11 @@ title: Guides
 sort: 0
 contributors:
   - skipjack
+  - EugeneHlushko
 ---
 
-This section contains guides for understanding and mastering the wide variety of tools and features that webpack offers. The first is a simple guide that takes you through [installation](/guides/installation).
+This section contains guides for understanding and mastering the wide variety of tools and features that webpack offers. The first is a simple guide that takes you through [getting started](/guides/getting-started/).
 
-The guides get more and more advanced as you go on. Most serve as a starting point, and once completed you should feel more comfortable diving into the actual [documentation](/configuration).
+The guides get more advanced as you go on. Most serve as a starting point, and once completed you should feel more comfortable diving into the actual [documentation](/configuration/).
 
 W> The output shown from running webpack in the guides may differ slightly from the output of newer versions. This is to be expected. As long as the bundles look similar and run correctly, then there shouldn't be any issues. If you do come across an example that seems to be broken by a new version, please create an issue and we will do our best to resolve the discrepancy.


### PR DESCRIPTION
Intro in the guides section can be improved, right now we were linking the installation guides which didnt have logical next steps and also is not close to be first in the list of guides. Now we are lining getting started guide which offers next steps and has installation guide as a dependency.

more and more is redundant, so that sentence was simplified.