### PR TITLE
chore(app): Fix warning for react-banner

### DIFF
--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -15,12 +15,15 @@ import 'docsearch.js/dist/cdn/docsearch.css';
 import './Navigation.scss';
 import './Search.scss';
 
+const onSearch = () => {};
+
 export default class Navigation extends React.Component {
   render() {
     let { pathname, links, toggleSidebar } = this.props;
 
     return (
       <Banner
+        onSearch={onSearch}
         blockName="navigation"
         logo={ <Logo light={ true } /> }
         url={ pathname }


### PR DESCRIPTION
Currently there's error related to react-banner in `development` mode when we input anything in the search box:

![image](https://user-images.githubusercontent.com/1091472/78668293-0560ff00-790d-11ea-8d2a-1628a22b7602.png)

It exists in `production` too:

![image](https://user-images.githubusercontent.com/1091472/78668559-743e5800-790d-11ea-8fd8-650468175621.png)

It is caused by https://github.com/skipjack/react-banner/blob/master/src/banner/banner-search.jsx#L55 calling `onSearch` prop which we do not provide.

This pull request set `onSearch` to an empty function to fix it.