### PR TITLE
changing source-maps to source-map

### DIFF
--- a/src/content/configuration/configuration-types.md
+++ b/src/content/configuration/configuration-types.md
@@ -30,7 +30,7 @@ One option is to export a function from your webpack configuration instead of ex
 +module.exports = function(env, argv) {
 +  return {
 +    mode: env.production ? 'production' : 'development',
-+    devtool: env.production ? 'source-maps' : 'eval',
++    devtool: env.production ? 'source-map' : 'eval',
      plugins: [
        new TerserPlugin({
          terserOptions: {


### PR DESCRIPTION
according to https://webpack.js.org/configuration/devtool the "devtool" option should be source-map (it was source-maps in the file).