### PR TITLE
docs(glossary): fix grammar

### DIFF
--- a/src/content/glossary.md
+++ b/src/content/glossary.md
@@ -16,7 +16,7 @@ This index lists common terms used throughout the webpack ecosystem.
 
 ## A
 
-- [__Asset__](/guides/asset-management/): This a general term for the images, fonts, media, and any other kind of files that are typically used in websites and other applications. These typically end up as individual files within the [output](/glossary/#o) but can also be inlined via things like the [style-loader](/loaders/style-loader) or [url-loader](/loaders/url-loader).
+- [__Asset__](/guides/asset-management/): This is a general term for the images, fonts, media, and any other kind of files that are typically used in websites and other applications. These typically end up as individual files within the [output](/glossary/#o) but can also be inlined via things like the [style-loader](/loaders/style-loader) or [url-loader](/loaders/url-loader).
 
 
 ## B


### PR DESCRIPTION
I think the `is` is missing here.