### PR TITLE
Overriding `output.assetModuleFilename`

### DIFF
--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -367,6 +367,36 @@ module.exports = {
 }
 ```
 
+## `Rule.generator.filename`
+
+The same as [`output.assetModuleFilename`](/configuration/output/#outputassetmodulefilename) but for specific rule. Overrides `output.assetModuleFilename` and works only with `asset` and `asset/resource` module types.
+
+__webpack.config.js__
+
+```js
+module.exports = {
+  //...
+  output: {
+    assetModuleFilename: 'images/[hash][ext]'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.png/,
+        type: 'asset/resource'
+      },
+      {
+        test: /\.html/,
+        type: 'asset/resource',
+        generator: {
+          filename: 'static/[hash][ext]'
+        }
+      }
+    ]
+  }
+}
+```
+
 ## `Rule.resource`
 
 A [`Condition`](#condition) matched with the resource. You can either supply a `Rule.resource` option or use the shortcut options `Rule.test`, `Rule.exclude`, and `Rule.include`. See details in [`Rule` conditions](#rule-conditions).

--- a/src/content/guides/asset-modules.md
+++ b/src/content/guides/asset-modules.md
@@ -143,7 +143,7 @@ module.exports = {
 };
 ```
 
-With this config all the `html` files will be emitted into `static` directory within output directory.
+With this config all the `html` files will be emitted into a `static` directory within the output directory.
 
 `Rule.generator.filename` is the same as [`output.assetModuleFilename`](/configuration/output/#outputassetmodulefilename) and works only with `asset` and `asset/resource` module types.
 

--- a/src/content/guides/asset-modules.md
+++ b/src/content/guides/asset-modules.md
@@ -109,6 +109,44 @@ module.exports = {
 };
 ```
 
+Another case to customize output filename is to emit some kind of assets to a specified directory:
+
+```diff
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    filename: 'main.js',
+    path: path.resolve(__dirname, 'dist'),
++   assetModuleFilename: 'images/[hash][ext]'
+  },
+  experiments: {
+    asset: true
+  },
+  module: {
+    rules: [
+      {
+        test: /\.png/,
+        type: 'asset/resource'
+-     }
++     },
++     {
++       test: /\.html/,
++       type: 'asset/resource',
++       generator: {
++         filename: 'static/[hash][ext]'
++       }
++     }
+    ]
+  },
+};
+```
+
+With this config all the `html` files will be emitted into `static` directory within output directory.
+
+`Rule.generator.filename` is the same as [`output.assetModuleFilename`](/configuration/output/#outputassetmodulefilename) and works only with `asset` and `asset/resource` module types.
+
 ## Inlining assets
 
 __webpack.config.js__
@@ -133,7 +171,15 @@ module.exports = {
 -       type: 'asset/resource'
 +       test: /\.svg/,
 +       type: 'asset/inline'
-      }
+-     },
++     }
+-     {
+-       test: /\.html/,
+-       type: 'asset/resource',
+-       generator: {
+-         filename: 'static/[hash][ext]'
+-       }
+-     }
     ]
   }
 };


### PR DESCRIPTION
Added some info about overriding `output.assetModuleFilename` after merging https://github.com/webpack/webpack/pull/10291