### PR TITLE
docs(writing-a-loader): changed the depreciated memory-fs in example

### DIFF
--- a/src/content/contribute/writing-a-loader.md
+++ b/src/content/contribute/writing-a-loader.md
@@ -5,6 +5,7 @@ contributors:
   - asulaiman
   - michael-ciniawsky
   - byzyk
+  - anikethsaha
 ---
 
 A loader is a node module that exports a function. This function is called when a resource should be transformed by this loader. The given function will have access to the [Loader API](/api/loaders/) using the `this` context provided to it.
@@ -309,7 +310,7 @@ __test/compiler.js__
 ```js
 import path from 'path';
 import webpack from 'webpack';
-import memoryfs from 'memory-fs';
+import { createFsFromVolume, Volume } from 'memfs';
 
 export default (fixture, options = {}) => {
   const compiler = webpack({
@@ -332,7 +333,7 @@ export default (fixture, options = {}) => {
     }
   });
 
-  compiler.outputFileSystem = new memoryfs();
+  compiler.outputFileSystem = createFsFromVolume(new Volume());
 
   return new Promise((resolve, reject) => {
     compiler.run((err, stats) => {


### PR DESCRIPTION
memory-fs is depreciated and its recommended to migrate to memfs
