### PR TITLE
Upgrade to hyperlink 4.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "html-webpack-template": "^6.1.0",
     "http-server": "^0.10.0",
     "husky": "^1.0.0-rc.8",
-    "hyperlink": "^4.3.1",
+    "hyperlink": "^4.4.0",
     "lint-staged": "^8.1.0",
     "loader-utils": "^1.1.0",
     "lodash": "^4.17.4",

--- a/src/content/api/hot-module-replacement.md
+++ b/src/content/api/hot-module-replacement.md
@@ -13,7 +13,7 @@ related:
     url: /guides/hot-module-replacement
 ---
 
-If [Hot Module Replacement](/concepts/hot-module-replacement) has been enabled via the [`HotModuleReplacementPlugin`](/plugins/hot-module-replacement-plugin), its interface will be exposed under the [`module.hot` property](/api/module-variables#modulehot-webpack-specific). Typically, users will check to see if the interface is accessible, then begin working with it. As an example, here's how you might `accept` an updated module:
+If [Hot Module Replacement](/concepts/hot-module-replacement) has been enabled via the [`HotModuleReplacementPlugin`](/plugins/hot-module-replacement-plugin), its interface will be exposed under the [`module.hot` property](/api/module-variables/#modulehot-webpack-specific). Typically, users will check to see if the interface is accessible, then begin working with it. As an example, here's how you might `accept` an updated module:
 
 ``` js
 if (module.hot) {

--- a/src/content/api/loaders.md
+++ b/src/content/api/loaders.md
@@ -99,9 +99,9 @@ module.exports.raw = true;
 
 Loaders are __always__ called from right to left. There are some instances where the loader only cares about the __metadata__ behind a request and can ignore the results of the previous loader. The `pitch` method on loaders is called from __left to right__ before the loaders are actually executed (from right to left).
 
-T> Loaders may be added inline in requests and disabled via inline prefixes, which will impact the order in which they are "pitched" and executed. See [`Rule.enforce`](/configuration/module#ruleenforce) for more details.
+T> Loaders may be added inline in requests and disabled via inline prefixes, which will impact the order in which they are "pitched" and executed. See [`Rule.enforce`](/configuration/module/#ruleenforce) for more details.
 
-For the following configuration of [`use`](/configuration/module#ruleuse):
+For the following configuration of [`use`](/configuration/module/#ruleuse):
 
 ``` javascript
 module.exports = {

--- a/src/content/api/module-methods.md
+++ b/src/content/api/module-methods.md
@@ -177,7 +177,7 @@ W> Using it asynchronously may not have the expected effect.
 require.resolve(dependency: String);
 ```
 
-Synchronously retrieve a module's ID. The compiler will ensure that the dependency is available in the output bundle. See [`module.id`](/api/module-variables#moduleid-commonjs) for more information.
+Synchronously retrieve a module's ID. The compiler will ensure that the dependency is available in the output bundle. See [`module.id`](/api/module-variables/#moduleid-commonjs) for more information.
 
 W> Module ID is a number in webpack (in contrast to NodeJS where it is a string -- the filename).
 

--- a/src/content/api/node.mdx
+++ b/src/content/api/node.mdx
@@ -232,7 +232,7 @@ of this function’s output.
 Returns a formatted string of the compilation information (similar to
 [CLI](/api/cli) output).
 
-Options are the same as [`stats.toJson(options)`](/api/node#statstojsonoptions) with one addition:
+Options are the same as [`stats.toJson(options)`](/api/node/#statstojsonoptions) with one addition:
 
 ``` js
 stats.toString({

--- a/src/content/api/stats.mdx
+++ b/src/content/api/stats.mdx
@@ -83,7 +83,7 @@ T> Asset's `info` property is available since webpack v4.40.0
 
 ### Chunk Objects
 
-Each `chunks` object represents a group of modules known as a [chunk](/glossary#c). Each object follows the following structure:
+Each `chunks` object represents a group of modules known as a [chunk](/glossary/#c). Each object follows the following structure:
 
 ```js-with-links
 {
@@ -143,13 +143,13 @@ What good would these statistics be without some description of the compiled app
   ],
   "errors": 0, // Number of errors when resolving or processing the module
   "failed": false, // Whether or not compilation failed on this module
-  "id": 0, // The ID of the module (analogous to [`module.id`](/api/module-variables#moduleid-commonjs))
+  "id": 0, // The ID of the module (analogous to [`module.id`](/api/module-variables/#moduleid-commonjs))
   "identifier": "(webpack)\\test\\browsertest\\lib\\index.web.js", // A unique ID used internally
   "name": "./lib/index.web.js", // Path to the actual file
   "optional": false, // All requests to this module are with `try... catch` blocks (irrelevant with ESM)
   "prefetched": false, // Indicates whether or not the module was [prefetched](/plugins/prefetch-plugin)
   "profile": {
-    // Module specific compilation stats corresponding to the [`--profile` flag](/api/cli#profiling) (in milliseconds)
+    // Module specific compilation stats corresponding to the [`--profile` flag](/api/cli/#profiling) (in milliseconds)
     "building": 73, // Loading and parsing
     "dependencies": 242, // Building dependencies
     "factory": 11 // Resolving dependencies

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -74,7 +74,7 @@ In a Rule the properties [`test`](#ruletest), [`include`](#ruleinclude), [`exclu
 
 When using multiple conditions, all conditions must match.
 
-W> Be careful! The resource is the _resolved_ path of the file, which means symlinked resources are the real path _not_ the symlink location. This is good to remember when using tools that symlink packages (like `npm link`), common conditions like `/node_modules/` may inadvertently miss symlinked files. Note that you can turn off symlink resolving (so that resources are resolved to the symlink path) via [`resolve.symlinks`](/configuration/resolve#resolvesymlinks).
+W> Be careful! The resource is the _resolved_ path of the file, which means symlinked resources are the real path _not_ the symlink location. This is good to remember when using tools that symlink packages (like `npm link`), common conditions like `/node_modules/` may inadvertently miss symlinked files. Note that you can turn off symlink resolving (so that resources are resolved to the symlink path) via [`resolve.symlinks`](/configuration/resolve/#resolvesymlinks).
 
 
 ### Rule results

--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -240,7 +240,7 @@ For example, if you have 2 libraries, with namespaces `library1` and `library2`,
 
 This option determines the name of each output bundle. The bundle is written to the directory specified by the [`output.path`](#outputpath) option.
 
-For a single [`entry`](/configuration/entry-context#entry) point, this can be a static name.
+For a single [`entry`](/configuration/entry-context/#entry) point, this can be a static name.
 
 __webpack.config.js__
 

--- a/src/content/glossary.md
+++ b/src/content/glossary.md
@@ -15,7 +15,7 @@ This index lists common terms used throughout the webpack ecosystem.
 
 ## A
 
-- [__Asset__](/guides/asset-management/): This a general term for the images, fonts, media, and any other kind of files that are typically used in websites and other applications. These typically end up as individual files within the [output](/glossary#o) but can also be inlined via things like the [style-loader](/loaders/style-loader) or [url-loader](/loaders/url-loader).
+- [__Asset__](/guides/asset-management/): This a general term for the images, fonts, media, and any other kind of files that are typically used in websites and other applications. These typically end up as individual files within the [output](/glossary/#o) but can also be inlined via things like the [style-loader](/loaders/style-loader) or [url-loader](/loaders/url-loader).
 
 
 ## B


### PR DESCRIPTION
Hyperlink 4.4.0 has a new feature that will detect broken fragment links of the form `/page#fragment` where `/page` is actually a redirect to `/page/` because it's a directory with an index file. In this case the server redirect will strip the fragment, thus breaking the intended link.

See errors in the current `master` branch here: https://travis-ci.org/webpack/webpack.js.org/jobs/604644796#L2041-L2159

The following commit fixes all those errors.

Relates to https://github.com/webpack/webpack.js.org/pull/3332
