### PR TITLE
docs(configuration): add onListening, update after and before in devServer

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -766,7 +766,7 @@ module.exports = {
 
 `function (server)`
 
-This option allow to developers run own scripts after run webpack-dev-server
+Provides an option to execute a custom function when `webpack-dev-server` starts listening for connections on a port.
 
 __webpack.config.js__
 
@@ -775,7 +775,8 @@ module.exports = {
   //...
   devServer: {
     onListening: function(server) {
-      // do fancy stuff
+      const port = server.listeningApp.address().port;
+      console.log('Listening on port:', port);
     }
   }
 };

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -63,7 +63,7 @@ T> HTML template is required to serve the bundle, usually it is an `index.html` 
 
 ## `devServer.after`
 
-`function (app, server)`
+`function (app, server, compiler)`
 
 Provides the ability to execute custom middleware after all other middleware
 internally within the server.
@@ -74,7 +74,7 @@ __webpack.config.js__
 module.exports = {
   //...
   devServer: {
-    after: function(app, server) {
+    after: function(app, server, compiler) {
       // do fancy stuff
     }
   }
@@ -130,7 +130,7 @@ webpack-dev-server --entry /entry/file --output-path /output/path --allowed-host
 
 ## `devServer.before`
 
-`function (app, server)`
+`function (app, server, compiler)`
 
 Provides the ability to execute custom middleware prior to all other middleware
 internally within the server. This could be used to define custom handlers, for
@@ -142,7 +142,7 @@ __webpack.config.js__
 module.exports = {
   //...
   devServer: {
-    before: function(app, server) {
+    before: function(app, server, compiler) {
       app.get('/some/path', function(req, res) {
         res.json({ custom: 'response' });
       });
@@ -762,6 +762,24 @@ module.exports = {
 };
 ```
 
+## `devServer.onListening`
+
+`function (server)`
+
+This option allow to developers run own scripts after run webpack-dev-server
+
+__webpack.config.js__
+
+```javascript
+module.exports = {
+  //...
+  devServer: {
+    onListening: function(server) {
+      // do fancy stuff
+    }
+  }
+};
+```
 
 ## `devServer.open`
 


### PR DESCRIPTION
onListening was added in 3.5.0
https://github.com/webpack/webpack-dev-server/pull/1760

compiler arg for after and before functions was added in 3.3.0
https://github.com/webpack/webpack-dev-server/blob/master/CHANGELOG.md#features-4

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.