### PR TITLE
docs(api): add deprecation warnings

### DIFF
--- a/src/content/api/compilation-hooks.md
+++ b/src/content/api/compilation-hooks.md
@@ -398,7 +398,7 @@ compilation.hooks.additionalAssets.tapAsync('MyPlugin', callback => {
 
 `AsyncSeriesHook`
 
-W> `optimizeChunkAssets` is deprecated (use [Compilation.hook.processAssets](#processassets) instead and use one of Compilation.PROCESS_ASSETS_STAGE_* as stage option)
+W> `optimizeChunkAssets` is deprecated (use the [Compilation.hook.processAssets](#processassets) instead and use one of the Compilation.PROCESS_ASSETS_STAGE_* as a stage option)
 
 Optimize any chunk assets. The assets are stored in `compilation.assets`. A
 `Chunk` has a property `files` which points to all files created by a chunk.

--- a/src/content/api/compilation-hooks.md
+++ b/src/content/api/compilation-hooks.md
@@ -431,7 +431,7 @@ compilation.hooks
 
 `SyncHook`
 
-W> `afterOptimizeChunkAssets` is deprecated (use [Compilation.hook.processAssets](#processassets) instead and use one of Compilation.PROCESS_ASSETS_STAGE_* as stage option)
+W> `afterOptimizeChunkAssets` is deprecated (use the [Compilation.hook.processAssets](#processassets) instead and use one of the Compilation.PROCESS_ASSETS_STAGE_* as a stage option)
 
 The chunk assets have been optimized.
 

--- a/src/content/api/compilation-hooks.md
+++ b/src/content/api/compilation-hooks.md
@@ -352,7 +352,7 @@ Executed before module assets creation.
 
 `SyncHook`
 
-W> `additionalChunkAssets` is deprecated (use [Compilation.hook.processAssets](#processassets) instead and use one of Compilation.PROCESS_ASSETS_STAGE_* as stage option)
+W> `additionalChunkAssets` is deprecated (use the [Compilation.hook.processAssets](#processassets) instead and use one of the Compilation.PROCESS_ASSETS_STAGE_* as a stage option)
 
 Create additional assets for the chunks.
 

--- a/src/content/api/compilation-hooks.md
+++ b/src/content/api/compilation-hooks.md
@@ -352,6 +352,8 @@ Executed before module assets creation.
 
 `SyncHook`
 
+W> `additionalChunkAssets` is deprecated (use [Compilation.hook.processAssets](#processassets) instead and use one of Compilation.PROCESS_ASSETS_STAGE_* as stage option)
+
 Create additional assets for the chunks.
 
 - Callback Parameters: `chunks`
@@ -396,6 +398,8 @@ compilation.hooks.additionalAssets.tapAsync('MyPlugin', callback => {
 
 `AsyncSeriesHook`
 
+W> `optimizeChunkAssets` is deprecated (use [Compilation.hook.processAssets](#processassets) instead and use one of Compilation.PROCESS_ASSETS_STAGE_* as stage option)
+
 Optimize any chunk assets. The assets are stored in `compilation.assets`. A
 `Chunk` has a property `files` which points to all files created by a chunk.
 Any additional chunk assets are stored in `compilation.additionalChunkAssets`.
@@ -426,6 +430,8 @@ compilation.hooks
 ### `afterOptimizeChunkAssets`
 
 `SyncHook`
+
+W> `afterOptimizeChunkAssets` is deprecated (use [Compilation.hook.processAssets](#processassets) instead and use one of Compilation.PROCESS_ASSETS_STAGE_* as stage option)
 
 The chunk assets have been optimized.
 


### PR DESCRIPTION
Adding deprecation warnings to avoid future usages now that [those compilation hooks were deprecated](https://github.com/webpack/webpack/blob/253cf465df3f1d577a6da25c554c5c0a7e64bf0b/lib/Compilation.js#L503) since webpack 5 beta 17.

It only includes those with warnings showed in console:

![image](https://user-images.githubusercontent.com/1091472/84568405-e457d700-adb1-11ea-9a80-917b9f8596ff.png)
Preview url: https://webpack-js-org-git-fork-chenxsan-feature-add-deprecation-83caf4.webpack-docs.vercel.app/api/compilation-hooks/#additionalchunkassets