### PR TITLE
fix header visibility on safari

### DIFF
--- a/src/components/Markdown/Markdown.scss
+++ b/src/components/Markdown/Markdown.scss
@@ -10,6 +10,9 @@ $someExtraHeight: 10px;
 $topHeightDesktop: $navigationHeight + $navigationSubHeight + $someExtraHeight;
 $topHeightDesktopWithBanner: $bannerHeight + $topHeightDesktop;
 
+$topHeightMobile: $navigationHeight;
+$topHeightMobileWithBanner: $bannerHeight + $topHeightMobile;
+
 .markdown {
   line-height: 1.5em;
 
@@ -32,22 +35,38 @@ $topHeightDesktopWithBanner: $bannerHeight + $topHeightDesktop;
     font-size: getFontSize(-1);
   }
 
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    &:before {
+      content: '';
+      display: block;
+      visibility: hidden;
+      pointer-events: none;
+      height: $topHeightMobile;
+      margin-top: -#{$topHeightMobile};
+      @include break {
+        height: $topHeightDesktop;
+        margin-top: -#{$topHeightDesktop};
+      }
+    }
+  }
+
   h1,
   h2,
   h3,
   h4,
   h5,
   h6 {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
+    display: block;
     font-family: $font-stack-heading;
     font-weight: 600;
     line-height: 1.4;
-    margin: 1.5em 0 0.25em;
+    margin: 0 0 0.25em;
     color: getColor(fiord);
     word-break: break-word;
-    scroll-margin-top: $topHeightDesktop;
 
     tt,
     code {
@@ -214,7 +233,7 @@ $topHeightDesktopWithBanner: $bannerHeight + $topHeightDesktop;
     border-right: 1px solid #cccccc;
 
     &:last-child {
-      border-right:none;
+      border-right: none;
     }
   }
 
@@ -246,7 +265,7 @@ $topHeightDesktopWithBanner: $bannerHeight + $topHeightDesktop;
     border-right: 1px solid #cccccc;
 
     &:last-child {
-      border-right:none;
+      border-right: none;
     }
 
     @include break {
@@ -272,7 +291,7 @@ $topHeightDesktopWithBanner: $bannerHeight + $topHeightDesktop;
     flex-direction: column;
     justify-content: baseline;
     margin: 10px 0;
-    padding: 0 10px
+    padding: 0 10px;
   }
 
   .description.desktop {
@@ -393,7 +412,23 @@ $topHeightDesktopWithBanner: $bannerHeight + $topHeightDesktop;
 }
 
 .notification-bar-visible .markdown {
-  h1,h2,h3,h4,h5,h6{
-    scroll-margin-top: $topHeightDesktopWithBanner;
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    &:before {
+      content: '';
+      display: block;
+      visibility: hidden;
+      pointer-events: none;
+      height: $topHeightMobileWithBanner;
+      margin-top: -#{$topHeightMobileWithBanner};
+      @include break {
+        height: $topHeightDesktopWithBanner;
+        margin-top: -#{$topHeightDesktopWithBanner};
+      }
+    }
   }
 }


### PR DESCRIPTION
The [`scroll-margin-top`](https://github.com/webpack/webpack.js.org/blob/master/src/components/Markdown/Markdown.scss#L50) we use is [not applied for scrolls to fragment target on safari](https://bugs.webkit.org/show_bug.cgi?id=189265) which causes problem for Safari users.

For example, when we open https://webpack.js.org/concepts/#entry on safari:

![image](https://user-images.githubusercontent.com/1091472/89651612-ca8cc900-d8f6-11ea-8a60-e425eb523e5f.png)

While on Chrome we have visible header:

![image](https://user-images.githubusercontent.com/1091472/89651745-f5771d00-d8f6-11ea-8fa7-25e4d7e475a5.png)

This pull request should fix the problem on safari.
