### PR TITLE
docs(multiple) remove webpack 1-2 notes as webpack 5 is closing in

### DIFF
--- a/src/content/configuration/index.mdx
+++ b/src/content/configuration/index.mdx
@@ -182,8 +182,6 @@ module.exports = {
         // flags to apply these rules, even if they are overridden (advanced option)
         loader: "babel-loader",
         // the loader which should be applied, it'll be resolved relative to the context
-        // -loader suffix is no longer optional in webpack2 for clarity reasons
-        // see webpack 1 upgrade guide
         options: {
           presets: ["es2015"]
         },

--- a/src/content/plugins/commons-chunk-plugin.md
+++ b/src/content/plugins/commons-chunk-plugin.md
@@ -69,8 +69,6 @@ new webpack.optimize.CommonsChunkPlugin(options);
 }
 ```
 
-T> The deprecated webpack 1 constructor `new webpack.optimize.CommonsChunkPlugin(options, filenameTemplate, selectedChunks, minChunks)` is no longer supported. Use a corresponding options object instead.
-
 
 ## Examples
 


### PR DESCRIPTION
Removing very old references.
Another question i have is should we remove LoaderOptionsPlugin and its references too or should we update its description.