### PR TITLE
move build script after cypress

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ jobs:
         - yarn lint:js || travis_terminate 1
         - yarn lint:markdown || travis_terminate 1
         - yarn lint:social || travis_terminate 1
-        - yarn build || travis_terminate 1
         - yarn lint:links || travis_terminate 1
         - yarn cypress:ci || travis_terminate 1
+        - yarn build || travis_terminate 1
 
     - stage: Build
       name: Proselint

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ jobs:
         - yarn lint:js || travis_terminate 1
         - yarn lint:markdown || travis_terminate 1
         - yarn lint:social || travis_terminate 1
-        - yarn lint:links || travis_terminate 1
         - yarn cypress:ci || travis_terminate 1
         - yarn build || travis_terminate 1
+        - yarn lint:links || travis_terminate 1
 
     - stage: Build
       name: Proselint


### PR DESCRIPTION
`cypress:ci` would start the server with `yarn start` script which would remove `dist` folder causing `Post-build` stage to fail.