### PR TITLE
chore: refactored the styling for markdown tables

### DIFF
--- a/src/components/Markdown/Markdown.scss
+++ b/src/components/Markdown/Markdown.scss
@@ -254,7 +254,7 @@ $topHeightDesktopWithBanner: $bannerHeight + $topHeightDesktop;
   }
 
   .title {
-    width: 40%;
+    width: unset;
     display: flex;
     flex-direction: column;
     justify-content: baseline;
@@ -266,11 +266,12 @@ $topHeightDesktopWithBanner: $bannerHeight + $topHeightDesktop;
   }
 
   .content {
-    width: 60%;
+    width: unset;
     display: flex;
     flex-direction: column;
     justify-content: baseline;
     margin: 10px 0;
+    padding: 0 10px
   }
 
   .description.desktop {


### PR DESCRIPTION
Made a Little change with the styling of `markdown` component

### Before

![image](https://user-images.githubusercontent.com/26347874/76343239-d2374a00-6325-11ea-8f34-d08b8b1c0da5.png)


### After

![image](https://user-images.githubusercontent.com/26347874/76343272-df543900-6325-11ea-9b7d-be605ccc8e4c.png)


### Before (Mobile view)

![image](https://user-images.githubusercontent.com/26347874/76343447-204c4d80-6326-11ea-91a6-d2e29809ebf2.png)


### After (Mobile view)

![image](https://user-images.githubusercontent.com/26347874/76343736-8d5fe300-6326-11ea-89cf-6390cb21521e.png)

