### PR TITLE
docs(ui) make mobile menu close button fixed for convenience

### DIFF
--- a/src/components/SidebarMobile/SidebarMobile.jsx
+++ b/src/components/SidebarMobile/SidebarMobile.jsx
@@ -113,7 +113,7 @@ export default class SidebarMobile extends React.Component {
    * @param {object} e - Native click event
    */
   _handleBodyClick = e => {
-    const {isOpen, toggle} = this.props;
+    const { isOpen, toggle } = this.props;
     if (isOpen && !this._container.contains(e.target)) {
       toggle(false);
     }

--- a/src/components/SidebarMobile/SidebarMobile.jsx
+++ b/src/components/SidebarMobile/SidebarMobile.jsx
@@ -39,8 +39,9 @@ export default class SidebarMobile extends React.Component {
     );
   }
 
-  _toggleBodyListener(add) {
+  _toggleBodyListener = (add) => {
     let actionName = add ? 'addEventListener' : 'removeEventListener';
+    window[actionName]('touchstart', this._handleBodyClick);
     window[actionName]('mousedown', this._handleBodyClick);
   }
 
@@ -109,14 +110,12 @@ export default class SidebarMobile extends React.Component {
   /**
    * Handle clicks on content
    *
-   * @param {object} e - Native click event
+   * @param {object} <embed src="" type=""/> - Native click event
    */
   _handleBodyClick = e => {
-    if (
-      this.props.isOpen &&
-      !this._container.contains(e.target)
-    ) {
-      this.props.toggle(false);
+    const {isOpen, toggle} = this.props;
+    if (isOpen && !this._container.contains(e.target)) {
+      toggle(false);
     }
   }
 

--- a/src/components/SidebarMobile/SidebarMobile.jsx
+++ b/src/components/SidebarMobile/SidebarMobile.jsx
@@ -39,7 +39,7 @@ export default class SidebarMobile extends React.Component {
     );
   }
 
-  _toggleBodyListener = (add) => {
+  _toggleBodyListener = add => {
     let actionName = add ? 'addEventListener' : 'removeEventListener';
     window[actionName]('touchstart', this._handleBodyClick);
     window[actionName]('mousedown', this._handleBodyClick);
@@ -110,7 +110,7 @@ export default class SidebarMobile extends React.Component {
   /**
    * Handle clicks on content
    *
-   * @param {object} <embed src="" type=""/> - Native click event
+   * @param {object} e - Native click event
    */
   _handleBodyClick = e => {
     const {isOpen, toggle} = this.props;

--- a/src/components/SidebarMobile/SidebarMobile.scss
+++ b/src/components/SidebarMobile/SidebarMobile.scss
@@ -50,9 +50,9 @@
 }
 
 .sidebar-mobile__close {
-  position: fixed;
+  position: absolute;
   cursor: pointer;
-  right: 40px;
+  right: 22px;
   top: 10px;
   font-size: 1.3em;
   background-color: getColor(denim);

--- a/src/components/SidebarMobile/SidebarMobile.scss
+++ b/src/components/SidebarMobile/SidebarMobile.scss
@@ -50,9 +50,9 @@
 }
 
 .sidebar-mobile__close {
-  position: absolute;
+  position: fixed;
   cursor: pointer;
-  right: 22px;
+  right: 40px;
   top: 10px;
   font-size: 1.3em;
   background-color: getColor(denim);


### PR DESCRIPTION
On mobile, body click wasn't closing the SidebarMobile as mobile doesn't trigger `mousedown` event when you touch