### PR TITLE
docs(api): update example link for webpack 5

### DIFF
--- a/src/content/api/node.mdx
+++ b/src/content/api/node.mdx
@@ -225,7 +225,7 @@ stats.toJson({
 All available options and presets are described in the stats [documentation](/configuration/stats).
 
 > Here’s an [example]
-(https://raw.githubusercontent.com/webpack/analyse/master/app/pages/upload/example1.json)
+(https://raw.githubusercontent.com/webpack/analyse/master/app/pages/upload/example2.json)
 of this function’s output.
 
 


### PR DESCRIPTION
I've submitted a pull request here https://github.com/webpack/webpack.js.org/pull/3537 two months ago which is unfortunately wrong as I found today.

According to webpack changelog https://github.com/webpack/changelog-v5#minor-changes:

> Stats json errors and warnings no longer contain strings but objects with information splitted into properties.
> MIGRATION: Access the information on the properties. i. e. message

Then `example2.json` is for webpack 5 while `example1.json` is for webpack 4.