### PR TITLE
fix: remove absent options from EvalSourceMapDevToolPlugin

### DIFF
--- a/src/content/plugins/eval-source-map-dev-tool-plugin.md
+++ b/src/content/plugins/eval-source-map-dev-tool-plugin.md
@@ -8,6 +8,7 @@ contributors:
   - madhavarshney
   - koke
   - jamesgeorge007
+  - anshumanv
 related:
   - title: Building Eval Source Maps
     url: https://survivejs.com/webpack/building/source-maps/#sourcemapdevtoolplugin-and-evalsourcemapdevtoolplugin
@@ -27,7 +28,6 @@ The following options are supported:
 - `test` (`string|RegExp|array`): Include source maps for modules based on their extension (defaults to `.js` and `.css`).
 - `include` (`string|RegExp|array`): Include source maps for module paths that match the given value.
 - `exclude` (`string|RegExp|array`): Exclude modules that match the given value from source map generation.
-- `filename` (`string`): Defines the output filename of the SourceMap (will be inlined if no value is provided).
 - `append` (`string`): Appends the given value to the original asset. Usually the `#sourceMappingURL` comment. `[url]` is replaced with a URL to the source map file. `false` disables the appending.
 - `moduleFilenameTemplate` (`string`): See [`output.devtoolModuleFilenameTemplate`](/configuration/output/#outputdevtoolmodulefilenametemplate).
 - `module` (`boolean`): Indicates whether loaders should generate source maps (defaults to `true`).


### PR DESCRIPTION
https://github.com/webpack/webpack.js.org/issues/3890

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
