### PR TITLE
fix bug for printable

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -63,6 +63,7 @@ module.exports = env => merge(common(env), {
         }))
       ],
       navigateFallback: '/app-shell/index.html',
+      navigateFallbackDenylist: [/printable/],
       runtimeCaching: [
         {
           urlPattern: /https:\/\/fonts\.gstatic\.com/, // cache google fonts for one year


### PR DESCRIPTION
closes https://github.com/webpack/webpack.js.org/issues/4083

When we open pages like https://webpack.js.org/concepts/printable/, it would fallback to `/app-shell/index.html` which is wrong as we already have those static html files under `/*/printable/index.html` to be served.