### PR TITLE
Docs(config) : Remove futureEmitAssets

### DIFF
--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -1085,23 +1085,6 @@ module.exports = {
 };
 ```
 
-## `output.futureEmitAssets`
-
-`boolean = false`
-
-Tells webpack to use the future version of asset emitting logic, which allows freeing memory of assets after emitting. It could break plugins which assume that assets are still readable after they were emitted.
-
-W> `output.futureEmitAssets` option will be removed in webpack v5.0.0 and this behaviour will become the new default.
-
-```javascript
-module.exports = {
-  //...
-  output: {
-    futureEmitAssets: true
-  }
-};
-```
-
 ## `output.ecmaVersion`
 
 `number = 6`


### PR DESCRIPTION
This [option](https://github.com/webpack/webpack.js.org/pull/3650#pullrequestreview-381794370) is no more there in webpack 5

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].
