### PR TITLE
docs(api) mention the version caveat for the new compilation object m…

### DIFF
--- a/src/content/api/compilation-object.md
+++ b/src/content/api/compilation-object.md
@@ -327,6 +327,8 @@ Parameters:
 
 `function (file, source, assetInfo = {})`
 
+W> Available since webpack 4.40.0
+
 Parameters:
 
 - `file` - file name of the asset
@@ -336,6 +338,8 @@ Parameters:
 ### updateAsset
 
 `function (file, newSourceOrFunction, assetInfoUpdateOrFunction)`
+
+W> Available since webpack 4.40.0
 
 Parameters:
 
@@ -347,11 +351,15 @@ Parameters:
 
 `function`
 
+W> Available since webpack 4.40.0
+
 Returns array of all assets under current compilation.
 
 ### getAsset
 
 `function (name)`
+
+W> Available since webpack 4.40.0
 
 Parameters:
 


### PR DESCRIPTION
…ethods
The methods added in https://github.com/webpack/webpack.js.org/pull/3282 need a note on the availability version since they were added pretty late onto webpack 4