### PR TITLE
fix(site): fix style for search result

### DIFF
--- a/src/components/Navigation/Search.scss
+++ b/src/components/Navigation/Search.scss
@@ -90,15 +90,9 @@
     color: getColor(dusty-grey);
 
     .algolia-docsearch-suggestion--highlight {
-      color: $text-color-highlight;
       box-shadow: none;
       font-weight: bold;
     }
-  }
-
-  .algolia-docsearch-suggestion--highlight {
-    color: $text-color-highlight;
-    background: rgba(getColor(malibu), 0.15);
   }
 
   .algolia-docsearch-suggestion--category-header {
@@ -116,11 +110,19 @@
     background: transparentize(getColor(dusty-grey), 0.92);
     display: block;
     color: transparent;
+    .algolia-docsearch-suggestion--highlight {
+      color: transparent;
+      background: transparent;
+    }
   }
 
   .algolia-docsearch-suggestion__secondary
     .algolia-docsearch-suggestion--subcategory-column {
     color: getColor(dove-grey);
+    .algolia-docsearch-suggestion--highlight {
+      color: $text-color-highlight;
+      background: rgba(getColor(malibu), 0.15);
+    }
   }
 
   .algolia-docsearch-suggestion--content {

--- a/src/components/Navigation/Search.scss
+++ b/src/components/Navigation/Search.scss
@@ -129,6 +129,16 @@
     padding: 8px 16px 8px 12px;
   }
 
+  .algolia-docsearch-suggestion__secondary {
+    border-top: 1px solid lighten(getColor(mine-shaft), 65%);
+  }
+
+  .ds-suggestion:first-of-type {
+    .algolia-docsearch-suggestion__secondary {
+      border-top: none;
+    }
+  }
+
   .ds-suggestion:nth-child(n + 2) {
     .algolia-docsearch-suggestion--category-header {
       border-top: 1px solid #dedede;


### PR DESCRIPTION
This pull request contains two commits, first commit would fix issue https://github.com/webpack/webpack.js.org/issues/3686

![compare@3x](https://user-images.githubusercontent.com/1091472/79232860-a49c6e00-7e9a-11ea-83b1-993997fb8d66.png)

While second commit adding borders would visually group suggestions together, 

![image](https://user-images.githubusercontent.com/1091472/79236229-44f49180-7e9f-11ea-8820-68c86aaf352c.png)

![image](https://user-images.githubusercontent.com/1091472/79295850-5922a800-7f0c-11ea-9915-fbae7f199026.png)


I'm not quite sure about the second one which is why I break it into another commit. I can squash them if anyone think it's a good idea to merge it.