### PR TITLE
Fix name of dev-tool name in description

### DIFF
--- a/src/content/guides/build-performance.md
+++ b/src/content/guides/build-performance.md
@@ -153,7 +153,7 @@ Be aware of the performance differences between the different `devtool` settings
 - The `cheap-source-map` variants are more performant if you can live with the slightly worse mapping quality.
 - Use a `eval-source-map` variant for incremental builds.
 
-=> In most cases, `cheap-module-eval-source-map` is the best option.
+=> In most cases, `eval-cheap-module-source-map` is the best option.
 
 
 ### Avoid Production Specific Tooling


### PR DESCRIPTION
The used value "cheap-module-eval-source-map" doesn't exist (maybe anymore) and "eval-cheap-module-source-map" should be used instead

https://webpack.js.org/configuration/devtool/