### PR TITLE
docs(guides): Update watch mode snippet in development guide

### DIFF
--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -184,9 +184,6 @@ __webpack.config.js__
       print: './src/print.js',
     },
     devtool: 'inline-source-map',
-+   devServer: {
-+     contentBase: './dist',
-+   },
     plugins: [
 -     new CleanWebpackPlugin(),
 +     new CleanWebpackPlugin({ cleanStaleWebpackAssets: false }),


### PR DESCRIPTION
Removing the `devServer` config property from watch mode snippet under Documentation > Guides > Development > Using Watch Mode.
