### PR TITLE
docs(api): update stats.mdx for webpack 5

### DIFF
--- a/src/content/api/stats.mdx
+++ b/src/content/api/stats.mdx
@@ -7,6 +7,7 @@ contributors:
   - byzyk
   - EugeneHlushko
   - superburrito
+  - chenxsan
 ---
 
 When compiling source code with webpack, users can generate a JSON file containing statistics about modules. These statistics can be used to analyze an application's dependency graph as well as to optimize compilation speed. The file is typically generated with the following CLI command:
@@ -52,10 +53,10 @@ The top-level structure of the output JSON file is fairly straightforward but th
     // A list of [module objects](#module-objects)
   ],
   'errors': [
-    // A list of [error strings](#errors-and-warnings)
+    // A list of [error objects](#errors-and-warnings)
   ],
   'warnings': [
-    // A list of [warning strings](#errors-and-warnings)
+    // A list of [warning objects](#errors-and-warnings)
   ]
 }
 ```
@@ -186,13 +187,46 @@ Every module also contains a list of `reasons` objects describing why that modul
 
 ### Errors and Warnings
 
-The `errors` and `warnings` properties each contain a list of strings. Each string contains a message and stack trace:
+The `errors` and `warnings` properties each contain a list of objects. Each object contains a message, a stack trace and various other properties:
 
-``` bash
-../cases/parsing/browserify/index.js
-Critical dependencies:
-2:114-121 This seem to be a pre-built javascript file. Even while this is possible, it's not recommended. Try to require to original source to get better results.
- @ ../cases/parsing/browserify/index.js 2:114-121
+```json
+{
+  "moduleIdentifier": "C:\\Repos\\webpack\\test\\cases\\context\\issue-5750\\index.js",
+  "moduleName": "(webpack)/test/cases/context/issue-5750/index.js",
+  "loc": "3:8-47",
+  "message": "Critical dependency: Contexts can't use RegExps with the 'g' or 'y' flags.",
+  "moduleId": 29595,
+  "moduleTrace": [
+    {
+      "originIdentifier": "C:\\Repos\\webpack\\test\\cases|sync|/^\\.\\/[^/]+\\/[^/]+\\/index\\.js$/",
+      "originName": "(webpack)/test/cases sync ^\\.\\/[^/]+\\/[^/]+\\/index\\.js$",
+      "moduleIdentifier": "C:\\Repos\\webpack\\test\\cases\\context\\issue-5750\\index.js",
+      "moduleName": "(webpack)/test/cases/context/issue-5750/index.js",
+      "dependencies": [
+        {
+          "loc": "./context/issue-5750/index.js"
+        }
+      ],
+      "originId": 32582,
+      "moduleId": 29595
+    },
+    {
+      "originIdentifier": "C:\\Repos\\webpack\\testCases.js",
+      "originName": "(webpack)/testCases.js",
+      "moduleIdentifier": "C:\\Repos\\webpack\\test\\cases|sync|/^\\.\\/[^/]+\\/[^/]+\\/index\\.js$/",
+      "moduleName": "(webpack)/test/cases sync ^\\.\\/[^/]+\\/[^/]+\\/index\\.js$",
+      "dependencies": [
+        {
+          "loc": "1:0-70"
+        }
+      ],
+      "originId": 8198,
+      "moduleId": 32582
+    }
+  ],
+  "details": "    at RequireContextDependency.getWarnings (C:\\Repos\\webpack\\lib\\dependencies\\ContextDependency.js:79:5)\n    at Compilation.reportDependencyErrorsAndWarnings (C:\\Repos\\webpack\\lib\\Compilation.js:1727:24)\n    at C:\\Repos\\webpack\\lib\\Compilation.js:1467:10\n    at _next2 (<anonymous>:16:1)\n    at eval (<anonymous>:42:1)\n    at C:\\Repos\\webpack\\node_modules\\neo-async\\async.js:2830:7\n    at Object.each (C:\\Repos\\webpack\\node_modules\\neo-async\\async.js:2850:39)\n    at C:\\Repos\\webpack\\lib\\FlagDependencyExportsPlugin.js:219:18\n    at C:\\Repos\\webpack\\node_modules\\neo-async\\async.js:2830:7\n    at Object.each (C:\\Repos\\webpack\\node_modules\\neo-async\\async.js:2850:39)\n    at C:\\Repos\\webpack\\lib\\FlagDependencyExportsPlugin.js:40:16\n    at Hook.eval [as callAsync] (<anonymous>:38:1)\n    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (C:\\Repos\\tapable\\lib\\Hook.js:18:14)\n    at Compilation.finish (C:\\Repos\\webpack\\lib\\Compilation.js:1462:28)\n    at C:\\Repos\\webpack\\lib\\Compiler.js:909:18\n    at processTicksAndRejections (internal/process/task_queues.js:75:11)\n",
+  "stack": "ModuleDependencyWarning: Critical dependency: Contexts can't use RegExps with the 'g' or 'y' flags.\n    at Compilation.reportDependencyErrorsAndWarnings (C:\\Repos\\webpack\\lib\\Compilation.js:1732:23)\n    at C:\\Repos\\webpack\\lib\\Compilation.js:1467:10\n    at _next2 (<anonymous>:16:1)\n    at eval (<anonymous>:42:1)\n    at C:\\Repos\\webpack\\node_modules\\neo-async\\async.js:2830:7\n    at Object.each (C:\\Repos\\webpack\\node_modules\\neo-async\\async.js:2850:39)\n    at C:\\Repos\\webpack\\lib\\FlagDependencyExportsPlugin.js:219:18\n    at C:\\Repos\\webpack\\node_modules\\neo-async\\async.js:2830:7\n    at Object.each (C:\\Repos\\webpack\\node_modules\\neo-async\\async.js:2850:39)\n    at C:\\Repos\\webpack\\lib\\FlagDependencyExportsPlugin.js:40:16\n    at Hook.eval [as callAsync] (<anonymous>:38:1)\n    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (C:\\Repos\\tapable\\lib\\Hook.js:18:14)\n    at Compilation.finish (C:\\Repos\\webpack\\lib\\Compilation.js:1462:28)\n    at C:\\Repos\\webpack\\lib\\Compiler.js:909:18\n    at processTicksAndRejections (internal/process/task_queues.js:75:11)\n"
+}
 ```
 
-W> Note that the stack traces are removed when `errorDetails: false` is passed to the `toJson` method. The `errorDetails` option is set to `true` by default.
+W> Note that the stack traces are removed when `errorStack: false` is passed to the `toJson` method. The `errorStack` option is set to `true` by default.


### PR DESCRIPTION
It's a follow-up to https://github.com/webpack/webpack.js.org/pull/3704, the error object was copied from [example2.json](https://raw.githubusercontent.com/webpack/analyse/master/app/pages/upload/example2.json).

Preview url: https://webpack-js-org-git-fork-chenxsan-bugfix-update-stats.webpack-docs.now.sh/api/stats/#errors-and-warnings