### PR TITLE
Fix typo in webpack 5 announcement

### DIFF
--- a/src/content/blog/2020-10-10-webpack-5-release.md
+++ b/src/content/blog/2020-10-10-webpack-5-release.md
@@ -14,7 +14,7 @@ We can't do major API or architectural improvements.
 
 So from time to time, there is a point where the difficulties pile up and we are forced to do breaking changes to not mess everything up.
 That's the time for a new major version.
-So webpack 5 contains these architectural improvements and the features that where not possible to implement without them.
+So webpack 5 contains these architectural improvements and the features that were not possible to implement without them.
 
 The major version was also the chance to revise some of the defaults and to align with proposals and specifications that come up in the meantime.
 


### PR DESCRIPTION
Change `where` to `were`.