### PR TITLE
docs(concepts) loaders command fix and message re-worked

### DIFF
--- a/src/content/concepts/loaders.mdx
+++ b/src/content/concepts/loaders.mdx
@@ -25,8 +25,7 @@ Loaders are transformations that are applied on the source code of a module. The
 For example, you can use loaders to tell webpack to load a CSS file or to convert TypeScript to JavaScript. To do this, you would start by installing the loaders you need:
 
 ``` bash
-npm install --save-dev css-loader
-npm install --save-dev ts-loader
+npm install --save-dev css-loader ts-loader
 ```
 
 And then instruct webpack to use the [`css-loader`](/loaders/css-loader) for every `.css` file and the [`ts-loader`](https://github.com/TypeStrong/ts-loader) for all `.ts` files:
@@ -141,8 +140,7 @@ This uses the `jade-loader` for `.jade` files, and the [`style-loader`](/loaders
 - Plugins can give loaders more features.
 - Loaders can emit additional arbitrary files.
 
-Loaders allow more power in the JavaScript ecosystem through preprocessing
-functions (loaders). Users now have more flexibility to include fine-grained logic such as compression, packaging, language translations and [more](/loaders).
+Loaders provide a way to customize the output through their preprocessing functions. Users now have more flexibility to include fine-grained logic such as compression, packaging, language translations and [more](/loaders).
 
 
 ## Resolving Loaders


### PR DESCRIPTION
npm install command wasnt running without `&&` notation so it makes sense to merge it.
The loaders ecosystem empowerment phrase was not backed up nor it wasn't straightforward, reworded it
