### PR TITLE
fix(ux) Fix scroll to top bug on Safari iOS 12.4.3

### DIFF
--- a/src/components/Page/Page.jsx
+++ b/src/components/Page/Page.jsx
@@ -42,7 +42,7 @@ class Page extends React.Component {
                 element.scrollIntoView();
               }
             } else {
-              document.documentElement.scrollTop = 0;
+              window.scrollTo(0, 0);
             }
             
           })


### PR DESCRIPTION
I was using Safari on iOS 12.4.3 to browse the document when I found the [scroll to top function](https://github.com/webpack/webpack.js.org/pull/3513/files#diff-215153bef266b7d16040d598cdf95b25R37) won't work as expected (Unfortunately I didn't notice it when I created https://github.com/webpack/webpack.js.org/pull/3656), you can see it from the video below if you don't have safari on iOS 12.4.3 to test:

https://imgur.com/mjRsGT3

But it did work on Safari on iOS 13.1.3 which mean it would be a [compatibility problem](https://stackoverflow.com/questions/58693386/why-does-scrolltop-position-not-work-on-mobile-safari):

![image](https://user-images.githubusercontent.com/1091472/87450312-ecb16500-c630-11ea-9fbf-2b8c421a4c69.png)


![image](https://user-images.githubusercontent.com/1091472/87450185-cab7e280-c630-11ea-9886-2214cee7f3fd.png)

Replacing it with `window.scrollTo` should hopefully support more browsers according to https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo#Browser_Compatibility

And yes, it works on my safari now https://imgur.com/a/tmlsqNr