### PR TITLE
Docs(config) : add module.unsafeCache to v4 docs

### DIFF
--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -14,6 +14,7 @@ contributors:
   - EugeneHlushko
   - superburrito
   - lukasgeiter
+  - jeffin143
   - salemhilal
 ---
 

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -14,6 +14,7 @@ contributors:
   - EugeneHlushko
   - superburrito
   - lukasgeiter
+  - salemhilal
 ---
 
 These options determine how the [different types of modules](/concepts/modules) within a project will be treated.
@@ -51,6 +52,28 @@ module.exports = {
 `[Rule]`
 
 An array of [Rules](#rule) which are matched to requests when modules are created. These rules can modify how the module is created. They can apply loaders to the module, or modify the parser.
+
+
+## `module.unsafeCache`
+
+`boolean` `function (module)`
+
+Cache the resolution of module requests, as well as the module's list of dependencies. Note that this feature can cause problems if the module is moved and should resolve to a different location. By default, this option is enabled only if [`cache`](/configuration/other-options/#cache) is enabled.
+
+__webpack.config.js__
+
+```javascript
+module.exports = {
+  //...
+  module: {
+    unsafeCache: false,
+  }
+};
+```
+
+W> In Webpack 5, the default value is `true` if the `cache` option is enabled _and_ the module appears to come from the node_modules directory.
+
+
 
 
 ## Rule

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -75,8 +75,6 @@ module.exports = {
 W> In webpack 5, the default value is `true` if the `cache` option is enabled _and_ the module appears to come from the node_modules directory.
 
 
-
-
 ## Rule
 
 `object`

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -72,7 +72,7 @@ module.exports = {
 };
 ```
 
-W> In Webpack 5, the default value is `true` if the `cache` option is enabled _and_ the module appears to come from the node_modules directory.
+W> In webpack 5, the default value is `true` if the `cache` option is enabled _and_ the module appears to come from the node_modules directory.
 
 
 


### PR DESCRIPTION
This PR mirrors #3714 for the v4 documentation.
It addresses the following issues:
- #2539
- webpack/webpack#10771