### PR TITLE
docs(guides): Removed unnecessary publicPath option

### DIFF
--- a/src/content/guides/code-splitting.md
+++ b/src/content/guides/code-splitting.md
@@ -211,7 +211,6 @@ __webpack.config.js__
     output: {
       filename: '[name].bundle.js',
 +     chunkFilename: '[name].bundle.js',
-      publicPath: 'dist/',
       path: path.resolve(__dirname, 'dist'),
     },
 -   optimization: {


### PR DESCRIPTION
In the Dynamic Imports section inside Code-Splitting Guide,
`output.publicPath` option isn't always required to use `output.chunkFilename`.