### PR TITLE
docs: use correct data types

### DIFF
--- a/src/content/contribute/plugin-patterns.md
+++ b/src/content/contribute/plugin-patterns.md
@@ -4,6 +4,7 @@ sort: 5
 contributors:
   - nveenjain
   - EugeneHlushko
+  - benglynn
 ---
 
 Plugins grant unlimited opportunity to perform customizations within the webpack build system. This allows you to create custom asset types, perform unique build modifications, or even enhance the webpack runtime while using middleware. The following are some features of webpack that become useful while writing plugins.
@@ -48,21 +49,21 @@ module.exports = MyPlugin;
 
 ### Monitoring the watch graph
 
-While running webpack middleware, each compilation includes a `fileDependencies` array (what files are being watched) and a `fileTimestamps` hash that maps watched file paths to a timestamp. These are extremely useful for detecting what files have changed within the compilation:
+While running webpack middleware, each compilation includes a `fileDependencies` set (what files are being watched) and a `fileTimestamps` map that maps watched file paths to a timestamp. These are extremely useful for detecting what files have changed within the compilation:
 
 ```javascript
 class MyPlugin {
   constructor() {
     this.startTime = Date.now();
-    this.prevTimestamps = {};
+    this.prevTimestamps = new Map();
   }
   apply(compiler) {
     compiler.hooks.emit.tapAsync('MyPlugin', (compilation, callback) => {
-      var changedFiles = Object.keys(compilation.fileTimestamps).filter(
+      const changedFiles = Array.from(compilation.fileTimestamps.keys()).filter(
         watchfile => {
           return (
-            (this.prevTimestamps[watchfile] || this.startTime) <
-            (compilation.fileTimestamps[watchfile] || Infinity)
+            (this.prevTimestamps.get(watchfile) || this.startTime) <
+            (compilation.fileTimestamps.get(watchfile) || Infinity)
           );
         }
       );
@@ -76,7 +77,7 @@ class MyPlugin {
 module.exports = MyPlugin;
 ```
 
-You may also feed new file paths into the watch graph to receive compilation triggers when those files change. Simply push valid file paths into the `compilation.fileDependencies` array to add them to the watch. Note: the `fileDependencies` array is rebuilt in each compilation, so your plugin must push its own watched dependencies into each compilation to keep them under watch.
+You may also feed new file paths into the watch graph to receive compilation triggers when those files change. Simply add valid file paths into the `compilation.fileDependencies` set to add them to the watch. Note: the `fileDependencies` set is rebuilt in each compilation, so your plugin must add its own watched dependencies into each compilation to keep them under watch.
 
 ## Changed chunks
 


### PR DESCRIPTION
The docs confused me when developing a plugin in 4.41.6. This PR updates the Plugin Patterns page to reference the correct data types for `fileDependencies` (a `Set` not an `Array`) and `fileTimestamps` (a `Map` not an `Object`). It also updates the example code accordingly.
