### PR TITLE
documentation for separate app and vendor entries

### DIFF
--- a/src/content/concepts/entry-points.md
+++ b/src/content/concepts/entry-points.md
@@ -68,6 +68,41 @@ Below is a list of entry configurations and their real-world use cases:
 
 ### Separate App and Vendor Entries
 
+__webpack.config.js__
+
+```javascript
+module.exports = {
+  entry: {
+    main: './src/app.js',
+    vendor: './src/vendor.js'
+  }
+};
+```
+
+__webpack.prod.js__
+
+```javascript
+module.exports = {
+  output: {
+    filename: [name].[contentHash].bundle.js
+  }
+};
+```
+
+__webpack.dev.js__
+
+```javascript
+module.exports = {
+  entry: {
+    filename: [name].bundle.js
+  }
+};
+```
+
+__What does this do?__ We are telling webpack that we would like 2 separate entry points (like the above example).
+
+__Why?__ The utility of this is that you can import required libraries or files that aren't modified (ex bootstrap, jquery, images, etc) inside vendor.js and they will be bundled together into their own HTML. Content Hash remains the same, which allows the browser to cache separately reducing load time.
+
 T> In webpack version < 4 it was common to add vendors as a separate entry point to compile it as a separate file (in combination with the `CommonsChunkPlugin`). <br><br> This is discouraged in webpack 4. Instead, the [`optimization.splitChunks`](/configuration/optimization/#optimizationsplitchunks) option takes care of separating vendors and app modules and creating a separate file. __Do not__ create an entry for vendors or other stuff that is not the starting point of execution.
 
 ### Multi Page Application


### PR DESCRIPTION
![Screenshot from 2020-01-01 16-20-39](https://user-images.githubusercontent.com/32176296/71641398-72874780-2cc1-11ea-9c8f-4f906dd6c1a4.png)

Closes https://github.com/webpack/webpack.js.org/issues/3244.

[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
