### PR TITLE
docs(config): Clarify `mode` option copy

### DIFF
--- a/src/content/configuration/mode.md
+++ b/src/content/configuration/mode.md
@@ -48,8 +48,7 @@ T> Please remember that setting `NODE_ENV` doesn't automatically set `mode`.
 
 ### Mode: development
 
-Adding the option `mode: 'development'` to your configuration will enable the
-following:
+Adding the option `mode: 'development'` to your configuration will enable the following:
 
 ```javascript
 // webpack.development.config.js
@@ -95,8 +94,7 @@ module.exports = {
 
 ### Mode: production
 
-Adding the option `mode: 'production'` to your configuration will enable the
-following:
+Adding the option `mode: 'production'` to your configuration will enable the following:
 
 ```javascript
 // webpack.development.config.js
@@ -140,8 +138,7 @@ module.exports = {
 
 ### Mode: none
 
-Adding the option `mode: 'none'` to your configuration will enable the
-following:
+Adding the option `mode: 'none'` to your configuration will enable the following:
 
 ```javascript
 // webpack.custom.config.js
@@ -171,7 +168,9 @@ module.exports = {
 };
 ```
 
-If you want to change the behavior according to the __mode__ variable inside the _webpack.config.js_, you have to export a function instead of an object:
+### Overrides
+
+If you want to change the options configured by the `mode` variable, you’ll need to export a function instead of an object to update your `config` object:
 
 ```javascript
 var config = {

--- a/src/content/configuration/mode.md
+++ b/src/content/configuration/mode.md
@@ -170,7 +170,7 @@ module.exports = {
 
 ### Overrides
 
-If you want to change the options configured by the `mode` variable, you’ll need to export a function instead of an object to update your `config` object:
+If you want to change the options configured by the `mode` variable, you’ll need to export a function instead of an object to override the options webpack enables:
 
 ```javascript
 var config = {

--- a/src/content/configuration/mode.md
+++ b/src/content/configuration/mode.md
@@ -6,6 +6,7 @@ contributors:
   - byzyk
   - mrichmond
   - Fental
+  - mattsacks
 related:
   - title: 'webpack default options (source code)'
     url: https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsDefaulter.js
@@ -47,112 +48,127 @@ T> Please remember that setting `NODE_ENV` doesn't automatically set `mode`.
 
 ### Mode: development
 
+Adding the option `mode: 'development'` to your configuration will enable the
+following:
 
-```diff
+```javascript
 // webpack.development.config.js
 module.exports = {
-+ mode: 'development'
-- devtool: 'eval',
-- cache: true,
-- performance: {
--   hints: false
-- },
-- output: {
--   pathinfo: true
-- },
-- optimization: {
--   namedModules: true,
--   namedChunks: true,
--   nodeEnv: 'development',
--   flagIncludedChunks: false,
--   occurrenceOrder: false,
--   concatenateModules: false,
--   splitChunks: {
--     hidePathInfo: false,
--     minSize: 10000,
--     maxAsyncRequests: Infinity,
--     maxInitialRequests: Infinity,
--   },
--   noEmitOnErrors: false,
--   checkWasmTypes: false,
--   minimize: false,
--   removeAvailableModules: false
-- },
-- plugins: [
--   new webpack.NamedModulesPlugin(),
--   new webpack.NamedChunksPlugin(),
--   new webpack.DefinePlugin({ "process.env.NODE_ENV": JSON.stringify("development") }),
-- ]
-}
+  // Enabling this option...
+  mode: 'development',
+
+  // ...turns on the following:
+  devtool: 'eval',
+  cache: true,
+  performance: {
+    hints: false
+  },
+  output: {
+    pathinfo: true
+  },
+  optimization: {
+    namedModules: true,
+    namedChunks: true,
+    nodeEnv: 'development',
+    flagIncludedChunks: false,
+    occurrenceOrder: false,
+    concatenateModules: false,
+    splitChunks: {
+      hidePathInfo: false,
+      minSize: 10000,
+      maxAsyncRequests: Infinity,
+      maxInitialRequests: Infinity,
+    },
+    noEmitOnErrors: false,
+    checkWasmTypes: false,
+    minimize: false,
+    removeAvailableModules: false
+  },
+  plugins: [
+    new webpack.NamedModulesPlugin(),
+    new webpack.NamedChunksPlugin(),
+    new webpack.DefinePlugin({ 'process.env.NODE_ENV': JSON.stringify('development') }),
+  ]
+};
 ```
 
 
 ### Mode: production
 
+Adding the option `mode: 'production'` to your configuration will enable the
+following:
 
-```diff
-// webpack.production.config.js
+```javascript
+// webpack.development.config.js
 module.exports = {
-+  mode: 'production',
-- performance: {
--   hints: 'warning'
-- },
-- output: {
--   pathinfo: false
-- },
-- optimization: {
--   namedModules: false,
--   namedChunks: false,
--   nodeEnv: 'production',
--   flagIncludedChunks: true,
--   occurrenceOrder: true,
--   concatenateModules: true,
--   splitChunks: {
--     hidePathInfo: true,
--     minSize: 30000,
--     maxAsyncRequests: 5,
--     maxInitialRequests: 3,
--   },
--   noEmitOnErrors: true,
--   checkWasmTypes: true,
--   minimize: true,
-- },
-- plugins: [
--   new TerserPlugin(/* ... */),
--   new webpack.DefinePlugin({ "process.env.NODE_ENV": JSON.stringify("production") }),
--   new webpack.optimize.ModuleConcatenationPlugin(),
--   new webpack.NoEmitOnErrorsPlugin()
-- ]
-}
+  // Enabling this option...
+  mode: 'production',
+
+  // ...turns on the following:
+  performance: {
+    hints: 'warning'
+  },
+  output: {
+    pathinfo: false
+  },
+  optimization: {
+    namedModules: false,
+    namedChunks: false,
+    nodeEnv: 'production',
+    flagIncludedChunks: true,
+    occurrenceOrder: true,
+    concatenateModules: true,
+    splitChunks: {
+      hidePathInfo: true,
+      minSize: 30000,
+      maxAsyncRequests: 5,
+      maxInitialRequests: 3,
+    },
+    noEmitOnErrors: true,
+    checkWasmTypes: true,
+    minimize: true,
+  },
+  plugins: [
+    new TerserPlugin(/* ... */),
+    new webpack.DefinePlugin({ 'process.env.NODE_ENV': JSON.stringify('production') }),
+    new webpack.optimize.ModuleConcatenationPlugin(),
+    new webpack.NoEmitOnErrorsPlugin()
+  ]
+};
 ```
 
 
 ### Mode: none
 
+Adding the option `mode: 'none'` to your configuration will enable the
+following:
 
-```diff
+```javascript
 // webpack.custom.config.js
 module.exports = {
-+ mode: 'none',
-- performance: {
--  hints: false
-- },
-- optimization: {
--   flagIncludedChunks: false,
--   occurrenceOrder: false,
--   concatenateModules: false,
--   splitChunks: {
--     hidePathInfo: false,
--     minSize: 10000,
--     maxAsyncRequests: Infinity,
--     maxInitialRequests: Infinity,
--   },
--   noEmitOnErrors: false,
--   checkWasmTypes: false,
--   minimize: false,
-- },
-- plugins: []
-}
+  // Enabling this option...
+  mode: 'none',
+  
+  // ...turns on the following:
+  performance: {
+    hints: false
+  },
+  optimization: {
+    flagIncludedChunks: false,
+    occurrenceOrder: false,
+    concatenateModules: false,
+    splitChunks: {
+      hidePathInfo: false,
+      minSize: 10000,
+      maxAsyncRequests: Infinity,
+      maxInitialRequests: Infinity,
+    },
+    noEmitOnErrors: false,
+    checkWasmTypes: false,
+    minimize: false,
+  },
+  plugins: []
+};
 ```
 
 If you want to change the behavior according to the __mode__ variable inside the _webpack.config.js_, you have to export a function instead of an object:


### PR DESCRIPTION
Just inserting a code diff doesn't effectively communicate what options are being configured. This PR updates the `mode` configuration option docs to better clarify what options get set via `mode` and how to override them.