### PR TITLE
docs(api) document runtime logger usage

### DIFF
--- a/src/content/api/logging.md
+++ b/src/content/api/logging.md
@@ -43,14 +43,9 @@ W> __Avoid noise in the log!__ Keep in mind that multiple plugins and loaders ar
 
 Runtime logger API is only intended to be used as a development tool, it is not intended to be included in [production mode](/configuration/mode/#mode-production).
 
-- To use the logger in runtime, require it directly from webpack:
-
-```javascript
-const logging = require('webpack/logging/runtime');
-```
-
-- To get individual logger by name use `logging.getLogger('name')`;
-- To override the default logger use:
+- `const logging = require('webpack/logging/runtime')`: to use the logger in runtime, require it directly from webpack
+- `logging.getLogger('name')`: to get individual logger by name
+- `logging.configureDefaultLogger(...)`: to override the default logger.
 
 ```javascript
 const logging = require('webpack/logging/runtime');
@@ -60,4 +55,4 @@ logging.configureDefaultLogger({
 });
 ```
 
-- To apply Plugins to the runtime logger use `logging.hooks.log`
+- `logging.hooks.log`: to apply Plugins to the runtime logger

--- a/src/content/api/logging.md
+++ b/src/content/api/logging.md
@@ -38,3 +38,26 @@ W> __Avoid noise in the log!__ Keep in mind that multiple plugins and loaders ar
 - `logger.groupCollapsed(...)`:  to group messages together. Displayed collapsed like `logger.log`. Displayed expanded when logging level is set to `'verbose'` or `'debug'`.
 - `logger.clear()`: to print a horizontal line. Displayed like `logger.log`
 - `logger.profile(...)`, `logger.profileEnd(...)`: to capture a profile. Delegated to `console.profile` when supported
+
+## Runtime Logger API
+
+Runtime logger API is only intended to be used as a development tool, it is not intended to be included in [production mode](/configuration/mode/#mode-production).
+
+- To use the logger in runtime, require it directly from webpack:
+
+```javascript
+const logging = require('webpack/logging/runtime');
+```
+
+- To get individual logger by name use `logging.getLogger('name')`;
+- To override the default logger use:
+
+```javascript
+const logging = require('webpack/logging/runtime');
+logging.configureDefaultLogger({
+  level: 'log',
+  debug: /something/
+});
+```
+
+- To apply Plugins to the runtime logger use `logging.hooks.log`


### PR DESCRIPTION
The last pull request in sequence to add logger api and close #3205 when all the linked PRs are also merged.

Applying Plugins to runtime logger doesnt have tests or examples in webpack repo, so its example to be added later