### PR TITLE
Fix name of dev-tool name in description

### DIFF
--- a/src/content/configuration/devtool.md
+++ b/src/content/configuration/devtool.md
@@ -94,7 +94,7 @@ The following options are ideal for development:
 
 `eval-cheap-source-map` - Similar to `eval-source-map`, each module is executed with `eval()`. It is "cheap" because it doesn't have column mappings, it only maps line numbers. It ignores SourceMaps from Loaders and only display transpiled code similar to the `eval` devtool.
 
-`cheap-module-eval-source-map` - Similar to `eval-cheap-source-map`, however, in this case Source Maps from Loaders are processed for better results. However Loader Source Maps are simplified to a single mapping per line.
+`eval-cheap-module-source-map` - Similar to `eval-cheap-source-map`, however, in this case Source Maps from Loaders are processed for better results. However Loader Source Maps are simplified to a single mapping per line.
 
 ### Special cases
 


### PR DESCRIPTION
The used value "cheap-module-eval-source-map" doesn't exist (maybe anymore) and "eval-cheap-module-source-map" should be used instead

https://webpack.js.org/configuration/devtool/