### PR TITLE
doc(plugins): add ChunksWebpackPlugin

### DIFF
--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -66,7 +66,7 @@ module.exports = {
 };
 ```
 
-HTML files are built in the output path directory with all the other assets.
+HTML files are built in the output path directory with the rest of the webpack output.
 
 Then, include the HTML files in the wanted pages.
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -100,7 +100,7 @@ new ChunksWebpackPlugin({
 });
 ```
 
-T> The default behavior will use the  `options.output.path` from the [webpack configuration](https://webpack.js.org/configuration/output/#outputpath).
+T> By default, plugin will use the [`output.path` option](/configuration/output/#outputpath) value.
 
 W> The `outputPath` must be an absolute path.
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -9,7 +9,7 @@ related:
     url: https://medium.com/@Yoriiis/the-real-power-of-webpack-4-splitchunks-plugin-fad097c45ba0
 ---
 
-The ChunksWebpackPlugin creates HTML files with entry points and chunks relations to serve your webpack bundles. It is very convenient with multiple page application which contains multiple entry points and it works without configuration.
+The ChunksWebpackPlugin creates HTML files with entry points and chunks relations to serve your webpack bundles. It is suitable with multiple page application which contains multiple entry points.
 
 Since Webpack 4, SplitChunksPlugin offer the possibility to optimizes all chunks. It can be particularly powerful, because it means that chunks can be shared even between async and non-async chunks. See the webpack documentation for [`splitChunks.chunks`](https://webpack.js.org/plugins/split-chunks-plugin/#splitchunkschunks).
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -240,7 +240,7 @@ W> This option cancels the main functionality of the plugin and HTML files will 
 
 ### Caching
 
-The [webpack caching](https://webpack.js.org/guides/caching) feature allows you to generate HTML files that include hash in the filename.
+The [webpack caching](/guides/caching/) feature allows you to generate HTML files that include hash in the filename.
 
 ```js
 const ChunksWebpackPlugin = require('chunks-webpack-plugin');

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -134,7 +134,7 @@ T> Keep the `{{chunk}}` placeholder, it is automatically replaced by the concate
 
 `string = '<script src="{{chunk}}"></script>'`
 
-Tells the plugin whether to personalize the default template for the HTML `<script>` tags. For example, add additional attributes, a CDN prefix or something else.
+Tells the plugin whether to personalize the default template for the HTML `<script>` tags. For example, add additional attributes or a CDN prefix.
 
 ```js
 new ChunksWebpackPlugin({

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -9,7 +9,7 @@ related:
     url: https://medium.com/@Yoriiis/the-real-power-of-webpack-4-splitchunks-plugin-fad097c45ba0
 ---
 
-The ChunksWebpackPlugin creates HTML files with entry points and chunks relations to serve your webpack bundles. It is suitable with multiple page application which contains multiple entry points.
+The `ChunksWebpackPlugin` creates HTML files with entry points and chunks relations to serve your webpack bundles. It is suitable with multiple page application that contains multiple entry points.
 
 Since Webpack 4, SplitChunksPlugin offer the possibility to optimizes all chunks. It can be particularly powerful, because it means that chunks can be shared even between async and non-async chunks. See the webpack documentation for [`splitChunks.chunks`](https://webpack.js.org/plugins/split-chunks-plugin/#splitchunkschunks).
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -181,7 +181,6 @@ return {
 };
 ```
 
-The `customFormatTags` function has two parameters:
 
 #### `chunksSorted`
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -191,7 +191,7 @@ The list of the chunks sorted by type: `styles` and `scripts`.
 
 #### `Entrypoint`
 
-`Object`
+`object`
 
 The object is included in every single ChunkGroup. The variable contains all information about the current entry point; log it on the console for more details.
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -37,7 +37,7 @@ yarn add chunks-webpack-plugin --dev
 
 ## Environment
 
-ChunksWebpackPlugin was built for Node.js `>=8.11.2` and webpack `>=4.x`.
+`ChunksWebpackPlugin` was built for Node.js `>=8.11.2` and webpack `>=4.x`.
 
 ## Example
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -53,8 +53,8 @@ The plugin will generate two HTML files for each entry points. Each filename con
 First, let's add the plugin to the webpack configuration.
 
 ```js
-var ChunksWebpackPlugin = require('chunks-webpack-plugin');
-var path = require('path');
+const ChunksWebpackPlugin = require('chunks-webpack-plugin');
+const path = require('path');
 
 module.exports = {
   entry: 'main.js',
@@ -146,7 +146,7 @@ T> Keep the `{{chunk}}` placeholder, it is automatically replaced by the concate
 
 ### `customFormatTags`
 
-`false || function (chunksSorted, files)`
+`boolean: false` `function (chunksSorted, Entrypoint) => object`
 
 Tells the plugin whether to personalize the default behavior for generating your own templates. The function is called for each entry point. Can be used to add a custom behavior for a specific entry point.
 
@@ -275,7 +275,7 @@ __main-scripts.html__
 Example of the webpack configuration with multiple entry points which share common code:
 
 ```js
-<span class="x x-first x-last">const</span> ChunksWebpackPlugin = require('chunks-webpack-plugin');
+const ChunksWebpackPlugin = require('chunks-webpack-plugin');
 const path = require('path');
 
 module.exports = {

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -272,7 +272,7 @@ __main-scripts.html__
 
 ### Multiple entry points
 
-Example of webpack configuration with multiple entry points which share common codes:
+Example of the webpack configuration with multiple entry points which share common code:
 
 ```js
 <span class="x x-first x-last">const</span> ChunksWebpackPlugin = require('chunks-webpack-plugin');

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -9,9 +9,9 @@ related:
     url: https://medium.com/@Yoriiis/the-real-power-of-webpack-4-splitchunks-plugin-fad097c45ba0
 ---
 
-The `ChunksWebpackPlugin` creates HTML files with entry points and chunks relations to serve your webpack bundles. It is suitable with multi-page applications that contains multiple entry points.
+The `ChunksWebpackPlugin` creates HTML files with entry points and chunks relations to serve your webpack bundles. It is suitable with multi-page applications that contain multiple entry points.
 
-Since webpack 4, `SplitChunksPlugin` offers the possibility to optimizes all chunks. It can be particularly powerful, because it means that chunks can be shared even between async and non-async chunks. See the webpack documentation for [`splitChunks.chunks`](/plugins/split-chunks-plugin/#splitchunkschunks) for details.
+Since webpack 4, `SplitChunksPlugin` offers the possibility to optimizes all chunks. It can be particularly powerful, because it means that chunks can be shared even between async and non-async chunks. See the webpack documentation of [`splitChunks.chunks`](/plugins/split-chunks-plugin/#splitchunkschunks) for details.
 
 `splitChunks.chunks` option can be set to automatically generate new chunks associated with an entry point. For example, entry points `a.js` and `b.js` share common code with the file `vendors~a~b.js`.
 
@@ -19,7 +19,7 @@ With multiple entry points, it can be difficult to identify relation between the
 
 `ChunksWebpackPlugin` parses the `entrypoints` [Map](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Map) from the webpack compilation to get all valid entry points and associated files. Then, it generates HTML files which include all assets filtered by an entry point and the `chunks-manifest.json` file.
 
-## Zero config
+## Zero configuration
 
 It works without configuration. For advanced usage, see the [using configuration section](#using-a-configuration).
 
@@ -41,7 +41,7 @@ yarn add chunks-webpack-plugin --dev
 
 ## Example
 
-For example usage, please see the [`ChunksWebpackPlugin` Github documentation](https://github.com/yoriiis/chunks-webpack-plugin/blob/master/README.md#example).
+For example usage, please see the [`ChunksWebpackPlugin` GitHub documentation](https://github.com/yoriiis/chunks-webpack-plugin/blob/master/README.md#example).
 
 ## Basic usage
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -21,7 +21,7 @@ With multiple entry points, it can be difficult to identify relation between the
 
 ## Zero config
 
-The plugin works without configuration. For advanced usage, see the section [using configuration](#using-a-configuration).
+It works without configuration. For advanced usage, see the [using configuration section](#using-a-configuration).
 
 ## Installation
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -236,7 +236,7 @@ new ChunksWebpackPlugin({
 });
 ```
 
-W> This option cancels the main functionality of the plugin and HTML files will not be generated. It can be useful only with addition of `generateChunksManifest` option for a custom generation of the HTML files.
+W> When set to `false`, HTML files will not be generated. It can only be useful together with  `generateChunksManifest` option set to `true` for custom generation of the HTML files.
 
 ### Caching
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -201,7 +201,7 @@ W> Use this variable only for a full customization if the `chunksSorted` variabl
 
 `boolean = false`
 
-Tells the plugin whether to generate the `chunks-manifest.json`. The file contains the list of all the chunks grouped by entry points.
+Tells the plugin whether to generate the `chunks-manifest.json`. The file contains the list of all chunks grouped by entry points.
 
 ```js
 new ChunksWebpackPlugin({

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -41,7 +41,7 @@ ChunksWebpackPlugin was built for Node.js `>=8.11.2` and webpack `>=4.x`.
 
 ## Example
 
-For example implementation, please see the [Github documentation](https://github.com/yoriiis/chunks-webpack-plugin/blob/master/README.md#example).
+For example usage, please see the [`ChunksWebpackPlugin` Github documentation](https://github.com/yoriiis/chunks-webpack-plugin/blob/master/README.md#example).
 
 ## Basic usage
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -120,7 +120,7 @@ new ChunksWebpackPlugin({
 
 `string = '<link rel="stylesheet" href="{{chunk}}" />'`
 
-Tells the plugin whether to personalize the default template for the HTML `<style>` tags. For example, add additional attributes, a CDN prefix or something else.
+Tells the plugin whether to personalize the default template for the HTML `<style>` tags. For example, add additional attributes or a CDN prefix.
 
 ```js
 new ChunksWebpackPlugin({

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -244,7 +244,7 @@ The [webpack caching](https://webpack.js.org/guides/caching) feature allows you 
 
 ```js
 const ChunksWebpackPlugin = require('chunks-webpack-plugin');
-var path = require('path');
+const path = require('path');
 
 module.exports = {
   entry: 'main.js',

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -25,7 +25,7 @@ It works without configuration. For advanced usage, see the [using configuration
 
 ## Installation
 
-The plugin is available as a package with the name of `chunks-webpack-plugin` on [npm](https://www.npmjs.com/package/chunks-webpack-plugin) and [Github](https://github.com/yoriiis/chunks-webpack-plugin).
+`ChunksWebpackPlugin` is available on npm as [`chunks-webpack-plugin`](https://www.npmjs.com/package/chunks-webpack-plugin) and as [`chunks-webpack-plugin` on Github](https://github.com/yoriiis/chunks-webpack-plugin).
 
 ```bash
 npm install chunks-webpack-plugin --save-dev
@@ -68,7 +68,7 @@ module.exports = {
 
 HTML files are built in the output path directory with the rest of the webpack output.
 
-Then, include the HTML files in the wanted pages.
+Now you can include the outputted HTML files into your HTML page templates. You can do it with e.g. Twig.
 
 __main-styles.html__
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -15,7 +15,7 @@ Since webpack 4, `SplitChunksPlugin` offers the possibility to optimizes all chu
 
 `splitChunks.chunks` option can be set to automatically generate new chunks associated with an entry point. For example, entry points `a.js` and `b.js` share common code with the file `vendors~a~b.js`.
 
-With multiple entry points, it can be difficult to identify relation between auto-generated chunks and entry points.
+With multiple entry points, it can be difficult to identify relation between the auto-generated chunks and entry points.
 
 The plugin parse the `entrypoints` [Map](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Map) object from the webpack compilation to get all valid entry points and associated files. Then, it generates HTML files which include all assets filtered by entry point and the `chunks-manifest.json` file.
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -11,7 +11,7 @@ related:
 
 The `ChunksWebpackPlugin` creates HTML files with entry points and chunks relations to serve your webpack bundles. It is suitable with multiple page application that contains multiple entry points.
 
-Since Webpack 4, SplitChunksPlugin offer the possibility to optimizes all chunks. It can be particularly powerful, because it means that chunks can be shared even between async and non-async chunks. See the webpack documentation for [`splitChunks.chunks`](https://webpack.js.org/plugins/split-chunks-plugin/#splitchunkschunks).
+Since webpack 4, `SplitChunksPlugin` offers the possibility to optimizes all chunks. It can be particularly powerful, because it means that chunks can be shared even between async and non-async chunks. See the webpack documentation for [`splitChunks.chunks`](/plugins/split-chunks-plugin/#splitchunkschunks) for details.
 
 This option automatically generate new chunks associated with an entry point. For example, entry points `a.js` and `b.js` share common codes with the file `vendors~a~b.js`.
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -13,7 +13,7 @@ The `ChunksWebpackPlugin` creates HTML files with entry points and chunks relati
 
 Since webpack 4, `SplitChunksPlugin` offers the possibility to optimizes all chunks. It can be particularly powerful, because it means that chunks can be shared even between async and non-async chunks. See the webpack documentation for [`splitChunks.chunks`](/plugins/split-chunks-plugin/#splitchunkschunks) for details.
 
-This option automatically generate new chunks associated with an entry point. For example, entry points `a.js` and `b.js` share common codes with the file `vendors~a~b.js`.
+`splitChunks.chunks` option can be set to automatically generate new chunks associated with an entry point. For example, entry points `a.js` and `b.js` share common code with the file `vendors~a~b.js`.
 
 With multiple entry points, it can be difficult to identify relation between auto-generated chunks and entry points.
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -148,7 +148,7 @@ T> Keep the `{{chunk}}` placeholder, it is automatically replaced by the concate
 
 `false || function (chunksSorted, files)`
 
-Tells the plugin whether to personalize the default behavior for generate your own templates. The function is called for each entry points. Custom behavior can also be add for a specific entry point if necessary.
+Tells the plugin whether to personalize the default behavior for generating your own templates. The function is called for each entry point. Can be used to add a custom behavior for a specific entry point.
 
 ```js
 new ChunksWebpackPlugin({

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -25,7 +25,7 @@ It works without configuration. For advanced usage, see the [using configuration
 
 ## Installation
 
-`ChunksWebpackPlugin` is available on npm as [`chunks-webpack-plugin`](https://www.npmjs.com/package/chunks-webpack-plugin) and as [`chunks-webpack-plugin` on Github](https://github.com/yoriiis/chunks-webpack-plugin).
+`ChunksWebpackPlugin` is available on npm as [`chunks-webpack-plugin`](https://www.npmjs.com/package/chunks-webpack-plugin) and as [`chunks-webpack-plugin` on GitHub](https://github.com/yoriiis/chunks-webpack-plugin).
 
 ```bash
 npm install chunks-webpack-plugin --save-dev

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -181,7 +181,6 @@ return {
 };
 ```
 
-
 #### `chunksSorted`
 
 `object`
@@ -271,7 +270,8 @@ __main-scripts.html__
 
 ### Multiple entry points
 
-Example of the webpack configuration with multiple entry points which share common code:
+Example of the webpack configuration with multiple entry points which share common code with the `splitChunks` option.
+
 
 ```js
 const ChunksWebpackPlugin = require('chunks-webpack-plugin');
@@ -286,7 +286,12 @@ module.exports = {
     path: path.resolve(__dirname, './dist'),
     filename: 'bundle.js'
   },
-  plugins: [new ChunksWebpackPlugin()]
+  plugins: [new ChunksWebpackPlugin()],
+  optimization: {
+    splitChunks: {
+      chunks: 'all'
+    }
+  }
 };
 ```
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -9,7 +9,7 @@ related:
     url: https://medium.com/@Yoriiis/the-real-power-of-webpack-4-splitchunks-plugin-fad097c45ba0
 ---
 
-The `ChunksWebpackPlugin` creates HTML files with entry points and chunks relations to serve your webpack bundles. It is suitable with multiple page application that contains multiple entry points.
+The `ChunksWebpackPlugin` creates HTML files with entry points and chunks relations to serve your webpack bundles. It is suitable with multi-page applications that contains multiple entry points.
 
 Since webpack 4, `SplitChunksPlugin` offers the possibility to optimizes all chunks. It can be particularly powerful, because it means that chunks can be shared even between async and non-async chunks. See the webpack documentation for [`splitChunks.chunks`](/plugins/split-chunks-plugin/#splitchunkschunks) for details.
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -17,7 +17,7 @@ Since webpack 4, `SplitChunksPlugin` offers the possibility to optimizes all chu
 
 With multiple entry points, it can be difficult to identify relation between the auto-generated chunks and entry points.
 
-The plugin parse the `entrypoints` [Map](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Map) object from the webpack compilation to get all valid entry points and associated files. Then, it generates HTML files which include all assets filtered by entry point and the `chunks-manifest.json` file.
+`ChunksWebpackPlugin` parses the `entrypoints` [Map](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Map) from the webpack compilation to get all valid entry points and associated files. Then, it generates HTML files which include all assets filtered by an entry point and the `chunks-manifest.json` file.
 
 ## Zero config
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -86,7 +86,7 @@ __main-scripts.html__
 
 ## Using a configuration
 
-You can pass configuration options to ChunksWebpackPlugin to overrides default settings. Allowed values are as follows:
+You can pass a configuration object to `ChunksWebpackPlugin` to override the default settings.
 
 ### `outputPath`
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -4,7 +4,7 @@ contributors:
   - yoriiis
 related:
   - title: SplitChunksPlugin
-    url: /plugins/split-chunks-plugin
+    url: /plugins/split-chunks-plugin/
   - title: The real power of Webpack 4 SplitChunks Plugin
     url: https://medium.com/@Yoriiis/the-real-power-of-webpack-4-splitchunks-plugin-fad097c45ba0
 ---

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -1,0 +1,322 @@
+---
+title: ChunksWebpackPlugin
+contributors:
+  - yoriiis
+related:
+  - title: SplitChunksPlugin
+    url: /plugins/split-chunks-plugin
+  - title: The real power of Webpack 4 SplitChunks Plugin
+    url: https://medium.com/@Yoriiis/the-real-power-of-webpack-4-splitchunks-plugin-fad097c45ba0
+---
+
+The ChunksWebpackPlugin creates HTML files with entry points and chunks relations to serve your webpack bundles. It is very convenient with multiple page application which contains multiple entry points and it works without configuration.
+
+Since Webpack 4, SplitChunksPlugin offer the possibility to optimizes all chunks. It can be particularly powerful, because it means that chunks can be shared even between async and non-async chunks. See the webpack documentation for [`splitChunks.chunks`](https://webpack.js.org/plugins/split-chunks-plugin/#splitchunkschunks).
+
+This option automatically generate new chunks associated with an entry point. For example, entry points `a.js` and `b.js` share common codes with the file `vendors~a~b.js`.
+
+With multiple entry points, it can be difficult to identify relation between auto-generated chunks and entry points.
+
+The plugin parse the `entrypoints` [Map](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Map) object from the webpack compilation to get all valid entry points and associated files. Then, it generates HTML files which include all assets filtered by entry point and the `chunks-manifest.json` file.
+
+## Zero config
+
+The plugin works without configuration. For advanced usage, see the section [using configuration](#using-a-configuration).
+
+## Installation
+
+The plugin is available as a package with the name of `chunks-webpack-plugin` on [npm](https://www.npmjs.com/package/chunks-webpack-plugin) and [Github](https://github.com/yoriiis/chunks-webpack-plugin).
+
+```bash
+npm install chunks-webpack-plugin --save-dev
+```
+
+```bash
+yarn add chunks-webpack-plugin --dev
+```
+
+## Environment
+
+ChunksWebpackPlugin was built for Node.js `>=8.11.2` and webpack `>=4.x`.
+
+## Example
+
+For example implementation, please see the [Github documentation](https://github.com/yoriiis/chunks-webpack-plugin/blob/master/README.md#example).
+
+## Basic usage
+
+The plugin will generate two HTML files for each entry points. Each filename contains the entry point name, the `{{entry}}` placeholder is automatically replaced.
+
+- `{{entry}}-styles.html`: contains all HTML `<link>` tags
+- `{{entry}}-scripts.html`: contains all HTML `<script>` tags
+
+First, let's add the plugin to the webpack configuration.
+
+```js
+var ChunksWebpackPlugin = require('chunks-webpack-plugin');
+var path = require('path');
+
+module.exports = {
+  entry: 'main.js',
+  output: {
+    filename: 'main.js',
+    path: path.resolve(__dirname, './dist')
+  },
+  plugins: [new ChunksWebpackPlugin()]
+};
+```
+
+HTML files are built in the output path directory with all the other assets.
+
+Then, include the HTML files in the wanted pages.
+
+__main-styles.html__
+
+```html
+<link rel="stylesheet" href="main.css" />
+```
+
+__main-scripts.html__
+
+```html
+<script src="main.js"></script>
+```
+
+---
+
+## Using a configuration
+
+You can pass configuration options to ChunksWebpackPlugin to overrides default settings. Allowed values are as follows:
+
+### `outputPath`
+
+`string = null`
+
+Tells the plugin whether to personalize the output path of the generated files.
+
+```js
+new ChunksWebpackPlugin({
+  outputPath: path.resolve(__dirname, './templates')
+});
+```
+
+T> The default behavior will use the  `options.output.path` from the [webpack configuration](https://webpack.js.org/configuration/output/#outputpath).
+
+W> The `outputPath` must be an absolute path.
+
+### `fileExtension`
+
+`string = '.html'`
+
+Tells the plugin whether to personalize the extension of the generated files.
+
+```js
+new ChunksWebpackPlugin({
+  fileExtension: '.html'
+});
+```
+
+### `templateStyle`
+
+`string = '<link rel="stylesheet" href="{{chunk}}" />'`
+
+Tells the plugin whether to personalize the default template for the HTML `<style>` tags. For example, add additional attributes, a CDN prefix or something else.
+
+```js
+new ChunksWebpackPlugin({
+  templateStyle: '<link rel="stylesheet" href="{{chunk}}" />'
+});
+```
+
+T> Keep the `{{chunk}}` placeholder, it is automatically replaced by the concatenation of the webpack public path and the chunk filename.
+
+### `templateScript`
+
+`string = '<script src="{{chunk}}"></script>'`
+
+Tells the plugin whether to personalize the default template for the HTML `<script>` tags. For example, add additional attributes, a CDN prefix or something else.
+
+```js
+new ChunksWebpackPlugin({
+  templateScript: '<script src="{{chunk}}"></script>'
+});
+```
+
+T> Keep the `{{chunk}}` placeholder, it is automatically replaced by the concatenation of the webpack public path and the chunk filename.
+
+### `customFormatTags`
+
+`false || function (chunksSorted, files)`
+
+Tells the plugin whether to personalize the default behavior for generate your own templates. The function is called for each entry points. Custom behavior can also be add for a specific entry point if necessary.
+
+```js
+new ChunksWebpackPlugin({
+  customFormatTags: (chunksSorted, Entrypoint) => {
+    // Generate all HTML style tags with a CDN prefix
+    const styles = chunksSorted.styles.map(chunkCss =>
+      `<link rel="stylesheet" href="https://cdn.domain.com/${chunkCss}" />`
+    ).join('');
+
+    // Generate all HTML style tags with CDN prefix and defer attribute
+    const scripts = chunksSorted.scripts.map(chunkJs =>
+      `<script defer src="https://cdn.domain.com/${chunkJs}"></script>`
+    ).join('');
+
+    return { styles, scripts };
+  }
+});
+```
+
+T> The arrow function syntax allow you to access the class properties.
+
+W> The function provides more flexibility by replacing the default behavior. Follow the example above to make sure it works.
+
+The function must return an object with the following format:
+
+```json
+{
+  "styles": "",
+  "scripts": ""
+}
+```
+
+The `customFormatTags` function has two parameters:
+
+#### `chunksSorted`
+
+`object`
+
+The list of the chunks sorted by type: `styles` and `scripts`.
+
+#### `Entrypoint`
+
+`Object`
+
+The object is included in every single ChunkGroup. The variable contains all information about the current entry point; log it on the console for more details.
+
+W> Use this variable only for a full customization if the `chunksSorted` variable does not meet your needs.
+
+### `generateChunksManifest`
+
+`boolean = false`
+
+Tells the plugin whether to generate the `chunks-manifest.json`. The file contains the list of all the chunks grouped by entry points.
+
+```js
+new ChunksWebpackPlugin({
+  generateChunksManifest: false
+});
+```
+
+Example of the output of the `chunks-manifest.json` file:
+
+```json
+{
+  "app-a": {
+    "styles": ["/dist/css/vendors~app-a~app-b.css", "/dist/css/app-a.css"],
+    "scripts": ["/dist/js/vendors~app-a~app-b.js", "/dist/js/app-a.js"]
+  },
+  "app-b": {
+    "styles": ["/dist/css/vendors~app-a~app-b.css", "/dist/css/app-b.css"],
+    "scripts": ["/dist/js/vendors~app-a~app-b.js", "/dist/js/app-b.js"]
+  }
+}
+```
+
+### `generateChunksFiles`
+
+`boolean = true`
+
+Tells the plugin whether to generate the HTML files.
+
+```js
+new ChunksWebpackPlugin({
+  generateChunksManifest: true
+});
+```
+
+W> This option cancels the main functionality of the plugin and HTML files will not be generated. It can be useful only with addition of `generateChunksManifest` option for a custom generation of the HTML files.
+
+### Caching
+
+The [webpack caching](https://webpack.js.org/guides/caching) feature allows you to generate HTML files that include hash in the filename.
+
+```js
+var ChunksWebpackPlugin = require('chunks-webpack-plugin');
+var path = require('path');
+
+module.exports = {
+  entry: 'main.js',
+  output: {
+    path: path.resolve(__dirname, './dist'),
+    filename: 'bundle.[contenthash].js'
+  },
+  plugins: [new ChunksWebpackPlugin()]
+};
+```
+
+This will generate the following HTML files with hash in the filename.
+
+__main-styles.html__
+
+```html
+<link rel="stylesheet" href="main.72dd90acdd3d4a4a1fd4.css" />
+```
+
+__main-scripts.html__
+
+```html
+<script src="main.72dd90acdd3d4a4a1fd4.js"></script>
+```
+
+### Multiple entry points
+
+Example of webpack configuration with multiple entry points which share common codes:
+
+```js
+var ChunksWebpackPlugin = require('chunks-webpack-plugin');
+var path = require('path');
+
+module.exports = {
+  entry: {
+    home: 'home.js',
+    news: 'news.js'
+  },
+  output: {
+    path: path.resolve(__dirname, './dist'),
+    filename: 'bundle.js'
+  },
+  plugins: [new ChunksWebpackPlugin()]
+};
+```
+
+The plugin will generate all files in the `./dist/` directory:
+
+__home-styles.html__
+
+```html
+<link rel="stylesheet" href="vendors~home~news.css" />
+<link rel="stylesheet" href="home.css" />
+```
+
+__home-scripts.html__
+
+```html
+<script src="vendors~home~news.js"></script>
+<script src="home.js"></script>
+```
+
+__news-styles.html__
+
+```html
+<link rel="stylesheet" href="vendors~home~news.css" />
+<link rel="stylesheet" href="news.css" />
+```
+
+__news-scripts.html__
+
+```html
+<script src="vendors~home~news.js"></script>
+<script src="news.js"></script>
+```

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -124,7 +124,7 @@ Tells the plugin whether to personalize the default template for the HTML `<styl
 
 ```js
 new ChunksWebpackPlugin({
-  templateStyle: '<link rel="stylesheet" href="{{chunk}}" />'
+  templateStyle: '<link rel="stylesheet" href="https://cdn.domain.com/{{chunk}}" />'
 });
 ```
 
@@ -138,7 +138,7 @@ Tells the plugin whether to personalize the default template for the HTML `<scri
 
 ```js
 new ChunksWebpackPlugin({
-  templateScript: '<script src="{{chunk}}"></script>'
+  templateScript: '<script defer src="{{chunk}}"></script>'
 });
 ```
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -174,11 +174,11 @@ W> The function provides more flexibility by replacing the default behavior. Fol
 
 The function must return an object with the following format:
 
-```json
-{
-  "styles": "",
-  "scripts": ""
-}
+```js
+return {
+  styles: '',
+  scripts: ''
+};
 ```
 
 The `customFormatTags` function has two parameters:

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -205,7 +205,7 @@ Tells the plugin whether to generate the `chunks-manifest.json`. The file contai
 
 ```js
 new ChunksWebpackPlugin({
-  generateChunksManifest: false
+  generateChunksManifest: true
 });
 ```
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -243,7 +243,7 @@ W> This option cancels the main functionality of the plugin and HTML files will 
 The [webpack caching](https://webpack.js.org/guides/caching) feature allows you to generate HTML files that include hash in the filename.
 
 ```js
-var ChunksWebpackPlugin = require('chunks-webpack-plugin');
+const ChunksWebpackPlugin = require('chunks-webpack-plugin');
 var path = require('path');
 
 module.exports = {

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -45,7 +45,7 @@ For example usage, please see the [`ChunksWebpackPlugin` Github documentation](h
 
 ## Basic usage
 
-The plugin will generate two HTML files for each entry points. Each filename contains the entry point name, the `{{entry}}` placeholder is automatically replaced.
+`ChunksWebpackPlugin` will generate two HTML files for each entry point. Each filename contains the entry point name, the `{{entry}}` placeholder is automatically replaced.
 
 - `{{entry}}-styles.html`: contains all HTML `<link>` tags
 - `{{entry}}-scripts.html`: contains all HTML `<script>` tags

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -232,7 +232,7 @@ Tells the plugin whether to generate the HTML files.
 
 ```js
 new ChunksWebpackPlugin({
-  generateChunksManifest: true
+  generateChunksFiles: false
 });
 ```
 

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -275,7 +275,7 @@ __main-scripts.html__
 Example of webpack configuration with multiple entry points which share common codes:
 
 ```js
-var ChunksWebpackPlugin = require('chunks-webpack-plugin');
+<span class="x x-first x-last">const</span> ChunksWebpackPlugin = require('chunks-webpack-plugin');
 var path = require('path');
 
 module.exports = {

--- a/src/content/plugins/chunks-webpack-plugin.md
+++ b/src/content/plugins/chunks-webpack-plugin.md
@@ -276,7 +276,7 @@ Example of webpack configuration with multiple entry points which share common c
 
 ```js
 <span class="x x-first x-last">const</span> ChunksWebpackPlugin = require('chunks-webpack-plugin');
-var path = require('path');
+const path = require('path');
 
 module.exports = {
   entry: {

--- a/src/content/plugins/index.md
+++ b/src/content/plugins/index.md
@@ -18,6 +18,7 @@ Name                                                     | Description
 -------------------------------------------------------- | -----------
 [`BabelMinifyWebpackPlugin`](/plugins/babel-minify-webpack-plugin) | Minification with [babel-minify](https://github.com/babel/minify)
 [`BannerPlugin`](/plugins/banner-plugin)                 | Add a banner to the top of each generated chunk
+[`ChunksWebpackPlugin`](/plugins/chunks-webpack-plugin)  | Create HTML files with entrypoints and chunks relations to serve your bundles
 [`CommonsChunkPlugin`](/plugins/commons-chunk-plugin)    | Extract common modules shared between chunks
 [`CompressionWebpackPlugin`](/plugins/compression-webpack-plugin) | Prepare compressed versions of assets to serve them with Content-Encoding
 [`ContextReplacementPlugin`](/plugins/context-replacement-plugin) | Override the inferred context of a `require` expression


### PR DESCRIPTION
This PR adds the `ChunksWebpackPlugin` to the plugins documentation page.
A dedicated page with instructions for use is also added.

[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests