### PR TITLE
docs(config) refactor stats options, update links, update info

### DIFF
--- a/src/content/api/loaders.md
+++ b/src/content/api/loaders.md
@@ -646,7 +646,7 @@ module.exports = function(source) {
 
 ## Logging
 
-Logging API is available since the release of webpack 4.37. When `logging` is enabled in [`stats configuration`](/configuration/stats/#stats) and/or when [`infrastructure logging`](/configuration/other-options/#infrastructurelogging) is enabled, loaders may log messages which will be printed out in the respective logger format (stats, infrastructure).
+Logging API is available since the release of webpack 4.37. When `logging` is enabled in [`stats configuration`](/configuration/stats/#statslogging) and/or when [`infrastructure logging`](/configuration/other-options/#infrastructurelogging) is enabled, loaders may log messages which will be printed out in the respective logger format (stats, infrastructure).
 
 - Loaders should prefer to use `this.getLogger()` for logging which is a shortcut to `compilation.getLogger()` with loader path and processed file. This kind of logging is stored to the Stats and formatted accordingly. It can be filtered and exported by the webpack user.
 - Loaders may use `this.getLogger('name')` to get an independent logger with a child name. Loader path and processed file is still added.

--- a/src/content/api/logging.md
+++ b/src/content/api/logging.md
@@ -13,7 +13,7 @@ webpack logger is available to [loaders](/loaders/) and [plugins](/api/plugins/#
 
 Benefits of custom logging API in webpack:
 
-- Common place to [configure the logging](/configuration/stats/#stats) display level
+- Common place to [configure the logging](/configuration/stats/#statslogging) display level
 - Logging output exportable as part of the `stats.json`
 - Stats presets affect logging output
 - Plugins can affect logging capturing and display level

--- a/src/content/api/plugins.md
+++ b/src/content/api/plugins.md
@@ -136,7 +136,7 @@ Note that only a subset of compiler and compilation hooks support the `reportPro
 
 ## Logging
 
-Logging API is available since the release of webpack 4.37. When `logging` is enabled in [`stats configuration`](/configuration/stats/#stats) and/or when [`infrastructure logging`](/configuration/other-options/#infrastructurelogging) is enabled, plugins may log messages which will be printed out in the respective logger format (stats, infrastructure).
+Logging API is available since the release of webpack 4.37. When `logging` is enabled in [`stats configuration`](/configuration/stats/#statslogging) and/or when [`infrastructure logging`](/configuration/other-options/#infrastructurelogging) is enabled, plugins may log messages which will be printed out in the respective logger format (stats, infrastructure).
 
 - Plugins should prefer to use `compilation.getLogger('PluginName')` for logging. This kind of logging is stored to the Stats and formatted accordingly. It can be filtered and exported by the user.
 - Plugins may use the `compiler.getInfrastructureLogger('PluginName')` for logging. Using `infrastructure` logging is not stored in the Stats and therefore not formatted. It's usually logged to the console/dashboard/GUI directly. It can be filtered by the user.

--- a/src/content/configuration/other-options.md
+++ b/src/content/configuration/other-options.md
@@ -196,7 +196,7 @@ Options for infrastructure level logging.
 
 `string`
 
-Enable infrastructure logging output. Similar to [`stats.logging`](/configuration/stats/#stats) option but for infrastructure. No default value is given.
+Enable infrastructure logging output. Similar to [`stats.logging`](/configuration/stats/#statslogging) option but for infrastructure. No default value is given.
 
 Possible values:
 

--- a/src/content/configuration/stats.md
+++ b/src/content/configuration/stats.md
@@ -54,7 +54,7 @@ module.exports = {
   stats: {
     all: undefined
   }
-}
+};
 ```
 
 ### `stats.assets`
@@ -69,7 +69,7 @@ module.exports = {
   stats: {
     assets: false
   }
-}
+};
 ```
 
 ### `stats.assetsSort`
@@ -84,7 +84,7 @@ module.exports = {
   stats: {
     assetsSort: '!size'
   }
-}
+};
 ```
 
 ### `stats.builtAt`
@@ -99,7 +99,7 @@ module.exports = {
   stats: {
     builtAt: false
   }
-}
+};
 ```
 
 ### `stats.cached`
@@ -114,7 +114,7 @@ module.exports = {
   stats: {
     cached: false
   }
-}
+};
 ```
 
 ### `stats.cachedAssets`
@@ -129,7 +129,7 @@ module.exports = {
   stats: {
     cachedAssets: false
   }
-}
+};
 ```
 
 ### `stats.children`
@@ -144,7 +144,7 @@ module.exports = {
   stats: {
     children: false
   }
-}
+};
 ```
 
 ### `stats.chunks`
@@ -159,7 +159,7 @@ module.exports = {
   stats: {
     chunks: false
   }
-}
+};
 ```
 
 ### `stats.chunkGroups`
@@ -174,7 +174,7 @@ module.exports = {
   stats: {
     chunkGroups: false
   }
-}
+};
 ```
 
 ### `stats.chunkModules`
@@ -189,7 +189,7 @@ module.exports = {
   stats: {
     chunkModules: false
   }
-}
+};
 ```
 
 ### `stats.chunkOrigins`
@@ -204,7 +204,7 @@ module.exports = {
   stats: {
     chunkOrigins: false
   }
-}
+};
 ```
 
 ### `stats.chunksSort`
@@ -219,7 +219,7 @@ module.exports = {
   stats: {
     chunksSort: 'name'
   }
-}
+};
 ```
 
 ### `stats.context`
@@ -234,7 +234,7 @@ module.exports = {
   stats: {
     context: '../src/components/'
   }
-}
+};
 ```
 
 ### `stats.colors`
