### PR TITLE
docs(multi) consistently use configuration vs config across the docs;…

### DIFF
--- a/src/content/api/cli.md
+++ b/src/content/api/cli.md
@@ -26,12 +26,12 @@ related:
     url: https://medium.com/@nimgrg/analysing-and-minimising-the-size-of-client-side-bundle-with-webpack-and-source-map-explorer-41096559beca#.c3t2srr8x
 ---
 
-For proper usage and easy distribution of this configuration, webpack can be configured with `webpack.config.js`. Any parameters sent to the CLI will map to a corresponding parameter in the config file.
+For proper usage and easy distribution of this configuration, webpack can be configured with `webpack.config.js`. Any parameters sent to the CLI will map to a corresponding parameter in the configuration file.
 
 Read the [installation guide](/guides/installation) if you don't already have webpack and CLI installed.
 
 
-## Usage with config file
+## Usage with configuration file
 
 ```bash
 webpack [--config webpack.config.js]
@@ -40,7 +40,7 @@ webpack [--config webpack.config.js]
 See [configuration](/configuration) for the options in the configuration file.
 
 
-## Usage without config file
+## Usage without configuration file
 
 ```sh
 webpack <entry> [<entry>] -o <output>
@@ -109,7 +109,7 @@ webpack --help
 webpack -h
 ```
 
-__Build source using a config file__
+__Build source using a configuration file__
 
 Specifies a different [configuration](/configuration) file to pick up. Use this if you want to specify something different from `webpack.config.js`, which is the default.
 
@@ -149,15 +149,15 @@ Invocation                               | Resulting environment
 
 T> See the [environment variables](/guides/environment-variables/) guide for more information on its usage.
 
-### Config Options
+### Configuration Options
 
 Parameter                 | Explanation                                 | Input type | Default
 ------------------------- | ------------------------------------------- | ---------- | ------------------
-`--config`                | Path to the config file                     | string     | webpack.config.js or webpackfile.js
-`--config-register, -r`   | Preload one or more modules before loading the webpack configuration | array |
-`--config-name`           | Name of the config to use                   | string     |
-`--env`                   | Environment passed to the config, when it is a function  | |
-`--mode`                  | Mode to use, either "development" or "production" | string |
+`--config`                | Path to the configuration file                                       | string | webpack.config.js or webpackfile.js
+`--config-register, -r`   | Preload one or more modules before loading the webpack configuration | array  |
+`--config-name`           | Name of the configuration to use                                     | string |
+`--env`                   | Environment passed to the configuration, when it is a function       |        |
+`--mode`                  | Mode to use                                                          | string | `'production'`
 
 ### Output Options
 

--- a/src/content/api/module-variables.md
+++ b/src/content/api/module-variables.md
@@ -79,24 +79,24 @@ See [node.js process](https://nodejs.org/api/process.html).
 
 ### `__dirname` (NodeJS)
 
-Depending on the config option `node.__dirname`:
+Depending on the configuration option `node.__dirname`:
 
 - `false`: Not defined
 - `mock`: equal "/"
 - `true`: [node.js __dirname](https://nodejs.org/api/globals.html#globals_dirname)
 
-If used inside an expression that is parsed by the Parser, the config option is treated as `true`.
+If used inside an expression that is parsed by the Parser, the configuration option is treated as `true`.
 
 
 ### `__filename` (NodeJS)
 
-Depending on the config option `node.__filename`:
+Depending on the configuration option `node.__filename`:
 
 - `false`: Not defined
 - `mock`: equal "/index.js"
 - `true`: [node.js __filename](https://nodejs.org/api/globals.html#globals_filename)
 
-If used inside an expression that is parsed by the Parser, the config option is treated as `true`.
+If used inside an expression that is parsed by the Parser, the configuration option is treated as `true`.
 
 
 ### `__resourceQuery` (webpack-specific)
@@ -116,7 +116,7 @@ __resourceQuery === '?test';
 
 ### `__webpack_public_path__` (webpack-specific)
 
-Equals the config option's `output.publicPath`.
+Equals the configuration option's `output.publicPath`.
 
 
 ### `__webpack_require__` (webpack-specific)
@@ -149,4 +149,4 @@ Generates a `require` function that is not parsed by webpack. Can be used to do 
 
 ### `DEBUG`  (webpack-specific)
 
-Equals the config option `debug`.
+Equals the configuration option `debug`.

--- a/src/content/comparison.md
+++ b/src/content/comparison.md
@@ -43,7 +43,7 @@ webpack is not the only module bundler out there. If you are choosing between us
 | Other Node.js stuff | process, __dir/filename, global | - | process, __dir/filename, global | process, __dir/filename, global for cjs | global ([commonjs-plugin](https://github.com/rollup/rollup-plugin-commonjs)) | |
 | Plugins | __yes__ | yes | __yes__ | yes | yes | yes |
 | Preprocessing | __loaders, [transforms](https://github.com/webpack-contrib/transform-loader)__ | loaders | transforms | plugin translate | plugin transforms | compilers, optimizers |
-| Replacement for browser | `web_modules`, `.web.js`, package.json field, alias config option | alias option | package.json field, alias option | package.json, alias option | no | |
+| Replacement for browser | `web_modules`, `.web.js`, package.json field, alias configuration option | alias option | package.json field, alias option | package.json, alias option | no | |
 | Requirable files | file system | __web__ | file system | through plugins | file system or through plugins | file system |
 | Runtime overhead | __243B + 20B per module + 4B per dependency__ | 14.7kB + 0B per module + (3B + X) per dependency | 415B + 25B per module + (6B + 2X) per dependency | 5.5kB for self-executing bundles, 38kB for full loader and polyfill, 0 plain modules, 293B CJS, 139B ES2015 System.register before gzip | __none for ES2015 modules__ (other formats may have) | |
 | Watch mode | yes | not required | [watchify](https://github.com/browserify/watchify) | not needed in dev | [rollup-watch](https://github.com/rollup/rollup-watch) | yes |

--- a/src/content/concepts/dependency-graph.md
+++ b/src/content/concepts/dependency-graph.md
@@ -13,7 +13,7 @@ related:
 
 Any time one file depends on another, webpack treats this as a _dependency_. This allows webpack to take non-code assets, such as images or web fonts, and also provide them as _dependencies_ for your application.
 
-When webpack processes your application, it starts from a list of modules defined on the command line or in its config file.
+When webpack processes your application, it starts from a list of modules defined on the command line or in its configuration file.
 Starting from these [_entry points_](/concepts/entry-points/), webpack recursively builds a _dependency graph_ that includes every module your application needs, then bundles all of those modules into a small number of _bundles_ - often, just one - to be loaded by the browser.
 
 T> Bundling your application is especially powerful for _HTTP/1.1_ clients, as it minimizes the number of times your app has to wait while the browser starts a new request. For _HTTP/2_, you can also use [Code Splitting](/guides/code-splitting/) to achieve best results.

--- a/src/content/concepts/index.md
+++ b/src/content/concepts/index.md
@@ -131,7 +131,7 @@ While loaders are used to transform certain types of modules, plugins can be lev
 
 T> Check out the [plugin interface](/api/plugins) and how to use it to extend webpack's capabilities.
 
-In order to use a plugin, you need to `require()` it and add it to the `plugins` array. Most plugins are customizable through options. Since you can use a plugin multiple times in a config for different purposes, you need to create an instance of it by calling it with the `new` operator.
+In order to use a plugin, you need to `require()` it and add it to the `plugins` array. Most plugins are customizable through options. Since you can use a plugin multiple times in a configuration for different purposes, you need to create an instance of it by calling it with the `new` operator.
 
 __webpack.config.js__
 
@@ -155,7 +155,7 @@ In the example above, the `html-webpack-plugin` generates an HTML file for your 
 
 T> There are many plugins that webpack provides out of the box! Check out the [list of plugins](/plugins).
 
-Using plugins in your webpack config is straightforward. However, there are many use cases that are worth further exploration. [Learn more about them here](/concepts/plugins).
+Using plugins in your webpack configuration is straightforward. However, there are many use cases that are worth further exploration. [Learn more about them here](/concepts/plugins).
 
 
 ## Mode

--- a/src/content/configuration/configuration-types.md
+++ b/src/content/configuration/configuration-types.md
@@ -89,4 +89,4 @@ module.exports = [{
 }];
 ```
 
