### PR TITLE
fixed centering .splash-viz__modules

### DIFF
--- a/src/components/SplashViz/SplashViz.scss
+++ b/src/components/SplashViz/SplashViz.scss
@@ -27,15 +27,13 @@
 
   &__modules {
     position: absolute;
-    left: 0;
-    right: 0;
-    top: 50%; // vertical center
-    bottom: 0;
+    top: 50%;
+    left: 50%;
     width: 75vw;
     min-width: 550px;
     max-width: map-get($screens, large);
     margin: 0 auto;
-    transform: translateY(-50%); // vertical center
+    transform: translate(-50%, -50%);
     display: none;
 
     @include break {


### PR DESCRIPTION
macOS Catalina 10.15.6(19G73)
Version: 84.0.4147.105(Official Build) (64 bit)


Before | After
-- | --
![スクリーンショット 2020-08-09 2 09 01](https://user-images.githubusercontent.com/6585191/89716123-53822e00-d9e5-11ea-8a9c-47d8a0ada859.png) | ![スクリーンショット 2020-08-09 2 08 55](https://user-images.githubusercontent.com/6585191/89716121-50873d80-d9e5-11ea-94a5-b0d837a51d13.png)