### PR TITLE
fix: corrected the path of the logger from webpack

### DIFF
--- a/src/content/api/logging.md
+++ b/src/content/api/logging.md
@@ -44,12 +44,12 @@ W> __Avoid noise in the log!__ Keep in mind that multiple plugins and loaders ar
 
 Runtime logger API is only intended to be used as a development tool, it is not intended to be included in [production mode](/configuration/mode/#mode-production).
 
-- `const logging = require('webpack/logging/runtime')`: to use the logger in runtime, require it directly from webpack
+- `const logging = require('webpack/lib/logging/runtime')`: to use the logger in runtime, require it directly from webpack
 - `logging.getLogger('name')`: to get individual logger by name
 - `logging.configureDefaultLogger(...)`: to override the default logger.
 
 ```javascript
-const logging = require('webpack/logging/runtime');
+const logging = require('webpack/lib/logging/runtime');
 logging.configureDefaultLogger({
   level: 'log',
   debug: /something/


### PR DESCRIPTION
_describe your changes..._

The path to webpack logger in the docs is fixed with the correct path

