### PR TITLE
UI: Fix word-break on headings

### DIFF
--- a/src/components/Markdown/Markdown.scss
+++ b/src/components/Markdown/Markdown.scss
@@ -46,7 +46,7 @@ $topHeightDesktopWithBanner: $bannerHeight + $topHeightDesktop;
     line-height: 1.4;
     margin: 1.5em 0 0.25em;
     color: getColor(fiord);
-    word-break: break-all;
+    word-break: break-word;
     scroll-margin-top: $topHeightDesktop;
 
     tt,


### PR DESCRIPTION
On smaller devices headings do not wrap correctly:
![image](https://user-images.githubusercontent.com/17808846/83645889-46932980-a5b3-11ea-9df0-3ca7115553a3.png)

After setting `word-break: break-word`:
![image](https://user-images.githubusercontent.com/17808846/83646064-78a48b80-a5b3-11ea-9594-78faac589bbd.png)



