### PR TITLE
docs(writing-a-plugin): added details about schema-utils

### DIFF
--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -74,7 +74,7 @@ module.exports = {
 ```
 
 
-Use [`schema-utils`](https://github.com/webpack/schema-utils) in order to validate the options being passed through the plugin options. Here is an example
+Use [`schema-utils`](https://github.com/webpack/schema-utils) in order to validate the options being passed through the plugin options. Here is an example:
 
 ```javascript
 

--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -74,7 +74,7 @@ module.exports = {
 ```
 
 
-Use [`schema-utils`](https://github.com/webpack/schema-utils) in order to validate the options being passed through the plugin option. Here is an example
+Use [`schema-utils`](https://github.com/webpack/schema-utils) in order to validate the options being passed through the plugin options. Here is an example
 
 ```javascript
 

--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -73,6 +73,34 @@ module.exports = {
 };
 ```
 
+
+Use [`schema-utils`](https://github.com/webpack/schema-utils) in order to validate the options being passed through the plugin option. Here is an example
+
+```javascript
+
+import validateOptions from 'schema-utils';
+
+// schema for options object
+const schema = {
+  type: 'object',
+  properties: {
+    test: {
+      type: 'string'
+    }
+  }
+};
+
+export default class HelloWorldPlugin {
+
+  constructor(options = {}){
+    validateOptions(schema, options, 'Hello World Plugin');
+  }
+
+  apply(compiler) {}
+}
+```
+
+
 ## Compiler and Compilation
 
 Among the two most important resources while developing plugins are the [`compiler`](/api/node/#compiler-instance) and [`compilation`](/api/compilation-hooks/) objects. Understanding their roles is an important first step in extending the webpack engine.


### PR DESCRIPTION
Added [`schema-utils`](https://github.com/webpack/schema-utils) in `writing-a-plugin` page for schema validation,

**screenshot**

![image](https://user-images.githubusercontent.com/26347874/71908044-4cffaf80-3193-11ea-9b00-b345a46de352.png)
