### PR TITLE
docs: update argument name

### DIFF
--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -239,7 +239,7 @@ For example, if you have 2 libraries, with namespaces `library1` and `library2`,
 
 ## `output.filename`
 
-`string` `function (pathData) => string`
+`string` `function (pathData, assetInfo) => string`
 
 This option determines the name of each output bundle. The bundle is written to the directory specified by the [`output.path`](#outputpath) option.
 

--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -22,6 +22,7 @@ contributors:
   - anikethsaha
   - jamesgeorge007
   - hiroppy
+  - chenxsan
 ---
 
 The top-level `output` key contains set of options instructing webpack on how and where it should output your bundles, assets and anything else you bundle or load with webpack.
@@ -238,7 +239,7 @@ For example, if you have 2 libraries, with namespaces `library1` and `library2`,
 
 ## `output.filename`
 
-`string` `function (chunkData) => string`
+`string` `function (pathData) => string`
 
 This option determines the name of each output bundle. The bundle is written to the directory specified by the [`output.path`](#outputpath) option.
 
@@ -330,8 +331,8 @@ __webpack.config.js__
 module.exports = {
   //...
   output: {
-    filename: (chunkData) => {
-      return chunkData.chunk.name === 'main' ? '[name].js': '[name]/[name].js';
+    filename: (pathData) => {
+      return pathData.chunk.name === 'main' ? '[name].js': '[name]/[name].js';
     },
   }
 };

--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -402,7 +402,7 @@ module.exports = {
 
 #### `splitChunks.cacheGroups.{cacheGroup}.filename`
 
-`string` `function (pathData): string`
+`string` `function (pathData, assetInfo): string`
 
 Allows to override the filename when and only when it's an initial chunk.
 All placeholders available in [`output.filename`](/configuration/output/#outputfilename) are also available here.

--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -402,7 +402,7 @@ module.exports = {
 
 #### `splitChunks.cacheGroups.{cacheGroup}.filename`
 
-`string` `function (pathData, assetInfo): string`
+`string` `function (pathData, assetInfo) => string`
 
 Allows to override the filename when and only when it's an initial chunk.
 All placeholders available in [`output.filename`](/configuration/output/#outputfilename) are also available here.

--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -13,6 +13,7 @@ contributors:
   - superburrito
   - ryandrew14
   - snitin315
+  - chenxsan
 related:
   - title: webpack's automatic deduplication algorithm example
     url: https://github.com/webpack/webpack/blob/master/examples/many-pages/README.md
@@ -401,7 +402,7 @@ module.exports = {
 
 #### `splitChunks.cacheGroups.{cacheGroup}.filename`
 
-`string` `function (chunkData): string`
+`string` `function (pathData): string`
 
 Allows to override the filename when and only when it's an initial chunk.
 All placeholders available in [`output.filename`](/configuration/output/#outputfilename) are also available here.
@@ -436,9 +437,9 @@ module.exports = {
     splitChunks: {
       cacheGroups: {
         defaultVendors: {
-          filename: (chunkData) => {
-            // Use chunkData object for generating filename string based on your requirements
-            return `${chunkData.chunk.name}-bundle.js`;
+          filename: (pathData) => {
+            // Use pathData object for generating filename string based on your requirements
+            return `${pathData.chunk.name}-bundle.js`;
           }
         }
       }


### PR DESCRIPTION
Not an issue at all, but I think would be an improvement if we can use the same name as types defined for typescript https://github.com/webpack/webpack/blob/082fce5000a5bdf0fbef99acc604d1c57eef511d/declarations/WebpackOptions.d.ts#L61