@@ -249,7 +249,7 @@ module.exports = {
   stats: {
     colors: true
   }
-}
+};
 ```
 
  It is also available as a CLI flag:
@@ -281,7 +281,7 @@ module.exports = {
   stats: {
     depth: true
   }
-}
+};
 ```
 
 ### `stats.entrypoints`
@@ -296,7 +296,7 @@ module.exports = {
   stats: {
     entrypoints: true
   }
-}
+};
 ```
 
 ### `stats.env`
@@ -311,7 +311,7 @@ module.exports = {
   stats: {
     env: true
   }
-}
+};
 ```
 
 ### `stats.errors`
@@ -326,7 +326,7 @@ module.exports = {
   stats: {
     errors: false
   }
-}
+};
 ```
 
 ### `stats.errorDetails`
@@ -341,7 +341,7 @@ module.exports = {
   stats: {
     errorDetails: false
   }
-}
+};
 ```
 
 ### `stats.excludeAssets`
@@ -355,12 +355,12 @@ module.exports = {
   //...
   stats: {
     excludeAssets: [
-      `filter`,
+      'filter',
       /filter/,
       (assetName) => assetName.contains('moduleA')
     ]
   }
-}
+};
 ```
 
 ### `stats.excludeModules`
@@ -374,12 +374,12 @@ module.exports = {
   //...
   stats: {
     excludeModules: [
-      `filter`,
+      'filter',
       /filter/,
       (moduleSource) => true
     ]
   }
-}
+};
 ```
 
 Setting `stats.excludeModules` to `false` will disable the exclude behaviour.
@@ -390,7 +390,7 @@ module.exports = {
   stats: {
     excludeModules: false
   }
-}
+};
 ```
 
 ### `stats.exclude`
@@ -409,7 +409,7 @@ module.exports = {
   stats: {
     hash: false
   }
-}
+};
 ```
 
 ### `stats.logging`
@@ -429,9 +429,9 @@ Tells `stats` whether to add logging output.
 module.exports = {
   //...
   stats: {
-    logging: `verbose`
+    logging: 'verbose'
   }
-}
+};
 ```
 
 ### `stats.loggingDebug`
@@ -445,12 +445,12 @@ module.exports = {
   //...
   stats: {
     loggingDebug: [
-      `MyPlugin`,
+      'MyPlugin',
       /MyPlugin/,
       (name) => name.contains('MyPlugin')
     ]
   }
-}
+};
 ```
 
 ### `stats.loggingTrace`
