### PR TITLE
Fix aspect ratio open collective sponsors

### DIFF
--- a/src/components/Support/Support.scss
+++ b/src/components/Support/Support.scss
@@ -25,26 +25,37 @@
   }
 
   &__latest-avatar {
-    height: 64px;
+    max-height: 64px;
     max-width: 192px;
+    vertical-align: middle;
   }
 
   &__bronze-avatar {
-    height: 32px;
+    max-height: 32px;
     max-width: 96px;
+    vertical-align: middle;
   }
 
   &__silver-avatar {
-    height: 64px;
+    max-height: 64px;
     max-width: 192px;
+    vertical-align: middle;
   }
 
   &__gold-avatar {
-    height: 96px;
+    max-height: 96px;
+    max-width: 288px;
+    vertical-align: middle;
   }
 
   &__platinum-avatar {
-    height: 128px;
+    max-height: 128px;
+    max-width: 100%;
+    vertical-align: middle;
+
+    @media (min-width: 400px) {
+      max-width: 384px;
+    }
   }
 
   &__backer-avatar {


### PR DESCRIPTION
Some sponsors on the homepage have stretched logos. This PR fixes this by using `max-height` instead of `height`. Images are also aligned in the middle for a more natural look. I've also limited the width of platinum & gold members, this has no effect at the moment but is just a fix just in case someone has a superwide logo in the future.

## Before

![webpack js org_(iPad Pro)](https://user-images.githubusercontent.com/11559216/64343689-4ac2f400-cfed-11e9-9788-5136bce060dd.png)

## After

![webpack js org_(iPad Pro) (1)](https://user-images.githubusercontent.com/11559216/64343702-4eef1180-cfed-11e9-9213-25d029b71739.png)

The difference is most noticeable in the **intracto** and **TEKHATTAN** logos (Bronze sponsors).

