### PR TITLE
fix(site): vertically align notification bar

### DIFF
--- a/src/components/NotificationBar/NotificationBar.scss
+++ b/src/components/NotificationBar/NotificationBar.scss
@@ -6,6 +6,8 @@
   background: getColor(emperor);
   width: 100%;
   min-height: 56px;
+  display: flex;
+  align-items: center;
 
   @media print {
     display: none;


### PR DESCRIPTION
Notification bar is not vertically aligned on desktop:

![align-center-vertically](https://user-images.githubusercontent.com/1091472/80853835-33b0d080-8c66-11ea-8b8c-d6757bd0105d.png)
