### PR TITLE
docs(configuration): fixed outdated reference to production mode resource

### DIFF
--- a/src/content/configuration/optimization.md
+++ b/src/content/configuration/optimization.md
@@ -507,7 +507,7 @@ module.exports = {
 
 `optimization.mangleExports` allows to control export mangling.
 
-By default `optimization.mangleExports` is enabled in `production` [mode](/concepts/mode/) and disabled elsewise.
+By default `optimization.mangleExports` is enabled in `production` [mode](/configuration/mode/) and disabled elsewise.
 
 __webpack.config.js__
 
@@ -526,7 +526,7 @@ module.exports = {
 
 `optimization.innerGraph` tells webpack whether to conduct inner graph analysis for unused exports.
 
-By default `optimization.innerGraph` is enabled in `production` [mode](/concepts/mode/) and disabled elsewise.
+By default `optimization.innerGraph` is enabled in `production` [mode](/configuration/mode/) and disabled elsewise.
 
 __webpack.config.js__
 

--- a/src/content/configuration/optimization.md
+++ b/src/content/configuration/optimization.md
@@ -8,6 +8,7 @@ contributors:
   - byzyk
   - madhavarshney
   - dhurlburtusa
+  - jamesgeorge007
 related:
   - title: 'webpack 4: Code Splitting, chunk graph and the splitChunks optimization'
     url: https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366


### PR DESCRIPTION
The respective relative links where kinda outdated eventhough they got resolved to the updated resource. Made them link up to the intended resource for the sake of consistency. 