### PR TITLE
docs(configuration): add resolve.restrictions

### DIFF
--- a/src/content/configuration/resolve.md
+++ b/src/content/configuration/resolve.md
@@ -15,6 +15,7 @@ contributors:
   - Aghassi
   - myshov
   - anikethsaha
+  - chenxsan
 ---
 
 These options change how modules are resolved. webpack provides reasonable defaults, but it is possible to change the resolving in detail. Have a look at [Module Resolution](/concepts/module-resolution) for more explanation of how the resolver works.
@@ -448,6 +449,23 @@ module.exports = {
       // additional logic
       return true;
     }
+  }
+};
+```
+
+### `resolve.restrictions`
+
+`[string | RegExp]`
+
+A list of resolve restrictions to restrict the paths a request can be resolved.
+
+__webpack.config.js__
+
+```js
+module.exports = {
+  //...
+  resolve: {
+    restrictions: [/\.(sass|scss|css)$/]
   }
 };
 ```

--- a/src/content/configuration/resolve.md
+++ b/src/content/configuration/resolve.md
@@ -455,9 +455,9 @@ module.exports = {
 
 ### `resolve.restrictions`
 
-`[string | RegExp]`
+`[string, RegExp]`
 
-A list of resolve restrictions to restrict the paths a request can be resolved.
+A list of resolve restrictions to restrict the paths that a request can be resolved on.
 
 __webpack.config.js__
 


### PR DESCRIPTION
Document `resolve.restrictions` introduced in [webpack v5.0.0-beta.18](https://github.com/webpack/webpack/releases/tag/v5.0.0-beta.18)

Preview url: https://webpack-js-org-git-fork-chenxsan-feature-add-resolve-dot-8423d9.webpack-docs.vercel.app/configuration/resolve/#resolverestrictions