### PR TITLE
add links to navigate between pages

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["env", { "modules": false }],
+    ["env"],
     "react"
   ],
   "plugins": [

--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["env"],
+    "env",
     "react"
   ],
   "plugins": [

--- a/src/components/Page/AdjacentPages.jsx
+++ b/src/components/Page/AdjacentPages.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import Link from '../Link/Link';
+import './AdjacentPages.scss';
+import PropTypes from 'prop-types';
+AdjacentPages.propTypes = {
+  previous: PropTypes.shape({
+    url: PropTypes.string,
+    title: PropTypes.string,
+  }),
+  next: PropTypes.shape({
+    url: PropTypes.string,
+    title: PropTypes.string,
+  }),
+};
+
+export default function AdjacentPages({ previous, next }) {
+  return (
+    <div className="adjacent-links">
+      {previous && (
+        <div className="adjacent-links__prev">
+          <div>« Previous</div>
+          <Link className="adjacent-links__link" to={previous.url}>
+            {previous.title}
+          </Link>
+        </div>
+      )}
+      {next && (
+        <div className="adjacent-links__next">
+          <div>Next »</div>
+          <Link className="adjacent-links__link" to={next.url}>
+            {next.title}
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Page/AdjacentPages.jsx
+++ b/src/components/Page/AdjacentPages.jsx
@@ -14,6 +14,7 @@ AdjacentPages.propTypes = {
 };
 
 export default function AdjacentPages({ previous, next }) {
+  if (!previous && !next) return null;
   return (
     <div className="adjacent-links">
       {previous && (

--- a/src/components/Page/AdjacentPages.jsx
+++ b/src/components/Page/AdjacentPages.jsx
@@ -26,7 +26,7 @@ export default function AdjacentPages({ previous, next }) {
       )}
       {next && (
         <div className="adjacent-links__next">
-          <div>Next »</div>
+          <div className="adjacent-links__label--next">Next »</div>
           <Link className="adjacent-links__link" to={next.url}>
             {next.title}
           </Link>

--- a/src/components/Page/AdjacentPages.scss
+++ b/src/components/Page/AdjacentPages.scss
@@ -1,0 +1,14 @@
+.adjacent-links {
+  display: flex;
+  padding: 30px 10px;
+  justify-content: space-between;
+  &__prev {
+    margin-right: auto;
+  }
+  &__next {
+    margin-left: auto;
+  }
+  &__link {
+    font-size: 1.125rem;
+  }
+}

--- a/src/components/Page/AdjacentPages.scss
+++ b/src/components/Page/AdjacentPages.scss
@@ -11,4 +11,7 @@
   &__link {
     font-size: 1.125rem;
   }
+  &__label--next {
+    text-align: right;
+  }
 }

--- a/src/components/Page/Page.jsx
+++ b/src/components/Page/Page.jsx
@@ -7,6 +7,7 @@ import Markdown from '../Markdown/Markdown';
 import Contributors from '../Contributors/Contributors';
 import {PlaceholderString} from '../Placeholder/Placeholder';
 import Configuration from '../Configuration/Configuration';
+import AdjacentPages from './AdjacentPages';
 
 // Load Styling
 import './Page.scss';
@@ -55,7 +56,7 @@ class Page extends React.Component {
   }
 
   render() {
-    const { title, contributors = [], related = [], ...rest } = this.props;
+    const { title, contributors = [], related = [], previous, next, ...rest } = this.props;
 
     const { contentLoaded } = this.state;
     const loadRelated = contentLoaded && related && related.length !== 0;
@@ -86,6 +87,10 @@ class Page extends React.Component {
           <h1>{title}</h1>
 
           {contentRender}
+          
+          {
+            (previous || next) && <AdjacentPages previous={previous} next={next} />
+          }
 
           {loadRelated && (
             <div className="related__section">

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -23,11 +23,11 @@ const docs = [
 const currentDocsVersion = 5;
 
 // Create and export the component
-export default ({
+export default function Sidebar({
   className = '',
   pages,
   currentPage
-}) => {
+}) {
   let group;
 
   return (
@@ -69,4 +69,4 @@ export default ({
       </div>
     </nav>
   );
-};
+}

--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -172,7 +172,7 @@ class Site extends React.Component {
       sort,
       anchors,
       children: children ? this._strip(children) : []
-    })).filter(page => page.title !== 'printable.md' && !page.content.includes('Printable'));
+    })).filter(page => (page.title !== 'printable.md' && !page.content.includes('Printable')));
   };
 }
 

--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -5,11 +5,7 @@ import { hot as Hot } from 'react-hot-loader';
 import DocumentTitle from 'react-document-title';
 
 // Import Utilities
-import {
-  extractPages,
-  extractSections,
-  getPageTitle
-} from '../../utilities/content-utils';
+import { extractPages, extractSections, getPageTitle } from '../../utilities/content-utils';
 import isClient from '../../utilities/is-client';
 import getAdjacentPages from '../../utilities/get-adjacent-pages';
 
@@ -72,13 +68,8 @@ class Site extends React.Component {
               {
                 content: 'Documentation',
                 url: '/concepts/',
-                isActive: url =>
-                  /^\/(api|concepts|configuration|guides|loaders|migrate|plugins)/.test(
-                    url
-                  ),
-                children: this._strip(
-                  sections.filter(item => item.name !== 'contribute')
-                )
+                isActive: url => /^\/(api|concepts|configuration|guides|loaders|migrate|plugins)/.test(url),
+                children: this._strip(sections.filter(item => item.name !== 'contribute'))
               },
               { content: 'Contribute', url: '/contribute/' },
               { content: 'Vote', url: '/vote/' },
@@ -87,21 +78,14 @@ class Site extends React.Component {
           />
         </div>
 
-        {isClient ? (
-          <SidebarMobile
+        {isClient ? <SidebarMobile
             isOpen={mobileSidebarOpen}
             sections={this._strip(Content.children)}
             toggle={this._toggleSidebar}
-          />
-        ) : null}
+          /> : null}
 
         <Switch>
-          <Route
-            exact
-            strict
-            path="/:url*"
-            render={props => <Redirect to={`${props.location.pathname}/`} />}
-          />
+          <Route exact strict path="/:url*" render={props => <Redirect to={`${props.location.pathname}/`}/>} />
           <Route path="/" exact component={Splash} />
           <Route
             render={props => (
@@ -110,10 +94,7 @@ class Site extends React.Component {
                   <Route path="/vote" component={Vote} />
                   <Route path="/organization" component={Organization} />
                   <Route path="/starter-kits" component={StarterKits} />
-                  <Route
-                    path="/app-shell"
-                    component={() => <React.Fragment />}
-                  />
+                  <Route path="/app-shell" component={() => <React.Fragment />} />
                   {pages.map(page => (
                     <Route
                       key={page.url}
@@ -176,9 +157,7 @@ class Site extends React.Component {
    * @return {array}       - ...
    */
   _strip = array => {
-    let anchorTitleIndex = array.findIndex(
-      item => item.name.toLowerCase() === 'index.md'
-    );
+    let anchorTitleIndex = array.findIndex(item => item.name.toLowerCase() === 'index.md');
 
     if (anchorTitleIndex !== -1) {
       array.unshift(array[anchorTitleIndex]);
@@ -186,8 +165,7 @@ class Site extends React.Component {
       array.splice(anchorTitleIndex + 1, 1);
     }
 
-    return array
-      .map(({ title, name, url, group, sort, anchors, children }) => ({
+    return array.map(({ title, name, url, group, sort, anchors, children }) => ({
         title: title || name,
         content: title || name,
         url,
@@ -196,10 +174,7 @@ class Site extends React.Component {
         anchors,
         children: children ? this._strip(children) : []
       }))
-      .filter(
-        page =>
-          page.title !== 'printable.md' && !page.content.includes('Printable')
-      );
+      .filter(page => page.title !== 'printable.md' && !page.content.includes('Printable'));
   };
 }
 

--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -5,8 +5,13 @@ import { hot as Hot } from 'react-hot-loader';
 import DocumentTitle from 'react-document-title';
 
 // Import Utilities
-import { extractPages, extractSections, getPageTitle } from '../../utilities/content-utils';
+import {
+  extractPages,
+  extractSections,
+  getPageTitle
+} from '../../utilities/content-utils';
 import isClient from '../../utilities/is-client';
+import getAdjacentPages from '../../utilities/get-adjacent-pages';
 
 // Import Components
 import NotificationBar from '../NotificationBar/NotificationBar';
@@ -48,36 +53,55 @@ class Site extends React.Component {
     let sections = extractSections(Content);
     let section = sections.find(({ url }) => location.pathname.startsWith(url));
     let pages = extractPages(Content);
-
+    const sidebarPages = this._strip(
+      section
+        ? section.children
+        : Content.children.filter(
+            item => item.type !== 'directory' && item.url !== '/'
+          )
+    );
     return (
       <div className="site">
         <DocumentTitle title={getPageTitle(Content, location.pathname)} />
         <div className="site__header">
           <NotificationBar />
           <Navigation
-          pathname={location.pathname}
-          toggleSidebar={this._toggleSidebar}
-          links={[
-            {
-              content: 'Documentation',
-              url: '/concepts/',
-              isActive: url => /^\/(api|concepts|configuration|guides|loaders|migrate|plugins)/.test(url),
-              children: this._strip(sections.filter(item => item.name !== 'contribute'))
-            },
-            { content: 'Contribute', url: '/contribute/' },
-            { content: 'Vote', url: '/vote/' },
-            { content: 'Blog', url: 'https://medium.com/webpack' }
-          ]}
+            pathname={location.pathname}
+            toggleSidebar={this._toggleSidebar}
+            links={[
+              {
+                content: 'Documentation',
+                url: '/concepts/',
+                isActive: url =>
+                  /^\/(api|concepts|configuration|guides|loaders|migrate|plugins)/.test(
+                    url
+                  ),
+                children: this._strip(
+                  sections.filter(item => item.name !== 'contribute')
+                )
+              },
+              { content: 'Contribute', url: '/contribute/' },
+              { content: 'Vote', url: '/vote/' },
+              { content: 'Blog', url: 'https://medium.com/webpack' }
+            ]}
           />
         </div>
 
-        {isClient ? <SidebarMobile
-          isOpen={mobileSidebarOpen}
-          sections={this._strip(Content.children)}
-          toggle={this._toggleSidebar} /> : null}
+        {isClient ? (
+          <SidebarMobile
+            isOpen={mobileSidebarOpen}
+            sections={this._strip(Content.children)}
+            toggle={this._toggleSidebar}
+          />
+        ) : null}
 
         <Switch>
-          <Route exact strict path="/:url*" render={props => <Redirect to={`${props.location.pathname}/`}/>} />
+          <Route
+            exact
+            strict
+            path="/:url*"
+            render={props => <Redirect to={`${props.location.pathname}/`} />}
+          />
           <Route path="/" exact component={Splash} />
           <Route
             render={props => (
@@ -86,7 +110,10 @@ class Site extends React.Component {
                   <Route path="/vote" component={Vote} />
                   <Route path="/organization" component={Organization} />
                   <Route path="/starter-kits" component={StarterKits} />
-                  <Route path="/app-shell" component={() => <React.Fragment />} />
+                  <Route
+                    path="/app-shell"
+                    component={() => <React.Fragment />}
+                  />
                   {pages.map(page => (
                     <Route
                       key={page.url}
@@ -95,20 +122,25 @@ class Site extends React.Component {
                       render={props => {
                         let path = page.path.replace('src/content/', '');
                         let content = this.props.import(path);
-
+                        const { previous, next } = getAdjacentPages(
+                          sidebarPages,
+                          page,
+                          'url'
+                        );
                         return (
                           <React.Fragment>
                             <Sponsors />
                             <Sidebar
                               className="site__sidebar"
                               currentPage={location.pathname}
-                              pages={this._strip(
-                                section
-                                  ? section.children
-                                  : Content.children.filter(item => item.type !== 'directory' && item.url !== '/')
-                              )}
+                              pages={sidebarPages}
                             />
-                            <Page {...page} content={content} />
+                            <Page
+                              {...page}
+                              content={content}
+                              previous={previous}
+                              next={next}
+                            />
                             <Gitter />
                           </React.Fragment>
                         );
@@ -144,7 +176,9 @@ class Site extends React.Component {
    * @return {array}       - ...
    */
   _strip = array => {
-    let anchorTitleIndex = array.findIndex(item => item.name.toLowerCase() === 'index.md');
+    let anchorTitleIndex = array.findIndex(
+      item => item.name.toLowerCase() === 'index.md'
+    );
 
     if (anchorTitleIndex !== -1) {
       array.unshift(array[anchorTitleIndex]);
@@ -152,15 +186,20 @@ class Site extends React.Component {
       array.splice(anchorTitleIndex + 1, 1);
     }
 
-    return array.map(({ title, name, url, group, sort, anchors, children }) => ({
-      title: title || name,
-      content: title || name,
-      url,
-      group,
-      sort,
-      anchors,
-      children: children ? this._strip(children) : []
-    })).filter(page => (page.title !== 'printable.md' && !page.content.includes('Printable')));
+    return array
+      .map(({ title, name, url, group, sort, anchors, children }) => ({
+        title: title || name,
+        content: title || name,
+        url,
+        group,
+        sort,
+        anchors,
+        children: children ? this._strip(children) : []
+      }))
+      .filter(
+        page =>
+          page.title !== 'printable.md' && !page.content.includes('Printable')
+      );
   };
 }
 

--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -62,27 +62,26 @@ class Site extends React.Component {
         <div className="site__header">
           <NotificationBar />
           <Navigation
-            pathname={location.pathname}
-            toggleSidebar={this._toggleSidebar}
-            links={[
-              {
-                content: 'Documentation',
-                url: '/concepts/',
-                isActive: url => /^\/(api|concepts|configuration|guides|loaders|migrate|plugins)/.test(url),
-                children: this._strip(sections.filter(item => item.name !== 'contribute'))
-              },
-              { content: 'Contribute', url: '/contribute/' },
-              { content: 'Vote', url: '/vote/' },
-              { content: 'Blog', url: 'https://medium.com/webpack' }
-            ]}
+          pathname={location.pathname}
+          toggleSidebar={this._toggleSidebar}
+          links={[
+            {
+              content: 'Documentation',
+              url: '/concepts/',
+              isActive: url => /^\/(api|concepts|configuration|guides|loaders|migrate|plugins)/.test(url),
+              children: this._strip(sections.filter(item => item.name !== 'contribute'))
+            },
+            { content: 'Contribute', url: '/contribute/' },
+            { content: 'Vote', url: '/vote/' },
+            { content: 'Blog', url: 'https://medium.com/webpack' }
+          ]}
           />
         </div>
 
         {isClient ? <SidebarMobile
-            isOpen={mobileSidebarOpen}
-            sections={this._strip(Content.children)}
-            toggle={this._toggleSidebar}
-          /> : null}
+          isOpen={mobileSidebarOpen}
+          sections={this._strip(Content.children)}
+          toggle={this._toggleSidebar} /> : null}
 
         <Switch>
           <Route exact strict path="/:url*" render={props => <Redirect to={`${props.location.pathname}/`}/>} />
@@ -166,15 +165,14 @@ class Site extends React.Component {
     }
 
     return array.map(({ title, name, url, group, sort, anchors, children }) => ({
-        title: title || name,
-        content: title || name,
-        url,
-        group,
-        sort,
-        anchors,
-        children: children ? this._strip(children) : []
-      }))
-      .filter(page => page.title !== 'printable.md' && !page.content.includes('Printable'));
+      title: title || name,
+      content: title || name,
+      url,
+      group,
+      sort,
+      anchors,
+      children: children ? this._strip(children) : []
+    })).filter(page => page.title !== 'printable.md' && !page.content.includes('Printable'));
   };
 }
 

--- a/src/utilities/get-adjacent-pages/index.js
+++ b/src/utilities/get-adjacent-pages/index.js
@@ -1,6 +1,5 @@
 module.exports = function getAdjacentPages(haystack, needle, by = 'url') {
-  let previous = undefined,
-    next = undefined;
+  let previous, next;
   const findMe = haystack.findIndex(page => page[by] === needle[by]);
   if (findMe !== -1) {
     previous = haystack[findMe - 1];

--- a/src/utilities/get-adjacent-pages/index.js
+++ b/src/utilities/get-adjacent-pages/index.js
@@ -1,0 +1,13 @@
+module.exports = function getAdjacentPages(haystack, needle, by = 'url') {
+  let previous = undefined,
+    next = undefined;
+  const findMe = haystack.findIndex(page => page[by] === needle[by]);
+  if (findMe !== -1) {
+    previous = haystack[findMe - 1];
+    next = haystack[findMe + 1];
+  }
+  return {
+    previous,
+    next
+  };
+};

--- a/src/utilities/get-adjacent-pages/index.js
+++ b/src/utilities/get-adjacent-pages/index.js
@@ -1,4 +1,4 @@
-module.exports = function getAdjacentPages(haystack, needle, by = 'url') {
+export default function getAdjacentPages(haystack, needle, by = 'url') {
   let previous, next;
   const findMe = haystack.findIndex(page => page[by] === needle[by]);
   if (findMe !== -1) {
@@ -9,4 +9,4 @@ module.exports = function getAdjacentPages(haystack, needle, by = 'url') {
     previous,
     next
   };
-};
+}

--- a/src/utilities/get-adjacent-pages/index.test.js
+++ b/src/utilities/get-adjacent-pages/index.test.js
@@ -1,0 +1,26 @@
+const getAdjacentPages = require('.');
+const needle = { url: '/webpack' };
+describe('getAdjacentPages', () => {
+  it('returns only next page', () => {
+    const pages = [needle, { url: '/webpack-doc' }];
+    const { previous, next } = getAdjacentPages(pages, needle, 'url');
+    expect(previous).toBeUndefined();
+    expect(next).toEqual({ url: '/webpack-doc' });
+  });
+  it('retuns only previous page', () => {
+    const pages = [{ url: '/webpack-doc' }, needle];
+    const { previous, next } = getAdjacentPages(pages, needle, 'url');
+    expect(next).toBeUndefined();
+    expect(previous).toEqual({ url: '/webpack-doc' });
+  });
+  it('returns both previous and next pages', () => {
+    const pages = [
+      { url: '/previous-webpack' },
+      needle,
+      { url: '/next-webpack' }
+    ];
+    const { previous, next } = getAdjacentPages(pages, needle, 'url');
+    expect(next).toEqual({ url: '/next-webpack' });
+    expect(previous).toEqual({ url: '/previous-webpack' });
+  });
+});

--- a/src/utilities/get-adjacent-pages/index.test.js
+++ b/src/utilities/get-adjacent-pages/index.test.js
@@ -1,4 +1,4 @@
-const getAdjacentPages = require('.');
+import getAdjacentPages from './index';
 const needle = { url: '/webpack' };
 describe('getAdjacentPages', () => {
   it('returns only next page', () => {


### PR DESCRIPTION
Sometimes I would read document on mobile phone and navigating between pages are not an easy task when you have to open sidebar menu first. This pull request adds links at the bottom of page for navigating to previous/next page, and I think it would improve users' experience.

Screenshot:
![image](https://user-images.githubusercontent.com/1091472/85189768-6d0bd100-b2e4-11ea-895c-737553c24e4f.png)

