### PR TITLE
Add description of the option `stats.preset`

### DIFF
--- a/src/content/configuration/stats.md
+++ b/src/content/configuration/stats.md
@@ -591,6 +591,21 @@ module.exports = {
 };
 ```
 
+### `stats.preset`
+
+`string`
+
+Sets the [preset](/configuration/stats/#stats) for the type of information that gets displayed. It is useful for [extending stats behaviours](/configuration/stats/#extending-stats-behaviours).
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    preset: 'minimal'
+  }
+};
+```
+
 ### `stats.providedExports`
 
 `boolean = false`


### PR DESCRIPTION
There is no description  of `stats.preset`. Because of this there is no entry in the left menu. 