### PR TITLE
docs(DevServer): expand on `devServer.openPage` usage

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -805,7 +805,7 @@ T> The browser application name is platform dependent. Don't hard code it in reu
 
 ## `devServer.openPage`
 
-`string` `array = []: string`
+`string` `[string]`
 
 Specify a page to navigate to when opening the browser.
 

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -840,6 +840,7 @@ module.exports = {
 ```
 
 Usage via the CLI
+
 ```bash
 webpack-dev-server --open-page "/different/page1,/different/page2"
 ```

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -13,6 +13,7 @@ contributors:
   - Loonride
   - dmohns
   - EslamHiko
+  - digitaljohn
 ---
 
 [webpack-dev-server](https://github.com/webpack/webpack-dev-server) can be used to quickly develop an application. See the [development guide](/guides/development/) to get started.
@@ -804,7 +805,7 @@ T> The browser application name is platform dependent. Don't hard code it in reu
 
 ## `devServer.openPage`
 
-`string`
+`string` `array = []: string`
 
 Specify a page to navigate to when opening the browser.
 
@@ -823,6 +824,24 @@ Usage via the CLI
 
 ```bash
 webpack-dev-server --open-page "/different/page"
+```
+
+If you wish to specify multiple pages to open in the browser.
+
+__webpack.config.js__
+
+```javascript
+module.exports = {
+  //...
+  devServer: {
+    openPage: ['/different/page1', '/different/page2']
+  }
+};
+```
+
+Usage via the CLI
+```bash
+webpack-dev-server --open-page "/different/page1,/different/page2"
 ```
 
 


### PR DESCRIPTION
Changed documentation of `devServer.openPage` based on **unreleased** changes discussed here:
https://github.com/webpack/webpack-dev-server/pull/2266

> DO NOT MERGE until the aforementioned PR is integrated.