### PR TITLE
scroll to top when change topic from the sidebar

### DIFF
--- a/src/components/Page/Page.jsx
+++ b/src/components/Page/Page.jsx
@@ -33,6 +33,8 @@ class Page extends React.Component {
           this.setState({
             content: module.default || module,
             contentLoaded: true
+          }, () => {
+            document.documentElement.scrollTop = 0;
           })
         )
         .catch(error =>

--- a/src/content/concepts/index.md
+++ b/src/content/concepts/index.md
@@ -17,6 +17,7 @@ contributors:
   - farskid
   - LukeMwila
   - Jalitha
+  - muhmushtaha
 ---
 
 At its core, __webpack__ is a _static module bundler_ for modern JavaScript applications. When webpack processes your application, it internally builds a [dependency graph](/concepts/dependency-graph/) which maps every module your project needs and generates one or more _bundles_.


### PR DESCRIPTION
I faced a problem when I was reading the docs which is if I was at the bottom of the page and moved to another section from the sidebar it will stay at the bottom of the page, so I added a scroll to top when I change the topic from the sidebar.

**Problem**
![problem](https://user-images.githubusercontent.com/25417060/73596574-d0f74e00-452b-11ea-9c76-c6b6301c0353.gif)


**Solution**
![solution](https://user-images.githubusercontent.com/25417060/73596582-ecfaef80-452b-11ea-8f12-4e356f1aff17.gif)
