### PR TITLE
docs(versions) adds a snippet of the current doc version and link to …

### DIFF
--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -20,7 +20,7 @@ const docs = [
   }
 ];
 
-const currentDocsVersion = 4;
+const currentDocsVersion = 5;
 
 // Create and export the component
 export default ({

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -9,6 +9,19 @@ import Print from '../Print/Print';
 // Load Styling
 import './Sidebar.scss';
 
+const docs = [
+  {
+    version: 5,
+    url: 'https://webpack.js.org',
+  },
+  {
+    version: 4,
+    url: 'https://v4.webpack.js.org',
+  }
+];
+
+const currentDocsVersion = 4;
+
 // Create and export the component
 export default ({
   className = '',
@@ -45,6 +58,14 @@ export default ({
             </div>
           );
         })}
+        <div className="sidebar__docs-version">
+          You are reading webpack {currentDocsVersion} documentation. Change here to:
+          <ul>
+            {docs.filter(item => item.version !== currentDocsVersion).map(item => <li key={`webpack-${item.version}-docs`}>
+              <a rel="nofollow" href={item.url}>webpack {item.version} documentation</a>
+            </li>)}
+          </ul>
+        </div>
       </div>
     </nav>
   );

--- a/src/components/Sidebar/Sidebar.scss
+++ b/src/components/Sidebar/Sidebar.scss
@@ -51,3 +51,20 @@
     }
   }
 }
+
+.sidebar__docs-version {
+  color: #535353;
+  border-top: 1px solid #f2f2f2;
+  margin-top: 12px;
+  padding-top: 12px;
+  font-size: 15px;
+
+  ul {
+    margin-top: 12px;
+
+    li {
+      margin-top: 6px;
+      list-style: none;
+    }
+  }
+}

--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -160,7 +160,7 @@ class Site extends React.Component {
       sort,
       anchors,
       children: children ? this._strip(children) : []
-    })).filter(page => page.title !== 'printable.md');
+    })).filter(page => (page.title !== 'printable.md' && !page.content.includes('Printable')));
   };
 }
 


### PR DESCRIPTION
…other version(s)

v4.webpack.js.org:

<img width="1037" alt="Screen Shot 2019-11-19 at 11 33 48 AM" src="https://user-images.githubusercontent.com/10549495/69139278-791a8080-0ac0-11ea-9038-8b67baf09aac.png">

And for current version it will say 5

