### PR TITLE
docs(plugins) remove non-existant option from plugin example

### DIFF
--- a/src/content/plugins/eval-source-map-dev-tool-plugin.md
+++ b/src/content/plugins/eval-source-map-dev-tool-plugin.md
@@ -9,6 +9,7 @@ contributors:
   - koke
   - jamesgeorge007
   - anshumanv
+  - EugeneHlushko
 related:
   - title: Building Eval Source Maps
     url: https://survivejs.com/webpack/building/source-maps/#sourcemapdevtoolplugin-and-evalsourcemapdevtoolplugin
@@ -62,7 +63,6 @@ The following code would exclude source maps for any modules in the `vendor.js` 
 
 ``` js
 new webpack.EvalSourceMapDevToolPlugin({
-  filename: '[name].js.map',
   exclude: ['vendor.js']
 });
 ```


### PR DESCRIPTION
Follow-up to remove the remainder of #3890 that was done partially in #3894 (missed)
Closes #3890