### PR TITLE
docs(config): remove other cache.store options from other parts of documentation

### DIFF
--- a/src/content/configuration/other-options.md
+++ b/src/content/configuration/other-options.md
@@ -281,7 +281,7 @@ module.exports = {
 };
 ```
 
-W> `cache.idleTimeout` is only available when [`cache.store`](#cachestore) is set to either `'pack'` or `'idle'`
+W> `cache.idleTimeout` is only available when [`cache.store`](#cachestore) is set to `'pack'`
 
 ### `cache.idleTimeoutForInitialStore`
 
@@ -300,7 +300,7 @@ module.exports = {
 };
 ```
 
-W> `cache.idleTimeoutForInitialStore` is only available when [`cache.store`](#cachestore) is set to either `'pack'` or `'idle'`
+W> `cache.idleTimeoutForInitialStore` is only available when [`cache.store`](#cachestore) is set to `'pack'`
 
 ## `loader`
 


### PR DESCRIPTION
Remove other `cache.store` options from other parts of documentation

Similar to #3393 but removes mention of `'idle'` as option of `cache.store` on other lines of the doc

(related to #3325 too)