### PR TITLE
Docs(config) : Change default value of watchOptions.aggregateTimeout

### DIFF
--- a/src/content/configuration/watch.md
+++ b/src/content/configuration/watch.md
@@ -34,7 +34,7 @@ T> In [webpack-dev-server](https://github.com/webpack/webpack-dev-server) and [w
 
 ## `watchOptions`
 
-`object` `number`
+`object` `number = 200`
 
 A set of options used to customize watch mode:
 
@@ -44,7 +44,7 @@ __webpack.config.js__
 module.exports = {
   //...
   watchOptions: {
-    aggregateTimeout: 300,
+    aggregateTimeout: 200,
     poll: 1000
   }
 };
@@ -64,7 +64,7 @@ module.exports = {
 
 ## `watchOptions.aggregateTimeout`
 
-`number = 300`
+`number = 200`
 
 Add a delay before rebuilding once the first file changed. This allows webpack to aggregate any other changes made during this time period into one rebuild. Pass a value in milliseconds:
 


### PR DESCRIPTION
I followed the same value while writing the docs but the default value is 200 and not 300 
https://github.com/webpack/webpack/blob/2346f6b245a92f317535018129260d7c015734c9/lib/Watching.js#L46

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].

