### PR TITLE
docs(guides): fix typos and a link hash

### DIFF
--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -231,7 +231,7 @@ __webpack.config.js__
 
 This tells `webpack-dev-server` to serve the files from the `dist` directory on `localhost:8080`.
 
-W> webpack-dev-server doesn't write any output files after compiling. Instead, it keeps bundle files in memory and serves them as if they were real files mounted at the server's root path. If your page expects to find the bundle files on a different path, you can change this with the [`publicPath`](/configuration/dev-server/#devserver-publicpath-) option in the dev server's configuration.
+W> webpack-dev-server doesn't write any output files after compiling. Instead, it keeps bundle files in memory and serves them as if they were real files mounted at the server's root path. If your page expects to find the bundle files on a different path, you can change this with the [`publicPath`](/configuration/dev-server/#devserverpublicpath-) option in the dev server's configuration.
 
 Let's add a script to easily run the dev server as well:
 

--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -21,7 +21,7 @@ If you've been following the guides, you should have a solid understanding of so
 
 W> The tools in this guide are __only meant for development__, please __avoid__ using them in production!
 
-Before proceeding, let's first set [`mode` to `'development'`](/configuration/mode/#mode-development).
+Let's start by setting [`mode` to `'development'`](/configuration/mode/#mode-development).
 
 __webpack.config.js__
 

--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -420,4 +420,4 @@ To disable this feature in some common editors, see the list below:
 
 ## Conclusion
 
-Now that you've learned how to automatically compile your code and run a simple development server, you can check out the next guide, which will cover [Code Splitting](/guides/code-splitting/).
+Now that you've learned how to automatically compile your code and run a simple development server, you can check out the next guide, which will cover [Hot Module Replacement](/guides/hot-module-replacement).

--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -21,7 +21,7 @@ If you've been following the guides, you should have a solid understanding of so
 
 W> The tools in this guide are __only meant for development__, please __avoid__ using them in production!
 
-Before proceeding lets first set [`mode` to `'development'`](/configuration/mode/#mode-development).
+Before proceeding, let's first set [`mode` to `'development'`](/configuration/mode/#mode-development).
 
 __webpack.config.js__
 
@@ -121,7 +121,7 @@ We can see that the error also contains a reference to the file (`print.js`) and
 
 ## Choosing a Development Tool
 
-W> Some text editors have a "safe write" function that might interfere with some of the following tools. Read [Adjusting Your text Editor](#adjusting-your-text-editor) for a solution to these issues.
+W> Some text editors have a "safe write" function that might interfere with some of the following tools. Read [Adjusting Your Text Editor](#adjusting-your-text-editor) for a solution to these issues.
 
 It quickly becomes a hassle to manually run `npm run build` every time you want to compile your code.
 
@@ -231,7 +231,7 @@ __webpack.config.js__
 
 This tells `webpack-dev-server` to serve the files from the `dist` directory on `localhost:8080`.
 
-W> webpack-dev-server doesn't write any output files after compiling. Instead, it keeps bundle files in memory and serves them as if they were real files mounted at the server's root path. If your page expects to find the bundle files in different path, you can change this with the [`publicPath`](/configuration/dev-server/#devserver-publicpath-) option in the dev server's configuration.
+W> webpack-dev-server doesn't write any output files after compiling. Instead, it keeps bundle files in memory and serves them as if they were real files mounted at the server's root path. If your page expects to find the bundle files on a different path, you can change this with the [`publicPath`](/configuration/dev-server/#devserver-publicpath-) option in the dev server's configuration.
 
 Let's add a script to easily run the dev server as well:
 
@@ -274,7 +274,7 @@ T> Now that your server is working, you might want to give [Hot Module Replaceme
 
 ### Using webpack-dev-middleware
 
-`webpack-dev-middleware` is a wrapper that will emit files processed by webpack to a server. This is used in `webpack-dev-server` internally, however it's available as a separate package to allow more custom setups if desired. We'll take a look at an example that combines webpack-dev-middleware with an express server.
+`webpack-dev-middleware` is a wrapper that will emit files processed by webpack to a server. This is used in `webpack-dev-server` internally, however it's available as a separate package to allow more custom setups if desired. We'll take a look at an example that combines `webpack-dev-middleware` with an express server.
 
 Let's install `express` and `webpack-dev-middleware` so we can get started:
 
@@ -420,4 +420,4 @@ To disable this feature in some common editors, see the list below:
 
 ## Conclusion
 
-Now that you've learned how to automatically compile your code and run a simple development server, you can check out the next guide, which will cover [Hot Module Replacement](/guides/hot-module-replacement).
+Now that you've learned how to automatically compile your code and run a simple development server, you can check out the next guide, which will cover [Code Splitting](/guides/code-splitting/).


### PR DESCRIPTION
In the [*Development*](https://webpack.js.org/guides/development/) guide,

- Replaced "lets" with "let's" when it was meant to be a contraction of "let us".
- Added a missing comma.
- Changed the capitalization of an anchor link's text so it's consistent with the title of the section that is being pointed to.
- Replaced "find the bundle files in different path" with a more appropriate "find the bundle files on a different path".
- Added backticks around `webpack-dev-middleware` where missing.
- ~~Fixed the link to the next guide, which is "Code Splitting" and not "Hot Module Replacement".~~ See https://github.com/webpack/webpack.js.org/pull/3245#pullrequestreview-273809991.
- Fixed the hash in the link to `devServer.publicPath`, which had an extra `-` (`#devserver-publicpath-` --> `#devserverpublicpath-`). The actual link is indeed https://webpack.js.org/configuration/dev-server/#devserverpublicpath-