### PR TITLE
docs(concepts) fix e.g. spelling

### DIFF
--- a/src/content/concepts/module-resolution.md
+++ b/src/content/concepts/module-resolution.md
@@ -61,7 +61,7 @@ You can replace the original module path by an alternate path by creating an ali
 Once the path is resolved based on the above rule, the resolver checks to see if the path points to a file or a directory. If the path points to a file:
 
 - If the path has a file extension, then the file is bundled straightaway.
-- Otherwise, the file extension is resolved using the [`resolve.extensions`](/configuration/resolve/#resolveextensions) option, which tells the resolver which extensions (eg - `.js`, `.jsx`) are acceptable for resolution.
+- Otherwise, the file extension is resolved using the [`resolve.extensions`](/configuration/resolve/#resolveextensions) option, which tells the resolver which extensions are acceptable for resolution e.g. `.js`, `.jsx`.
 
 If the path points to a folder, then the following steps are taken to find the right file with the right extension:
 


### PR DESCRIPTION
We usually use `e.g.` across the docs and it seems pretty off here