### PR TITLE
Build performance: progress plugin

### DIFF
--- a/src/content/guides/build-performance.md
+++ b/src/content/guides/build-performance.md
@@ -111,7 +111,7 @@ Profile them to not introduce a performance problem here.
 
 ### Progress plugin
 
-If you already have a fast build time `progress-plugin` can be excessive. If you have long build times consider removing `progress-plugin` where the build happens to be remotely, for example your server or CI.
+If you already have a fast build time, `progress-plugin` can be excessive. If you have long build times, consider removing `progress-plugin` where the build happens to be remotely, for example your server or CI.
 
 ---
 

--- a/src/content/guides/build-performance.md
+++ b/src/content/guides/build-performance.md
@@ -111,7 +111,6 @@ Profile them to not introduce a performance problem here.
 
 ### Progress plugin
 
-
 It is possible to shorten build times by removing `progress-plugin` from webpack's configuration. Keep in mind, `progress-plugin` might not provide as much value for fast builds as well, so make sure you are leveraging the benefits of using it.
 
 ---

--- a/src/content/guides/build-performance.md
+++ b/src/content/guides/build-performance.md
@@ -109,6 +109,10 @@ Enable persistent caching with the `cache-loader`. Clear cache directory on `"po
 
 Profile them to not introduce a performance problem here.
 
+### Progress plugin
+
+If you already have a fast build time `progress-plugin` can be excessive. If you have long build times consider removing `progress-plugin` where the build happens to be remotely, for example your server or CI.
+
 ---
 
 

--- a/src/content/guides/build-performance.md
+++ b/src/content/guides/build-performance.md
@@ -111,7 +111,8 @@ Profile them to not introduce a performance problem here.
 
 ### Progress plugin
 
-If you already have a fast build time, `progress-plugin` can be excessive. If you have long build times, consider removing `progress-plugin` where the build happens to be remotely, for example your server or Continious Integration.
+
+It is possible to shorten build times by removing `progress-plugin` from webpack's configuration. Keep in mind, `progress-plugin` might not provide as much value for fast builds as well, so make sure you are leveraging the benefits of using it.
 
 ---
 

--- a/src/content/guides/build-performance.md
+++ b/src/content/guides/build-performance.md
@@ -111,7 +111,7 @@ Profile them to not introduce a performance problem here.
 
 ### Progress plugin
 
-If you already have a fast build time, `progress-plugin` can be excessive. If you have long build times, consider removing `progress-plugin` where the build happens to be remotely, for example your server or CI.
+If you already have a fast build time, `progress-plugin` can be excessive. If you have long build times, consider removing `progress-plugin` where the build happens to be remotely, for example your server or Continious Integration.
 
 ---
 


### PR DESCRIPTION
Hello, I've recently discovered that Progress plugin tend to slow down build time and therefore wanted to note that in the docs.

In my tests by removing `progress-plugin` I was able to shave off 15~30 seconds from a production build time. At our compony prod build usually takes about 5 minutes so the change may reduce the build time from 5 to 10%. Also since prod builds tend to happen remotely on a server or a CI system I think it is a good idea to keep the log files leaner.

I am not too sure about the wording and would love to get any feedback. Thank you for the awesome docs.