-T> If you pass a name to [`--config-name`](/api/cli/#config-options) flag, webpack will only build that specific configuration.
+T> If you pass a name to [`--config-name`](/api/cli/#configuration-options) flag, webpack will only build that specific configuration.

--- a/src/content/configuration/configuration-types.md
+++ b/src/content/configuration/configuration-types.md
@@ -13,14 +13,14 @@ contributors:
   - anshumanv
 ---
 
-Besides exporting a single config object, there are a few more ways that cover other needs as well.
+Besides exporting a single configuration object, there are a few more ways that cover other needs as well.
 
 
 ## Exporting a Function
 
 Eventually you will find the need to disambiguate in your `webpack.config.js` between [development](/guides/development) and [production builds](/guides/production). You have (at least) two options:
 
-One option is to export a function from your webpack config instead of exporting an object. The function will be invoked with two arguments:
+One option is to export a function from your webpack configuration instead of exporting an object. The function will be invoked with two arguments:
 
 - An environment as the first parameter. See the [environment options CLI documentation](/api/cli/#environment-options) for syntax examples.
 - An options map (`argv`) as the second parameter. This describes the options passed to webpack, with keys such as [`output-filename`](/api/cli/#output-options) and [`optimize-minimize`](/api/cli/#optimize-options).

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -1002,7 +1002,7 @@ webpack-dev-server --port 8080
 
 Proxying some URLs can be useful when you have a separate API backend development server and you want to send API requests on the same domain.
 
-The dev-server makes use of the powerful [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware) package. Check out its [documentation](https://github.com/chimurai/http-proxy-middleware#options) for more advanced usages. Note that some of `http-proxy-middleware`'s features do not require a `target` key, e.g. its `router` feature, but you will still need to include a `target` key in your config here, otherwise `webpack-dev-server` won't pass it along to `http-proxy-middleware`).
+The dev-server makes use of the powerful [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware) package. Check out its [documentation](https://github.com/chimurai/http-proxy-middleware#options) for more advanced usages. Note that some of `http-proxy-middleware`'s features do not require a `target` key, e.g. its `router` feature, but you will still need to include a `target` key in your configuration here, otherwise `webpack-dev-server` won't pass it along to `http-proxy-middleware`).
 
 With a backend on `localhost:3000`, you can use this to enable proxying:
 
@@ -1039,7 +1039,7 @@ module.exports = {
 };
 ```
 
-A backend server running on HTTPS with an invalid certificate will not be accepted by default. If you want to, modify your config like this:
+A backend server running on HTTPS with an invalid certificate will not be accepted by default. If you want to, modify your configuration like this:
 
 __webpack.config.js__
 

--- a/src/content/configuration/index.mdx
+++ b/src/content/configuration/index.mdx
@@ -25,9 +25,9 @@ All the available configuration options are specified below.
 T> New to webpack? Check out our guide to some of webpack's [core concepts](/concepts) to get started!
 
 
-## Use different config file
+## Use different configuration file
 
-If for some reason you want to use different config file depending on certain situations you can change this via command line by using the `--config` flag.
+If for some reason you want to use different configuration file depending on certain situations you can change this via command line by using the `--config` flag.
 
 **package.json**
 
@@ -481,4 +481,4 @@ found 0 vulnerabilities
 Congratulations! Your new webpack configuration file has been created!
 ```
 
-[createapp.dev - create a webpack config in your browser](https://createapp.dev/webpack) is an online tool for creating custom webpack configuration. It allows you to select various features that will be combined and added to resulting configuration file. Also, it generates an example project based on provided webpack configuration that you can review in your browser and download.
+[createapp.dev - create a webpack configuration in your browser](https://createapp.dev/webpack) is an online tool for creating custom webpack configuration. It allows you to select various features that will be combined and added to resulting configuration file. Also, it generates an example project based on provided webpack configuration that you can review in your browser and download.

--- a/src/content/configuration/other-options.md
+++ b/src/content/configuration/other-options.md
@@ -194,7 +194,7 @@ module.exports = {
 
 `string = ''`
 
-Version of the cache data. Different versions won't allow to reuse the cache and override existing content. Update the version when config changed in a way which doesn't allow to reuse cache. This will invalidate the cache.
+Version of the cache data. Different versions won't allow to reuse the cache and override existing content. Update the version when configuration changed in a way which doesn't allow to reuse cache. This will invalidate the cache.
 
 `cache.version` option is only available when [`cache.type`](#cachetype) is set to `filesystem`.
 

--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -518,7 +518,7 @@ T> Read the [authoring libraries guide](/guides/author-libraries/) guide for mor
 
 `string` `[string]`
 
-Configure which module or modules will be exposed via the `libraryTarget`. It is `undefined` by default, same behaviour will be applied if you set `libraryTarget` to an empty string e.g. `''` it will export the whole (namespace) object. The examples below demonstrate the effect of this config when using `libraryTarget: 'var'`.
+Configure which module or modules will be exposed via the `libraryTarget`. It is `undefined` by default, same behaviour will be applied if you set `libraryTarget` to an empty string e.g. `''` it will export the whole (namespace) object. The examples below demonstrate the effect of this configuration when using `libraryTarget: 'var'`.
 
 The following configurations are supported:
 

--- a/src/content/configuration/watch.md
+++ b/src/content/configuration/watch.md
@@ -159,7 +159,7 @@ On macOS, folders can get corrupted in certain scenarios. See [this article](htt
 
 ### Windows Paths
 
-Because webpack expects absolute paths for many config options such as `__dirname + '/app/folder'` the Windows `\` path separator can break some functionality.
+Because webpack expects absolute paths for many configuration options such as `__dirname + '/app/folder'` the Windows `\` path separator can break some functionality.
 
 Use the correct separators. I.e. `path.resolve(__dirname, 'app/folder')` or `path.join(__dirname, 'app', 'folder')`.
 

--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -61,14 +61,14 @@ class HelloWorldPlugin {
 module.exports = HelloWorldPlugin;
 ```
 
-Then to use the plugin, include an instance in your webpack config `plugins` array:
+Then to use the plugin, include an instance in your webpack configuration `plugins` array:
 
 ```javascript
 // webpack.config.js
 var HelloWorldPlugin = require('hello-world');
 
 module.exports = {
-  // ... config settings here ...
+  // ... configuration settings here ...
   plugins: [new HelloWorldPlugin({ options: true })]
 };
 ```

--- a/src/content/contribute/writing-a-scaffold.md
+++ b/src/content/contribute/writing-a-scaffold.md
@@ -183,7 +183,7 @@ module.exports = class WebpackGenerator extends Generator {
 
 ## Some more configs
 
-Let's look at `dev-config.js`. We have access to user's answers, use them to assign values to desired config properties, in this case - `entry`. We've also added an output property that has a `filename`.
+Let's look at `dev-config.js`. We have access to user's answers, use them to assign values to desired configuration properties, in this case - `entry`. We've also added an output property that has a `filename`.
 
 T> String values must be quoted twice. This is to preserve our ability to add other functionality, using only " ", while " 'Mystring' " resolves to a string.
 

--- a/src/content/glossary.md
+++ b/src/content/glossary.md
@@ -29,7 +29,7 @@ This index lists common terms used throughout the webpack ecosystem.
 
 - __Chunk__: This webpack-specific term is used internally to manage the bundling process. Bundles are composed out of chunks, of which there are several types (e.g. entry and child). Typically, _chunks_ directly correspond with the output _bundles_ however, there are some configurations that don't yield a one-to-one relationship.
 - [__Code Splitting__](/guides/code-splitting/): Refers to dividing your code into various bundles/chunks which you can then load on demand instead of loading a single bundle containing everything.
-- [__Configuration__](/concepts/configuration/): webpack config file is a plain old JavaScript file that exports an object. This object is then processed by webpack based upon its defined properties.
+- [__Configuration__](/concepts/configuration/): webpack configuration file is a plain old JavaScript file that exports an object. This object is then processed by webpack based upon its defined properties.
 
 
 ## D

--- a/src/content/guides/asset-modules.md
+++ b/src/content/guides/asset-modules.md
@@ -146,7 +146,7 @@ module.exports = {
 };
 ```
 
-With this config all the `html` files will be emitted into a `static` directory within the output directory.
+With this configuration all the `html` files will be emitted into a `static` directory within the output directory.
 
 `Rule.generator.filename` is the same as [`output.assetModuleFilename`](/configuration/output/#outputassetmodulefilename) and works only with `asset` and `asset/resource` module types.
 

--- a/src/content/guides/code-splitting.md
+++ b/src/content/guides/code-splitting.md
@@ -196,7 +196,7 @@ Two similar techniques are supported by webpack when it comes to dynamic code sp
 
 W> `import()` calls use [promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) internally. If you use `import()` with older browsers, remember to shim `Promise` using a polyfill such as [es6-promise](https://github.com/stefanpenner/es6-promise) or [promise-polyfill](https://github.com/taylorhakes/promise-polyfill).
 
-Before we start, let's remove the extra [`entry`](/concepts/entry-points/) and [`optimization.splitChunks`](/plugins/split-chunks-plugin) from our config as they won't be needed for this next demonstration:
+Before we start, let's remove the extra [`entry`](/concepts/entry-points/) and [`optimization.splitChunks`](/plugins/split-chunks-plugin) from our configuration as they won't be needed for this next demonstration:
 
 __webpack.config.js__
 

--- a/src/content/guides/development-vagrant.md
+++ b/src/content/guides/development-vagrant.md
@@ -72,7 +72,7 @@ The server should be accessible on `http://10.10.10.61:8080` now. If you make a 
 
 To mimic a more production-like environment, it is also possible to proxy the webpack-dev-server with nginx.
 
-In your nginx config file, add the following:
+In your nginx configuration file, add the following:
 
 ```nginx
 server {

--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -195,7 +195,7 @@ The `webpack-dev-server` provides you with a simple web server and the ability t
 npm install --save-dev webpack-dev-server
 ```
 
-Change your config file to tell the dev server where to look for files:
+Change your configuration file to tell the dev server where to look for files:
 
 __webpack.config.js__
 

--- a/src/content/guides/entry-advanced.md
+++ b/src/content/guides/entry-advanced.md
@@ -72,7 +72,7 @@ module.exports = {
 };
 ```
 
-Running webpack with above config will output into `./dist` as we did not specify different output path. `./dist` directory will now contain four files:
+Running webpack with above configuration will output into `./dist` as we did not specify different output path. `./dist` directory will now contain four files:
 
 - home.js
 - home.css

--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -260,7 +260,7 @@ The 'mode' option has not been set, webpack will fallback to 'production' for th
 You can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/configuration/mode/
 ```
 
-T> If a `webpack.config.js` is present, the `webpack` command picks it up by default. We use the `--config` option here only to show that you can pass a config of any name. This will be useful for more complex configurations that need to be split into multiple files.
+T> If a `webpack.config.js` is present, the `webpack` command picks it up by default. We use the `--config` option here only to show that you can pass a configuration of any name. This will be useful for more complex configurations that need to be split into multiple files.
 
 A configuration file allows far more flexibility than simple CLI usage. We can specify loader rules, plugins, resolve options and many other enhancements this way. See the [configuration documentation](/configuration) to learn more.
 

--- a/src/content/guides/hot-module-replacement.md
+++ b/src/content/guides/hot-module-replacement.md
@@ -134,7 +134,7 @@ main.js:4395 [WDS] Hot Module Replacement enabled.
 
 ## Via the Node.js API
 
-When using Webpack Dev Server with the Node.js API, don't put the dev server options on the webpack config object. Instead, pass them as a second parameter upon creation. For example:
+When using Webpack Dev Server with the Node.js API, don't put the dev server options on the webpack configuration object. Instead, pass them as a second parameter upon creation. For example:
 
 `new WebpackDevServer(compiler, options)`
 

--- a/src/content/migrate/4.md
+++ b/src/content/migrate/4.md
@@ -37,7 +37,7 @@ Many 3rd party plugins need to be updated to the latest versions to be compatibl
 
 ## mode
 
-Add the new [`mode`](/configuration/mode/) option to your config. Set it to production or development in your configuration depending on config type.
+Add the new [`mode`](/configuration/mode/) option to your configuration. Set it to `'production'`, `'development'` or `'none'` depending on your configuration type.
 
 
 __webpack.config.js__
@@ -45,11 +45,11 @@ __webpack.config.js__
 ``` diff
 module.exports = {
   // ...
-  mode: 'production',
++  mode: 'production',
 }
 ```
 
-T> The purpose of `development` mode and `production` mode is different. You can use `webpack-merge` as shown in [production guide](/guides/production/#setup) to optimize configurations.
+T> The purpose of `'development'` mode and `'production'` mode is different. You can use `webpack-merge` as shown in [production guide](/guides/production/#setup) to optimize configurations.
 
 ## Deprecated/Removed plugins
 

--- a/src/content/plugins/dll-plugin.md
+++ b/src/content/plugins/dll-plugin.md
@@ -18,7 +18,7 @@ The `DllPlugin` and `DllReferencePlugin` provide means to split bundles in a way
 
 ## `DllPlugin`
 
-This plugin is used in a separate webpack config exclusively to create a dll-only-bundle. It creates a `manifest.json` file, which is used by the [`DllReferencePlugin`](#dllreferenceplugin) to map dependencies.
+This plugin is used in a separate webpack configuration exclusively to create a dll-only-bundle. It creates a `manifest.json` file, which is used by the [`DllReferencePlugin`](#dllreferenceplugin) to map dependencies.
 
 - `context` (optional): context of requests in the manifest file (defaults to the webpack context.)
 - `name`: name of the exposed dll function ([TemplatePaths](https://github.com/webpack/webpack/blob/master/lib/TemplatedPathPlugin.js): `[hash]` & `[name]` )

--- a/src/content/plugins/html-webpack-plugin.md
+++ b/src/content/plugins/html-webpack-plugin.md
@@ -21,7 +21,7 @@ npm install --save-dev html-webpack-plugin
 
 The plugin will generate an HTML5 file for you that includes all your webpack
 bundles in the body using `script` tags. Just add the plugin to your webpack
-config as follows:
+configuration as follows:
 
 ```javascript
 var HtmlWebpackPlugin = require('html-webpack-plugin');

--- a/src/content/plugins/normal-module-replacement-plugin.md
+++ b/src/content/plugins/normal-module-replacement-plugin.md
@@ -21,7 +21,7 @@ new webpack.NormalModuleReplacementPlugin(
 
 Replace a specific module when building for a [development environment](/guides/production).
 
-Say you have a config file `some/path/config.development.module.js` and a special version for production in `some/path/config.production.module.js`
+Say you have a configuration file `some/path/config.development.module.js` and a special version for production in `some/path/config.production.module.js`
 
 Just add the following plugin when building for production:
 
@@ -53,7 +53,7 @@ module.exports = function(env) {
 };
 ```
 
-Create the two config files:
+Create the two configuration files:
 
 __app/config-VERSION_A.js__
 
@@ -71,14 +71,14 @@ export default {
 };
 ```
 
-Then import that config using the keyword you're looking for in the regexp:
+Then import that configuration using the keyword you're looking for in the regexp:
 
 ``` javascript
 import config from 'app/config-APP_TARGET';
 console.log(config.title);
 ```
 
-And now you just get the right config imported depending on which target you're building for:
+And now you just get the right configuration imported depending on which target you're building for:
 
 ```bash
 webpack --env.APP_TARGET VERSION_A


### PR DESCRIPTION
… various improvements

- consistently say "configuration" across the docs
- show default for `mode` on cli page, remove duplication
- mention none mode in migration enum
