### PR TITLE
fix: changed the wrong cheap-eval-source-map to eval-cheap-source-map

### DIFF
--- a/src/content/configuration/devtool.md
+++ b/src/content/configuration/devtool.md
@@ -8,6 +8,7 @@ contributors:
   - lricoy
   - madhavarshney
   - wizardofhogwarts
+  - anikethsaha
 related:
   - title: Enabling Source Maps
     url: https://survivejs.com/webpack/developing-with-webpack/enabling-sourcemaps/
@@ -91,9 +92,9 @@ The following options are ideal for development:
 
 `eval-source-map` - Each module is executed with `eval()` and a SourceMap is added as a DataUrl to the `eval()`. Initially it is slow, but it provides fast rebuild speed and yields real files. Line numbers are correctly mapped since it gets mapped to the original code. It yields the best quality SourceMaps for development.
 
-`cheap-eval-source-map` - Similar to `eval-source-map`, each module is executed with `eval()`. It is "cheap" because it doesn't have column mappings, it only maps line numbers. It ignores SourceMaps from Loaders and only display transpiled code similar to the `eval` devtool.
+`eval-cheap-source-map` - Similar to `eval-source-map`, each module is executed with `eval()`. It is "cheap" because it doesn't have column mappings, it only maps line numbers. It ignores SourceMaps from Loaders and only display transpiled code similar to the `eval` devtool.
 
-`cheap-module-eval-source-map` - Similar to `cheap-eval-source-map`, however, in this case Source Maps from Loaders are processed for better results. However Loader Source Maps are simplified to a single mapping per line.
+`cheap-module-eval-source-map` - Similar to `eval-cheap-source-map`, however, in this case Source Maps from Loaders are processed for better results. However Loader Source Maps are simplified to a single mapping per line.
 
 ### Special cases
 


### PR DESCRIPTION
fixes the wrong `cheap-eval-source-map` to `eval-cheap-source-map` 

Reporting source : https://twitter.com/rossipedia/status/1230913226000330753 