### PR TITLE
Documented target option to revert to es5 syntax

### DIFF
--- a/src/content/migrate/5.md
+++ b/src/content/migrate/5.md
@@ -146,7 +146,7 @@ Deprecation warnings. You might get a lot of deprecation warnings. This is not a
 
 #### Turn off ES2015 syntax in runtime code, if necessary
 
-By default, webpack's runtime code uses ES2015 syntax to build smaller bundles. If your build targets environments that don't support this syntax (like IE11), you'll need to set `output.ecmaVersion: 5` to revert to ES5 syntax.
+By default, webpack's runtime code uses ES2015 syntax to build smaller bundles. If your build targets environments that don't support this syntax (like IE11), you'll need to set `config.target: ["web", "es5"]` to revert to ES5 syntax(web if target environment is browser).
 
 #### Everything works?
 

--- a/src/content/migrate/5.md
+++ b/src/content/migrate/5.md
@@ -7,6 +7,7 @@ contributors:
   - keichinger
   - EugeneHlushko
   - MattGoldwater
+  - rramaa
 ---
 
 This guide aims to help you migrating to webpack 5 when using webpack directly. If you are using a higher level tool to run webpack, please refer to the tool for migration instructions.

--- a/src/content/migrate/5.md
+++ b/src/content/migrate/5.md
@@ -146,7 +146,7 @@ Deprecation warnings. You might get a lot of deprecation warnings. This is not a
 
 #### Turn off ES2015 syntax in runtime code, if necessary
 
-By default, webpack's runtime code uses ES2015 syntax to build smaller bundles. If your build targets environments that don't support this syntax (like IE11), you'll need to set `config.target: ["web", "es5"]` to revert to ES5 syntax(web if target environment is browser).
+By default, webpack's runtime code uses ES2015 syntax to build smaller bundles. If your build targets environments that don't support this syntax (like IE11), you'll need to set `target: ["web", "es5"]` to revert to ES5 syntax (`web` if target environment is browser).
 
 #### Everything works?
 

--- a/src/content/migrate/5.md
+++ b/src/content/migrate/5.md
@@ -147,7 +147,7 @@ Deprecation warnings. You might get a lot of deprecation warnings. This is not a
 
 #### Turn off ES2015 syntax in runtime code, if necessary
 
-By default, webpack's runtime code uses ES2015 syntax to build smaller bundles. If your build targets environments that don't support this syntax (like IE11), you'll need to set `target: ["web", "es5"]` to revert to ES5 syntax (`web` if target environment is browser).
+By default, webpack's runtime code uses ES2015 syntax to build smaller bundles. If your build targets environments that don't support this syntax (like IE11), you'll need to set `target: ['web', 'es5']` to revert to ES5 syntax (`'web'` if target environment is browser).
 
 #### Everything works?
 


### PR DESCRIPTION
`output.ecmaVersion` is removed in the release candidate
Documented the target option, through which the same thing can be achieved
