### PR TITLE
docs(config): cleanup default values

### DIFF
--- a/src/content/configuration/other-options.md
+++ b/src/content/configuration/other-options.md
@@ -11,6 +11,7 @@ contributors:
   - EugeneHlushko
   - skovy
   - rishabh3112
+  - Neob91
 related:
   - title: Using Records
     url: https://survivejs.com/webpack/optimizing/separating-manifest/#using-records
@@ -167,9 +168,9 @@ module.exports = {
 
 ### `cache.store`
 
-`string: 'pack'`
+`string = 'pack': 'pack'`
 
-`cache.store` tells webpack when to store data on the file system. Defaults to `'pack'`.
+`cache.store` tells webpack when to store data on the file system.
 
 - `'pack'`: Store data when compiler is idle in a single file for all cached items
 
@@ -191,9 +192,9 @@ module.exports = {
 
 ### `cache.version`
 
-`string: ''`
+`string = ''`
 
-Version of the cache data. Different versions won't allow to reuse the cache and override existing content. Update the version when config changed in a way which doesn't allow to reuse cache. This will invalidate the cache. Defaults to `''`.
+Version of the cache data. Different versions won't allow to reuse the cache and override existing content. Update the version when config changed in a way which doesn't allow to reuse cache. This will invalidate the cache.
 
 `cache.version` option is only available when [`cache.type`](#cachetype) is set to `filesystem`.
 

--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -18,6 +18,7 @@ contributors:
   - EugeneHlushko
   - g-plane
   - smelukov
+  - Neob91
 ---
 
 The top-level `output` key contains set of options instructing webpack on how and where it should output your bundles, assets and anything else you bundle or load with webpack.
@@ -833,7 +834,7 @@ The dependencies for your library will be defined by the [`externals`](/configur
 
 ## `output.path`
 
-`string: path.join(process.cwd(), 'dist')`
+`string = path.join(process.cwd(), 'dist')`
 
 The output directory as an __absolute__ path.
 

--- a/src/content/configuration/watch.md
+++ b/src/content/configuration/watch.md
@@ -8,6 +8,7 @@ contributors:
   - EugeneHlushko
   - byzyk
   - spicalous
+  - Neob91
 ---
 
 webpack can watch files and recompile whenever they change. This page explains how to enable this and a couple of tweaks you can make if watching does not work properly for you.
@@ -121,9 +122,9 @@ T> If watching does not work for you, try out this option. Watching does not wor
 
 ## `info-verbosity`
 
-`string: 'none' | 'info' | 'verbose'`
+`string = 'info': 'none' | 'info' | 'verbose'`
 
-Controls verbosity of the lifecycle messaging, e.g. the `Started watching files...` log. Setting `info-verbosity` to `verbose` will also message to console at the beginning and the end of incremental build. `info-verbosity` is set to `info` by default.
+Controls verbosity of the lifecycle messaging, e.g. the `Started watching files...` log. Setting `info-verbosity` to `verbose` will also message to console at the beginning and the end of incremental build.
 
 ```bash
 webpack --watch --info-verbosity verbose


### PR DESCRIPTION
Some definitions of accepted/default config values didn't adhere to the writer's guide - I fixed them.
