### PR TITLE
docs(devServer): add type array for contentBasePublicPath option

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -19,6 +19,7 @@ contributors:
   - jamesgeorge007
   - g100g
   - anikethsaha
+  - snitin315
 ---
 
 [webpack-dev-server](https://github.com/webpack/webpack-dev-server) can be used to quickly develop an application. See the [development guide](/guides/development/) to get started.
@@ -292,7 +293,7 @@ webpack-dev-server --content-base /path/to/content/dir
 
 ## `devServer.contentBasePublicPath`
 
-`string = '/'`
+`string = '/'` `[string]`
 
 Tell the server at what URL to serve `devServer.contentBase` static content. If there was a file `assets/manifest.json`, it would be served at `/serve-content-base-at-this-url/manifest.json`
 
@@ -310,6 +311,22 @@ module.exports = {
 };
 ```
 
+T> In case when you have several micro applications which all have custom static folders, you can pass an array of strings.
+
+__webpack.config.js__
+
+```javascript
+module.exports = {
+  //...
+  devServer: {
+    contentBase: [contentBasePublic, contentBaseOther],
+    contentBasePublicPath: [
+      contentBasePublicPath,
+      contentBasePublicOtherPath,
+    ]
+  }
+};
+```
 
 ## `devServer.disableHostCheck`
 

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -269,7 +269,7 @@ module.exports = {
 };
 ```
 
-It is also possible to serve from multiple directories:
+It is also possible to serve from multiple directories in case you want to serve static content at multiple URLs with [`contentBasePublicPath`](#devservercontentbasepublicpath):
 
 __webpack.config.js__
 
@@ -311,7 +311,7 @@ module.exports = {
 };
 ```
 
-Provide an array of strings in case you have multiple static folders set in  [`contentBase`](#devservercontentbase)
+Provide an array of strings in case you have multiple static folders set in [`contentBase`](#devservercontentbase).
 
 __webpack.config.js__
 
@@ -322,7 +322,7 @@ module.exports = {
     contentBase: [contentBasePublic, contentBaseOther],
     contentBasePublicPath: [
       contentBasePublicPath,
-      contentBasePublicOtherPath,
+      contentBasePublicOtherPath
     ]
   }
 };

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -311,7 +311,7 @@ module.exports = {
 };
 ```
 
-T> In case when you have several micro applications which all have custom static folders, you can pass an array of strings.
+Provide an array of strings in case you have multiple static folders set in  [`contentBase`](#devservercontentbase)
 
 __webpack.config.js__
 


### PR DESCRIPTION
Fixes #3668 

added type array for contentBasePublicPath option.

[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
