### PR TITLE
docs(migrate) mention internal changes in migration guide

### DIFF
--- a/src/content/migrate/5.md
+++ b/src/content/migrate/5.md
@@ -158,6 +158,6 @@ Please open a Pull Request to help the next person using this guide.
 
 ## Changes to internals
 
-The changes to webpack internals like for example: adding types, refactoring code and methods renaming are listed here for anyone interested. But they are not intended as a part of common use-case migration.
+The changes to webpack internals such as: adding types, refactoring code and methods renaming are listed here for anyone interested. But they are not intended as a part of common use-case migration.
 
 - `Module.nameForCondition`, `Module.updateCacheModule` and `Module.chunkCondition` are no longer optional.

--- a/src/content/migrate/5.md
+++ b/src/content/migrate/5.md
@@ -156,3 +156,8 @@ Create an [issue](https://github.com/webpack/webpack/issues/new?template=Bug_rep
 
 Please open a Pull Request to help the next person using this guide.
 
+## Changes to internals
+
+The changes to webpack internals like for example: adding types, refactoring code and methods renaming are listed here for anyone interested. But they are not intended as a part of common use-case migration.
+
+- `Module.nameForCondition`, `Module.updateCacheModule` and `Module.chunkCondition` are no longer optional.


### PR DESCRIPTION
- Closes #2393 
- mention that internals changes are listed just for information but not necessarily valuable for common users