### PR TITLE
docs(dev-server): add devServer.config CLI flag

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -247,6 +247,15 @@ Usage via the CLI
 webpack-dev-server --compress
 ```
 
+## `devServer.config` - CLI only
+
+`string`
+
+Specifies a different [configuration](/configuration) file to pick up. Use this if you want to specify something different from `webpack.config.js`, which is the default.
+
+```bash
+webpack-dev-server --config example.config.js
+```
 
 ## `devServer.contentBase`
 

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -20,6 +20,7 @@ contributors:
   - g100g
   - anikethsaha
   - snitin315
+  - maxloh
 ---
 
 [webpack-dev-server](https://github.com/webpack/webpack-dev-server) can be used to quickly develop an application. See the [development guide](/guides/development/) to get started.


### PR DESCRIPTION
The `devServer.config` option is available in dev-server but never be documented

Related: https://stackoverflow.com/a/45929177/11077662