@@ -466,7 +466,7 @@ module.exports = {
   stats: {
     loggingTrace: false
   }
-}
+};
 ```
 
 ### `stats.maxModules`
@@ -481,7 +481,7 @@ module.exports = {
   stats: {
     maxModules: 5
   }
-}
+};
 ```
 
 ### `stats.modules`
@@ -496,7 +496,7 @@ module.exports = {
   stats: {
     modules: false
   }
-}
+};
 ```
 
 ### `stats.modulesSort`
@@ -511,7 +511,7 @@ module.exports = {
   stats: {
     modulesSort: 'size'
   }
-}
+};
 ```
 
 ### `stats.moduleTrace`
@@ -526,7 +526,7 @@ module.exports = {
   stats: {
     moduleTrace: false
   }
-}
+};
 ```
 
 ### `stats.outputPath`
@@ -541,7 +541,7 @@ module.exports = {
   stats: {
     outputPath: false
   }
-}
+};
 ```
 
 ### `stats.performance`
@@ -556,7 +556,7 @@ module.exports = {
   stats: {
     performance: false
   }
-}
+};
 ```
 
 ### `stats.providedExports`
@@ -571,7 +571,7 @@ module.exports = {
   stats: {
     providedExports: true
   }
-}
+};
 ```
 
 ### `stats.publicPath`
@@ -586,7 +586,7 @@ module.exports = {
   stats: {
     publicPath: false
   }
-}
+};
 ```
 
 ### `stats.reasons`
@@ -601,7 +601,7 @@ module.exports = {
   stats: {
     reasons: false
   }
-}
+};
 ```
 
 ### `stats.source`
@@ -616,7 +616,7 @@ module.exports = {
   stats: {
     source: true
   }
-}
+};
 ```
 
 ### `stats.timings`
@@ -631,7 +631,7 @@ module.exports = {
   stats: {
     timings: false
   }
-}
+};
 ```
 
 ### `stats.usedExports`
@@ -646,7 +646,7 @@ module.exports = {
   stats: {
     usedExports: true
   }
-}
+};
 ```
 
 ### `stats.version`
@@ -661,7 +661,7 @@ module.exports = {
   stats: {
     version: false
   }
-}
+};
 ```
 
 ### `stats.warnings`
@@ -676,7 +676,7 @@ module.exports = {
   stats: {
     warnings: false
   }
-}
+};
 ```
 
 ### `stats.warningsFilter`
@@ -690,37 +690,37 @@ module.exports = {
   //...
   stats: {
     warningsFilter: [
-      `filter`,
+      'filter',
       /filter/,
       (warning) => true
     ]
   }
-}
+};
 ```
 
 ### Sorting fields
 
 For `assetsSort`, `chunksSort` and `modulesSort` there are several possible fields that you can sort items by:
 
-- `id` is the item's id;
-- `name` - a item's name that was assigned to it upon importing;
-- `size` - a size of item in bytes;
-- `chunks` - what chunks the item originates from (for example, if there are multiple subchunks for one chunk - the subchunks will be grouped together according to their main chunk);
-- `errors` - amount of errors in items;
-- `warnings` - amount of warnings in items;
-- `failed` - whether the item has failed compilation;
-- `cacheable` - whether the item is cacheable;
-- `built` - whether the asset has been built;
-- `prefetched` - whether the asset will be prefetched;
-- `optional` - whether the asset is optional;
-- `identifier` - identifier of the item;
-- `index` - item's processing index;
-- `index2`
-- `profile`
-- `issuer` - an identifier of the issuer;
-- `issuerId` - an id of the issuer;
-- `issuerName` - a name of the issuer;
-- `issuerPath` - a full issuer object. There's no real need to sort by this field;
+- `'id'` is the item's id;
+- `'name'` - a item's name that was assigned to it upon importing;
+- `'size'` - a size of item in bytes;
+- `'chunks'` - what chunks the item originates from (for example, if there are multiple subchunks for one chunk - the subchunks will be grouped together according to their main chunk);
+- `'errors'` - amount of errors in items;
+- `'warnings'` - amount of warnings in items;
+- `'failed'` - whether the item has failed compilation;
+- `'cacheable'` - whether the item is cacheable;
+- `'built'` - whether the asset has been built;
+- `'prefetched'` - whether the asset will be prefetched;
+- `'optional'` - whether the asset is optional;
+- `'identifier'` - identifier of the item;
+- `'index'` - item's processing index;
+- `'index2'`
+- `'profile'`
+- `'issuer'` - an identifier of the issuer;
+- `'issuerId'` - an id of the issuer;
+- `'issuerName'` - a name of the issuer;
+- `'issuerPath'` - a full issuer object. There's no real need to sort by this field;
 
 ### Extending stats behaviours
 

