### PR TITLE
fix: #3540 (Links don't scroll to correct position)

### DIFF
--- a/src/components/Markdown/Markdown.scss
+++ b/src/components/Markdown/Markdown.scss
@@ -2,6 +2,14 @@
 @import 'functions';
 @import 'prism-theme';
 
+$bannerHeight: 56px;
+$navigationHeight: 56px;
+$navigationSubHeight: 28px;
+$someExtraHeight: 10px;
+
+$topHeightDesktop: $navigationHeight + $navigationSubHeight + $someExtraHeight;
+$topHeightDesktopWithBanner: $bannerHeight + $topHeightDesktop;
+
 .markdown {
   line-height: 1.5em;
 
@@ -38,6 +46,7 @@
     margin: 1.5em 0 0.25em;
     color: getColor(fiord);
     word-break: break-all;
+    scroll-margin-top: $topHeightDesktop;
 
     tt,
     code {
@@ -380,5 +389,11 @@
     tt {
       white-space: pre-line;
     }
+  }
+}
+
+.notification-bar-visible .markdown {
+  h1,h2,h3,h4,h5,h6{
+    scroll-margin-top: $topHeightDesktopWithBanner;
   }
 }

--- a/src/components/NotificationBar/NotificationBar.jsx
+++ b/src/components/NotificationBar/NotificationBar.jsx
@@ -52,10 +52,16 @@ export default class NotificationBar extends React.Component {
     this.state = {
       dismissed: barDismissed()
     };
+    if (!this.state.dismissed && typeof document !== 'undefined') {
+      document.body.classList.add('notification-bar-visible');
+    }
   }
 
   onClose() {
     this.setState(state => {
+      if (!state.dismissed && typeof document !== 'undefined') {
+        document.body.classList.remove('notification-bar-visible');
+      }
       return {
         dismissed: !state.dismissed
       };


### PR DESCRIPTION
Fix #3540

It isn't *perfect* because it doesn't cover all the possible heights the topbar can be in (mobile: 56px, mobile with banner: 56px + 58px, desktop: 56px + 27.3px, desktop with banner: 56px + 27.3px + 56px). 

I've tried to optimize for (probably) the most common use case desktop (56px + 27.3px)

Here is what it looks like on desktop now:
![desktop-normal](https://user-images.githubusercontent.com/23744935/74602159-390a7000-50a6-11ea-8f35-7e1a6c8aaba0.png)

<br>

On desktop with banner (heading is covered):
![desktop_banner](https://user-images.githubusercontent.com/23744935/74602197-871f7380-50a6-11ea-8fb6-6b4be6df3f51.png)

<br>

On mobile (space at the top is a bit larger):
![mobile](https://user-images.githubusercontent.com/23744935/74602221-c2ba3d80-50a6-11ea-8f02-60bcd8106b4a.png)
