### PR TITLE
docs(webpack5): add new cache options

### DIFF
--- a/src/content/configuration/other-options.md
+++ b/src/content/configuration/other-options.md
@@ -10,6 +10,7 @@ contributors:
   - vansosnin
   - EugeneHlushko
   - skovy
+  - rishabh3112
 related:
   - title: Using Records
     url: https://survivejs.com/webpack/optimizing/separating-manifest/#using-records
@@ -210,6 +211,43 @@ module.exports = {
 
 W> Don't share the cache between calls with different options.
 
+### `cache.idleTimeout`
+
+`number = 10000`
+
+Time in `ms`. `cache.idleTimeout` denotes the time period after which the cache storing should happen. Defaults to `10000` which is equivalent to `10s`
+
+__webpack.config.js__
+
+```javascript
+module.exports = {
+  //..
+  cache: {
+    idleTimeout: 10000
+  }
+}
+```
+
+W> `cache.idleTimeout` is only available for when [`cache.store`](#cachestore) is set to either `'pack'` or `'idle'`
+
+### `cache.idleTimeoutForInitialStore`
+
+`number = 0`
+
+Time in `ms`. `cache.idleTimeoutForInitialStore` is the time period after which the initial cache storing should happen. It defaults to `0` which is equivalent to `0s`.
+
+__webpack.config.js__
+
+```javascript
+module.exports = {
+  //..
+  cache: {
+    idleTimoutForInitialStore: 0
+  }
+}
+```
+
+W> `cache.idleTimeoutForInitialStore` is only available for when [`cache.store`](#cachestore) is set to either `'pack'` or `'idle'`
 
 ## `loader`
 

--- a/src/content/configuration/other-options.md
+++ b/src/content/configuration/other-options.md
@@ -225,7 +225,7 @@ module.exports = {
   cache: {
     idleTimeout: 10000
   }
-}
+};
 ```
 
 W> `cache.idleTimeout` is only available for when [`cache.store`](#cachestore) is set to either `'pack'` or `'idle'`
@@ -244,7 +244,7 @@ module.exports = {
   cache: {
     idleTimoutForInitialStore: 0
   }
-}
+};
 ```
 
 W> `cache.idleTimeoutForInitialStore` is only available for when [`cache.store`](#cachestore) is set to either `'pack'` or `'idle'`

--- a/src/content/configuration/other-options.md
+++ b/src/content/configuration/other-options.md
@@ -228,7 +228,7 @@ module.exports = {
 };
 ```
 
-W> `cache.idleTimeout` is only available for when [`cache.store`](#cachestore) is set to either `'pack'` or `'idle'`
+W> `cache.idleTimeout` is only available when [`cache.store`](#cachestore) is set to either `'pack'` or `'idle'`
 
 ### `cache.idleTimeoutForInitialStore`
 

--- a/src/content/configuration/other-options.md
+++ b/src/content/configuration/other-options.md
@@ -215,7 +215,7 @@ W> Don't share the cache between calls with different options.
 
 `number = 10000`
 
-Time in `ms`. `cache.idleTimeout` denotes the time period after which the cache storing should happen. Defaults to `10000` which is equivalent to `10s`
+Time in milliseconds. `cache.idleTimeout` denotes the time period after which the cache storing should happen.
 
 __webpack.config.js__
 

--- a/src/content/configuration/other-options.md
+++ b/src/content/configuration/other-options.md
@@ -247,7 +247,7 @@ module.exports = {
 };
 ```
 
-W> `cache.idleTimeoutForInitialStore` is only available for when [`cache.store`](#cachestore) is set to either `'pack'` or `'idle'`
+W> `cache.idleTimeoutForInitialStore` is only available when [`cache.store`](#cachestore) is set to either `'pack'` or `'idle'`
 
 ## `loader`
 

--- a/src/content/configuration/other-options.md
+++ b/src/content/configuration/other-options.md
@@ -234,7 +234,7 @@ W> `cache.idleTimeout` is only available when [`cache.store`](#cachestore) is se
 
 `number = 0`
 
-Time in `ms`. `cache.idleTimeoutForInitialStore` is the time period after which the initial cache storing should happen. It defaults to `0` which is equivalent to `0s`.
+Time in milliseconds. `cache.idleTimeoutForInitialStore` is the time period after which the initial cache storing should happen.
 
 __webpack.config.js__
 


### PR DESCRIPTION
_describe your changes..._

Part of #2774
Adds documentations for:
1. `cache.idleTimeout` option
2. `cache.idleTimeoutForInitialStore` option