--- a/src/content/configuration/stats.md
+++ b/src/content/configuration/stats.md
@@ -253,10 +253,10 @@ module.exports = {
 ```
 
  It is also available as a CLI flag:
- 
- ```bash
- webpack-cli --colors
- ```
+
+```bash
+webpack-cli --colors
+```
 
  You can specify your own terminal output colors using [ANSI escape sequences](https://en.wikipedia.org/wiki/ANSI_escape_code)
 

--- a/src/content/configuration/stats.md
+++ b/src/content/configuration/stats.md
@@ -44,195 +44,658 @@ module.exports = {
 
 For more granular control, it is possible to specify exactly what information you want. Please note that all of the options in this object are optional.
 
-<!-- eslint-skip -->
+### `stats.all`
 
-```js
+A fallback value for stats options when an option is not defined. It has precedence over local webpack defaults.
+
+```javascript
 module.exports = {
   //...
   stats: {
-    // fallback value for stats options when an option is not defined
-    // (has precedence over local webpack defaults)
-    all: undefined,
-
-    // Add asset Information
-    assets: true,
-
-    // Sort assets by a field
-    // You can reverse the sort with `!field`.
-    // Some possible values: 'id' (default), 'name', 'size', 'chunks', 'failed', 'issuer'
-    // For a complete list of fields see the bottom of the page
-    assetsSort: 'field',
-
-    // Add build date and time information
-    builtAt: true,
-
-    // Add information about cached (not built) modules
-    cached: true,
-
-    // Show cached assets (setting this to `false` only shows emitted files)
-    cachedAssets: true,
-
-    // Add children information
-    children: true,
-
-    // Add chunk information (setting this to `false` allows for a less verbose output)
-    chunks: true,
-
-    // Add namedChunkGroups information
-    chunkGroups: true,
-
-    // Add built modules information to chunk information
-    chunkModules: true,
-
-    // Add the origins of chunks and chunk merging info
-    chunkOrigins: true,
-
-    // Sort the chunks by a field
-    // You can reverse the sort with `!field`. Default is `id`.
-    // Some other possible values: 'name', 'size', 'chunks', 'failed', 'issuer'
-    // For a complete list of fields see the bottom of the page
-    chunksSort: 'field',
-
-    // Context directory for request shortening
-    context: '../src/',
-
-    // `webpack --colors` equivalent
-    colors: false,
-
-    // Display the distance from the entry point for each module
-    depth: false,
-
-    // Display the entry points with the corresponding bundles
-    entrypoints: false,
-
-    // Add --env information
-    env: false,
-
-    // Add errors
-    errors: true,
-
-    // Add details to errors (like resolving log)
-    errorDetails: true,
-
-    // Exclude assets from being displayed in stats
-    // This can be done with a String, a RegExp, a Function getting the assets name
-    // and returning a boolean or an Array of the above.
-    // Possible values: String | RegExp | (assetName) => boolean | [String, RegExp, (assetName) => boolean]
-    // Example values: 'filter' | /filter/ | ['filter', /filter/] | (assetName) => assetName.contains('moduleA')
-    excludeAssets: [],
-
-    // Exclude modules from being displayed in stats
-    // This can be done with a String, a RegExp, a Function getting the modules source
-    // and returning a boolean or an Array of the above.
-    // Possible values: String | RegExp | (moduleSource) => boolean | [String, RegExp, (moduleSource) => boolean]
-    // Example values: 'filter' | /filter/ | ['filter', /filter/] | (moduleSource) => true
-    excludeModules: exclude || [],
-
-    // See excludeModules
-    // Possible values: String | RegExp | (moduleSource) => boolean | [String, RegExp, (moduleSource) => boolean]
-    // Example values: 'filter' | /filter/ | ['filter', /filter/] | (moduleSource) => true
-    exclude: excludeModules || [],
-
-    // Add the hash of the compilation
-    hash: true,
-
-    // Add logging output
-    // Possible values: 'none', 'error', 'warn', 'info', 'log', 'verbose', true, false
-    // 'none', false - disable logging
-    // 'error' - errors only
-    // 'warn' - errors and warnings only
-    // 'info' - errors, warnings, and info messages
-    // 'log', true - errors, warnings, info messages, log messages, groups, clears.
-    //    Collapsed groups are displayed in a collapsed state.
-    // 'verbose' - log everything except debug and trace.
-    //    Collapsed groups are displayed in expanded state.
-    logging: 'info',
-
-    // Include debug information of specified loggers such as plugins or loaders.
-    // Provide an array of filters to match plugins or loaders.
-    // Filters can be Strings, RegExps or Functions.
-    // when stats.logging is false, stats.loggingDebug option is ignored.
-    // Possible values: String | RegExp | (warning) => boolean | [String, RegExp, (name) => boolean]
-    // Example values: 'MyPlugin' | /MyPlugin/ | ['MyPlugin', /MyPlugin/] | (name) => name.contains('MyPlugin')
-    loggingDebug: [],
-
-    // Enable stack traces in logging output for errors, warnings and traces.
-    loggingTrace: true,
-
-    // Set the maximum number of modules to be shown
-    maxModules: 15,
-
-    // Add built modules information
-    modules: true,
-
-    // Sort the modules by a field
-    // You can reverse the sort with `!field`. Default is `id`.
-    // Some other possible values: 'name', 'size', 'chunks', 'failed', 'issuer'
-    // For a complete list of fields see the bottom of the page
-    modulesSort: 'field',
-
-    // Show dependencies and origin of warnings/errors (since webpack 2.5.0)
-    moduleTrace: true,
-
-    // Show outputPath
-    outputPath: true | false,
-
-    // Show performance hint when file size exceeds `performance.maxAssetSize`
-    performance: true,
-
-    // Show the exports of the modules
-    providedExports: false,
-
-    // Add public path information
-    publicPath: true,
-
-    // Add information about the reasons why modules are included
-    reasons: true,
-
-    // Add the source code of modules
-    source: false,
-
-    // Add timing information
-    timings: true,
-
-    // Show which exports of a module are used
-    usedExports: false,
-
-    // Add webpack version information
-    version: true,
-
-    // Add warnings
-    warnings: true,
-
-    // Filter warnings to be shown (since webpack 2.4.0),
-    // can be a String, Regexp, a function getting the warning and returning a boolean
-    // or an Array of a combination of the above. First match wins.
-    // Possible values: String | RegExp | (warning) => boolean | [String, RegExp, (warning) => boolean]
-    // Example values: 'filter' | /filter/ | ['filter', /filter/] | (warning) => true
-    warningsFilter: null
+    all: undefined
   }
 }
 ```
 
-If you want to use one of the pre-defined behaviours e.g. `'minimal'` but still override one or more of the rules, see [the source code](https://github.com/webpack/webpack/blob/master/lib/Stats.js#L1394-L1401). You would want to copy the configuration options from `case 'minimal': ...` and add your additional rules while providing an object to `stats`.
+### `stats.assets`
 
-__webpack.config.js__
+`boolean = true`
+
+Tells `stats` whether to show the asset information. Set `stats.assets` to `false` to hide it.
 
 ```javascript
 module.exports = {
-  //..
+  //...
   stats: {
-    // copied from `'minimal'`
-    all: false,
-    modules: true,
-    maxModules: 0,
-    errors: true,
-    warnings: true,
-    // our additional options
-    moduleTrace: true,
-    errorDetails: true
+    assets: false
   }
+}
+```
+
+### `stats.assetsSort`
+
+`string = 'id'`
+
+Tells `stats` to sort the assets by a given field. All of the [sorting fields](#sorting-fields) are allowed to be used as values for `stats.assetsSort`. Use `!` prefix in the value to reverse the sort order by a given field.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    assetsSort: '!size'
+  }
+}
+```
+
+### `stats.builtAt`
+
+`boolean = true`
+
+Tells `stats` whether to add the build date and the build time information. Set `stats.builtAt` to `false` to hide it.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    builtAt: false
+  }
+}
+```
+
+### `stats.cached`
+
+`boolean = true`
+
+Tells `stats` whether to add information about the cached modules (not the ones that were built).
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    cached: false
+  }
+}
+```
+
+### `stats.cachedAssets`
+
+`boolean = true`
+
+Tells `stats` whether to add information about the cached assets. Setting `stats.cachedAssets` to `false` will tell `stats` to only show the emitted files (not the ones that were built).
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    cachedAssets: false
+  }
+}
+```
+
+### `stats.children`
+
+`boolean = true`
+
+Tells `stats` whether to add information about the children.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    children: false
+  }
+}
+```
+
+### `stats.chunks`
+
+`boolean = true`
+
+Tells `stats` whether to add information about the chunk. Setting `stats.chunks` to `false` results in a less verbose output.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    chunks: false
+  }
+}
+```
+
+### `stats.chunkGroups`
+
+`boolean = true`
+
+Tells `stats` whether to add information about the `namedChunkGroups`.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    chunkGroups: false
+  }
+}
+```
+
+### `stats.chunkModules`
+
+`boolean = true`
+
+Tells `stats` whether to add information about the built modules to information about the chunk.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    chunkModules: false
+  }
+}
+```
+
+### `stats.chunkOrigins`
+
+`boolean = true`
+
+Tells `stats` whether to add information about the origins of chunks and chunk merging.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    chunkOrigins: false
+  }
+}
+```
+
+### `stats.chunksSort`
+
+`string = 'id'`
+
+Tells `stats` to sort the chunks by a given field. All of the [sorting fields](#sorting-fields) are allowed to be used as values for `stats.chunksSort`. Use `!` prefix in the value to reverse the sort order by a given field.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    chunksSort: 'name'
+  }
+}
+```
+
+### `stats.context`
+
+`string = '../src/'`
+
+Sets the context directory for shortening the request information.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    context: '../src/components/'
+  }
+}
+```
+
+### `stats.colors`
+
+`boolean = false` `object`
+
+Tells `stats` whether to output in the different colors.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    colors: true
+  }
+}
+```
+
+ It is also available as a CLI flag:
+ 
+ ```bash
+ webpack-cli --colors
+ ```
+
+ You can specify your own terminal output colors using [ANSI escape sequences](https://en.wikipedia.org/wiki/ANSI_escape_code)
+
+```js
+module.exports = {
+  //...
+  colors: {
+    green: '\u001b[32m',
+  },
 };
+```
+
+### `stats.depth`
+
+`boolean = false`
+
+Tells `stats` whether to display the distance from the entry point for each module.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    depth: true
+  }
+}
+```
+
+### `stats.entrypoints`
+
+`boolean = false`
+
+Tells `stats` whether to display the entry points with the corresponding bundles.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    entrypoints: true
+  }
+}
+```
+
+### `stats.env`
+
+`boolean = false`
+
+Tells `stats` whether to display the `--env` information.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    env: true
+  }
+}
+```
+
+### `stats.errors`
+
+`boolean = true`
+
+Tells `stats` whether to display the errors.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    errors: false
+  }
+}
+```
+
+### `stats.errorDetails`
+
+`boolean = true`
+
+Tells `stats` whether to add the details to the errors.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    errorDetails: false
+  }
+}
+```
+
+### `stats.excludeAssets`
+
+`array = []: string | RegExp | function (assetName) => boolean` `string` `RegExp` `function (assetName) => boolean`
+
+Tells `stats` to exclude the matching assets information. This can be done with a `string`, a `RegExp`, a `function` that is getting the assets name as an argument and returns a `boolean`. `stats.excludeAssets` can be an `array` of any of the above.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    excludeAssets: [
+      `filter`,
+      /filter/,
+      (assetName) => assetName.contains('moduleA')
+    ]
+  }
+}
+```
+
+### `stats.excludeModules`
+
+`array = []: string | RegExp | function (assetName) => boolean` `string` `RegExp` `function (assetName) => boolean` `boolean: false`
+
+Tells `stats` to exclude the matching modules information. This can be done with a `string`, a `RegExp`, a `function` that is getting the module's source as an argument and returns a `boolean`. `stats.excludeModules` can be an `array` of any of the above. `stats.excludeModules`'s configuration [is merged](https://github.com/webpack/webpack/blob/master/lib/Stats.js#L215) with the `stats.exclude`'s configuration value.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    excludeModules: [
+      `filter`,
+      /filter/,
+      (moduleSource) => true
+    ]
+  }
+}
+```
+
+Setting `stats.excludeModules` to `false` will disable the exclude behaviour.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    excludeModules: false
+  }
+}
+```
+
+### `stats.exclude`
+
+See [`stats.excludeModules`](#statsexcludemodules).
+
+### `stats.hash`
+
+`boolean = true`
+
+Tells `stats` whether to add information about the hash of the compilation.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    hash: false
+  }
+}
+```
+
+### `stats.logging`
+
+`string = 'info': 'none' | 'error' | 'warn' | 'info' | 'log' | 'verbose'` `boolean`
+
+Tells `stats` whether to add logging output.
+
+- `'none'`, `false` - disable logging
+- `'error'` - errors only
+- `'warn'` - errors and warnings only
+- `'info'` - errors, warnings, and info messages
+- `'log'`, `true` - errors, warnings, info messages, log messages, groups, clears. Collapsed groups are displayed in a collapsed state.
+- `'verbose'` - log everything except debug and trace. Collapsed groups are displayed in expanded state.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    logging: `verbose`
+  }
+}
+```
+
+### `stats.loggingDebug`
+
+`array = []: string | RegExp | function (name) => boolean` `string` `RegExp` `function (name) => boolean`
+
+Tells `stats` to include the debug information of the specified loggers such as Plugins or Loaders. When [`stats.logging`](#statslogging) is set to `false`, `stats.loggingDebug` option is ignored.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    loggingDebug: [
+      `MyPlugin`,
+      /MyPlugin/,
+      (name) => name.contains('MyPlugin')
+    ]
+  }
+}
+```
+
+### `stats.loggingTrace`
+
+`boolean = true`
+
+Enable stack traces in the logging output for errors, warnings and traces. Set `stats.loggingTrace` to hide the trace.
+
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    loggingTrace: false
+  }
+}
+```
+
+### `stats.maxModules`
+
+`number = 15`
+
+Set the maximum number of modules to be shown.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    maxModules: 5
+  }
+}
+```
+
+### `stats.modules`
+
+`boolean = true`
+
+Tells `stats` whether to add information about the built modules.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    modules: false
+  }
+}
+```
+
+### `stats.modulesSort`
+
+`string = 'id'`
+
+Tells `stats` to sort the modules by a given field. All of the [sorting fields](#sorting-fields) are allowed to be used as values for `stats.modulesSort`. Use `!` prefix in the value to reverse the sort order by a given field.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    modulesSort: 'size'
+  }
+}
+```
+
+### `stats.moduleTrace`
+
+`boolean = true`
+
+Tells `stats` to show dependencies and the origin of warnings/errors. `stats.moduleTrace` is available since webpack 2.5.0.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    moduleTrace: false
+  }
+}
+```
+
+### `stats.outputPath`
+
+`boolean = true`
+
+Tells `stats` to show the `outputPath`.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    outputPath: false
+  }
+}
+```
+
+### `stats.performance`
+
+`boolean = true`
+
+Tells `stats` to show performance hint when the file size exceeds [`performance.maxAssetSize`](/configuration/performance/#performancemaxassetsize).
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    performance: false
+  }
+}
+```
+
+### `stats.providedExports`
+
+`boolean = false`
+
+Tells `stats` to show the exports of the modules.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    providedExports: true
+  }
+}
+```
+
+### `stats.publicPath`
+
+`boolean = true`
+
+Tells `stats` to show the `publicPath`.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    publicPath: false
+  }
+}
+```
+
+### `stats.reasons`
+
+`boolean = true`
+
+Tells `stats` to add information about the reasons of why modules are included.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    reasons: false
+  }
+}
+```
+
+### `stats.source`
+
+`boolean = false`
+
+Tells `stats` to add the source code of modules.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    source: true
+  }
+}
+```
+
+### `stats.timings`
+
+`boolean = true`
+
+Tells `stats` to add the timing information.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    timings: false
+  }
+}
+```
+
+### `stats.usedExports`
+
+`boolean = false`
+
+Tells `stats` whether to show which exports of a module are used.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    usedExports: true
+  }
+}
+```
+
+### `stats.version`
+
+`boolean = true`
+
+Tells `stats` to add information about the webpack version used.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    version: false
+  }
+}
+```
+
+### `stats.warnings`
+
+`boolean = true`
+
+Tells `stats` to add warnings.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    warnings: false
+  }
+}
+```
+
+### `stats.warningsFilter`
+
+`array = []: string | RegExp | function (warning) => boolean` `string` `RegExp` `function (warning) => boolean`
+
+Tells `stats` to exclude the warnings that are matching given filters. This can be done with a `string`, a `RegExp`, a `function` that is getting a warning as an argument and returns a `boolean`. `stats.warningsFilter` can be an `array` of any of the above.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    warningsFilter: [
+      `filter`,
+      /filter/,
+      (warning) => true
+    ]
+  }
+}
 ```
 
 ### Sorting fields
@@ -259,15 +722,25 @@ For `assetsSort`, `chunksSort` and `modulesSort` there are several possible fiel
 - `issuerName` - a name of the issuer;
 - `issuerPath` - a full issuer object. There's no real need to sort by this field;
 
-### Colors
+### Extending stats behaviours
 
-You can specify your own terminal output colors using [ANSI escape sequences](https://en.wikipedia.org/wiki/ANSI_escape_code)
+If you want to use one of the pre-defined behaviours e.g. `'minimal'` but still override one or more of the rules, see [the source code](https://github.com/webpack/webpack/blob/master/lib/Stats.js#L1394-L1401). You would want to copy the configuration options from `case 'minimal': ...` and add your additional rules while providing an object to `stats`.
 
-```js
+__webpack.config.js__
+
+```javascript
 module.exports = {
-  //...
-  colors: {
-    green: '\u001b[32m',
-  },
+  //..
+  stats: {
+    // copied from `'minimal'`
+    all: false,
+    modules: true,
+    maxModules: 0,
+    errors: true,
+    warnings: true,
+    // our additional options
+    moduleTrace: true,
+    errorDetails: true
+  }
 };
 ```


### PR DESCRIPTION
Finally got my hands into refactoring the non accessible version of the stats config. Now all the options are properly documented (based on the available info and somewhere enhanced) and have new type system as a demonstration. If we decide to change the types notation i will update this PR.

- stats options have types and defaults in a common format
- stats options can now be linked to
- some of the stats options are now explained better 
- provided direct links to stats.logging\]

P.S. Sorry for the big diff but dont see how i'd split that work.