### PR TITLE
docs(examples) fix examples missing a require

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -258,6 +258,8 @@ By default, it will use your current working directory to serve content. To disa
 __webpack.config.js__
 
 ```javascript
+const path = require('path');
+
 module.exports = {
   //...
   devServer: {
@@ -271,6 +273,8 @@ It is also possible to serve from multiple directories:
 __webpack.config.js__
 
 ```javascript
+const path = require('path');
+
 module.exports = {
   //...
   devServer: {
@@ -295,6 +299,8 @@ Tell the server at what URL to serve `devServer.contentBase` static content. If 
 __webpack.config.js__
 
 ```javascript
+const path = require('path');
+
 module.exports = {
   //...
   devServer: {

--- a/src/content/configuration/entry-context.md
+++ b/src/content/configuration/entry-context.md
@@ -21,6 +21,8 @@ The entry object is where webpack looks to start building the bundle. The contex
 The base directory, an __absolute path__, for resolving entry points and loaders from configuration.
 
 ``` js
+const path = require('path');
+
 module.exports = {
   //...
   context: path.resolve(__dirname, 'app')
@@ -68,14 +70,14 @@ module.exports = {
   entry: {
     home: './home.js',
     shared: ['react', 'react-dom', 'redux', 'react-redux'],
-    catalog: { 
-      import: './catalog.js', 
-      filename: 'pages/catalog.js', 
+    catalog: {
+      import: './catalog.js',
+      filename: 'pages/catalog.js',
       dependOn:'shared'
     },
-    personal: { 
-      import: './personal.js', 
-      filename: 'pages/personal.js', 
+    personal: {
+      import: './personal.js',
+      filename: 'pages/personal.js',
       dependOn:'shared'
     }
   }

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -674,6 +674,8 @@ Conditions can be one of these:
 __Example:__
 
 ```javascript
+const path = require('path');
+
 module.exports = {
   //...
   module: {

--- a/src/content/configuration/other-options.md
+++ b/src/content/configuration/other-options.md
@@ -287,6 +287,8 @@ Use this option to generate a JSON file containing webpack "records" -- pieces o
 __webpack.config.js__
 
 ```javascript
+const path = require('path');
+
 module.exports = {
   //...
   recordsPath: path.join(__dirname, 'records.json')
@@ -316,6 +318,8 @@ Specify where the records should be written. The following example shows how you
 __webpack.config.js__
 
 ```javascript
+const path = require('path');
+
 module.exports = {
   //...
   recordsInputPath: path.join(__dirname, 'records.json'),

--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -884,6 +884,8 @@ The output directory as an __absolute__ path.
 __webpack.config.js__
 
 ```javascript
+const path = require('path');
+
 module.exports = {
   //...
   output: {
@@ -932,6 +934,8 @@ Simple rule: The URL of your [`output.path`](#outputpath) from the view of the H
 __webpack.config.js__
 
 ```javascript
+const path = require('path');
+
 module.exports = {
   //...
   output: {

--- a/src/content/configuration/resolve.md
+++ b/src/content/configuration/resolve.md
@@ -47,6 +47,8 @@ Create aliases to `import` or `require` certain modules more easily. For example
 __webpack.config.js__
 
 ```js
+const path = require('path');
+
 module.exports = {
   //...
   resolve: {
@@ -75,6 +77,8 @@ A trailing `$` can also be added to the given object's keys to signify an exact 
 __webpack.config.js__
 
 ```js
+const path = require('path');
+
 module.exports = {
   //...
   resolve: {
@@ -317,6 +321,8 @@ If you want to add a directory to search in that takes precedence over `node_mod
 __webpack.config.js__
 
 ```js
+const path = require('path');
+
 module.exports = {
   //...
   resolve: {

--- a/src/content/contribute/writing-a-loader.md
+++ b/src/content/contribute/writing-a-loader.md
@@ -21,6 +21,8 @@ To test a single loader, you can simply use `path` to `resolve` a local file wit
 __webpack.config.js__
 
 ```js
+const path = require('path');
+
 module.exports = {
   //...
   module: {
@@ -44,6 +46,8 @@ To test multiple, you can utilize the `resolveLoader.modules` configuration to u
 __webpack.config.js__
 
 ```js
+const path = require('path');
+
 module.exports = {
   //...
   resolveLoader: {

--- a/src/content/guides/build-performance.md
+++ b/src/content/guides/build-performance.md
@@ -49,6 +49,8 @@ module.exports = {
 Use the `include` field to only apply the loader modules that actually need to be transformed by it:
 
 ```js
+const path = require('path');
+
 module.exports = {
   //...
   module: {

--- a/src/content/plugins/dll-plugin.md
+++ b/src/content/plugins/dll-plugin.md
@@ -81,6 +81,8 @@ W> `DllReferencePlugin` and `DllPlugin` are used in _separate_ webpack configs.
 __webpack.vendor.config.js__
 
 ```javascript
+const path = require('path');
+
 new webpack.DllPlugin({
   context: __dirname,
   name: '[name]_[hash]',

--- a/src/content/plugins/provide-plugin.md
+++ b/src/content/plugins/provide-plugin.md
@@ -31,6 +31,8 @@ By default, module resolution path is current folder (`./**)` and `node_modules`
 It is also possible to specify full path:
 
 ```js
+const path = require('path');
+
 new webpack.ProvidePlugin({
   identifier: path.resolve(path.join(__dirname, 'src/module1'))
   // ...


### PR DESCRIPTION
In order to make all of our examples accessible i've added the missing require call to `path` as we already had it in almost all examples using `path` directly