### PR TITLE
docs(configuration): mention jsonp

### DIFF
--- a/src/content/configuration/externals.md
+++ b/src/content/configuration/externals.md
@@ -300,7 +300,7 @@ For more information on how to use this configuration, please refer to the artic
 
 `string = 'var'`
 
-Specifies the default type of externals. `amd`, `root`, `system` and `jsonp` externals __depend on the [`output.libraryTarget`](/configuration/output/#outputlibrarytarget)__ being set to the same value e.g. you can only consume `amd` externals within an `amd` library.
+Specifies the default type of externals. `amd`, `umd`, `system` and `jsonp` externals __depend on the [`output.libraryTarget`](/configuration/output/#outputlibrarytarget)__ being set to the same value e.g. you can only consume `amd` externals within an `amd` library.
 
 Supported types:
 

--- a/src/content/configuration/externals.md
+++ b/src/content/configuration/externals.md
@@ -300,7 +300,7 @@ For more information on how to use this configuration, please refer to the artic
 
 `string = 'var'`
 
-Specifies the default type of externals. `amd`, `root` and `system` externals __depend on the [`output.libraryTarget`](/configuration/output/#outputlibrarytarget)__ being set to the same value e.g. you can only consume `amd` externals within an `amd` library.
+Specifies the default type of externals. `amd`, `root`, `system` and `jsonp` externals __depend on the [`output.libraryTarget`](/configuration/output/#outputlibrarytarget)__ being set to the same value e.g. you can only consume `amd` externals within an `amd` library.
 
 Supported types:
 


### PR DESCRIPTION
https://github.com/webpack/webpack/blob/f4b5555691cef31127e7ab9d7a998ad4f547368a/declarations/WebpackOptions.d.ts#L134

 > * Specifies the default type of externals ('amd*', 'umd*', 'system' and 'jsonp' depend on output.libraryTarget set to the same value).