### PR TITLE
docs(mode): minor fix on mode options enum

### DIFF
--- a/src/content/configuration/mode.md
+++ b/src/content/configuration/mode.md
@@ -13,7 +13,7 @@ related:
 
 Providing the `mode` configuration option tells webpack to use its built-in optimizations accordingly.
 
-`string = 'production': 'none' | 'development' | 'production'`
+`string = 'none' | 'development' | 'production'`
 
 ## Usage
 


### PR DESCRIPTION
Fix typo in mode enum, since production repeats twice.
