### PR TITLE
docs(api): remove redundant new keyword

### DIFF
--- a/src/content/api/node.mdx
+++ b/src/content/api/node.mdx
@@ -340,7 +340,7 @@ instead of to disk:
 const { createFsFromVolume, Volume } = require('memfs');
 const webpack = require('webpack');
 
-const fs = new createFsFromVolume(new Volume());
+const fs = createFsFromVolume(new Volume());
 const compiler = webpack({ /* options */ });
 
 compiler.outputFileSystem = fs;

--- a/src/content/contribute/writing-a-loader.md
+++ b/src/content/contribute/writing-a-loader.md
@@ -6,6 +6,7 @@ contributors:
   - michael-ciniawsky
   - byzyk
   - anikethsaha
+  - jamesgeorge007
 ---
 
 A loader is a node module that exports a function. This function is called when a resource should be transformed by this loader. The given function will have access to the [Loader API](/api/loaders/) using the `this` context provided to it.


### PR DESCRIPTION
Follow up of #3545 

`createFsFromVolume()` is a function and should be invoked directly.