### PR TITLE
small typo fix for default entry point

### DIFF
--- a/src/content/configuration/index.mdx
+++ b/src/content/configuration/index.mdx
@@ -15,9 +15,10 @@ contributors:
   - dasarianudeep
   - lukasgeiter
   - EugeneHlushko
+  - bigdawggi
 ---
 
-Out of the box, webpack won't require you to use a configuration file. However, it will assume the entry point of your project is `src/index` and will output the result in `dist/main.js` minified and optimized for production.
+Out of the box, webpack won't require you to use a configuration file. However, it will assume the entry point of your project is `src/index.js` and will output the result in `dist/main.js` minified and optimized for production.
 
 Usually your projects will need to extend this functionality, for this you can create a `webpack.config.js` file in the root folder and webpack will automatically use it.
 


### PR DESCRIPTION
Entry point only has `src/index`, when it should be `src/index.js`