### PR TITLE
docs: Remove redundant word

### DIFF
--- a/src/content/guides/asset-management.md
+++ b/src/content/guides/asset-management.md
@@ -502,7 +502,7 @@ import { foo } from './data.json';
 
 ## Global Assets
 
-The coolest part of everything mentioned above, is that loading assets this way allows you to group modules and assets together in a more intuitive way. Instead of relying on a global `/assets` directory that contains everything, you can group assets with the code that uses them. For example, a structure like this can be useful:
+The coolest part of everything mentioned above, is that loading assets this way allows you to group modules and assets in a more intuitive way. Instead of relying on a global `/assets` directory that contains everything, you can group assets with the code that uses them. For example, a structure like this can be useful:
 
 ``` diff
 - |- /assets


### PR DESCRIPTION
'group' itself is explanatory. No need to mention 'together' explicitly.