### PR TITLE
docs(plugins): clean option

### DIFF
--- a/src/content/plugins/hot-module-replacement-plugin.md
+++ b/src/content/plugins/hot-module-replacement-plugin.md
@@ -3,6 +3,7 @@ title: HotModuleReplacementPlugin
 contributors:
   - skipjack
   - byzyk
+  - chenxsan
 related:
   - title: Concepts - Hot Module Replacement
     url: /concepts/hot-module-replacement
@@ -32,6 +33,5 @@ The following options are accepted:
 
 - `multiStep` (boolean): If `true`, the plugin will build in two steps -- first compiling the hot update chunks, and then the remaining normal assets.
 - `fullBuildTimeout` (number): The delay between the two steps when `multiStep` is enabled.
-- `requestTimeout` (number): The timeout used for manifest download (since webpack 3.0.0)
 
 W> These options are experimental and may be deprecated. As mentioned above, they are typically not necessary and including a `new webpack.HotModuleReplacementPlugin()` is enough.


### PR DESCRIPTION
The `requestTimeout` option was removed in this commit https://github.com/webpack/webpack/commit/9d918615922f8e7fb8ab1c9712135908cf1cadd7#diff-8941681d920ac4feda44f522b986c2d0L99. There're only `multiStep` and `fullBuildTimeout` left as we can see here https://github.com/webpack/webpack/blob/master/types.d.ts#L2599