### PR TITLE
Added browserslist output.target and output.environment

### DIFF
--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -1151,9 +1151,9 @@ module.exports = {
 
 ## `output.workerChunkLoading`
 
-`string: 'require' | 'import-scripts' | 'async-node' | 'import' | 'universal'` `boolean: false` 
+`string: 'require' | 'import-scripts' | 'async-node' | 'import' | 'universal'` `boolean: false`
 
-The new option `workerChunkLoading` controls the chunk loading of workers. 
+The new option `workerChunkLoading` controls the chunk loading of workers.
 
 T> The default value of this option is depending on the `target` setting. For more details, search for `"workerChunkLoading"`: [in the webpack defaults](https://github.com/webpack/webpack/blob/master/lib/config/defaults.js).
 
@@ -1200,24 +1200,32 @@ module.exports = {
 };
 ```
 
-## `output.ecmaVersion`
+## `output.environment`
 
-`number = 6`
-
-Tell webpack the maximum EcmaScript version of the webpack generated code. It should be one of these:
-
-- should be >= 5, should be <= 11
-- should be >= 2009, should be <= 2020
+Tell webpack what kind of ES-features may be used in the generated runtime-code.
 
 ```javascript
 module.exports = {
   output: {
-    ecmaVersion: 6
+    environment: {
+      // The environment supports arrow functions ('() => { ... }').
+      arrowFunction: true,
+      // The environment supports BigInt as literal (123n).
+      bigIntLiteral: false,
+      // The environment supports const and let for variable declarations.
+      const: true,
+      // The environment supports destructuring ('{ a, b } = obj').
+      destructuring: true,
+      // The environment supports an async import() function to import EcmaScript modules.
+      dynamicImport: false,
+      // The environment supports 'for of' iteration ('for (const x of array) { ... }').
+      forOf: true,
+      // The environment supports EcmaScript Module syntax to import EcmaScript modules (import ... from '...').
+      module: false,
+    }
   }
 };
 ```
-
-T> The default value of `output.ecmaVersion` in webpack 4 is `5`.
 
 ## `output.compareBeforeEmit`
 

--- a/src/content/configuration/output.md
+++ b/src/content/configuration/output.md
@@ -1220,7 +1220,7 @@ module.exports = {
       dynamicImport: false,
       // The environment supports 'for of' iteration ('for (const x of array) { ... }').
       forOf: true,
-      // The environment supports EcmaScript Module syntax to import EcmaScript modules (import ... from '...').
+      // The environment supports ECMAScript Module syntax to import ECMAScript modules (import ... from '...').
       module: false,
     }
   }

--- a/src/content/configuration/target.md
+++ b/src/content/configuration/target.md
@@ -10,13 +10,14 @@ contributors:
   - tbroadley
   - byzyk
   - EugeneHlushko
+  - smelukov
 ---
 
 webpack can compile for multiple environments or _targets_. To understand what a `target` is in detail, read through [the targets concept page](/concepts/targets/).
 
 ## `target`
 
-`string` `function (compiler)`
+`string` `function (compiler)` = `"browserslist"` or `"web"` if no browserslist-config found
 
 Instructs webpack to target a specific environment.
 
@@ -35,9 +36,24 @@ Option                | Description
 `node-webkit`         | Compile for usage in WebKit and uses JSONP for chunk loading. Allows importing of built-in Node.js modules and [`nw.gui`](http://docs.nwjs.io/en/latest/) (experimental)
 `web`                 | Compile for usage in a browser-like environment __(default)__
 `webworker`           | Compile as WebWorker
+`browserslist`        | Infer a platform and the ES-features from a browserslist-config
 
 For example, when the `target` is set to `"electron-main"`, webpack includes multiple electron specific variables. For more information on which templates and externals are used, you can refer to webpack's [source code](https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsApply.js#L148-L183).
 
+#### `browserslist`
+
+If a project has a browserslist config, then webpack will use it for:
+
+- determinate ES-features that may be used to generate a runtime-code (all the chunks and modules are wrapped by runtime code).
+- infer an environment (e.g: `last 2 node versions` the same as `target: "node"` with some [`output.environment`](/configuration/output/#outputenvironment) settings)
+
+Supported browserslist values:
+
+- `browserslist` - use automatically resolved browserslist config and environment (from the nearest `package.json` or `BROWSERLIST` environment variable)
+- `browserslist:modern` - use `modern` environment from automatically resolved browserslist config
+- `browserslist:last 2 versions` - use an explicit browserslist query (config will be ignored)
+- `browserslist:/path/to/config` - explicitly specify browserslist config
+- `browserslist:/path/to/config:modern` - explicitly specify browserslist config and an environment
 
 ### `function`
 

--- a/src/content/configuration/target.md
+++ b/src/content/configuration/target.md
@@ -19,7 +19,7 @@ webpack can compile for multiple environments or _targets_. To understand what a
 
 `string` `function (compiler) => string`
 
-Instructs webpack to target a specific environment. Defaults to `'browserslist'` or to `'web'` when no browserslist-config was found.
+Instructs webpack to target a specific environment. Defaults to `'browserslist'` or to `'web'` when no browserslist configuration was found.
 
 
 ### `string`
@@ -44,8 +44,8 @@ For example, when the `target` is set to `"electron-main"`, webpack includes mul
 
 If a project has a browserslist config, then webpack will use it for:
 
-- determinate ES-features that may be used to generate a runtime-code (all the chunks and modules are wrapped by runtime code).
-- infer an environment (e.g: `last 2 node versions` the same as `target: "node"` with some [`output.environment`](/configuration/output/#outputenvironment) settings)
+- Determinate ES-features that may be used to generate a runtime-code (all the chunks and modules are wrapped by runtime code).
+- Infer an environment (e.g: `last 2 node versions` the same as `target: "node"` with some [`output.environment`](/configuration/output/#outputenvironment) settings).
 
 Supported browserslist values:
 

--- a/src/content/configuration/target.md
+++ b/src/content/configuration/target.md
@@ -17,9 +17,9 @@ webpack can compile for multiple environments or _targets_. To understand what a
 
 ## `target`
 
-`string` `function (compiler)` = `"browserslist"` or `"web"` if no browserslist-config found
+`string` `function (compiler) => string`
 
-Instructs webpack to target a specific environment.
+Instructs webpack to target a specific environment. Defaults to `'browserslist'` or to `'web'` when no browserslist-config was found.
 
 
 ### `string`


### PR DESCRIPTION
Added browserslist output.target and output.environment
closes #4009

* ~The versions allow to infer features of the platform like if arrow functions are supported or not.~
* ~`output.ecmaVersion` has been replaced with `output.environment.*` and a list of boolean flags for features used by webpack (e. g. arrowFunction).~