### PR TITLE
typo

### DIFF
--- a/src/content/concepts/plugins.md
+++ b/src/content/concepts/plugins.md
@@ -35,7 +35,7 @@ class ConsoleLogOnBuildWebpackPlugin {
 module.exports = ConsoleLogOnBuildWebpackPlugin;
 ```
 
-The first parameter of the tap method of the compiler hook should be a camelized version of the plugin name. It is advisable to use a constant for this so it can be reused in all hooks.
+The first parameter of the top method of the compiler hook should be a camelized version of the plugin name. It is advisable to use a constant for this so it can be reused in all hooks.
 
 ## Usage
 


### PR DESCRIPTION
there is a typo which should be 'top method' instead of 'tap method', I think.



[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
