### PR TITLE
feat(optimize) disable bundlesize to fix prod deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "fetch:starter-kits": "node src/utilities/fetch-starter-kits.js",
     "prebuild": "npm run clean",
     "build": "run-s fetch printable content && cross-env NODE_ENV=production webpack --config webpack.ssg.js && run-s clean-printable content && cross-env NODE_ENV=production webpack --config webpack.prod.js",
-    "postbuild": "bundlesize && npm run sitemap",
+    "postbuild": "npm run sitemap",
     "build-test": "npm run build && http-server dist/",
     "test": "npm run lint",
     "lint": "run-s lint:*",


### PR DESCRIPTION
Could be related: https://github.com/siddharthkp/bundlesize/issues/93

Master doesn't get deployed, until we figure out proper fix lets just disable it

ref: https://travis-ci.org/github/webpack/webpack.js.org/jobs/694100391

```
$ bundlesize && npm run sitemap
 ERROR  Could not add github status.
        401: Bad credentials 

```