### PR TITLE
docs(DevServer): document writeToDisk output dir

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -1533,7 +1533,7 @@ See [WatchOptions](/configuration/watch/) for more options.
 
 `boolean = false` `function (filePath)`
 
-Tells `devServer` to write generated assets to the disk.
+Tells `devServer` to write generated assets to the disk. The output is written to the [output.path](/configuration/output/#outputpath) directory, which is `./dist` by default.
 
 __webpack.config.js__
 

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -1533,7 +1533,7 @@ See [WatchOptions](/configuration/watch/) for more options.
 
 `boolean = false` `function (filePath)`
 
-Tells `devServer` to write generated assets to the disk. The output is written to the [output.path](/configuration/output/#outputpath) directory, which is `./dist` by default.
+Tells `devServer` to write generated assets to the disk. The output is written to the [output.path](/configuration/output/#outputpath) directory.
 
 __webpack.config.js__
 


### PR DESCRIPTION
Tell users of `DevServer.writeToDisk` where to find the output that gets written to disk.

fixes #3304 