### PR TITLE
docs(configuration): update rule test

### DIFF
--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -708,7 +708,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.m?js/,
+        test: /\.m?js$/,
         resolve: {
           fullySpecified: false // disable the behaviour
         }


### PR DESCRIPTION
`/\.m?js/` could match `.json` too https://github.com/webpack/webpack/issues/11467#issuecomment-707722067, which is not what we want.