### PR TITLE
fix syntax error in splitChunks plugin exmple

### DIFF
--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -242,7 +242,7 @@ module.exports = {
         commons: {
           test: /[\\/]node_modules[\\/]/,
           // cacheGroupKey here is `commons` as the key of the cacheGroup
-          name(module, chunks, cacheGroupKey) {
+          name: (module, chunks, cacheGroupKey) {
             const moduleFileName = module.identifier().split('/').reduceRight(item => item);
             const allChunksNames = chunks.map((item) => item.name).join('~');
             return `${cacheGroupKey}-${allChunksNames}-${moduleFileName}`;


### PR DESCRIPTION
In the [splitChunks.name](https://webpack.js.org/plugins/split-chunks-plugin/#splitchunksname) example of splitChunks. A colon is missing after the name attribute. 

Screen shot attached.

![color_error](https://user-images.githubusercontent.com/48244930/94936549-d3111280-04e7-11eb-9339-f7295348af91.PNG)
 