### PR TITLE
docs(guides): remove superfluous link

### DIFF
--- a/src/content/guides/asset-management.md
+++ b/src/content/guides/asset-management.md
@@ -624,12 +624,6 @@ __src/index.js__
   document.body.appendChild(component());
 ```
 
-
-## Next guide
-
-Let's move on to [Output Management](https://webpack.js.org/guides/output-management/)
-
-
 ## Further Reading
 
 - [Loading Fonts](https://survivejs.com/webpack/loading/fonts/) on SurviveJS


### PR DESCRIPTION
Now we have links navigating to previous/next pages, I think there's no need to mention the next guide in the page again:

![image](https://user-images.githubusercontent.com/1091472/92005893-9df19300-ed76-11ea-8f2b-10746ac773f1.png)
