### PR TITLE
docs(config) re-arrange stats page top to make more sense to the read…

### DIFF
--- a/src/content/api/compiler-hooks.md
+++ b/src/content/api/compiler-hooks.md
@@ -266,7 +266,7 @@ Called after emitting assets to output directory.
 
 `AsyncSeriesHook`
 
-Executed when an asset has been emitted. Provides access to information about the emitted asset, such as its output path and byte content. 
+Executed when an asset has been emitted. Provides access to information about the emitted asset, such as its output path and byte content.
 
 - Callback Parameters: `file`, `info`
 
@@ -328,6 +328,6 @@ Allows to use infrastructure logging when enabled in the configuration via [`inf
 
 `SyncBailHook`
 
-Allows to log into [stats](/configuration/stats/) when enabled, see [`stats.logging`, `stats.loggingDebug` and `stats.loggingTrace` options](/configuration/stats/#stats).
+Allows to log into [stats](/configuration/stats/) when enabled, see [`stats.logging`, `stats.loggingDebug` and `stats.loggingTrace` options](/configuration/stats/#stats-options).
 
 - Callback Parameters: `origin`, `logEntry`

--- a/src/content/api/loaders.md
+++ b/src/content/api/loaders.md
@@ -363,7 +363,7 @@ Here is a Warning!
  @ ./src/index.js 1:0-25
  ```
 
-T> Note that the warnings will not be displayed if `stats.warnings` is set to `false`, or some other omit setting is used to `stats` such as `none` or `errors-only`. See the [stats configuration](/configuration/stats/#stats).
+T> Note that the warnings will not be displayed if `stats.warnings` is set to `false`, or some other omit setting is used to `stats` such as `none` or `errors-only`. See the [stats presets configuration](/configuration/stats/#stats-presets).
 
 ### `this.emitError`
 

--- a/src/content/api/stats.mdx
+++ b/src/content/api/stats.mdx
@@ -27,7 +27,7 @@ The top-level structure of the output JSON file is fairly straightforward but th
   'version': '5.0.0-alpha.6', // Version of webpack used for the compilation
   'hash': '11593e3b3ac85436984a', // Compilation specific hash
   'time': 2469, // Compilation time in milliseconds
-  'filteredModules': 0, // A count of excluded modules when [`exclude`](/configuration/stats/#stats) is passed to the [`toJson`](/api/node/#statstojsonoptions) method
+  'filteredModules': 0, // A count of excluded modules when [`exclude`](/configuration/stats/#statsexclude) is passed to the [`toJson`](/api/node/#statstojsonoptions) method
   'outputPath': ''/', // path to webpack output directory
   'assetsByChunkName': {
     // Chunk name to emitted asset(s) mapping

--- a/src/content/configuration/other-options.md
+++ b/src/content/configuration/other-options.md
@@ -399,7 +399,7 @@ module.exports = {
 
 `string` `RegExp` `function(name) => boolean` `[string, RegExp, function(name) => boolean]`
 
-Enable debug information of specified loggers such as plugins or loaders. Similar to [`stats.loggingDebug`](/configuration/stats/#stats) option but for infrastructure. No default value is given.
+Enable debug information of specified loggers such as plugins or loaders. Similar to [`stats.loggingDebug`](/configuration/stats/#statsloggingdebug) option but for infrastructure. No default value is given.
 
 __webpack.config.js__
 

--- a/src/content/configuration/stats.md
+++ b/src/content/configuration/stats.md
@@ -636,7 +636,7 @@ module.exports = {
 
 `string` `boolean: false`
 
-Sets the [preset](/configuration/stats/#stats) for the type of information that gets displayed. It is useful for [extending stats behaviours](/configuration/stats/#extending-stats-behaviours).
+Sets the [preset](/configuration/stats/#stats-presets) for the type of information that gets displayed. It is useful for [extending stats behaviours](/configuration/stats/#extending-stats-behaviours).
 
 ```javascript
 module.exports = {
@@ -647,7 +647,7 @@ module.exports = {
 };
 ```
 
-Setting value of `stats.preset` to `false` tells webpack to use `'none'` [stats preset](/configuration/stats/#stats).
+Setting value of `stats.preset` to `false` tells webpack to use `'none'` [stats preset](/configuration/stats/#stats-presets).
 
 ### `stats.providedExports`
 

--- a/src/content/configuration/stats.md
+++ b/src/content/configuration/stats.md
@@ -16,19 +16,17 @@ contributors:
   - pixel-ray
 ---
 
+`object` `string`
+
 The `stats` option lets you precisely control what bundle information gets displayed. This can be a nice middle ground if you don't want to use `quiet` or `noInfo` because you want some bundle information, but not all of it.
 
-T> For webpack-dev-server, this property needs to be in the `devServer` object.
+T> For webpack-dev-server, this property needs to be in the [`devServer` configuration object](/configuration/dev-server/#devserverstats-).
 
-T> For webpack-dev-middleware, this property needs to be in the webpack-dev-middleware's `options` object.
+T> For [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware), this property needs to be in the webpack-dev-middleware's `options` object.
 
 W> This option does not have any effect when using the Node.js API.
 
-## `stats`
-
-`object` `string`
-
-There are some presets available to use as a shortcut. Use them like this:
+__webpack.js.org__
 
 ```js
 module.exports = {
@@ -36,6 +34,11 @@ module.exports = {
   stats: 'errors-only'
 };
 ```
+
+## Stats Presets
+
+webpack comes with certain presets available for the stats output:
+
 
 | Preset              | Alternative | Description                                                    |
 | ------------------- | ----------- | -------------------------------------------------------------- |
@@ -47,7 +50,11 @@ module.exports = {
 | `'verbose'`         | _none_      | Output everything                                              |
 | `'detailed'`        | _none_      | Output everything except `chunkModules` and `chunkRootModules` |
 
-For more granular control, it is possible to specify exactly what information you want. Please note that all of the options in this object are optional.
+## Stats Options
+
+It is possible to specify which information you want to see in the stats output.
+
+T> All of the options in the stats configuration object are optional.
 
 ### `stats.all`
 


### PR DESCRIPTION
…er. Add links

- Change page content + header structure
- simplify reading
- add sub sections for presets + options
- link back to dev-server and dev-middleware

![Screenshot_2020-04-14 Stats webpack(1)](https://user-images.githubusercontent.com/10549495/79268732-eaa9ff80-7ea3-11ea-8cb2-0656a6c59436.png)

