### PR TITLE
docs(loggingDebug): add more details for stats.loggingDebug core logging

### DIFF
--- a/src/content/configuration/stats.md
+++ b/src/content/configuration/stats.md
@@ -12,6 +12,7 @@ contributors:
   - Raiondesu
   - EugeneHlushko
   - grgur
+  - skovy
 ---
 
 The `stats` option lets you precisely control what bundle information gets displayed. This can be a nice middle ground if you don't want to use `quiet` or `noInfo` because you want some bundle information, but not all of it.
@@ -154,6 +155,7 @@ module.exports = {
     // when stats.logging is false, stats.loggingDebug option is ignored.
     // Possible values: String | RegExp | (warning) => boolean | [String, RegExp, (name) => boolean]
     // Example values: 'MyPlugin' | /MyPlugin/ | ['MyPlugin', /MyPlugin/] | (name) => name.contains('MyPlugin')
+    // Enable core logging: /webpack/
     loggingDebug: [],
 
     // Enable stack traces in logging output for errors, warnings and traces.


### PR DESCRIPTION
The `stats.loggingDebug` option was originally added in https://github.com/webpack/webpack/pull/9436. 

But https://github.com/webpack/webpack/pull/9476 added support for core logging with `/webpack/`.

Resolves https://github.com/webpack/webpack.js.org/issues/3215.