### PR TITLE
docs(concepts) a follow up on page creation

### DIFF
--- a/src/content/concepts/under-the-hood.md
+++ b/src/content/concepts/under-the-hood.md
@@ -1,11 +1,12 @@
 ---
 title: Under The Hood
-sort: 1
+sort: 13
 contributors:
   - smelukov
+  - EugeneHlushko
 ---
 
-> This section describes webpack internals and useful for plugin developers
+> This section describes webpack internals and can be useful for plugin developers
 
 The bundling is a function that takes some files and emits others.
 
@@ -27,7 +28,7 @@ __./app.js__
 export default 'the app';
 ```
 
-By using each other, the modules form a graph (`ModuleGraph`). 
+By using each other, the modules form a graph (`ModuleGraph`).
 
 Usually, modules don't exist by themselves and combine into chunks.
 Chunks combine into chunk groups and form a graph (`ChunkGraph`) interconnected through modules.
@@ -60,18 +61,16 @@ module.exports = {
 Two chunk groups with names `home` and `about` are created.
 Each of them has a chunk with a module - `./home.js` for `home` and `./about.js` for `about`
 
-> There might be more than one chunk in the chunk group. For example [SplitChunkPlugin](/plugins/split-chunks-plugin/) does so - it splits a chunk into one or more chunks.
+> There might be more than one chunk in a chunk group. For example [SplitChunskPlugin](/plugins/split-chunks-plugin/) splits a chunk into one or more chunks.
 
 ## Chunks
 
-Chunks come in two forms - `initial` and `non-initial`
+Chunks come in two forms:
 
-`initial` is the main chunk for the entry point. This chunk contains all the modules (and its dependencies) that you specify for an entry point.
+- `initial` is the main chunk for the entry point. This chunk contains all the modules and its dependencies that you specify for an entry point.
+- `non-initial` is a chunk that may be lazy-loaded. It may appear when [dynamic import](/guides/code-splitting/#dynamic-imports) or [SplitChunksPlugin](/plugins/split-chunks-plugin/) is being used.
 
-`non-initial` is a chunk that may be lazy-loaded. It may appear when [dynamic import](/guides/code-splitting/#dynamic-imports) or [SplitChunkPlugin](/plugins/split-chunks-plugin/) is being used.
-
-Each chunk has a corresponding __asset__.
-The assets are the output files - the result of bundling.
+Each chunk has a corresponding __asset__. The assets are the output files - the result of bundling.
 
 __webpack.config.js__
 
@@ -102,11 +101,11 @@ Non-initial chunk for `./app.jsx` is created as this module is imported dynamica
 
 __Output:__
 
-- `/dist/main.js` - an initial chunk 
-- `/dist/394.js` - non-initial chunk
+- `/dist/main.js` - an `initial` chunk
+- `/dist/394.js` - `non-initial` chunk
 
-By default, there is no name for non-initial chunks so that a unique ID is used instead of a name.
-In the case of dynamic import we may specify a chunk name explicitly by using a ["magic" comment](/api/module-methods/#magic-comments):
+By default, there is no name for `non-initial` chunks so that a unique ID is used instead of a name.
+When using dynamic import we may specify a chunk name explicitly by using a ["magic" comment](/api/module-methods/#magic-comments):
 
 ```js
 import(
@@ -117,18 +116,18 @@ import(
 
 __Output:__
 
-- `/dist/main.js` - an initial chunk 
-- `/dist/app.js` - non-initial chunk
+- `/dist/main.js` - an `initial` chunk
+- `/dist/app.js` - `non-initial` chunk
 
 ## Output
 
-The names of the output files are affected by two fields in the config:
+The names of the output files are affected by the two fields in the config:
 
-- `output.filename` - for initial chunk files
-- `output.chunkFilename` - for non-initial chunk files
+- [`output.filename`](/configuration/output/#outputfilename) - for `initial` chunk files
+- [`output.chunkFilename`](/configuration/output/#outputchunkfilename) - for `non-initial` chunk files
 
-A few placeholders are available in these fields. Most often:
+A [few placeholders](/configuration/output/#template-strings) are available in these fields. Most often:
 
 - `[id]` - chunk id (e.g. `[id].js` -> `485.js`)
 - `[name]` - chunk name (e.g. `[name].js` -> `app.js`). If a chunk has no name, then its id will used
-- `[contenthash]` - md4-hash from output file content (e.g. `[contenthash].js` -> `4ea6ff1de66c537eb9b2.js`)
+- `[contenthash]` - md4-hash of the output file content (e.g. `[contenthash].js` -> `4ea6ff1de66c537eb9b2.js`)

--- a/src/content/concepts/under-the-hood.md
+++ b/src/content/concepts/under-the-hood.md
@@ -30,7 +30,7 @@ export default 'the app';
 
 By using each other, the modules form a graph (`ModuleGraph`).
 
-Usually, modules don't exist by themselves and combine into chunks.
+During the bundling process, modules are combined into chunks.
 Chunks combine into chunk groups and form a graph (`ChunkGraph`) interconnected through modules.
 When you describe an entry point - under the hood, you create a chunk group with one chunk.
 

--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -322,6 +322,8 @@ Note this option is called filename but you are still allowed to use something l
 
 Note this option does not affect output files for on-demand-loaded chunks. For these files the [`output.chunkFilename`](#outputchunkfilename) option is used. Files created by loaders also aren't affected. In this case you would have to try the specific loader's available options.
 
+## Template strings
+
 The following substitutions are available in template strings (via webpack's internal [`TemplatedPathPlugin`](https://github.com/webpack/webpack/blob/master/lib/TemplatedPathPlugin.js)):
 
 | Template      | Description                                                                         |


### PR DESCRIPTION
- a follow up to do small grammar fixes
- added a link to template strings in output
- fix name of SplitChunksPlugin
- shortened info in `initial` and `non-initial`, use consistently