### PR TITLE
docs(configuration): specify default value as part of type information

### DIFF
--- a/src/content/configuration/optimization.md
+++ b/src/content/configuration/optimization.md
@@ -23,11 +23,9 @@ Since version 4 webpack runs optimizations for you depending on the chosen  [`mo
 
 ## `optimization.minimize`
 
-`boolean`
+`boolean = true`
 
 Tell webpack to minimize the bundle using the [TerserPlugin](/plugins/terser-webpack-plugin/) or the plugin(s) specified in [`optimization.minimizer`](#optimizationminimizer).
-
-This is `true` by default in `production` mode.
 
 __webpack.config.js__
 


### PR DESCRIPTION
webpack defaults to `production` mode.