### PR TITLE
docs(guides) authoring libraries: source maps revamp

### DIFF
--- a/src/content/guides/author-libraries.md
+++ b/src/content/guides/author-libraries.md
@@ -176,20 +176,18 @@ module.exports = {
 };
 ```
 
-## Base Configuration with source map 
+## Base Configuration with source map
 
- Source maps is a useful debugging tool to enable you to view where the original code was.
- For more information about getting source maps setup and available options please refer to:
- https://webpack.js.org/configuration/devtool/
- To see code examples please refer to this repo:
- https://github.com/webpack/webpack/tree/master/examples/source-map
+ Source maps is a useful debugging tool that allows you to view where the minified code originated from.
+
+__webpack.config.js__
 
 ``` js
 const path = require('path');
 
 module.exports = [
   'source-map'
-].map(devtool =>({
+].map(devtool => ({
   mode: 'development',
   entry: './src/index.js',
   output: {
@@ -202,6 +200,10 @@ module.exports = [
   }
 }));
  ```
+
+>  For more information about getting source maps setup and available options please refer to [Devtool configuration](https://webpack.js.org/configuration/devtool/)
+
+> To see code examples please refer to [webpack repository](https://github.com/webpack/webpack/tree/master/examples/source-map)
 
 ## Externalize Lodash
 


### PR DESCRIPTION
================= Was =================
<img width="740" alt="Screen Shot 2019-12-24 at 12 43 47 PM" src="https://user-images.githubusercontent.com/10549495/71409728-40d00a00-264b-11ea-910d-9594013b2feb.png">


================= Now =================
<img width="779" alt="Screen Shot 2019-12-24 at 12 43 37 PM" src="https://user-images.githubusercontent.com/10549495/71409734-462d5480-264b-11ea-9f75-066669e60252.png">
