### PR TITLE
minor grammatical fix

### DIFF
--- a/src/content/concepts/under-the-hood.md
+++ b/src/content/concepts/under-the-hood.md
@@ -68,7 +68,7 @@ Chunks come in two forms - `initial` and `non-initial`
 
 `initial` is the main chunk for the entry point. This chunk contains all the modules (and its dependencies) that you specify for an entry point.
 
-`non-initlal` is a chunk that may be lazy-loaded. It may appear when [dynamic import](/guides/code-splitting/#dynamic-imports) or [SplitChunkPlugin](/plugins/split-chunks-plugin/) is being used.
+`non-initial` is a chunk that may be lazy-loaded. It may appear when [dynamic import](/guides/code-splitting/#dynamic-imports) or [SplitChunkPlugin](/plugins/split-chunks-plugin/) is being used.
 
 Each chunk has a corresponding __asset__.
 The assets are the output files - the result of bundling.


### PR DESCRIPTION
gramma fix


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests

Sorry github was degradating and I did not mention this problem in original PR..
