### PR TITLE
docs(contrib) Kick off types generalization work

### DIFF
--- a/src/content/contribute/writers-guide.md
+++ b/src/content/contribute/writers-guide.md
@@ -202,5 +202,3 @@ To mark a number, use `number`:
 To mark an object, use `object`:
 
 `object = { prop1 string = 'none', prop2 boolean = false, prop3 function (module) => string }`
-
-

--- a/src/content/contribute/writers-guide.md
+++ b/src/content/contribute/writers-guide.md
@@ -189,7 +189,7 @@ To mark a function, also list arguments when they are available:
 
 Where `(compilation, module, path)` lists the arguments that the provided function will receive and `=> boolean` means that the return value of the function must be a `boolean`.
 
-To mark a Plugin as an available option value type, use camel case title of the Plugin:
+To mark a Plugin as an available option value type, use the camel case title of the Plugin:
 
 `TerserPlugin` `[TerserPlugin]`
 

--- a/src/content/contribute/writers-guide.md
+++ b/src/content/contribute/writers-guide.md
@@ -187,7 +187,7 @@ To mark a function, also list arguments when they are available:
 
 `function (compilation, module, path) => boolean`
 
-Where `(compilation, module, path)` lists the arguments that the provided function will receive and `=> boolean` means that return value of the function must be a `boolean`.
+Where `(compilation, module, path)` lists the arguments that the provided function will receive and `=> boolean` means that the return value of the function must be a `boolean`.
 
 To mark a Plugin as an available option value type, use camel case title of the Plugin:
 

--- a/src/content/contribute/writers-guide.md
+++ b/src/content/contribute/writers-guide.md
@@ -193,7 +193,7 @@ To mark a Plugin as an available option value type, use the camel case title of 
 
 `TerserPlugin` `[TerserPlugin]`
 
-Which means that the option exptects one or few `TerserPlugin` instances.
+Which means that the option expects one or few `TerserPlugin` instances.
 
 To mark a number, use `number`:
 

--- a/src/content/contribute/writers-guide.md
+++ b/src/content/contribute/writers-guide.md
@@ -3,6 +3,7 @@ title: Writer's Guide
 sort: 1
 contributors:
   - pranshuchittora
+  - EugeneHlushko
 ---
 
 The following sections contain all you need to know about editing and formatting the content within this site. Make sure to do some research before starting your edits or additions. Sometimes the toughest part is finding where the content should live and determining whether or not it already exists.
