### PR TITLE
Docs(plugin): schema-utils api changed

### DIFF
--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -76,7 +76,7 @@ module.exports = {
 ```
 
 
-Use [`schema-utils`](https://github.com/webpack/schema-utils) in order to validate the options being passed through the plugin options.(Notice that [`schema-utils`](https://github.com/webpack/schema-utils) api has changed, but webpack use the v1.0.0 version, so you should the same version with webpack.) Here is an example:
+Use [`schema-utils`](https://github.com/webpack/schema-utils) in order to validate the options being passed through the plugin options.(Notice that [`schema-utils`](https://github.com/webpack/schema-utils) API has changed, but webpack use the v1.0.0 version, so you should use the same version with webpack.) Here is an example:
 
 ```javascript
 

--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -76,7 +76,7 @@ module.exports = {
 ```
 
 
-Use [`schema-utils`](https://github.com/webpack/schema-utils) in order to validate the options being passed through the plugin options. Here is an example:
+Use [`schema-utils`](https://github.com/webpack/schema-utils) in order to validate the options being passed through the plugin options.(Notice that [`schema-utils`](https://github.com/webpack/schema-utils) api has changed, but webpack use the v1.0.0 version, so you should the same version with webpack.) Here is an example:
 
 ```javascript
 
@@ -95,7 +95,7 @@ const schema = {
 export default class HelloWorldPlugin {
 
   constructor(options = {}){
-    validateOptions(schema, options, { name: 'Hello World Plugin' });
+    validateOptions(schema, options, 'Hello World Plugin');
   }
 
   apply(compiler) {}

--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -95,7 +95,7 @@ const schema = {
 export default class HelloWorldPlugin {
 
   constructor(options = {}){
-    validateOptions(schema, options, 'Hello World Plugin');
+    validateOptions(schema, options, { name: 'Hello World Plugin' });
   }
 
   apply(compiler) {}

--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -76,7 +76,11 @@ module.exports = {
 ```
 
 
-Use [`schema-utils`](https://github.com/webpack/schema-utils) in order to validate the options being passed through the plugin options.(Notice that [`schema-utils`](https://github.com/webpack/schema-utils) API has changed, but webpack use the v1.0.0 version, so you should use the same version with webpack.) Here is an example:
+Use [`schema-utils`](https://github.com/webpack/schema-utils) in order to validate the options being passed through the plugin options. Here is an example:
+
+// example goes here 
+
+W> [`schema-utils`](https://github.com/webpack/schema-utils) API has changed in recent versions, although webpack still uses the `v1.0.0` version and we ask you to do the same until further notice.
 
 ```javascript
 

--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -78,10 +78,6 @@ module.exports = {
 
 Use [`schema-utils`](https://github.com/webpack/schema-utils) in order to validate the options being passed through the plugin options. Here is an example:
 
-// example goes here 
-
-W> [`schema-utils`](https://github.com/webpack/schema-utils) API has changed in recent versions, although webpack still uses the `v1.0.0` version and we ask you to do the same until further notice.
-
 ```javascript
 
 import validateOptions from 'schema-utils';
@@ -106,6 +102,7 @@ export default class HelloWorldPlugin {
 }
 ```
 
+W> [`schema-utils`](https://github.com/webpack/schema-utils) API has changed in recent versions, although webpack still uses the `v1.0.0` version and we ask you to do the same until further notice.
 
 ## Compiler and Compilation
 


### PR DESCRIPTION
schema-utils api has change the third param to type below

```ts
export type ValidationErrorConfiguration = {
  name?: string | undefined;
  baseDataPath?: string | undefined;
  postFormatter?: PostFormatter | undefined;
};
```

see: [https://github.com/webpack/schema-utils/pull/41](https://github.com/webpack/schema-utils/pull/41)

from the guide, the developer may use the latest version of schema-utils that not matched the version that webpack used.

So I add a notice to warning this.