### PR TITLE
docs(plugins) : Remove note about splitChunk.name:False 

### DIFF
--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -206,8 +206,6 @@ If you choose to specify a function, you may find the `chunk.name` and `chunk.ha
 
 If the `splitChunks.name` matches an [entry point](/configuration/entry-context/#entry) name, the entry point will be removed.
 
-T> It is recommended to set `splitChunks.name` to `false` for production builds so that it doesn't change names unnecessarily.
-
 __main.js__
 
 ```js


### PR DESCRIPTION
Refer :

There is chunkIds: "named" as default in dev mode which is better 

https://github.com/webpack/webpack/pull/8432#issuecomment-447661876

https://github.com/webpack/webpack/blob/b0cdbf87b02685cd21dc7726eb7227872e142f5d/lib/config/defaults.js#L523

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].
