### PR TITLE
fix(component): fix style bugs in Footer component

### DIFF
--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -23,6 +23,9 @@
 .footer__right {
   flex: 0 0 auto;
   display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  max-width: 100%;
   margin: auto;
   align-items: center;
   padding: 0.25em 0;


### PR DESCRIPTION
Fix style bugs in `Footer` component which caused body's max width wider than screen width in mobile phone browser.

Before style change:

![body's width become wider than screen width](https://user-images.githubusercontent.com/18362949/76285249-42b87980-62da-11ea-91ea-22af33d5209b.jpeg)


After style change:

![normal](https://user-images.githubusercontent.com/18362949/76285257-477d2d80-62da-11ea-9808-cb3c3dfb39d0.jpeg)


