### PR TITLE
add eslint-webpack-plugin to plugins list

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,5 +173,8 @@
     "webpack-pwa-manifest": "^4.0.0",
     "webpack.vote": "https://github.com/webpack/voting-app.git",
     "whatwg-fetch": "^2.0.3"
+  },
+  "resolutions": {
+    "remark-responsive-tables": "git://github.com/chenxsan/remark-responsive-tables.git#bugfix/fix-empty-head"
   }
 }

--- a/repositories/plugins.json
+++ b/repositories/plugins.json
@@ -6,5 +6,6 @@
   "webpack-contrib/closure-webpack-plugin",
   "webpack-contrib/mini-css-extract-plugin",
   "webpack-contrib/terser-webpack-plugin",
-  "webpack-contrib/css-minimizer-webpack-plugin"
+  "webpack-contrib/css-minimizer-webpack-plugin",
+  "webpack-contrib/eslint-webpack-plugin"
 ]

--- a/src/content/plugins/index.md
+++ b/src/content/plugins/index.md
@@ -11,6 +11,7 @@ contributors:
   - byzyk
   - EugeneHlushko
   - snitin315
+  - chenxsan
 ---
 
 webpack has a rich plugin interface. Most of the features within webpack itself use this plugin interface. This makes webpack __flexible__.
@@ -25,6 +26,7 @@ Name                                                     | Description
 [`DefinePlugin`](/plugins/define-plugin)           | Allow global constants configured at compile time
 [`DllPlugin`](/plugins/dll-plugin)                 | Split bundles in order to drastically improve build time
 [`EnvironmentPlugin`](/plugins/environment-plugin) | Shorthand for using the [`DefinePlugin`](/plugins/define-plugin) on `process.env` keys
+[`EslintWebpackPlugin`](/plugins/eslint-webpack-plugin) | A ESLint plugin for webpack
 [`HotModuleReplacementPlugin`](/plugins/hot-module-replacement-plugin) | Enable Hot Module Replacement (HMR)
 [`HtmlWebpackPlugin`](/plugins/html-webpack-plugin)          | Easily create HTML files to serve your bundles
 [`IgnorePlugin`](/plugins/ignore-plugin)                     | Exclude certain modules from bundles

--- a/yarn.lock
+++ b/yarn.lock
@@ -12245,10 +12245,9 @@ remark-react@^4.0.0:
     refractor "^3.1.0"
     unist-util-visit "1.3.1"
 
-remark-responsive-tables@1.0.0:
+remark-responsive-tables@1.0.0, "remark-responsive-tables@git://github.com/chenxsan/remark-responsive-tables.git#bugfix/fix-empty-head":
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/remark-responsive-tables/-/remark-responsive-tables-1.0.0.tgz#4827a1a516ee3b902d2b70bb2179313e03be7d2d"
-  integrity sha512-fcjcn83o2p2YxHq/AQ33Daypcency42MrY4ccCf7leWzZAYJ1wibPTaji23zt0S+R02rab2AQLwx84I4OY5rDA==
+  resolved "git://github.com/chenxsan/remark-responsive-tables.git#6d363c396d21ac6150e24bf414050865befbe591"
   dependencies:
     unist-util-visit "1.3.1"
 


### PR DESCRIPTION
CI for pull request https://github.com/webpack/webpack.js.org/pull/3963 failed now https://travis-ci.org/github/webpack/webpack.js.org/jobs/730802775#L992, it might be a result of the update here https://github.com/webpack-contrib/eslint-loader/commit/fc94b5d976f3176eba6d1460fba9dde99227ac32 because eslint-webpack-plugin is not existed yet in this repository.

BTW, it's wrong to edit the `plugins.json` or `loaders.json` file like this, they should be generated by `src/utils/fetch-package-repos.js` automatically. But let's fix that later after the webpack 5 branch get merged as there're already multiple manual edits as I found, e.g. https://github.com/webpack/webpack.js.org/pull/3985, https://github.com/webpack/webpack.js.org/pull/3903