### PR TITLE
Change `: false` to `= false` in other options

### DIFF
--- a/src/content/configuration/other-options.md
+++ b/src/content/configuration/other-options.md
@@ -22,7 +22,7 @@ W> Help Wanted: This page is still a work in progress. If you are familiar with 
 
 ## `amd`
 
-`object` `boolean: false`
+`object` `boolean = false`
 
 Set the value of `require.amd` or `define.amd`. Setting `amd` to `false` will disable webpack's AMD support.
 


### PR DESCRIPTION
This brings it in line with the writers guide. https://webpack.js.org/contribute/writers-guide/#configuration-defaults-and-types
