### PR TITLE
Correct `stats.entrypoints` default value

### DIFF
--- a/src/content/configuration/stats.md
+++ b/src/content/configuration/stats.md
@@ -288,7 +288,7 @@ module.exports = {
 
 ### `stats.entrypoints`
 
-`boolean = false`
+`boolean = true`
 
 Tells `stats` whether to display the entry points with the corresponding bundles.
 
@@ -296,7 +296,7 @@ Tells `stats` whether to display the entry points with the corresponding bundles
 module.exports = {
   //...
   stats: {
-    entrypoints: true
+    entrypoints: false
   }
 };
 ```


### PR DESCRIPTION
While configuring the stats to display, without using the entrypoints option, I found out the entrypoints were appearing to the log, even when in the documentation was shown with a default value of `false`. I checked in the [file where defaults are defined](https://github.com/webpack/webpack/blob/beec753201763fa3724bd965a93106126d13b271/lib/stats/DefaultStatsPresetPlugin.js), and in line 112 it implicitly appears the default value is `true`, so I've edited the documentation to reflect it.
