### PR TITLE
Docs: IgnorePlugin: Clarify the “deprecated” usage

### DIFF
--- a/src/content/plugins/ignore-plugin.md
+++ b/src/content/plugins/ignore-plugin.md
@@ -6,6 +6,7 @@ contributors:
   - DullReferenceException
   - EugeneHlushko
   - FadySamirSadek
+  - iamakulov
 ---
 
 IgnorePlugin prevents generation of modules for `import` or `require` calls matching the regular expressions or filter functions:
@@ -17,7 +18,7 @@ IgnorePlugin prevents generation of modules for `import` or `require` calls matc
 
 ```javascript
 new webpack.IgnorePlugin({resourceRegExp, contextRegExp});
-// old way, deprecated in webpack v5
+// Supported in webpack 4 and earlier, unsupported in webpack 5:
 new webpack.IgnorePlugin(resourceRegExp, [contextRegExp]);
 ```
 


### PR DESCRIPTION
“Deprecated” means “it works but will be deleted soon”, which is not the case in webpack 5. Webpack 5 drop support for the old approach completely.