### PR TITLE
docs(types) mention computed object key syntax and correct existing case

### DIFF
--- a/src/content/concepts/entry-points.md
+++ b/src/content/concepts/entry-points.md
@@ -44,7 +44,7 @@ This is a great choice when you are looking to quickly setup a webpack configura
 
 ## Object Syntax
 
-Usage: `entry: { [entryChunkName] string [string] }`
+Usage: `entry: { <entryChunkName> string | [string] }`
 
 __webpack.config.js__
 

--- a/src/content/contribute/writers-guide.md
+++ b/src/content/contribute/writers-guide.md
@@ -206,3 +206,13 @@ To mark a number, use `number`:
 To mark an object, use `object`:
 
 `object = { prop1 string = 'none': 'none' | 'development' | 'production', prop2 boolean = false, prop3 function (module) => string }`
+
+When object's key can have multiple types, use `|` to list them. Here is an example, where `prop1` can be both a string and an array of strings:
+
+`object = { prop1 string = 'none': 'none' | 'development' | 'production' | [string]}`
+
+This allows us to display the defaults, enumeration and other information.
+
+If the object's key is dynamic, user-defined, use `<key>` to describe it:
+
+`object = { <key> string }`


### PR DESCRIPTION
- add the missing `<>` syntax for computed object props to the writers guide
- change recently updated example accordingly

Reference of current usage: https://webpack.js.org/configuration/entry-context/#entry