### PR TITLE
docs(readme): hyperlinking versioning issue in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Since webpack 4 we have created a subdomain-based archive for older states of do
 matching older webpack version. webpack 4's documentation is available at
 [https://v4.webpack.js.org/](https://v4.webpack.js.org/) and is deployed from [`gh-pages` branch of v4.webpack.js.org repository](https://github.com/webpack/v4.webpack.js.org/tree/gh-pages)
 
-There are various known issues that need fixing (#3366).
+There are various known issues that need fixing ([#3366](https://github.com/webpack/webpack.js.org/issues/3366)).
 
 ## Contributing
 


### PR DESCRIPTION
_describe your changes..._
fixes: #3605

hyperlinking #3366 in the readme file 

[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
