### PR TITLE
use Ubuntu bionic(18.04) to run CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 language: node_js
 node_js: "12"
 


### PR DESCRIPTION
Ubuntu `trusty` (14.04) is EOL, https://docs.travis-ci.com/user/reference/linux/#migration-guides

cc @sokra Any specific reason using Ubuntu [trusty here](https://github.com/webpack/webpack.js.org/pull/4033/files#diff-354f30a63fb0907d4ad57269548329e3) instead of other LTS versions?