### PR TITLE
docs(configuration): config Rule.resolve with an object in module

### DIFF
--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -17,6 +17,7 @@ contributors:
   - skovy
   - smelukov
   - opl-
+  - Mistyyyy
 ---
 
 These options determine how the [different types of modules](/concepts/modules) within a project will be treated.
@@ -602,8 +603,12 @@ module.exports = {
   },
   module: {
     rules: [
-      alias: {
-        'footer': './footer/overriden.js'
+      {
+        resolve: {
+          alias: {
+            'footer': './footer/overriden.js'
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
[https://webpack.js.org/configuration/module/#ruleresolve](https://webpack.js.org/configuration/module/#ruleresolve)

The config Rule.resolve in module would cause a syntax error.