@@ -159,3 +160,47 @@ Please do not assume things are simple. Avoid words like 'just', 'simply'.
 - Simply run command...
 + Run the `command-name` command...
 ```
+
+### Configuration defaults and types
+
+Always provide types and defaults to all of the documentation options in order to keep documentation accessible and well-written. We are adding types and defaults after entitling the documented option:
+
+__configuration.example.option__
+
+`string = 'none'`
+
+Where `= 'none'` means that default value is `'none'` for the given option.
+
+`string = 'none': 'none' | 'development' | 'production'`
+
+Where `: 'none' | 'development' | 'production'` enumerates the possible type values, in this case, three strings are acceptable: `'none' | 'development' | 'production'`.
+
+Use space between types to list all available types for the given option:
+
+`string = 'none': 'none' | 'development' | 'production'` `boolean`
+
+To mark an array, use square brackets:
+
+`string` `[string]`
+
+To mark a function, also list arguments when they are available:
+
+`function (compilation, module, path) => boolean`
+
+Where `(compilation, module, path)` lists the arguments that the provided function will receive and `=> boolean` means that return value of the function must be a `boolean`.
+
+To mark a Plugin as an available option value type, use camel case title of the Plugin:
+
+`TerserPlugin` `[TerserPlugin]`
+
+Which means that option exptects one or few `TerserPlugin` instances.
+
+To mark a number, use `number`:
+
+`number = 15: 5, 15, 30`
+
+To mark an object, use `object`
+
+`object = { prop1 string = true, prop2 boolean = false, prop3 function (module) => string}`
+
+

--- a/src/content/contribute/writers-guide.md
+++ b/src/content/contribute/writers-guide.md
@@ -201,6 +201,6 @@ To mark a number, use `number`:
 
 To mark an object, use `object`:
 
-`object = { prop1 string = true, prop2 boolean = false, prop3 function (module) => string}`
+`object = { prop1 string = true, prop2 boolean = false, prop3 function (module) => string }`
 
 

--- a/src/content/contribute/writers-guide.md
+++ b/src/content/contribute/writers-guide.md
@@ -201,6 +201,6 @@ To mark a number, use `number`:
 
 To mark an object, use `object`:
 
-`object = { prop1 string = true, prop2 boolean = false, prop3 function (module) => string }`
+`object = { prop1 string = 'none', prop2 boolean = false, prop3 function (module) => string }`
 
 

--- a/src/content/contribute/writers-guide.md
+++ b/src/content/contribute/writers-guide.md
@@ -169,7 +169,7 @@ __configuration.example.option__
 
 `string = 'none'`
 
-Where `= 'none'` means that default value is `'none'` for the given option.
+Where `= 'none'` means that the default value is `'none'` for the given option.
 
 `string = 'none': 'none' | 'development' | 'production'`
 

--- a/src/content/contribute/writers-guide.md
+++ b/src/content/contribute/writers-guide.md
@@ -193,7 +193,7 @@ To mark a Plugin as an available option value type, use camel case title of the 
 
 `TerserPlugin` `[TerserPlugin]`
 
-Which means that option exptects one or few `TerserPlugin` instances.
+Which means that the option exptects one or few `TerserPlugin` instances.
 
 To mark a number, use `number`:
 

--- a/src/content/contribute/writers-guide.md
+++ b/src/content/contribute/writers-guide.md
@@ -173,7 +173,7 @@ Where `= 'none'` means that default value is `'none'` for the given option.
 
 `string = 'none': 'none' | 'development' | 'production'`
 
-Where `: 'none' | 'development' | 'production'` enumerates the possible type values, in this case, three strings are acceptable: `'none' | 'development' | 'production'`.
+Where `: 'none' | 'development' | 'production'` enumerates the possible type values, in this case, three strings are acceptable: `'none'`, `'development'`, and `'production'`.
 
 Use space between types to list all available types for the given option:
 

--- a/src/content/contribute/writers-guide.md
+++ b/src/content/contribute/writers-guide.md
@@ -163,7 +163,7 @@ Please do not assume things are simple. Avoid words like 'just', 'simply'.
 
 ### Configuration defaults and types
 
-Always provide types and defaults to all of the documentation options in order to keep documentation accessible and well-written. We are adding types and defaults after entitling the documented option:
+Always provide types and defaults to all of the documentation options in order to keep the documentation accessible and well-written. We are adding types and defaults after entitling the documented option:
 
 __configuration.example.option__
 

--- a/src/content/contribute/writers-guide.md
+++ b/src/content/contribute/writers-guide.md
@@ -199,7 +199,7 @@ To mark a number, use `number`:
 
 `number = 15: 5, 15, 30`
 
-To mark an object, use `object`
+To mark an object, use `object`:
 
 `object = { prop1 string = true, prop2 boolean = false, prop3 function (module) => string}`
 

--- a/src/content/contribute/writers-guide.md
+++ b/src/content/contribute/writers-guide.md
@@ -201,4 +201,4 @@ To mark a number, use `number`:
 
 To mark an object, use `object`:
 
-`object = { prop1 string = 'none', prop2 boolean = false, prop3 function (module) => string }`
+`object = { prop1 string = 'none': 'none' | 'development' | 'production', prop2 boolean = false, prop3 function (module) => string }`


### PR DESCRIPTION
It's been a while since i've started introducing types to the arguments, but usually it wasnt really clear what is right and what is wrong.

When we defined the current typing we did not consider some of the options:
- function return types
- defaults combined with enums
- objects and their prop types and their defaults if present

This should fix all the issues to date