### PR TITLE
Break flex items into multiple lines

### DIFF
--- a/src/components/Markdown/Markdown.scss
+++ b/src/components/Markdown/Markdown.scss
@@ -39,6 +39,7 @@ $topHeightDesktopWithBanner: $bannerHeight + $topHeightDesktop;
   h5,
   h6 {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     font-family: $font-stack-heading;
     font-weight: 600;


### PR DESCRIPTION
Headings look weird currently, take this heading on page https://webpack.js.org/migrate/3/#automatic--loader-module-name-extension-removed for example:

![image](https://user-images.githubusercontent.com/1091472/78553618-29084480-783c-11ea-8adf-721fb24d5d5c.png)

Applying `flex-wrap: wrap` will make it look better:

![compare](https://user-images.githubusercontent.com/1091472/78553752-6076f100-783c-11ea-93c7-7fde983ed1eb.png)
