### PR TITLE
Guides(Shimming): Correct the resolve file path of rule test

### DIFF
--- a/src/content/guides/shimming.md
+++ b/src/content/guides/shimming.md
@@ -179,7 +179,7 @@ __webpack.config.js__
 +   module: {
 +     rules: [
 +       {
-+         test: require.resolve('index.js'),
++         test: require.resolve('./src/index.js'),
 +         use: 'imports-loader?this=>window',
 +       },
 +     ],
@@ -237,11 +237,11 @@ __webpack.config.js__
     module: {
       rules: [
         {
-          test: require.resolve('index.js'),
+          test: require.resolve('./src/index.js'),
           use: 'imports-loader?this=>window',
         },
 +       {
-+         test: require.resolve('globals.js'),
++         test: require.resolve('./src/globals.js'),
 +         use: 'exports-loader?file,parse=helpers.parse',
 +       },
       ],
@@ -355,11 +355,11 @@ __webpack.config.js__
     module: {
       rules: [
         {
-          test: require.resolve('index.js'),
+          test: require.resolve('./src/index.js'),
           use: 'imports-loader?this=>window',
         },
         {
-          test: require.resolve('globals.js'),
+          test: require.resolve('./src/globals.js'),
           use: 'exports-loader?file,parse=helpers.parse',
         },
       ],


### PR DESCRIPTION
The index.js and globals.js are in the src directory, so the `require.resolve('index.js')` should be `require.resolve('./src/index.js')`, or else it will throw `error: Cannot find module 'index.js'` when built, and so does globals.js.