### PR TITLE
Fix node defaults

### DIFF
--- a/src/content/configuration/node.md
+++ b/src/content/configuration/node.md
@@ -50,14 +50,18 @@ Since webpack 3.0.0, the `node` option may be set to `false` to completely turn 
 
 ## `node.global`
 
-`boolean = false`
+`boolean = true`
+
+Defaults to `false` for [targets](https://webpack.js.org/configuration/target/) `node`, `async-node` and `electron-main`.
 
 See [the source](https://nodejs.org/api/globals.html) for the exact behavior of this object.
 
 
 ## `node.__filename`
 
-`string` `boolean = false`
+`boolean` `string = mock`
+
+Defaults to `false` for [targets](https://webpack.js.org/configuration/target/) `node`, `async-node` and `electron-main`.
 
 Options:
 
@@ -68,7 +72,9 @@ Options:
 
 ## `node.__dirname`
 
-`string` `boolean = false`
+`boolean` `string = mock`
+
+Defaults to `false` for [targets](https://webpack.js.org/configuration/target/) `node`, `async-node` and `electron-main`.
 
 Options:
 


### PR DESCRIPTION
This PR fixes the documented node defaults.

See https://github.com/webpack/webpack/blob/v5.0.0-beta.20/lib/config/defaults.js#L478-L510 for the actual node default configs.

### Timeline

* Node defaults were restored in PR https://github.com/webpack/webpack/pull/8602
* Documentation was updated accordingly in https://github.com/webpack/webpack.js.org/pull/2753
* Node defaults were changed for targets  `node`, `async-node` and `electron-main` in https://github.com/webpack/webpack/pull/9172
* Documentation was wrongly updated for the non-default targets `node`, `async-node` and `electron-main`, but should reflect the default target `web` https://github.com/webpack/webpack.js.org/pull/3602

Relates to https://github.com/webpack/webpack/pull/11054.

I would much prefer to disable node for all targets, but @sokra explained why it is not done in https://github.com/webpack/webpack/pull/11054#issuecomment-645673452.