### PR TITLE
Fix typos across webpack.js.org repo

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -775,7 +775,7 @@ module.exports = {
 
 `boolean = false`
 
-Tells dev-server to supress messages like the webpack bundle information. Errors and warnings will still be shown.
+Tells dev-server to suppress messages like the webpack bundle information. Errors and warnings will still be shown.
 
 __webpack.config.js__
 

--- a/src/content/configuration/index.mdx
+++ b/src/content/configuration/index.mdx
@@ -281,7 +281,7 @@ module.exports = {
       // properties that are read from description file
       // when a folder is requested
       aliasFields: ["browser"],
-      // properites that are read from description file
+      // properties that are read from description file
       // to alias requests in this package
       enforceExtension: false,
       // if true request must not include an extension

--- a/src/utilities/process-readme.js
+++ b/src/utilities/process-readme.js
@@ -37,7 +37,7 @@ function linkFixerFactory(sourceUrl) {
       href = url.resolve(rendered_url, href);
     }
 
-    // Modify absolute documenation links to be root relative
+    // Modify absolute documentation links to be root relative
     if (beginsWithDocsDomainRegex.test(href)) {
       href = href.replace(beginsWithDocsDomainRegex, '');
     }


### PR DESCRIPTION
:writing_hand: **Fix typos across webpack.js.org repo**

**Files that have typos**

```
webpack.js.org/src/content/configuration/dev-server.md:778:20: "supress" is a misspelling of "suppress"
webpack.js.org/src/content/configuration/index.mdx:284:9: "properites" is a misspelling of "properties"
webpack.js.org/src/utilities/process-readme.js:40:23: "documenation" is a misspelling of "documentation"
```

**PS:** I use [**client9/misspell**](https://github.com/client9/misspell) to scan typos :heart: 

Making the world a better place :innocent: