### PR TITLE
docs(configuration): update link

### DIFF
--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -816,7 +816,7 @@ Example for an `expr` dynamic dependency: `require(expr)`.
 
 Example for an `wrapped` dynamic dependency: `require('./templates/' + expr)`.
 
-Here are the available options with their [defaults](https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsDefaulter.js):
+Here are the available options with their [defaults](https://github.com/webpack/webpack/blob/master/lib/config/defaults.js):
 
 __webpack.config.js__
 


### PR DESCRIPTION
The defaults part was moved to https://github.com/webpack/webpack/blob/master/lib/config/defaults.js in this commit https://github.com/webpack/webpack/commit/6477ca56f8046e4642d983f68a68805b83982537#diff-7473dd12403a310ad8cf18d0ab9f10b9