### PR TITLE
docs(format) single quotes in js spotted, minor grammar

### DIFF
--- a/src/content/api/hot-module-replacement.md
+++ b/src/content/api/hot-module-replacement.md
@@ -164,10 +164,10 @@ The `info` parameter will be an object containing some of the following values:
 
 ```js
 {
-  type: "self-declined" | "declined" |
-        "unaccepted" | "accepted" |
-        "disposed" | "accept-errored" |
-        "self-accept-errored" | "self-accept-error-handler-errored",
+  type: 'self-declined' | 'declined' |
+        'unaccepted' | 'accepted' |
+        'disposed' | 'accept-errored' |
+        'self-accept-errored' | 'self-accept-error-handler-errored',
   moduleId: 4, // The module in question.
   dependencyId: 3, // For errors: the module id owning the accept handler.
   chain: [1, 2, 3, 4], // For declined/accepted/unaccepted: the chain from where the update was propagated.

--- a/src/content/api/loaders.md
+++ b/src/content/api/loaders.md
@@ -80,7 +80,7 @@ T> Loaders were originally designed to work in synchronous loader pipelines, lik
 
 ### "Raw" Loader
 
-By default, the resource file is converted to a UTF-8 string and passed to the loader. By setting the `raw` flag, the loader will receive the raw `Buffer`. Every loader is allowed to deliver its result as `String` or as `Buffer`. The compiler converts them between loaders.
+By default, the resource file is converted to a UTF-8 string and passed to the loader. By setting the `raw` flag to `true`, the loader will receive the raw `Buffer`. Every loader is allowed to deliver its result as a `String` or as a `Buffer`. The compiler converts them between loaders.
 
 __raw-loader.js__
 
@@ -206,7 +206,7 @@ Since webpack 4, the formerly `this.options.context` is provided as `this.rootCo
 
 The resolved request string.
 
-In the example: `"/abc/loader1.js?xyz!/abc/node_modules/loader2/index.js!/abc/resource.js?rrr"`
+In the example: `'/abc/loader1.js?xyz!/abc/node_modules/loader2/index.js!/abc/resource.js?rrr'`
 
 
 ### `this.query`
@@ -311,28 +311,28 @@ In the example: in loader1: `0`, in loader2: `1`
 
 The resource part of the request, including query.
 
-In the example: `"/abc/resource.js?rrr"`
+In the example: `'/abc/resource.js?rrr'`
 
 
 ### `this.resourcePath`
 
 The resource file.
 
-In the example: `"/abc/resource.js"`
+In the example: `'/abc/resource.js'`
 
 
 ### `this.resourceQuery`
 
 The query of the resource.
 
-In the example: `"?rrr"`
+In the example: `'?rrr'`
 
 
 ### `this.target`
 
 Target of compilation. Passed from configuration options.
 
-Example values: `"web"`, `"node"`
+Example values: `'web'`, `'node'`
 
 
 ### `this.webpack`

--- a/src/content/api/module-variables.md
+++ b/src/content/api/module-variables.md
@@ -82,7 +82,7 @@ See [node.js process](https://nodejs.org/api/process.html).
 Depending on the config option `node.__dirname`:
 
 - `false`: Not defined
-- `mock`: equal "/"
+- `mock`: equal to `'/'`
 - `true`: [node.js __dirname](https://nodejs.org/api/globals.html#globals_dirname)
 
 If used inside an expression that is parsed by the Parser, the config option is treated as `true`.
@@ -93,7 +93,7 @@ If used inside an expression that is parsed by the Parser, the config option is 
 Depending on the config option `node.__filename`:
 
 - `false`: Not defined
-- `mock`: equal "/index.js"
+- `mock`: equal to `'/index.js'`
 - `true`: [node.js __filename](https://nodejs.org/api/globals.html#globals_filename)
 
 If used inside an expression that is parsed by the Parser, the config option is treated as `true`.


### PR DESCRIPTION
While reviewing recent PR i spotted mis- formatting on api pages, just cleared the occurrences and found another grammar improvement 