### PR TITLE
Include optimization.noEmitOnErrors in migration guide

### DIFF
--- a/src/content/migrate/5.md
+++ b/src/content/migrate/5.md
@@ -70,6 +70,7 @@ Update the following options to their new version (if used):
 - `NamedModulesPlugin` ↦ `optimization.moduleIds: 'named'`
 - `NamedChunksPlugin` ↦ `optimization.chunkIds: 'named'`
 - `HashedModulesPlugin` ↦ `optimization.moduleIds: 'hashed'`
+- `optimization.noEmitOnErrors: false` ↦ `optimization.emitOnErrors: true`
 - `optimization.occurrenceOrder: true` ↦ `optimization: { chunkIds: 'total-size', moduleIds: 'size' }`
 - `optimization.splitChunks.cacheGroups.vendors` ↦ `optimization.splitChunks.cacheGroups.defaultVendors`
 - `Compilation.entries` ↦ `Compilation.entryDependencies`


### PR DESCRIPTION
The `optimization.noEmitOnErrors` option has been inverted to `optimization.emitOnErrors`, which I just noticed by accident. This step is currently missing from the migration guide.