### PR TITLE
docs(guides): fix typos in HMR guide

### DIFF
--- a/src/content/guides/hot-module-replacement.md
+++ b/src/content/guides/hot-module-replacement.md
@@ -343,4 +343,4 @@ There are many other loaders and examples out in the community to make HMR inter
 - [Angular HMR](https://github.com/gdi2290/angular-hmr): No loader necessary! A simple change to your main NgModule file is all that's required to have full control over the HMR APIs.
 - [Svelte Loader](https://github.com/sveltejs/svelte-loader): This loader supports HMR for Svelte components out of the box.
 
-T> If you know of any other loaders or plugins that help with or enhance Hot Module Replacement, please submit a pull request to add them to this list!
+T> If you know of any other loaders or plugins that help with or enhance HMR, please submit a pull request to add them to this list!

--- a/src/content/guides/hot-module-replacement.md
+++ b/src/content/guides/hot-module-replacement.md
@@ -114,7 +114,7 @@ __print.js__
 ``` diff
   export default function printMe() {
 -   console.log('I get called from print.js!');
-+   console.log('Updating print.js...')
++   console.log('Updating print.js...');
   }
 ```
 
@@ -343,4 +343,4 @@ There are many other loaders and examples out in the community to make HMR inter
 - [Angular HMR](https://github.com/gdi2290/angular-hmr): No loader necessary! A simple change to your main NgModule file is all that's required to have full control over the HMR APIs.
 - [Svelte Loader](https://github.com/sveltejs/svelte-loader): This loader supports HMR for Svelte components out of the box.
 
-T> If you know of any other loaders or plugins that help with or enhance Hot Module Replacement please submit a pull request to add to this list!
+T> If you know of any other loaders or plugins that help with or enhance Hot Module Replacement, please submit a pull request to add them to this list!


### PR DESCRIPTION
In the [*Hot Module Replacement*](https://webpack.js.org/guides/hot-module-replacement/) guide,

- Added a missing semicolon.
- Added a missing comma.
- Added a missing pronoun.