### PR TITLE
Add `: false` to `bail` documentation

### DIFF
--- a/src/content/configuration/other-options.md
+++ b/src/content/configuration/other-options.md
@@ -48,7 +48,7 @@ As it happens, the AMD support in webpack ignores the defined name anyways.
 
 ## `bail`
 
-`boolean: false`
+`boolean = false`
 
 Fail out on the first error instead of tolerating it. By default webpack will log these errors in red in the terminal, as well as the browser console when using HMR, but continue bundling. To enable it:
 

--- a/src/content/configuration/other-options.md
+++ b/src/content/configuration/other-options.md
@@ -48,7 +48,7 @@ As it happens, the AMD support in webpack ignores the defined name anyways.
 
 ## `bail`
 
-`boolean`
+`boolean: false`
 
 Fail out on the first error instead of tolerating it. By default webpack will log these errors in red in the terminal, as well as the browser console when using HMR, but continue bundling. To enable it:
 


### PR DESCRIPTION
This will make it clearer that this is `false` by default.

https://github.com/webpack/webpack/blob/408a4ae77eb3f7441d6dd2dc011f23e491e8fbfb/lib/Compilation.js#L501
