### PR TITLE
Docs(plugin): Remove NoHotModuleReplacementPlugin from internal-plugin

### DIFF
--- a/src/content/plugins/internal-plugins.md
+++ b/src/content/plugins/internal-plugins.md
@@ -138,12 +138,6 @@ Decorates the templates by generating a SourceMap for each chunk.
 
 `sourceMapFilename` the filename template of the SourceMap. `[hash]`, `[name]`, `[id]`, `[file]` and `[filebase]` are replaced. If this argument is missing, the SourceMap will be inlined as DataUrl.
 
-### NoHotModuleReplacementPlugin
-
-`NoHotModuleReplacementPlugin()`
-
-Defines `module.hot` as `false` to remove hot module replacement code.
-
 ### HotModuleReplacementPlugin
 
 `HotModuleReplacementPlugin(options)`


### PR DESCRIPTION
I couldn't find this in webpack internals Hence I am not sure we should document this 

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].
