### PR TITLE
docs(migrate): fix webpack version

### DIFF
--- a/src/content/migrate/5.md
+++ b/src/content/migrate/5.md
@@ -7,6 +7,7 @@ contributors:
   - keichinger
   - EugeneHlushko
   - MattGoldwater
+  - chenxsan
 ---
 
 This guide aims to help you migrating to webpack 5 when using webpack directly. If you are using a higher level tool to run webpack, please refer to the tool for migration instructions.
@@ -92,9 +93,9 @@ T> webpack 5 removes these options from the configuration schema and will always
 
 #### Upgrade webpack version
 
-npm: `npm install webpack@next --dev`
+npm: `npm install webpack@beta --dev`
 
-Yarn: `yarn add webpack@next -D`
+Yarn: `yarn add webpack@beta -D`
 
 #### Clean up configuration
 


### PR DESCRIPTION
The latest webpack 5 is published under `beta` not `next` as far as I see here https://www.npmjs.com/package/webpack?activeTab=versions:

![image](https://user-images.githubusercontent.com/1091472/80001432-efe4fb00-84f0-11ea-8685-9b603765ac74.png)

