### PR TITLE
Update links behind subscription wall

### DIFF
--- a/src/content/configuration/watch.md
+++ b/src/content/configuration/watch.md
@@ -115,7 +115,7 @@ T> If you use `require.context`, webpack will watch your entire directory. You w
 
 `boolean = false` `number`
 
-Turn on [polling](https://whatis.techtarget.com/definition/polling) by passing `true`, or specifying a poll interval in milliseconds:
+Turn on [polling](https://en.wikipedia.org/wiki/Polling_(computer_science)) by passing `true`, or specifying a poll interval in milliseconds:
 
 __webpack.config.js__
 

--- a/src/content/guides/caching.md
+++ b/src/content/guides/caching.md
@@ -20,7 +20,7 @@ related:
 
 T> The examples in this guide stem from [getting started](/guides/getting-started), [output management](/guides/output-management) and [code splitting](/guides/code-splitting).
 
-So we're using webpack to bundle our modular application which yields a deployable `/dist` directory. Once the contents of `/dist` have been deployed to a server, clients (typically browsers) will hit that server to grab the site and its assets. The last step can be time consuming, which is why browsers use a technique called [caching](https://searchstorage.techtarget.com/definition/cache). This allows sites to load faster with less unnecessary network traffic. However, it can also cause headaches when you need new code to be picked up.
+So we're using webpack to bundle our modular application which yields a deployable `/dist` directory. Once the contents of `/dist` have been deployed to a server, clients (typically browsers) will hit that server to grab the site and its assets. The last step can be time consuming, which is why browsers use a technique called [caching](https://en.wikipedia.org/wiki/Cache_(computing)). This allows sites to load faster with less unnecessary network traffic. However, it can also cause headaches when you need new code to be picked up.
 
 This guide focuses on the configuration needed to ensure files produced by webpack compilation can remain cached unless their content has changed.
 


### PR DESCRIPTION
Update the polling link and cache link to the wikipedia ones since the currently linked articles are behind a subscription wall

![image](https://user-images.githubusercontent.com/7217420/80205484-fa0b1480-862a-11ea-9f2c-d968d6151478.png)
