### PR TITLE
chore(print): removes top margin in the print mode

### DIFF
--- a/src/components/Site/Site.scss
+++ b/src/components/Site/Site.scss
@@ -4,8 +4,8 @@
   min-height: 100vh;
   background: #ffffff;
 
-  &__header{
-    z-index:100;
+  &__header {
+    z-index: 100;
     position: fixed;
     width: 100%;
   }
@@ -15,6 +15,10 @@
     position: relative;
     display: flex;
     margin-top: 110px;
+
+    @media print {
+      margin-top: 0px;
+    }
   }
 
   &__sidebar {


### PR DESCRIPTION
**Current Behaviour**

![Screenshot from 2020-09-20 00-43-34](https://user-images.githubusercontent.com/32242596/93687391-38720600-fadb-11ea-8ed8-9b41dc779767.png)


**Proposed Behaviour**

![Screenshot from 2020-09-20 00-44-22](https://user-images.githubusercontent.com/32242596/93687402-458ef500-fadb-11ea-828b-a2585f62dd23.png)

**Description**
IMO that much blank space from the top is not required.
