### PR TITLE
Document "Automatic dependency collection" in Why Webpack

### DIFF
--- a/src/content/concepts/why-webpack.md
+++ b/src/content/concepts/why-webpack.md
@@ -46,7 +46,7 @@ The good news for web projects is that modules are becoming an official feature 
 
 ## Automatic Dependency Collection
 
-Old school Task Runners and even Google Closure Compiler requires you to manually declare all dependencies upfront. While bundlers like webpack automatically builds and infer your [dependency graph](https://webpack.js.org/concepts/dependency-graph/) based on what is imported and exported. This along with other [plugins](https://webpack.js.org/concepts/plugins/) and [loaders](https://webpack.js.org/concepts/loaders/) make for a great developer experience.
+Old school Task Runners and even Google Closure Compiler requires you to manually declare all dependencies upfront. While bundlers like webpack automatically builds and infer your [dependency graph](/concepts/dependency-graph/) based on what is imported and exported. This along with other [plugins](/concepts/plugins/) and [loaders](/concepts/loaders/) make for a great developer experience.
 
 ## Wouldn't it be nice…
 

--- a/src/content/concepts/why-webpack.md
+++ b/src/content/concepts/why-webpack.md
@@ -44,6 +44,9 @@ But there is no browser support for CommonJS. There are no [live bindings](https
 
 The good news for web projects is that modules are becoming an official feature in the ECMAScript standard. However, browser support is incomplete and bundling is still faster and currently recommended over these early module implementations.
 
+## Automatic Dependency Collection
+
+Old school Task Runners and even Google Closure Compiler require you to manually declare all dependencies upfront. Bundlers like Webpack automatically build and infer your [dependency graph](https://webpack.js.org/concepts/dependency-graph/) based on what is imported and exported. This and other [plugins](https://webpack.js.org/concepts/plugins/) and [loaders](https://webpack.js.org/concepts/loaders/) make for a great developer experience.
 
 ## Wouldn't it be nice…
 

--- a/src/content/concepts/why-webpack.md
+++ b/src/content/concepts/why-webpack.md
@@ -46,7 +46,7 @@ The good news for web projects is that modules are becoming an official feature 
 
 ## Automatic Dependency Collection
 
-Old school Task Runners and even Google Closure Compiler require you to manually declare all dependencies upfront. Bundlers like Webpack automatically build and infer your [dependency graph](https://webpack.js.org/concepts/dependency-graph/) based on what is imported and exported. This and other [plugins](https://webpack.js.org/concepts/plugins/) and [loaders](https://webpack.js.org/concepts/loaders/) make for a great developer experience.
+Old school Task Runners and even Google Closure Compiler requires you to manually declare all dependencies upfront. While bundlers like webpack automatically builds and infer your [dependency graph](https://webpack.js.org/concepts/dependency-graph/) based on what is imported and exported. This along with other [plugins](https://webpack.js.org/concepts/plugins/) and [loaders](https://webpack.js.org/concepts/loaders/) make for a great developer experience.
 
 ## Wouldn't it be nice…
 


### PR DESCRIPTION
Document "Automatic dependency collection" in Why Webpack

In reviewing a [blogpost of mine](https://www.swyx.io/writing/jobs-of-js-build-tools), @TheLarkInn said that dependency collection ought to have much higher priority as people don't appreciate how this departs from older tools. So I proposed adding it to the docs.

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
