### PR TITLE
docs(module): add more information about nested rules

### DIFF
--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -16,6 +16,7 @@ contributors:
   - lukasgeiter
   - skovy
   - smelukov
+  - opl-
 ---
 
 These options determine how the [different types of modules](/concepts/modules) within a project will be treated.
@@ -101,7 +102,13 @@ The [`parser`](#ruleparser) property affects the parser options.
 
 Nested rules can be specified under the properties [`rules`](#rulerules) and [`oneOf`](#ruleoneof).
 
-These rules are evaluated when the Rule condition matches.
+These rules are evaluated only when the parent Rule condition matches. Each nested rule can contain its own conditions.
+
+The order of evaluation is as follows:
+
+1. The parent rule
+2. [`rules`](#rulerules)
+3. [`oneOf`](#ruleoneof)
 
 
 ## `Rule.enforce`
@@ -202,6 +209,9 @@ module.exports = {
   }
 };
 ```
+
+T> See [`Nested rules`](#nested-rules) for more information.
+
 
 ## `Rule.options` / `Rule.query`
 
@@ -411,6 +421,8 @@ module.exports = {
 ## `Rule.rules`
 
 An array of [`Rules`](#rule) that is also used when the Rule matches.
+
+T> See [`Nested rules`](#nested-rules) for more information.
 
 
 ## `Rule.sideEffects`


### PR DESCRIPTION
This change explains better the relationship between `Rule.rules` and `Rule.oneOf`.

It also makes the two more connected, by pointing to the Nested rules section, which is motivated by both [webpack-chain](https://github.com/neutrinojs/webpack-chain/pull/220) and [vue-loader](https://github.com/vuejs/vue-loader/blob/cf00a45cde52f3961b36b37265761b0d92affb0c/lib/plugin-webpack4.js#L149) developers having missed the existence of `Rule.rules`

EDIT: ~~Just realized I forgot to pull master before adding my changes. Fixing it right now.~~ Done. :+1:
