### PR TITLE
Fix of Issue #3572

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -33,7 +33,7 @@ First let's create a directory, initialize npm, [install webpack locally](/guide
 mkdir webpack-demo
 cd webpack-demo
 npm init -y
-npm install webpack webpack-cli --save-dev
+npm install webpack@4.x  webpack-cli@3.x --save-dev
 ```
 
 T> Throughout the Guides we will use `diff` blocks to show you what changes we're making to directories, files, and code.


### PR DESCRIPTION
Specified the version of webpack in webpack cli in `webpack-4` branch, So when v5 will release the v4 documentation will work fine.

### from
```
npm install webpack  webpack-cli --save-dev
``` 
### to
```
npm install webpack@4.x  webpack-cli@3.x --save-dev
``` 