### PR TITLE
docs(output): fix typo

### DIFF
--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -557,7 +557,7 @@ T> Read the [authoring libraries guide](/guides/author-libraries/) guide for mor
 
 This option allows loading asynchronous chunks with a custom script type, such as `<script type="module" ...>`.
 
-T> If [`output.module`](#outputmodule) is set to `true`, `ouput.scriptType` will default to `'module'` instead of `false`.
+T> If [`output.module`](#outputmodule) is set to `true`, `output.scriptType` will default to `'module'` instead of `false`.
 
 ```javascript
 module.exports = {

--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -551,7 +551,7 @@ W> Note that if an `array` is provided as an `entry` point, only the last module
 
 T> Read the [authoring libraries guide](/guides/author-libraries/) guide for more information on `output.library` as well as `output.libraryTarget`.
 
-## ouput.scriptType
+## output.scriptType
 
 `string: 'module' | 'text/javascript'` `boolean = false`
 


### PR DESCRIPTION
Fix small typo in docs.