### PR TITLE
docs(parser): fix expression and expressionAnyMember examples

### DIFF
--- a/src/content/api/parser.md
+++ b/src/content/api/parser.md
@@ -516,7 +516,7 @@ Called when parsing an expression.
 ```js
 const a = this;
 
-parser.hooks.new.for('this').tap('MyPlugin', expression => {});
+parser.hooks.expression.for('this').tap('MyPlugin', expression => {});
 ```
 
 
@@ -532,7 +532,7 @@ Executed when parsing a `MemberExpression`.
 ```js
 const a = process.env;
 
-parser.hooks.new.for('process').tap('MyPlugin', expression => {});
+parser.hooks.expressionAnyMember.for('process').tap('MyPlugin', expression => {});
 ```
 
 


### PR DESCRIPTION
This is something I noticed when reading the [JavascriptParser Hooks](https://webpack.js.org/api/parser) documentation. It looks like `parser.hooks.new` was mistakenly used for `expression` and `expressionAnyMember`
