### PR TITLE
docs(module): update module.type naming change

### DIFF
--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -14,6 +14,7 @@ contributors:
   - EugeneHlushko
   - superburrito
   - lukasgeiter
+  - skovy
 ---
 
 These options determine how the [different types of modules](/concepts/modules) within a project will be treated.
@@ -296,7 +297,7 @@ Indicate what parts of the module contain side effects. See [Tree Shaking](/guid
 
 `string`
 
-Possible values: `'javascript/auto' | 'javascript/dynamic' | 'javascript/esm' | 'json' | 'webassembly/experimental'`
+Possible values: `'javascript/auto' | 'javascript/dynamic' | 'javascript/esm' | 'json' | 'webassembly/sync' | 'webassembly/async'`
 
 `Rule.type` sets the type for a matching module. This prevents defaultRules and their default importing behaviors from occurring. For example, if you want to load a `.json` file through a custom loader, you'd need to set the `type` to `javascript/auto` to bypass webpack's built-in json importing. (See [v4.0 changelog](https://github.com/webpack/webpack/releases/tag/v4.0.0) for more details)
 


### PR DESCRIPTION
Resolves https://github.com/webpack/webpack.js.org/issues/3195

Changed in https://github.com/webpack/webpack/pull/9415.