### PR TITLE
docs(comntrib) typed shortlists

### DIFF
--- a/src/content/contribute/writers-guide.md
+++ b/src/content/contribute/writers-guide.md
@@ -216,3 +216,14 @@ This allows us to display the defaults, enumeration and other information.
 If the object's key is dynamic, user-defined, use `<key>` to describe it:
 
 `object = { <key> string }`
+
+### Options shortlists and their typing
+
+Sometimes, we want to describe certain properties of objects and functions in lists. When applicable add typing directly to the list where properties are enlisted:
+
+- `madeUp` (`boolean = true`): short description
+- `shortText` (`string = 'i am text'`): another short description
+
+W> `:` is not important here, note the property, type and default.
+
+An example can be found on the [`options` section of the EvalSourceMapDevToolPlugin's page](/plugins/eval-source-map-dev-tool-plugin/#options).

--- a/src/content/contribute/writers-guide.md
+++ b/src/content/contribute/writers-guide.md
@@ -224,6 +224,6 @@ Sometimes, we want to describe certain properties of objects and functions in li
 - `madeUp` (`boolean = true`): short description
 - `shortText` (`string = 'i am text'`): another short description
 
-W> `:` is not important here, note the property, type and default.
+W> `:` is not a necessity here, note the property, type and default.
 
 An example can be found on the [`options` section of the EvalSourceMapDevToolPlugin's page](/plugins/eval-source-map-dev-tool-plugin/#options).


### PR DESCRIPTION
We didn't have this in the guide, only on certain pages of the docs. Now its more obvious how to treat such lists

ref #3520