### PR TITLE
UX: Make Content links visible (not hidden behind site header)

### DIFF
--- a/src/components/Markdown/Markdown.scss
+++ b/src/components/Markdown/Markdown.scss
@@ -38,6 +38,11 @@
     margin: 1.5em 0 0.25em;
     color: getColor(fiord);
     word-break: break-all;
+    
+    &[id] {
+      padding-top: 100px;
+      margin-top: calc(-100px + 1.5em);
+    }
 
     tt,
     code {

--- a/src/components/Markdown/Markdown.scss
+++ b/src/components/Markdown/Markdown.scss
@@ -2,6 +2,20 @@
 @import 'functions';
 @import 'prism-theme';
 
+.page .markdown {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    .page &[id] {
+      padding-top: 100px;
+      margin-top: calc(-100px + 1.5em);
+    }
+  }
+}
+
 .markdown {
   line-height: 1.5em;
 
@@ -38,11 +52,6 @@
     margin: 1.5em 0 0.25em;
     color: getColor(fiord);
     word-break: break-all;
-    
-    &[id] {
-      padding-top: 100px;
-      margin-top: calc(-100px + 1.5em);
-    }
 
     tt,
     code {

--- a/src/components/Markdown/Markdown.scss
+++ b/src/components/Markdown/Markdown.scss
@@ -9,7 +9,7 @@
   h4,
   h5,
   h6 {
-    .page &[id] {
+    &[id] {
       padding-top: 100px;
       margin-top: calc(-100px + 1.5em);
     }


### PR DESCRIPTION
Fixes the issue where one must constantly scroll up a bit after clicking a sidebar link (because content is hidden behind the site header).

The current documention site hides headers behind the site header. Clicking on a sidebar link, you should notice that you have to scroll up to see the title. This improves the experience.

This doesn't account for the additional notification banner that pushes the header down.

You can experiment with this proposed fix by adding this to the live site in dev tools:
```css
.markdown h3[id] {
    padding-top: 100px;
    margin-top: calc(-100px + 1.5em);
}
```
