### PR TITLE
docs(api) document assetEmitted hook

### DIFF
--- a/src/content/api/compiler-hooks.md
+++ b/src/content/api/compiler-hooks.md
@@ -248,6 +248,13 @@ Called after emitting assets to output directory.
 
 - Callback Parameters: `compilation`
 
+### `assetEmitted`
+
+`AsyncSeriesHook`
+
+Allows to get byte content of emitted asset. Available since webpack v4.39.0
+
+- Callback Parameters: `file`, `content`
 
 ### `done`
 


### PR DESCRIPTION
As per title, this hook was added in webpack 4.39.0