### PR TITLE
docs(configuration): fix deprecated apply usage

### DIFF
--- a/src/content/configuration/target.md
+++ b/src/content/configuration/target.md
@@ -58,10 +58,8 @@ const webpack = require('webpack');
 
 const options = {
   target: (compiler) => {
-    compiler.apply(
-      new webpack.JsonpTemplatePlugin(options.output),
-      new webpack.LoaderTargetPlugin('web')
-    );
+    new webpack.JsonpTemplatePlugin(options.output).apply(compiler);
+    new webpack.LoaderTargetPlugin('web').apply(compiler);
   }
 };
 ```


### PR DESCRIPTION
Calling `apply` on Tappable is marked deprecated.
