### PR TITLE
Fix: corrected the mentioned loader api adddependency

### DIFF
--- a/src/content/api/loaders.md
+++ b/src/content/api/loaders.md
@@ -402,7 +402,7 @@ addDependency(file: string)
 dependency(file: string) // shortcut
 ```
 
-Add a file as dependency of the loader result in order to make them watchable. For example, [`html-loader`](https://github.com/webpack-contrib/html-loader) uses this technique as it finds `src` and `src-set` attributes. Then, it sets the URLs for those attributes as dependencies of the html file that is parsed.
+Add a file as dependency of the loader result in order to make them watchable. For example, [`sass-loader`](https://github.com/webpack-contrib/sass-loader), [`less-loader`](https://github.com/webpack-contrib/less-loader) uses this to recompile whenever any imported `css` file changes.
 
 
 ### `this.addContextDependency`


### PR DESCRIPTION
`html-loader` doesnt uses `addDependency` method, _Might be outdated with the changes_
I changed the example with `sass-loader` and `less-loader` which does use it

Follow up of https://github.com/webpack/webpack.js.org/pull/3353

_I messed up the reverting and somehow I couldnt reopen that PR even though this branch is ahead of master so had to make a new one_
