### PR TITLE
Fix typo in 'Under the hood' page

### DIFF
--- a/src/content/concepts/under-the-hood.md
+++ b/src/content/concepts/under-the-hood.md
@@ -61,7 +61,7 @@ module.exports = {
 Two chunk groups with names `home` and `about` are created.
 Each of them has a chunk with a module - `./home.js` for `home` and `./about.js` for `about`
 
-> There might be more than one chunk in a chunk group. For example [SplitChunskPlugin](/plugins/split-chunks-plugin/) splits a chunk into one or more chunks.
+> There might be more than one chunk in a chunk group. For example [SplitChunksPlugin](/plugins/split-chunks-plugin/) splits a chunk into one or more chunks.
 
 ## Chunks
 


### PR DESCRIPTION
This PR fixes a typo in 'under the hood' page of the docs.