### PR TITLE
ui(vote) fix markdown styles squeezing vote layout

### DIFF
--- a/src/components/Vote/Vote.jsx
+++ b/src/components/Vote/Vote.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import Container from '../Container/Container';
 import 'webpack.vote/dist/style.min.css';
 
+// Load Styling
+import './Vote.scss';
+
 export default class Vote extends React.Component {
   state = {
     VoteApp: null

--- a/src/components/Vote/Vote.scss
+++ b/src/components/Vote/Vote.scss
@@ -1,0 +1,6 @@
+.vote {
+  ul,
+  ol {
+    padding-left: 0;
+  }
+}


### PR DESCRIPTION
Noticed markdown styles squeezing vote layout, fixed.

Before
![Screenshot_2020-04-14 webpack](https://user-images.githubusercontent.com/10549495/79266784-d1ec1a80-7ea0-11ea-8278-88ba823cd5fd.png)


After
![Screenshot_2020-04-14 Vote webpack](https://user-images.githubusercontent.com/10549495/79266793-d6183800-7ea0-11ea-863e-583d767883cb.png)
