### PR TITLE
docs(guides): update against webpack 5

### DIFF
--- a/src/content/guides/asset-management.md
+++ b/src/content/guides/asset-management.md
@@ -26,32 +26,30 @@ Let's make a minor change to our project before we get started:
 __dist/index.html__
 
 ``` diff
-  <!doctype html>
-  <html>
-    <head>
+ <html>
+   <head>
+     <meta charset="utf-8" />
 -    <title>Getting Started</title>
 +    <title>Asset Management</title>
-    </head>
-    <body>
--     <script src="main.js"></script>
-+     <script src="bundle.js"></script>
-    </body>
-  </html>
+   </head>
+   <body>
+-    <script src="main.js"></script>
++    <script src="bundle.js"></script>
+   </body>
+ </html>
 ```
 
 __webpack.config.js__
 
 ``` diff
-  const path = require('path');
-
-  module.exports = {
-    entry: './src/index.js',
-    output: {
--     filename: 'main.js',
-+     filename: 'bundle.js',
-      path: path.resolve(__dirname, 'dist'),
-    },
-  };
+ module.exports = {
+   entry: './src/index.js',
+   output: {
+-    filename: 'main.js',
++    filename: 'bundle.js',
+     path: path.resolve(__dirname, 'dist'),
+   },
+ };
 ```
 
 
@@ -66,23 +64,18 @@ npm install --save-dev style-loader css-loader
 __webpack.config.js__
 
 ``` diff
-  const path = require('path');
-
-  module.exports = {
-    entry: './src/index.js',
-    output: {
-      filename: 'bundle.js',
-      path: path.resolve(__dirname, 'dist'),
-    },
-+   module: {
-+     rules: [
-+       {
-+         test: /\.css$/,
-+         use: ['style-loader', 'css-loader'],
-+       },
-+     ],
-+   },
-  };
+     filename: 'bundle.js',
+     path: path.resolve(__dirname, 'dist'),
+   },
++  module: {
++    rules: [
++      {
++        test: /\.css$/i,
++        use: ['style-loader', 'css-loader'],
++      },
++    ],
++  },
+ };
 ```
 
 Module loaders can be chained. Each loader in the chain applies transformations to the processed resource. A chain is executed in reverse order. The first loader passes its result (resource with applied transformations) to the next one, and so forth. Finally, webpack expects JavaScript to be returned by the last loader in the chain. 
@@ -121,20 +114,18 @@ __src/style.css__
 __src/index.js__
 
 ``` diff
-  import _ from 'lodash';
-+ import './style.css';
-
-  function component() {
-    const element = document.createElement('div');
-
-    // Lodash, now imported by this script
-    element.innerHTML = _.join(['Hello', 'webpack'], ' ');
-+   element.classList.add('hello');
-
-    return element;
-  }
-
-  document.body.appendChild(component());
+ import _ from 'lodash';
++import './style.css';
+ 
+ function component() {
+   const element = document.createElement('div');
+ 
+   // Lodash, now imported by this script
+   element.innerHTML = _.join(['Hello', 'webpack'], ' ');
++  element.classList.add('hello');
+ 
+   return element;
+ }
 ```
 
 Now run your build command:
@@ -152,10 +143,10 @@ cacheable modules 539 KiB
     ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
     ./node_modules/style-loader/dist/runtime/injectStylesIntoStyleTag.js 6.67 KiB [built] [code generated]
     ./node_modules/css-loader/dist/runtime/api.js 1.57 KiB [built] [code generated]
-  modules by path ./src/ 963 bytes
-    ./src/index.js + 1 modules 639 bytes [built] [code generated]
+  modules by path ./src/ 964 bytes
+    ./src/index.js + 1 modules 640 bytes [built] [code generated]
     ./node_modules/css-loader/dist/cjs.js!./src/style.css 324 bytes [built] [code generated]
-webpack 5.2.0 compiled successfully in 3365 ms
+webpack 5.2.0 compiled successfully in 2605 ms
 ```
 
 Open up `dist/index.html` in your browser again and you should see that `Hello webpack` is now styled in red. To see what webpack did, inspect the page (don't view the page source, as it won't show you the result, because the `<style>` tag is dynamically created by JavaScript) and look at the page's head tags. It should contain the style block that we imported in `index.js`.
@@ -170,27 +161,16 @@ So now we're pulling in our CSS, but what about our images like backgrounds and 
 __webpack.config.js__
 
 ``` diff
-  const path = require('path');
-
-  module.exports = {
-    entry: './src/index.js',
-    output: {
-      filename: 'bundle.js',
-      path: path.resolve(__dirname, 'dist'),
-    },
-    module: {
-      rules: [
-        {
-          test: /\.css$/,
-          use: ['style-loader', 'css-loader'],
-        },
-+       {
-+         test: /\.(png|svg|jpg|jpeg|gif)$/i,
-+         type: 'asset/resource',
-+       },
-      ],
-    },
-  };
+         test: /\.css$/i,
+         use: ['style-loader', 'css-loader'],
+       },
++      {
++        test: /\.(png|svg|jpg|jpeg|gif)$/i,
++        type: 'asset/resource',
++      },
+     ],
+   },
+ };
 ```
 
 Now, when you `import MyImage from './my-image.png'`, that image will be processed and added to your `output` directory _and_ the `MyImage` variable will contain the final url of that image after processing. When using the [css-loader](/loaders/css-loader), as shown above, a similar process will occur for `url('./my-image.png')` within your CSS. The loader will recognize this is a local file, and replace the `'./my-image.png'` path with the final path to the image in your `output` directory. The [html-loader](/loaders/html-loader) handles `<img src="./my-image.png" />` in the same manner.
@@ -216,36 +196,33 @@ __project__
 __src/index.js__
 
 ``` diff
-  import _ from 'lodash';
-  import './style.css';
-+ import Icon from './icon.png';
+ import _ from 'lodash';
+ import './style.css';
++import Icon from './icon.png';
+ 
+ function component() {
+   const element = document.createElement('div');
 
-  function component() {
-    const element = document.createElement('div');
-
-    // Lodash, now imported by this script
-    element.innerHTML = _.join(['Hello', 'webpack'], ' ');
-    element.classList.add('hello');
-
-+   // Add the image to our existing div.
-+   const myIcon = new Image();
-+   myIcon.src = Icon;
+   element.innerHTML = _.join(['Hello', 'webpack'], ' ');
+   element.classList.add('hello');
+ 
++  // Add the image to our existing div.
++  const myIcon = new Image();
++  myIcon.src = Icon;
 +
-+   element.appendChild(myIcon);
-
-    return element;
-  }
-
-  document.body.appendChild(component());
++  element.appendChild(myIcon);
++
+   return element;
+ }
 ```
 
 __src/style.css__
 
 ``` diff
-  .hello {
-    color: red;
-+   background: url('./icon.png');
-  }
+ .hello {
+   color: red;
++  background: url('./icon.png');
+ }
 ```
 
 Let's create a new build and open up the index.html file again:
@@ -255,7 +232,7 @@ $ npm run build
 
 ...
 [webpack-cli] Compilation finished
-asset bundle.js 73.4 KiB [emitted] [compared for emit] [minimized] (name: main) 1 related asset
+asset bundle.js 73.4 KiB [emitted] [minimized] (name: main) 1 related asset
 asset bc67ebaf980e8f20b8c3.png 8.29 KiB [emitted] [immutable] [from: src/icon.png] (auxiliary name: main)
 runtime modules 1.82 KiB 6 modules
 orphan modules 326 bytes [orphan] 1 module
@@ -267,10 +244,10 @@ cacheable modules 540 KiB (javascript) 8.29 KiB (asset)
     ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
     ./node_modules/style-loader/dist/runtime/injectStylesIntoStyleTag.js 6.67 KiB [built] [code generated]
   modules by path ./src/ 1.45 KiB (javascript) 8.29 KiB (asset)
-    ./src/index.js + 1 modules 794 bytes [built] [code generated]
+    ./src/index.js + 1 modules 795 bytes [built] [code generated]
     ./src/icon.png 42 bytes (javascript) 8.29 KiB (asset) [built] [code generated]
-    ./node_modules/css-loader/dist/cjs.js!./src/style.css 646 bytes [built] [code generated]
-webpack 5.2.0 compiled successfully in 2671 ms
+    ./node_modules/css-loader/dist/cjs.js!./src/style.css 648 bytes [built] [code generated]
+webpack 5.2.0 compiled successfully in 2703 ms
 ```
 
 If all went well, you should now see your icon as a repeating background, as well as an `img` element beside our `Hello webpack` text. If you inspect this element, you'll see that the actual filename has changed to something like `bc67ebaf980e8f20b8c3.png`. This means webpack found our file in the `src` folder and processed it!
@@ -283,31 +260,16 @@ So what about other assets like fonts? The Asset Modules will take any file you 
 __webpack.config.js__
 
 ``` diff
-  const path = require('path');
-
-  module.exports = {
-    entry: './src/index.js',
-    output: {
-      filename: 'bundle.js',
-      path: path.resolve(__dirname, 'dist'),
-    },
-    module: {
-      rules: [
-        {
-          test: /\.css$/,
-          use: ['style-loader', 'css-loader'],
-        },
-        {
-          test: /\.(png|svg|jpg|jpeg|gif)$/i,
-          type: 'asset/resource',
-        },
-+       {
-+         test: /\.(woff|woff2|eot|ttf|otf)$/,
-+         type: 'asset/resource'
-+       },
-      ],
-    },
-  };
+         test: /\.(png|svg|jpg|jpeg|gif)$/i,
+         type: 'asset/resource',
+       },
++      {
++        test: /\.(woff|woff2|eot|ttf|otf)$/i,
++        type: 'asset/resource',
++      },
+     ],
+   },
+ };
 ```
 
 Add some font files to your project:
@@ -335,18 +297,17 @@ With the loader configured and fonts in place, you can incorporate them via an `
 __src/style.css__
 
 ``` diff
-+ @font-face {
-+   font-family: 'GoogleFont';
-+   src:  url('./google-font.woff2') format('woff2');
-+   font-weight: 600;
-+   font-style: normal;
-+ }
-
-  .hello {
-    color: red;
-+   font-family: 'GoogleFont';
-    background: url('./icon.png');
-  }
++@font-face {
++  font-family: 'GoogleFont';
++  src: url('./google-font.woff2') format('woff2');
++  font-weight: 600;
++  font-style: normal;
++}
+ .hello {
+   color: red;
++  font-family: 'GoogleFont';
+   background: url('./icon.png');
+ }
 ```
 
 Now run a new build and let's see if webpack handled our fonts:
@@ -356,8 +317,9 @@ $ npm run build
 
 ...
 [webpack-cli] Compilation finished
-assets by status 21.3 KiB [cached] 2 assets
+assets by status 8.29 KiB [cached] 1 asset
 asset bundle.js 73.6 KiB [emitted] [minimized] (name: main) 1 related asset
+asset 8d763566e205be31fe8e.woff2 13 KiB [emitted] [immutable] [from: src/google-font.woff2] (auxiliary name: main)
 runtime modules 1.82 KiB 6 modules
 orphan modules 326 bytes [orphan] 1 module
 cacheable modules 541 KiB (javascript) 21.3 KiB (asset)
@@ -367,15 +329,15 @@ cacheable modules 541 KiB (javascript) 21.3 KiB (asset)
       ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
       ./node_modules/style-loader/dist/runtime/injectStylesIntoStyleTag.js 6.67 KiB [built] [code generated]
     modules by path ./src/ 1.76 KiB
-      ./src/index.js + 1 modules 794 bytes [built] [code generated]
+      ./src/index.js + 1 modules 795 bytes [built] [code generated]
       ./node_modules/css-loader/dist/cjs.js!./src/style.css 1010 bytes [built] [code generated]
   asset modules 84 bytes (javascript) 21.3 KiB (asset)
     ./src/icon.png 42 bytes (javascript) 8.29 KiB (asset) [built] [code generated]
     ./src/google-font.woff2 42 bytes (javascript) 13 KiB (asset) [built] [code generated]
-webpack 5.2.0 compiled successfully in 2622 ms
+webpack 5.2.0 compiled successfully in 2680 ms
 ```
 
-Open up `index.html` again and see if our `Hello webpack` text has changed to the new font. If all is well, you should see the changes.
+Open up `dist/index.html` again and see if our `Hello webpack` text has changed to the new font. If all is well, you should see the changes.
 
 
 ## Loading Data
@@ -389,39 +351,20 @@ npm install --save-dev csv-loader xml-loader
 __webpack.config.js__
 
 ``` diff
-const path = require('path');
-
-module.exports = {
-  entry: './src/index.js',
-  output: {
-    filename: 'bundle.js',
-    path: path.resolve(__dirname, 'dist'),
-  },
-  module: {
-    rules: [
-      {
-        test: /\.css$/,
-        use: ['style-loader', 'css-loader'],
-      },
-      {
-        test: /\.(png|svg|jpg|jpeg|gif)$/i,
-        type: 'asset/resource',
-      },
-      {
-        test: /\.(woff|woff2|eot|ttf|otf)$/i,
-        type: 'asset/resource'
-      },
-+     {
-+       test: /\.(csv|tsv)$/,
-+       use: ['csv-loader'],
-+     },
-+     {
-+       test: /\.xml$/,
-+       use: ['xml-loader'],
-+     },
-    ],
-  },
-};
+         test: /\.(woff|woff2|eot|ttf|otf)$/i,
+         type: 'asset/resource',
+       },
++      {
++        test: /\.(csv|tsv)$/i,
++        use: ['csv-loader'],
++      },
++      {
++        test: /\.xml$/i,
++        use: ['xml-loader'],
++      },
+     ],
+   },
+ };
 ```
 
 Add some data files to your project:
@@ -472,32 +415,23 @@ Now you can `import` any one of those four types of data (JSON, CSV, TSV, XML) a
 __src/index.js__
 
 ``` diff
-  import _ from 'lodash';
-  import './style.css';
-  import Icon from './icon.png';
-+ import Data from './data.xml';
-+ import Notes from './data.csv';
+ import _ from 'lodash';
+ import './style.css';
+ import Icon from './icon.png';
++import Data from './data.xml';
++import Notes from './data.csv';
+ 
+ function component() {
+   const element = document.createElement('div');
 
-  function component() {
-    const element = document.createElement('div');
-
-    // Lodash, now imported by this script
-    element.innerHTML = _.join(['Hello', 'webpack'], ' ');
-    element.classList.add('hello');
-
-    // Add the image to our existing div.
-    const myIcon = new Image();
-    myIcon.src = Icon;
-
-    element.appendChild(myIcon);
-
-+   console.log(Data);
-+   console.log(Notes);
-
-    return element;
-  }
-
-  document.body.appendChild(component());
+   // ...
+   element.appendChild(myIcon);
+ 
++  console.log(Data);
++  console.log(Notes);
++
+   return element;
+ }
 ```
 
 Re-run the `npm run build` command and open `dist/index.html`. If you look at the console in your developer tools, you should be able to see your imported data being logged to the console!
@@ -572,62 +506,59 @@ And configure them in your webpack configuration:
 __webpack.config.js__
 
 ```diff
-+ const toml = require('toml'); 
-+ const yaml = require('yamljs');
-+ const json5 = require('json5');
-  module.exports = {
-    // ...
-    module: {
-      rules: [
-        // ...
-+       {
-+         test: /\.toml$/,
-+         type: 'json',
-+         parser: {
-+           parse: toml.parse,
-+         },
-+       },
-+       {
-+         test: /\.yaml$/,
-+         type: 'json',
-+         parser: {
-+           parse: yaml.parse,
-+         },
-+       },
-+       {
-+         test: /\.json5$/,
-+         type: 'json',
-+         parser: {
-+           parse: json5.parse,
-+         },
-+       },
-      ]
-    }
-  };
+ const path = require('path');
++const toml = require('toml');
++const yaml = require('yamljs');
++const json5 = require('json5');
+ 
+ // ...
+         test: /\.xml$/i,
+         use: ['xml-loader'],
+       },
++      {
++        test: /\.toml$/i,
++        type: 'json',
++        parser: {
++          parse: toml.parse,
++        },
++      },
++      {
++        test: /\.yaml$/i,
++        type: 'json',
++        parser: {
++          parse: yaml.parse,
++        },
++      },
++      {
++        test: /\.json5$/i,
++        type: 'json',
++        parser: {
++          parse: json5.parse,
++        },
++      },
+     ],
+   },
+ };
 ```
 
 __src/index.js__
 
 ```diff
-  // ...
-  import Notes from './data.csv';
-+ import toml from './data.toml';
-+ import yaml from './data.yaml';
-+ import json from './data.json5';
-+ 
-+ console.log(toml.title); // output `TOML Example`
-+ console.log(toml.owner.name); // output `Tom Preston-Werner`
-+ 
-+ console.log(yaml.title); // output `YAML Example`
-+ console.log(yaml.owner.name); // output `Tom Preston-Werner`
-+ 
-+ console.log(json.title); // output `JSON5 Example`
-+ console.log(json.owner.name); // output `Tom Preston-Werner`
-  function component() {
-    const element = document.createElement('div');
-    // ...
-  }
-  // ...
+ import Icon from './icon.png';
+ import Data from './data.xml';
+ import Notes from './data.csv';
++import toml from './data.toml';
++import yaml from './data.yaml';
++import json from './data.json5';
++
++console.log(toml.title); // output `TOML Example`
++console.log(toml.owner.name); // output `Tom Preston-Werner`
++
++console.log(yaml.title); // output `YAML Example`
++console.log(yaml.owner.name); // output `Tom Preston-Werner`
++
++console.log(json.title); // output `JSON5 Example`
++console.log(json.owner.name); // output `Tom Preston-Werner`
 ```
 
 Re-run the `npm run build` command and open `dist/index.html`. You should be able to see your imported data being logged to the console!
@@ -680,105 +611,101 @@ __project__
 __webpack.config.js__
 
 ```diff
-  const path = require('path');
-- const toml = require('toml'); 
-- const yaml = require('yamljs');
-- const json5 = require('json5');
-  module.exports = {
-    entry: './src/index.js',
-    output: {
-      filename: 'bundle.js',
-      path: path.resolve(__dirname, 'dist'),
-    },
--   module: {
--     rules: [
--       {
--         test: /\.css$/,
--         use: ['style-loader', 'css-loader'],
--       },
--       {
--         test: /\.(png|svg|jpg|jpeg|gif)$/i,
--         type: 'asset/resource',
--       },
--       {
--         test: /\.(woff|woff2|eot|ttf|otf)$/i,
--         type: 'asset/resource',
--       },
--       {
--         test: /\.(csv|tsv)$/,
--         use: ['csv-loader'],
--       },
--       {
--         test: /\.xml$/,
--         use: ['xml-loader'],
--       },
--       {
--         test: /\.toml$/,
--         type: 'json',
--         parser: {
--           parse: toml.parse,
--         },
--       },
--       {
--         test: /\.yaml$/,
--         type: 'json',
--         parser: {
--           parse: yaml.parse,
--         },
--       },
--       {
--         test: /\.json5$/,
--         type: 'json',
--         parser: {
--           parse: json5.parse,
--         },
--       },
--     ],
--   },
-  }
+ const path = require('path');
+-const toml = require('toml');
+-const yaml = require('yamljs');
+-const json5 = require('json5');
+ 
+ module.exports = {
+   entry: './src/index.js',
+   // ...
+-  module: {
+-    rules: [
+-      {
+-        test: /\.css$/i,
+-        use: ['style-loader', 'css-loader'],
+-      },
+-      {
+-        test: /\.(png|svg|jpg|jpeg|gif)$/i,
+-        type: 'asset/resource',
+-      },
+-      {
+-        test: /\.(woff|woff2|eot|ttf|otf)$/i,
+-        type: 'asset/resource',
+-      },
+-      {
+-        test: /\.(csv|tsv)$/i,
+-        use: ['csv-loader'],
+-      },
+-      {
+-        test: /\.xml$/i,
+-        use: ['xml-loader'],
+-      },
+-      {
+-        test: /\.toml$/i,
+-        type: 'json',
+-        parser: {
+-          parse: toml.parse,
+-        },
+-      },
+-      {
+-        test: /\.yaml$/i,
+-        type: 'json',
+-        parser: {
+-          parse: yaml.parse,
+-        },
+-      },
+-      {
+-        test: /\.json5$/i,
+-        type: 'json',
+-        parser: {
+-          parse: json5.parse,
+-        },
+-      },
+-    ],
+-  },
+ };
 ```
 
 __src/index.js__
 
 ``` diff
-  import _ from 'lodash';
-- import './style.css';
-- import Icon from './icon.png';
-- import Data from './data.xml';
-- import Notes from './data.csv';
-- import toml from './data.toml';
-- import yaml from './data.yaml';
-- import json from './data.json5';
-- 
-- console.log(toml.title); // output `TOML Example`
-- console.log(toml.owner.name); // output `Tom Preston-Werner`
-- 
-- console.log(yaml.title); // output `YAML Example`
-- console.log(yaml.owner.name); // output `Tom Preston-Werner`
-- 
-- console.log(json.title); // output `JSON5 Example`
-- console.log(json.owner.name); // output `Tom Preston-Werner`
+ import _ from 'lodash';
+-import './style.css';
+-import Icon from './icon.png';
+-import Data from './data.xml';
+-import Notes from './data.csv';
+-import toml from './data.toml';
+-import yaml from './data.yaml';
+-import json from './data.json5';
 -
-  function component() {
-    const element = document.createElement('div');
+-console.log(toml.title); // output `TOML Example`
+-console.log(toml.owner.name); // output `Tom Preston-Werner`
 -
--   // Lodash, now imported by this script
-    element.innerHTML = _.join(['Hello', 'webpack'], ' ');
--   element.classList.add('hello');
+-console.log(yaml.title); // output `YAML Example`
+-console.log(yaml.owner.name); // output `Tom Preston-Werner`
 -
--   // Add the image to our existing div.
--   const myIcon = new Image();
--   myIcon.src = Icon;
+-console.log(json.title); // output `JSON5 Example`
+-console.log(json.owner.name); // output `Tom Preston-Werner`
+ 
+ function component() {
+   const element = document.createElement('div');
+ 
+-  // Lodash, now imported by this script
+   element.innerHTML = _.join(['Hello', 'webpack'], ' ');
+-  element.classList.add('hello');
 -
--   element.appendChild(myIcon);
+-  // Add the image to our existing div.
+-  const myIcon = new Image();
+-  myIcon.src = Icon;
 -
--   console.log(Data);
--   console.log(Notes);
-
-    return element;
-  }
-
-  document.body.appendChild(component());
+-  element.appendChild(myIcon);
+-
+-  console.log(Data);
+-  console.log(Notes);
+ 
+   return element;
+ }
 ```
 
 

--- a/src/content/guides/asset-management.md
+++ b/src/content/guides/asset-management.md
@@ -87,7 +87,7 @@ __webpack.config.js__
 
 Module loaders can be chained. Each loader in the chain applies transformations to the processed resource. A chain is executed in reverse order. The first loader passes its result (resource with applied transformations) to the next one, and so forth. Finally, webpack expects JavaScript to be returned by the last loader in the chain. 
 
-The above order of loaders should be maintained: `'style-loader'` comes first and followed by `'css-loader'`. If this convention is not followed, webpack is likely to throw errors.
+The above order of loaders should be maintained: [`'style-loader'`](/loaders/style-loader) comes first and followed by [`'css-loader'`](/loaders/css-loader). If this convention is not followed, webpack is likely to throw errors.
 
 T> webpack uses a regular expression to determine which files it should look for and serve to a specific loader. In this case, any file that ends with `.css` will be served to the `style-loader` and the `css-loader`.
 

--- a/src/content/guides/asset-management.md
+++ b/src/content/guides/asset-management.md
@@ -746,6 +746,18 @@ __src/index.js__
 - import Icon from './icon.png';
 - import Data from './data.xml';
 - import Notes from './data.csv';
+- import toml from './data.toml';
+- import yaml from './data.yaml';
+- import json from './data.json5';
+- 
+- console.log(toml.title); // output `TOML Example`
+- console.log(toml.owner.name); // output `Tom Preston-Werner`
+- 
+- console.log(yaml.title); // output `YAML Example`
+- console.log(yaml.owner.name); // output `Tom Preston-Werner`
+- 
+- console.log(json.title); // output `JSON5 Example`
+- console.log(json.owner.name); // output `Tom Preston-Werner`
 -
   function component() {
     const element = document.createElement('div');

--- a/src/content/guides/asset-management.md
+++ b/src/content/guides/asset-management.md
@@ -389,7 +389,7 @@ npm install --save-dev csv-loader xml-loader
 __webpack.config.js__
 
 ``` diff
-const path = require('path')
+const path = require('path');
 
 module.exports = {
   entry: './src/index.js',

--- a/src/content/guides/asset-management.md
+++ b/src/content/guides/asset-management.md
@@ -26,6 +26,7 @@ Let's make a minor change to our project before we get started:
 __dist/index.html__
 
 ``` diff
+ <!DOCTYPE html>
  <html>
    <head>
      <meta charset="utf-8" />
@@ -42,6 +43,8 @@ __dist/index.html__
 __webpack.config.js__
 
 ``` diff
+ const path = require('path');
+ 
  module.exports = {
    entry: './src/index.js',
    output: {
@@ -64,6 +67,11 @@ npm install --save-dev style-loader css-loader
 __webpack.config.js__
 
 ``` diff
+ const path = require('path');
+ 
+ module.exports = {
+   entry: './src/index.js',
+   output: {
      filename: 'bundle.js',
      path: path.resolve(__dirname, 'dist'),
    },
@@ -126,6 +134,8 @@ __src/index.js__
  
    return element;
  }
+ 
+ document.body.appendChild(component());
 ```
 
 Now run your build command:
@@ -135,7 +145,7 @@ $ npm run build
 
 ...
 [webpack-cli] Compilation finished
-asset bundle.js 72.6 KiB [emitted] [minimized] (name: main) 1 related asset
+asset bundle.js 72.6 KiB [compared for emit] [minimized] (name: main) 1 related asset
 runtime modules 1000 bytes 5 modules
 orphan modules 326 bytes [orphan] 1 module
 cacheable modules 539 KiB
@@ -143,10 +153,10 @@ cacheable modules 539 KiB
     ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
     ./node_modules/style-loader/dist/runtime/injectStylesIntoStyleTag.js 6.67 KiB [built] [code generated]
     ./node_modules/css-loader/dist/runtime/api.js 1.57 KiB [built] [code generated]
-  modules by path ./src/ 964 bytes
+  modules by path ./src/ 966 bytes
     ./src/index.js + 1 modules 640 bytes [built] [code generated]
-    ./node_modules/css-loader/dist/cjs.js!./src/style.css 324 bytes [built] [code generated]
-webpack 5.2.0 compiled successfully in 2605 ms
+    ./node_modules/css-loader/dist/cjs.js!./src/style.css 326 bytes [built] [code generated]
+webpack 5.4.0 compiled successfully in 2900 ms
 ```
 
 Open up `dist/index.html` in your browser again and you should see that `Hello webpack` is now styled in red. To see what webpack did, inspect the page (don't view the page source, as it won't show you the result, because the `<style>` tag is dynamically created by JavaScript) and look at the page's head tags. It should contain the style block that we imported in `index.js`.
@@ -161,6 +171,17 @@ So now we're pulling in our CSS, but what about our images like backgrounds and 
 __webpack.config.js__
 
 ``` diff
+ const path = require('path');
+ 
+ module.exports = {
+   entry: './src/index.js',
+   output: {
+     filename: 'bundle.js',
+     path: path.resolve(__dirname, 'dist'),
+   },
+   module: {
+     rules: [
+       {
          test: /\.css$/i,
          use: ['style-loader', 'css-loader'],
        },
@@ -202,7 +223,8 @@ __src/index.js__
  
  function component() {
    const element = document.createElement('div');
-
+ 
+   // Lodash, now imported by this script
    element.innerHTML = _.join(['Hello', 'webpack'], ' ');
    element.classList.add('hello');
  
@@ -214,6 +236,8 @@ __src/index.js__
 +
    return element;
  }
+ 
+ document.body.appendChild(component());
 ```
 
 __src/style.css__
@@ -232,25 +256,25 @@ $ npm run build
 
 ...
 [webpack-cli] Compilation finished
+asset 3b7bf087cbac835e6f7d.png 233 KiB [emitted] [immutable] [from: src/icon.png] (auxiliary name: main)
 asset bundle.js 73.4 KiB [emitted] [minimized] (name: main) 1 related asset
-asset bc67ebaf980e8f20b8c3.png 8.29 KiB [emitted] [immutable] [from: src/icon.png] (auxiliary name: main)
 runtime modules 1.82 KiB 6 modules
 orphan modules 326 bytes [orphan] 1 module
-cacheable modules 540 KiB (javascript) 8.29 KiB (asset)
+cacheable modules 540 KiB (javascript) 233 KiB (asset)
   modules by path ./node_modules/ 539 KiB
     modules by path ./node_modules/css-loader/dist/runtime/*.js 2.38 KiB
       ./node_modules/css-loader/dist/runtime/api.js 1.57 KiB [built] [code generated]
       ./node_modules/css-loader/dist/runtime/getUrl.js 830 bytes [built] [code generated]
     ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
     ./node_modules/style-loader/dist/runtime/injectStylesIntoStyleTag.js 6.67 KiB [built] [code generated]
-  modules by path ./src/ 1.45 KiB (javascript) 8.29 KiB (asset)
+  modules by path ./src/ 1.45 KiB (javascript) 233 KiB (asset)
     ./src/index.js + 1 modules 795 bytes [built] [code generated]
-    ./src/icon.png 42 bytes (javascript) 8.29 KiB (asset) [built] [code generated]
+    ./src/icon.png 42 bytes (javascript) 233 KiB (asset) [built] [code generated]
     ./node_modules/css-loader/dist/cjs.js!./src/style.css 648 bytes [built] [code generated]
-webpack 5.2.0 compiled successfully in 2703 ms
+webpack 5.4.0 compiled successfully in 5879 ms
 ```
 
-If all went well, you should now see your icon as a repeating background, as well as an `img` element beside our `Hello webpack` text. If you inspect this element, you'll see that the actual filename has changed to something like `bc67ebaf980e8f20b8c3.png`. This means webpack found our file in the `src` folder and processed it!
+If all went well, you should now see your icon as a repeating background, as well as an `img` element beside our `Hello webpack` text. If you inspect this element, you'll see that the actual filename has changed to something like `3b7bf087cbac835e6f7d.png`. This means webpack found our file in the `src` folder and processed it!
 
 
 ## Loading Fonts
@@ -260,6 +284,21 @@ So what about other assets like fonts? The Asset Modules will take any file you 
 __webpack.config.js__
 
 ``` diff
+ const path = require('path');
+ 
+ module.exports = {
+   entry: './src/index.js',
+   output: {
+     filename: 'bundle.js',
+     path: path.resolve(__dirname, 'dist'),
+   },
+   module: {
+     rules: [
+       {
+         test: /\.css$/i,
+         use: ['style-loader', 'css-loader'],
+       },
+       {
          test: /\.(png|svg|jpg|jpeg|gif)$/i,
          type: 'asset/resource',
        },
@@ -285,7 +324,8 @@ __project__
     |- bundle.js
     |- index.html
   |- /src
-+   |- google-fonts.woff2
++   |- my-fonts.woff
++   |- my-fonts.woff2
     |- icon.png
     |- style.css
     |- index.js
@@ -298,14 +338,16 @@ __src/style.css__
 
 ``` diff
 +@font-face {
-+  font-family: 'GoogleFont';
-+  src: url('./google-font.woff2') format('woff2');
++  font-family: 'MyFont';
++  src: url('./my-font.woff2') format('woff2'),
++    url('./my-font.woff') format('woff');
 +  font-weight: 600;
 +  font-style: normal;
 +}
++
  .hello {
    color: red;
-+  font-family: 'GoogleFont';
++  font-family: 'MyFont';
    background: url('./icon.png');
  }
 ```
@@ -317,24 +359,27 @@ $ npm run build
 
 ...
 [webpack-cli] Compilation finished
-assets by status 8.29 KiB [cached] 1 asset
-asset bundle.js 73.6 KiB [emitted] [minimized] (name: main) 1 related asset
-asset 8d763566e205be31fe8e.woff2 13 KiB [emitted] [immutable] [from: src/google-font.woff2] (auxiliary name: main)
+assets by status 233 KiB [cached] 1 asset
+assets by info 33.2 KiB [immutable]
+  asset 55055dbfc7c6a83f60ba.woff 18.8 KiB [emitted] [immutable] [from: src/my-font.woff] (auxiliary name: main)
+  asset 8f717b802eaab4d7fb94.woff2 14.5 KiB [emitted] [immutable] [from: src/my-font.woff2] (auxiliary name: main)
+asset bundle.js 73.7 KiB [emitted] [minimized] (name: main) 1 related asset
 runtime modules 1.82 KiB 6 modules
 orphan modules 326 bytes [orphan] 1 module
-cacheable modules 541 KiB (javascript) 21.3 KiB (asset)
+cacheable modules 541 KiB (javascript) 266 KiB (asset)
   javascript modules 541 KiB
     modules by path ./node_modules/ 539 KiB
       modules by path ./node_modules/css-loader/dist/runtime/*.js 2.38 KiB 2 modules
       ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
       ./node_modules/style-loader/dist/runtime/injectStylesIntoStyleTag.js 6.67 KiB [built] [code generated]
-    modules by path ./src/ 1.76 KiB
+    modules by path ./src/ 1.98 KiB
       ./src/index.js + 1 modules 795 bytes [built] [code generated]
-      ./node_modules/css-loader/dist/cjs.js!./src/style.css 1010 bytes [built] [code generated]
-  asset modules 84 bytes (javascript) 21.3 KiB (asset)
-    ./src/icon.png 42 bytes (javascript) 8.29 KiB (asset) [built] [code generated]
-    ./src/google-font.woff2 42 bytes (javascript) 13 KiB (asset) [built] [code generated]
-webpack 5.2.0 compiled successfully in 2680 ms
+      ./node_modules/css-loader/dist/cjs.js!./src/style.css 1.21 KiB [built] [code generated]
+  asset modules 126 bytes (javascript) 266 KiB (asset)
+    ./src/icon.png 42 bytes (javascript) 233 KiB (asset) [built] [code generated]
+    ./src/my-font.woff2 42 bytes (javascript) 14.5 KiB (asset) [built] [code generated]
+    ./src/my-font.woff 42 bytes (javascript) 18.8 KiB (asset) [built] [code generated]
+webpack 5.4.0 compiled successfully in 3763 ms
 ```
 
 Open up `dist/index.html` again and see if our `Hello webpack` text has changed to the new font. If all is well, you should see the changes.
@@ -351,6 +396,25 @@ npm install --save-dev csv-loader xml-loader
 __webpack.config.js__
 
 ``` diff
+ const path = require('path');
+ 
+ module.exports = {
+   entry: './src/index.js',
+   output: {
+     filename: 'bundle.js',
+     path: path.resolve(__dirname, 'dist'),
+   },
+   module: {
+     rules: [
+       {
+         test: /\.css$/i,
+         use: ['style-loader', 'css-loader'],
+       },
+       {
+         test: /\.(png|svg|jpg|jpeg|gif)$/i,
+         type: 'asset/resource',
+       },
+       {
          test: /\.(woff|woff2|eot|ttf|otf)$/i,
          type: 'asset/resource',
        },
@@ -423,8 +487,15 @@ __src/index.js__
  
  function component() {
    const element = document.createElement('div');
-
-   // ...
+ 
+   // Lodash, now imported by this script
+   element.innerHTML = _.join(['Hello', 'webpack'], ' ');
+   element.classList.add('hello');
+ 
+   // Add the image to our existing div.
+   const myIcon = new Image();
+   myIcon.src = Icon;
+ 
    element.appendChild(myIcon);
  
 +  console.log(Data);
@@ -432,6 +503,8 @@ __src/index.js__
 +
    return element;
  }
+ 
+ document.body.appendChild(component());
 ```
 
 Re-run the `npm run build` command and open `dist/index.html`. If you look at the console in your developer tools, you should be able to see your imported data being logged to the console!
@@ -511,7 +584,31 @@ __webpack.config.js__
 +const yaml = require('yamljs');
 +const json5 = require('json5');
  
- // ...
+ module.exports = {
+   entry: './src/index.js',
+   output: {
+     filename: 'bundle.js',
+     path: path.resolve(__dirname, 'dist'),
+   },
+   module: {
+     rules: [
+       {
+         test: /\.css$/i,
+         use: ['style-loader', 'css-loader'],
+       },
+       {
+         test: /\.(png|svg|jpg|jpeg|gif)$/i,
+         type: 'asset/resource',
+       },
+       {
+         test: /\.(woff|woff2|eot|ttf|otf)$/i,
+         type: 'asset/resource',
+       },
+       {
+         test: /\.(csv|tsv)$/i,
+         use: ['csv-loader'],
+       },
+       {
          test: /\.xml$/i,
          use: ['xml-loader'],
        },
@@ -544,6 +641,8 @@ __webpack.config.js__
 __src/index.js__
 
 ```diff
+ import _ from 'lodash';
+ import './style.css';
  import Icon from './icon.png';
  import Data from './data.xml';
  import Notes from './data.csv';
@@ -559,6 +658,27 @@ __src/index.js__
 +
 +console.log(json.title); // output `JSON5 Example`
 +console.log(json.owner.name); // output `Tom Preston-Werner`
+ 
+ function component() {
+   const element = document.createElement('div');
+ 
+   // Lodash, now imported by this script
+   element.innerHTML = _.join(['Hello', 'webpack'], ' ');
+   element.classList.add('hello');
+ 
+   // Add the image to our existing div.
+   const myIcon = new Image();
+   myIcon.src = Icon;
+ 
+   element.appendChild(myIcon);
+ 
+   console.log(Data);
+   console.log(Notes);
+ 
+   return element;
+ }
+ 
+ document.body.appendChild(component());
 ```
 
 Re-run the `npm run build` command and open `dist/index.html`. You should be able to see your imported data being logged to the console!
@@ -601,7 +721,8 @@ __project__
 -   |- data.toml
 -   |- data.yaml
 -   |- data.json5
--   |- google-font.woff2
+-   |- my-font.woff
+-   |- my-font.woff2
 -   |- icon.png
 -   |- style.css
     |- index.js
@@ -618,7 +739,10 @@ __webpack.config.js__
  
  module.exports = {
    entry: './src/index.js',
-   // ...
+   output: {
+     filename: 'bundle.js',
+     path: path.resolve(__dirname, 'dist'),
+   },
 -  module: {
 -    rules: [
 -      {
@@ -706,6 +830,8 @@ __src/index.js__
  
    return element;
  }
+ 
+ document.body.appendChild(component());
 ```
 
 

--- a/src/content/guides/asset-management.md
+++ b/src/content/guides/asset-management.md
@@ -78,10 +78,7 @@ __webpack.config.js__
 +     rules: [
 +       {
 +         test: /\.css$/,
-+         use: [
-+           'style-loader',
-+           'css-loader',
-+         ],
++         use: ['style-loader', 'css-loader'],
 +       },
 +     ],
 +   },
@@ -90,7 +87,7 @@ __webpack.config.js__
 
 Module loaders can be chained. Each loader in the chain applies transformations to the processed resource. A chain is executed in reverse order. The first loader passes its result (resource with applied transformations) to the next one, and so forth. Finally, webpack expects JavaScript to be returned by the last loader in the chain. 
 
-The above order of loaders should be maintained: 'style-loader' comes first and followed by 'css-loader'. If this convention is not followed, webpack is likely to throw errors.
+The above order of loaders should be maintained: `'style-loader'` comes first and followed by `'css-loader'`. If this convention is not followed, webpack is likely to throw errors.
 
 T> webpack uses a regular expression to determine which files it should look for and serve to a specific loader. In this case, any file that ends with `.css` will be served to the `style-loader` and the `css-loader`.
 
@@ -143,27 +140,32 @@ __src/index.js__
 Now run your build command:
 
 ``` bash
-npm run build
+$ npm run build
 
 ...
-    Asset      Size  Chunks             Chunk Names
-bundle.js  76.4 KiB       0  [emitted]  main
-Entrypoint main = bundle.js
-...
+[webpack-cli] Compilation finished
+asset bundle.js 72.6 KiB [emitted] [minimized] (name: main) 1 related asset
+runtime modules 1000 bytes 5 modules
+orphan modules 326 bytes [orphan] 1 module
+cacheable modules 539 KiB
+  modules by path ./node_modules/ 538 KiB
+    ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
+    ./node_modules/style-loader/dist/runtime/injectStylesIntoStyleTag.js 6.67 KiB [built] [code generated]
+    ./node_modules/css-loader/dist/runtime/api.js 1.57 KiB [built] [code generated]
+  modules by path ./src/ 963 bytes
+    ./src/index.js + 1 modules 639 bytes [built] [code generated]
+    ./node_modules/css-loader/dist/cjs.js!./src/style.css 324 bytes [built] [code generated]
+webpack 5.2.0 compiled successfully in 3365 ms
 ```
 
-Open up `index.html` in your browser again and you should see that `Hello webpack` is now styled in red. To see what webpack did, inspect the page (don't view the page source, as it won't show you the result, because the `<style>` tag is dynamically created by JavaScript) and look at the page's head tags. It should contain the style block that we imported in `index.js`.
+Open up `dist/index.html` in your browser again and you should see that `Hello webpack` is now styled in red. To see what webpack did, inspect the page (don't view the page source, as it won't show you the result, because the `<style>` tag is dynamically created by JavaScript) and look at the page's head tags. It should contain the style block that we imported in `index.js`.
 
 Note that you can, and in most cases should, [minimize css](/plugins/mini-css-extract-plugin/#minimizing-for-production) for better load times in production. On top of that, loaders exist for pretty much any flavor of CSS you can think of -- [postcss](/loaders/postcss-loader), [sass](/loaders/sass-loader), and [less](/loaders/less-loader) to name a few.
 
 
 ## Loading Images
 
-So now we're pulling in our CSS, but what about our images like backgrounds and icons? Using the [file-loader](/loaders/file-loader) we can easily incorporate those in our system as well:
-
-``` bash
-npm install --save-dev file-loader
-```
+So now we're pulling in our CSS, but what about our images like backgrounds and icons? As of webpack 5, using the [Asset Modules](/guides/asset-modules/) we can easily incorporate those in our system as well:
 
 __webpack.config.js__
 
@@ -180,16 +182,11 @@ __webpack.config.js__
       rules: [
         {
           test: /\.css$/,
-          use: [
-            'style-loader',
-            'css-loader'
-          ],
+          use: ['style-loader', 'css-loader'],
         },
 +       {
-+         test: /\.(png|svg|jpg|gif)$/,
-+         use: [
-+           'file-loader',
-+         ],
++         test: /\.(png|svg|jpg|jpeg|gif)$/i,
++         type: 'asset/resource',
 +       },
       ],
     },
@@ -254,24 +251,34 @@ __src/style.css__
 Let's create a new build and open up the index.html file again:
 
 ``` bash
-npm run build
+$ npm run build
 
 ...
-                               Asset      Size  Chunks                    Chunk Names
-da4574bb234ddc4bb47cbe1ca4b20303.png  3.01 MiB          [emitted]  [big]
-                           bundle.js  76.7 KiB       0  [emitted]         main
-Entrypoint main = bundle.js
-...
+[webpack-cli] Compilation finished
+asset bundle.js 73.4 KiB [emitted] [compared for emit] [minimized] (name: main) 1 related asset
+asset bc67ebaf980e8f20b8c3.png 8.29 KiB [emitted] [immutable] [from: src/icon.png] (auxiliary name: main)
+runtime modules 1.82 KiB 6 modules
+orphan modules 326 bytes [orphan] 1 module
+cacheable modules 540 KiB (javascript) 8.29 KiB (asset)
+  modules by path ./node_modules/ 539 KiB
+    modules by path ./node_modules/css-loader/dist/runtime/*.js 2.38 KiB
+      ./node_modules/css-loader/dist/runtime/api.js 1.57 KiB [built] [code generated]
+      ./node_modules/css-loader/dist/runtime/getUrl.js 830 bytes [built] [code generated]
+    ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
+    ./node_modules/style-loader/dist/runtime/injectStylesIntoStyleTag.js 6.67 KiB [built] [code generated]
+  modules by path ./src/ 1.45 KiB (javascript) 8.29 KiB (asset)
+    ./src/index.js + 1 modules 794 bytes [built] [code generated]
+    ./src/icon.png 42 bytes (javascript) 8.29 KiB (asset) [built] [code generated]
+    ./node_modules/css-loader/dist/cjs.js!./src/style.css 646 bytes [built] [code generated]
+webpack 5.2.0 compiled successfully in 2671 ms
 ```
 
-If all went well, you should now see your icon as a repeating background, as well as an `img` element beside our `Hello webpack` text. If you inspect this element, you'll see that the actual filename has changed to something like `5c999da72346a995e7e2718865d019c8.png`. This means webpack found our file in the `src` folder and processed it!
-
-T> A logical next step from here is minifying and optimizing your images. Check out the [image-webpack-loader](https://github.com/tcoopman/image-webpack-loader) and [url-loader](/loaders/url-loader) for more on how you can enhance your image loading process.
+If all went well, you should now see your icon as a repeating background, as well as an `img` element beside our `Hello webpack` text. If you inspect this element, you'll see that the actual filename has changed to something like `bc67ebaf980e8f20b8c3.png`. This means webpack found our file in the `src` folder and processed it!
 
 
 ## Loading Fonts
 
-So what about other assets like fonts? The file and url loaders will take any file you load through them and output it to your build directory. This means we can use them for any kind of file, including fonts. Let's update our `webpack.config.js` to handle font files:
+So what about other assets like fonts? The Asset Modules will take any file you load through them and output it to your build directory. This means we can use them for any kind of file, including fonts. Let's update our `webpack.config.js` to handle font files:
 
 __webpack.config.js__
 
@@ -288,22 +295,15 @@ __webpack.config.js__
       rules: [
         {
           test: /\.css$/,
-          use: [
-            'style-loader',
-            'css-loader'
-          ],
+          use: ['style-loader', 'css-loader'],
         },
         {
-          test: /\.(png|svg|jpg|gif)$/,
-          use: [
-            'file-loader',
-          ],
+          test: /\.(png|svg|jpg|jpeg|gif)$/i,
+          type: 'asset/resource',
         },
 +       {
 +         test: /\.(woff|woff2|eot|ttf|otf)$/,
-+         use: [
-+           'file-loader',
-+         ],
++         type: 'asset/resource'
 +       },
       ],
     },
@@ -323,8 +323,7 @@ __project__
     |- bundle.js
     |- index.html
   |- /src
-+   |- my-font.woff
-+   |- my-font.woff2
++   |- google-fonts.woff2
     |- icon.png
     |- style.css
     |- index.js
@@ -337,16 +336,15 @@ __src/style.css__
 
 ``` diff
 + @font-face {
-+   font-family: 'MyFont';
-+   src:  url('./my-font.woff2') format('woff2'),
-+         url('./my-font.woff') format('woff');
++   font-family: 'GoogleFont';
++   src:  url('./google-font.woff2') format('woff2');
 +   font-weight: 600;
 +   font-style: normal;
 + }
 
   .hello {
     color: red;
-+   font-family: 'MyFont';
++   font-family: 'GoogleFont';
     background: url('./icon.png');
   }
 ```
@@ -354,16 +352,27 @@ __src/style.css__
 Now run a new build and let's see if webpack handled our fonts:
 
 ``` bash
-npm run build
+$ npm run build
 
 ...
-                                 Asset      Size  Chunks                    Chunk Names
-5439466351d432b73fdb518c6ae9654a.woff2  19.5 KiB          [emitted]
- 387c65cc923ad19790469cfb5b7cb583.woff  23.4 KiB          [emitted]
-  da4574bb234ddc4bb47cbe1ca4b20303.png  3.01 MiB          [emitted]  [big]
-                             bundle.js    77 KiB       0  [emitted]         main
-Entrypoint main = bundle.js
-...
+[webpack-cli] Compilation finished
+assets by status 21.3 KiB [cached] 2 assets
+asset bundle.js 73.6 KiB [emitted] [minimized] (name: main) 1 related asset
+runtime modules 1.82 KiB 6 modules
+orphan modules 326 bytes [orphan] 1 module
+cacheable modules 541 KiB (javascript) 21.3 KiB (asset)
+  javascript modules 541 KiB
+    modules by path ./node_modules/ 539 KiB
+      modules by path ./node_modules/css-loader/dist/runtime/*.js 2.38 KiB 2 modules
+      ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
+      ./node_modules/style-loader/dist/runtime/injectStylesIntoStyleTag.js 6.67 KiB [built] [code generated]
+    modules by path ./src/ 1.76 KiB
+      ./src/index.js + 1 modules 794 bytes [built] [code generated]
+      ./node_modules/css-loader/dist/cjs.js!./src/style.css 1010 bytes [built] [code generated]
+  asset modules 84 bytes (javascript) 21.3 KiB (asset)
+    ./src/icon.png 42 bytes (javascript) 8.29 KiB (asset) [built] [code generated]
+    ./src/google-font.woff2 42 bytes (javascript) 13 KiB (asset) [built] [code generated]
+webpack 5.2.0 compiled successfully in 2622 ms
 ```
 
 Open up `index.html` again and see if our `Hello webpack` text has changed to the new font. If all is well, you should see the changes.
@@ -380,50 +389,39 @@ npm install --save-dev csv-loader xml-loader
 __webpack.config.js__
 
 ``` diff
-  const path = require('path');
+const path = require('path')
 
-  module.exports = {
-    entry: './src/index.js',
-    output: {
-      filename: 'bundle.js',
-      path: path.resolve(__dirname, 'dist'),
-    },
-    module: {
-      rules: [
-        {
-          test: /\.css$/,
-          use: [
-            'style-loader',
-            'css-loader'
-          ],
-        },
-        {
-          test: /\.(png|svg|jpg|gif)$/,
-          use: [
-            'file-loader',
-          ],
-        },
-        {
-          test: /\.(woff|woff2|eot|ttf|otf)$/,
-          use: [
-            'file-loader',
-          ],
-        },
-+       {
-+         test: /\.(csv|tsv)$/,
-+         use: [
-+           'csv-loader',
-+         ],
-+       },
-+       {
-+         test: /\.xml$/,
-+         use: [
-+           'xml-loader',
-+         ],
-+       },
-      ],
-    },
-  };
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader'],
+      },
+      {
+        test: /\.(png|svg|jpg|jpeg|gif)$/i,
+        type: 'asset/resource',
+      },
+      {
+        test: /\.(woff|woff2|eot|ttf|otf)$/i,
+        type: 'asset/resource'
+      },
++     {
++       test: /\.(csv|tsv)$/,
++       use: ['csv-loader'],
++     },
++     {
++       test: /\.xml$/,
++       use: ['xml-loader'],
++     },
+    ],
+  },
+};
 ```
 
 Add some data files to your project:
@@ -502,7 +500,7 @@ __src/index.js__
   document.body.appendChild(component());
 ```
 
-Re-run the `npm run build` command and open `index.html`. If you look at the console in your developer tools, you should be able to see your imported data being logged to the console!
+Re-run the `npm run build` command and open `dist/index.html`. If you look at the console in your developer tools, you should be able to see your imported data being logged to the console!
 
 T> This can be especially helpful when implementing some sort of data visualization using a tool like [d3](https://github.com/d3). Instead of making an ajax request and parsing the data at runtime you can load it into your module during the build process so that the parsed data is ready to go as soon as the module hits the browser.
 
@@ -573,56 +571,66 @@ And configure them in your webpack configuration:
 
 __webpack.config.js__
 
-```javascript
-const toml = require('toml'); 
-const yaml = require('yamljs');
-const json5 = require('json5');
-module.exports = {
-  // ...
-  module: {
-    rules: [
-      {
-        test: /\.toml$/,
-        type: 'json',
-        parser: {
-          parse: toml.parse
-        }
-      },
-      {
-        test: /\.yaml$/,
-        type: 'json',
-        parser: {
-          parse: yaml.parse
-        }
-      },
-      {
-        test: /\.json5$/,
-        type: 'json',
-        parser: {
-          parse: json5.parse
-        }
-      }
-    ]
-  }
-};
+```diff
++ const toml = require('toml'); 
++ const yaml = require('yamljs');
++ const json5 = require('json5');
+  module.exports = {
+    // ...
+    module: {
+      rules: [
+        // ...
++       {
++         test: /\.toml$/,
++         type: 'json',
++         parser: {
++           parse: toml.parse,
++         },
++       },
++       {
++         test: /\.yaml$/,
++         type: 'json',
++         parser: {
++           parse: yaml.parse,
++         },
++       },
++       {
++         test: /\.json5$/,
++         type: 'json',
++         parser: {
++           parse: json5.parse,
++         },
++       },
+      ]
+    }
+  };
 ```
 
 __src/index.js__
 
-```javascript
-import toml from './data.toml';
-import yaml from './data.yaml';
-import json from './data.json5';
-
-console.log(toml.title); // output `TOML Example`
-console.log(toml.owner.name); // output `Tom Preston-Werner`
-
-console.log(yaml.title); // output `YAML Example`
-console.log(yaml.owner.name); // output `Tom Preston-Werner`
-
-console.log(json.title); // output `JSON5 Example`
-console.log(json.owner.name); // output `Tom Preston-Werner`
+```diff
+  // ...
+  import Notes from './data.csv';
++ import toml from './data.toml';
++ import yaml from './data.yaml';
++ import json from './data.json5';
++ 
++ console.log(toml.title); // output `TOML Example`
++ console.log(toml.owner.name); // output `Tom Preston-Werner`
++ 
++ console.log(yaml.title); // output `YAML Example`
++ console.log(yaml.owner.name); // output `Tom Preston-Werner`
++ 
++ console.log(json.title); // output `JSON5 Example`
++ console.log(json.owner.name); // output `Tom Preston-Werner`
+  function component() {
+    const element = document.createElement('div');
+    // ...
+  }
+  // ...
 ```
+
+Re-run the `npm run build` command and open `dist/index.html`. You should be able to see your imported data being logged to the console!
 
 ## Global Assets
 
@@ -659,8 +667,10 @@ __project__
   |- /src
 -   |- data.xml
 -   |- data.csv
--   |- my-font.woff
--   |- my-font.woff2
+-   |- data.toml
+-   |- data.yaml
+-   |- data.json5
+-   |- google-font.woff2
 -   |- icon.png
 -   |- style.css
     |- index.js
@@ -669,9 +679,11 @@ __project__
 
 __webpack.config.js__
 
-``` diff
+```diff
   const path = require('path');
-
+- const toml = require('toml'); 
+- const yaml = require('yamljs');
+- const json5 = require('json5');
   module.exports = {
     entry: './src/index.js',
     output: {
@@ -682,38 +694,48 @@ __webpack.config.js__
 -     rules: [
 -       {
 -         test: /\.css$/,
--         use: [
--           'style-loader',
--           'css-loader',
--         ],
+-         use: ['style-loader', 'css-loader'],
 -       },
 -       {
--         test: /\.(png|svg|jpg|gif)$/,
--         use: [
--           'file-loader',
--         ],
+-         test: /\.(png|svg|jpg|jpeg|gif)$/i,
+-         type: 'asset/resource',
 -       },
 -       {
--         test: /\.(woff|woff2|eot|ttf|otf)$/,
--         use: [
--           'file-loader',
--         ],
+-         test: /\.(woff|woff2|eot|ttf|otf)$/i,
+-         type: 'asset/resource',
 -       },
 -       {
 -         test: /\.(csv|tsv)$/,
--         use: [
--           'csv-loader',
--         ],
+-         use: ['csv-loader'],
 -       },
 -       {
 -         test: /\.xml$/,
--         use: [
--           'xml-loader',
--         ],
+-         use: ['xml-loader'],
+-       },
+-       {
+-         test: /\.toml$/,
+-         type: 'json',
+-         parser: {
+-           parse: toml.parse,
+-         },
+-       },
+-       {
+-         test: /\.yaml$/,
+-         type: 'json',
+-         parser: {
+-           parse: yaml.parse,
+-         },
+-       },
+-       {
+-         test: /\.json5$/,
+-         type: 'json',
+-         parser: {
+-           parse: json5.parse,
+-         },
 -       },
 -     ],
 -   },
-  };
+  }
 ```
 
 __src/index.js__

--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -13,6 +13,7 @@ contributors:
   - byzyk
   - trivikr
   - aholzner
+  - chenxsan
 ---
 
 T> This guide extends on code examples found in the [Output Management](/guides/output-management) guide.
@@ -26,28 +27,13 @@ Let's start by setting [`mode` to `'development'`](/configuration/mode/#mode-dev
 __webpack.config.js__
 
 ``` diff
-  const path = require('path');
-  const HtmlWebpackPlugin = require('html-webpack-plugin');
-  const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-
-  module.exports = {
-+   mode: 'development',
-    entry: {
-      app: './src/index.js',
-      print: './src/print.js',
-    },
-    plugins: [
-      // new CleanWebpackPlugin(['dist/*']) for < v2 versions of CleanWebpackPlugin
-      new CleanWebpackPlugin(),
-      new HtmlWebpackPlugin({
-        title: 'Development',
-      }),
-    ],
-    output: {
-      filename: '[name].bundle.js',
-      path: path.resolve(__dirname, 'dist'),
-    },
-  };
+ const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+ 
+ module.exports = {
++  mode: 'development',
+   entry: {
+     app: './src/index.js',
+     print: './src/print.js',
 ```
 
 ## Using source maps
@@ -63,28 +49,13 @@ For this guide, let's use the `inline-source-map` option, which is good for illu
 __webpack.config.js__
 
 ``` diff
-  const path = require('path');
-  const HtmlWebpackPlugin = require('html-webpack-plugin');
-  const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-
-  module.exports = {
-    mode: 'development',
-    entry: {
-      app: './src/index.js',
-      print: './src/print.js',
-    },
-+   devtool: 'inline-source-map',
-    plugins: [
-      new CleanWebpackPlugin(),
-      new HtmlWebpackPlugin({
-        title: 'Development',
-      }),
-    ],
-    output: {
-      filename: '[name].bundle.js',
-      path: path.resolve(__dirname, 'dist'),
-    },
-  };
+     app: './src/index.js',
+     print: './src/print.js',
+   },
++  devtool: 'inline-source-map',
+   plugins: [
+     new CleanWebpackPlugin(),
+     new HtmlWebpackPlugin({
 ```
 
 Now let's make sure we have something to debug, so let's create an error in our `print.js` file:
@@ -102,11 +73,16 @@ Run an `npm run build`, it should compile to something like this:
 
 ``` bash
 ...
-          Asset       Size  Chunks                    Chunk Names
-  app.bundle.js    1.44 MB    0, 1  [emitted]  [big]  app
-print.bundle.js    6.43 kB       1  [emitted]         print
-     index.html  248 bytes          [emitted]
-...
+[webpack-cli] Compilation finished
+asset app.bundle.js 1.38 MiB [emitted] (name: app)
+asset print.bundle.js 6.25 KiB [emitted] (name: print)
+asset index.html 276 bytes [emitted]
+runtime modules 1.9 KiB 9 modules
+cacheable modules 530 KiB
+  ./src/index.js 407 bytes [built] [code generated]
+  ./src/print.js 84 bytes [built] [code generated]
+  ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
+webpack 5.2.0 compiled successfully in 668 ms
 ```
 
 Now open the resulting `index.html` file in your browser. Click the button and look in your console where the error is displayed. The error should say something like this:
@@ -127,7 +103,7 @@ It quickly becomes a hassle to manually run `npm run build` every time you want 
 
 There are a couple of different options available in webpack that help you automatically compile your code whenever it changes:
 
- 1. webpack's Watch Mode
+ 1. webpack's [Watch Mode](/configuration/watch/#watch)
  2. webpack-dev-server
  3. webpack-dev-middleware
 
@@ -143,29 +119,13 @@ Let's add an npm script that will start webpack's Watch Mode:
 __package.json__
 
 ``` diff
-  {
-    "name": "webpack-demo",
-    "version": "1.0.0",
-    "description": "",
-    "scripts": {
-      "test": "echo \"Error: no test specified\" && exit 1",
-+     "watch": "webpack --watch",
-      "build": "webpack"
-    },
-    "keywords": [],
-    "author": "",
-    "license": "ISC",
-    "devDependencies": {
-      "clean-webpack-plugin": "^2.0.0",
-      "css-loader": "^0.28.4",
-      "csv-loader": "^2.1.1",
-      "file-loader": "^0.11.2",
-      "html-webpack-plugin": "^2.29.0",
-      "style-loader": "^0.18.2",
-      "webpack": "^4.30.0",
-      "xml-loader": "^1.2.1"
-    }
-  }
+   "private": true,
+   "scripts": {
+     "test": "echo \"Error: no test specified\" && exit 1",
++    "watch": "webpack --watch",
+     "build": "webpack"
+   },
+   "repository": {
 ```
 
 Tell `CleanWebpackPlugin` that we don't want to remove the `index.html` file after the incremental build triggered by watch. We do this with the [`cleanStaleWebpackAssets` option](https://github.com/johnagan/clean-webpack-plugin#options-and-defaults-optional):
@@ -173,29 +133,14 @@ Tell `CleanWebpackPlugin` that we don't want to remove the `index.html` file aft
 __webpack.config.js__
 
 ``` diff
-  const path = require('path');
-  const HtmlWebpackPlugin = require('html-webpack-plugin');
-  const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-
-  module.exports = {
-    mode: 'development',
-    entry: {
-      app: './src/index.js',
-      print: './src/print.js',
-    },
-    devtool: 'inline-source-map',
-    plugins: [
--     new CleanWebpackPlugin(),
-+     new CleanWebpackPlugin({ cleanStaleWebpackAssets: false }),
-      new HtmlWebpackPlugin({
-        title: 'Development',
-      }),
-    ],
-    output: {
-      filename: '[name].bundle.js',
-      path: path.resolve(__dirname, 'dist'),
-    },
-  };
+   },
+   devtool: 'inline-source-map',
+   plugins: [
+-    new CleanWebpackPlugin(),
++    new CleanWebpackPlugin({ cleanStaleWebpackAssets: false }),
+     new HtmlWebpackPlugin({
+       title: 'Output Management',
+     }),
 ```
 
 Now run `npm run watch` from the command line and see how webpack compiles your code.
@@ -206,10 +151,10 @@ Now, while webpack is watching your files, let's remove the error we introduced 
 __src/print.js__
 
 ``` diff
-  export default function printMe() {
--   cosnole.log('I get called from print.js!');
-+   console.log('I get called from print.js!');
-  }
+ export default function printMe() {
+-  cosnole.log('I get called from print.js!');
++  console.log('I get called from print.js!');
+ }
 ```
 
 Now save your file and check the terminal window. You should see that webpack automatically recompiles the changed module!
@@ -230,31 +175,15 @@ Change your configuration file to tell the dev server where to look for files:
 __webpack.config.js__
 
 ``` diff
-  const path = require('path');
-  const HtmlWebpackPlugin = require('html-webpack-plugin');
-  const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-
-  module.exports = {
-    mode: 'development',
-    entry: {
-      app: './src/index.js',
-      print: './src/print.js',
-    },
-    devtool: 'inline-source-map',
-+   devServer: {
-+     contentBase: './dist',
-+   },
-    plugins: [
-      new CleanWebpackPlugin({ cleanStaleWebpackAssets: false }),
-      new HtmlWebpackPlugin({
-        title: 'Development',
-      }),
-    ],
-    output: {
-      filename: '[name].bundle.js',
-      path: path.resolve(__dirname, 'dist'),
-    },
-  };
+     print: './src/print.js',
+   },
+   devtool: 'inline-source-map',
++  devServer: {
++    contentBase: './dist',
++  },
+   plugins: [
+     new CleanWebpackPlugin({ cleanStaleWebpackAssets: false }),
+     new HtmlWebpackPlugin({
 ```
 
 This tells `webpack-dev-server` to serve the files from the `dist` directory on `localhost:8080`.
@@ -266,33 +195,13 @@ Let's add a script to easily run the dev server as well:
 __package.json__
 
 ``` diff
-  {
-    "name": "development",
-    "version": "1.0.0",
-    "description": "",
-    "private": true,
-    "scripts": {
-      "test": "echo \"Error: no test specified\" && exit 1",
-      "watch": "webpack --watch",
-+     "start": "webpack serve --open",
-      "build": "webpack"
-    },
-    "keywords": [],
-    "author": "",
-    "license": "ISC",
-    "devDependencies": {
-      "clean-webpack-plugin": "^2.0.0",
-      "css-loader": "^0.28.4",
-      "csv-loader": "^2.1.1",
-      "express": "^4.15.3",
-      "file-loader": "^0.11.2",
-      "html-webpack-plugin": "^2.29.0",
-      "style-loader": "^0.18.2",
-      "webpack": "^4.30.0",
-      "webpack-dev-server": "^3.8.0",
-      "xml-loader": "^1.2.1"
-    }
-  }
+   "scripts": {
+     "test": "echo \"Error: no test specified\" && exit 1",
+     "watch": "webpack --watch",
++    "start": "webpack serve --open",
+     "build": "webpack"
+   },
+   "repository": {
 ```
 
 Now we can run `npm start` from the command line and we will see our browser automatically loading up our page. If you now change any of the source files and save them, the web server will automatically reload after the code has been compiled. Give it a try!

--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -72,7 +72,7 @@ document.body.appendChild(component());
 __index.html__
 
 ``` html
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -92,23 +92,14 @@ T> If you want to learn more about the inner workings of `package.json`, then we
 __package.json__
 
 ``` diff
-  {
-    "name": "webpack-demo",
-    "version": "1.0.0",
-    "description": "",
-+   "private": true,
--   "main": "index.js",
-    "scripts": {
-      "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "keywords": [],
-    "author": "",
-    "license": "ISC",
-    "devDependencies": {
-      "webpack": "^5.2.0",
-      "webpack-cli": "^4.1.0"
-    }
-  }
+   "name": "webpack-demo",
+   "version": "1.0.0",
+   "description": "",
+-  "main": "index.js",
++  "private": true,
+   "scripts": {
+     "test": "echo \"Error: no test specified\" && exit 1"
+   },
 ```
 
 In this example, there are implicit dependencies between the `<script>` tags. Our `index.js` file depends on `lodash` being included in the page before it runs. This is because `index.js` never explicitly declared a need for `lodash`; it just assumes that the global variable `_` exists.
@@ -150,19 +141,16 @@ Now, lets import `lodash` in our script:
 __src/index.js__
 
 ``` diff
-+ import _ from 'lodash';
++import _ from 'lodash';
 +
-  function component() {
-    const element = document.createElement('div');
-
--   // Lodash, currently included via a script, is required for this line to work
-+   // Lodash, now imported by this script
-    element.innerHTML = _.join(['Hello', 'webpack'], ' ');
-
-    return element;
-  }
-
-  document.body.appendChild(component());
+ function component() {
+   const element = document.createElement('div');
+ 
+-  // Lodash, currently included via a script, is required for this line to work
++  // Lodash, now imported by this script
+   element.innerHTML = _.join(['Hello', 'webpack'], ' ');
+ 
+   return element;
 ```
 
 Now, since we'll be bundling our scripts, we have to update our `index.html` file. Let's remove the lodash `<script>`, as we now `import` it, and modify the other `<script>` tag to load the bundle, instead of the raw `/src` file:
@@ -170,9 +158,8 @@ Now, since we'll be bundling our scripts, we have to update our `index.html` fil
 __dist/index.html__
 
 ``` diff
-  <!doctype html>
-  <html>
    <head>
+     <meta charset="utf-8" />
      <title>Getting Started</title>
 -    <script src="https://unpkg.com/lodash@4.17.20"></script>
    </head>
@@ -180,7 +167,7 @@ __dist/index.html__
 -    <script src="./src/index.js"></script>
 +    <script src="main.js"></script>
    </body>
-  </html>
+ </html>
 ```
 
 In this setup, `index.js` explicitly requires `lodash` to be present, and binds it as `_` (no global scope pollution). By stating what dependencies a module needs, webpack can use this information to build a dependency graph. It then uses the graph to generate an optimized bundle where scripts will be executed in the correct order.
@@ -188,14 +175,15 @@ In this setup, `index.js` explicitly requires `lodash` to be present, and binds 
 With that said, let's run `npx webpack`, which will take our script at `src/index.js` as the [entry point](/concepts/entry-points), and will generate `dist/main.js` as the [output](/concepts/output). The `npx` command, which ships with Node 8.2/npm 5.2.0 or higher, runs the webpack binary (`./node_modules/.bin/webpack`) of the webpack package we installed in the beginning:
 
 ``` bash
-npx webpack
+$ npx webpack
+...
 [webpack-cli] Compilation finished
 asset main.js 69.3 KiB [emitted] [minimized] (name: main) 1 related asset
 runtime modules 1000 bytes 5 modules
 cacheable modules 530 KiB
-  ./src/index.js 257 bytes [built] [code generated]
+  ./src/index.js 258 bytes [built] [code generated]
   ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
-webpack 5.2.0 compiled successfully in 2499 ms
+webpack 5.2.0 compiled successfully in 2419 ms
 ...
 
 WARNING in configuration
@@ -252,16 +240,14 @@ module.exports = {
 Now, let's run the build again but instead using our new configuration file:
 
 ``` bash
-npx webpack --config webpack.config.js
-
-...
-  Asset      Size  Chunks             Chunk Names
-main.js  70.4 KiB       0  [emitted]  main
-...
-
-WARNING in configuration
-The 'mode' option has not been set, webpack will fallback to 'production' for this value. Set 'mode' option to 'development' or 'production' to enable defaults for each environment.
-You can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/configuration/mode/
+$ npx webpack --config webpack.config.js
+[webpack-cli] Compilation finished
+asset main.js 69.3 KiB [compared for emit] [minimized] (name: main) 1 related asset
+runtime modules 1000 bytes 5 modules
+cacheable modules 530 KiB
+  ./src/index.js 258 bytes [built] [code generated]
+  ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
+webpack 5.2.0 compiled successfully in 2448 ms
 ```
 
 T> If a `webpack.config.js` is present, the `webpack` command picks it up by default. We use the `--config` option here only to show that you can pass a configuration of any name. This will be useful for more complex configurations that need to be split into multiple files.
@@ -276,26 +262,15 @@ Given it's not particularly fun to run a local copy of webpack from the CLI, we 
 __package.json__
 
 ``` diff
-  {
-    "name": "webpack-demo",
-    "version": "1.0.0",
-    "description": "",
-    "scripts": {
--      "test": "echo \"Error: no test specified\" && exit 1"
-+      "test": "echo \"Error: no test specified\" && exit 1",
-+      "build": "webpack"
-    },
-    "keywords": [],
-    "author": "",
-    "license": "ISC",
-    "devDependencies": {
-      "webpack": "^5.2.0",
-      "webpack-cli": "^4.1.0"
-    },
-    "dependencies": {
-      "lodash": "^4.17.20"
-    }
-  }
+   "description": "",
+   "private": true,
+   "scripts": {
+-    "test": "echo \"Error: no test specified\" && exit 1"
++    "test": "echo \"Error: no test specified\" && exit 1",
++    "build": "webpack"
+   },
+   "repository": {
+     "type": "git",
 ```
 
 Now the `npm run build` command can be used in place of the `npx` command we used earlier. Note that within `scripts` we can reference locally installed npm packages by name the same way we did with `npx`. This convention is the standard in most npm-based projects because it allows all contributors to use the same set of common scripts (each with flags like `--config` if necessary).

--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -46,7 +46,7 @@ Throughout the Guides we will use __`diff` blocks__ to show you what changes we'
 + this is a new line you should copy into your code
 - and this line should be removed from your code
 
-As the code might get very long,
+As the code might get long,
   1. sometimes we only show part of it,
   2. sometimes we use `// ...` to indicate those code folded
 

--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -27,7 +27,7 @@ contributors:
 
 webpack is used to compile JavaScript modules. Once [installed](/guides/installation), you can interact with webpack either from its [CLI](/api/cli) or [API](/api/node). If you're still new to webpack, please read through the [core concepts](/concepts) and [this comparison](/comparison) to learn why you might use it over the other tools that are out in the community.
 
-W> Since webpack v5.0.0-beta.1 the minimum Node.js version to run webpack is 10.13.0 (LTS)
+W> The minimum Node.js version to run webpack 5 is 10.13.0 (LTS)
 
 ## Basic Setup
 

--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -40,7 +40,20 @@ npm init -y
 npm install webpack webpack-cli --save-dev
 ```
 
-T> Throughout the Guides we will use `diff` blocks to show you what changes we're making to directories, files, and code.
+Throughout the Guides we will use __`diff` blocks__ to show you what changes we're making to directories, files, and code. For instance:
+
+```diff
++ this is a new line you should copy into your code
+- and this line should be removed from your code
+
+As the code might get very long,
+  1. sometimes we only show part of it,
+  2. sometimes we use `// ...` to indicate those code folded
+
+Which means you should only care about those lines prefixing with `+`, `-` characters.
+
+Avoid copying the whole code block, otherwise your code might not work as expected
+```
 
 Now we'll create the following directory structure, files and their contents:
 
@@ -312,7 +325,7 @@ webpack-demo
 |- /node_modules
 ```
 
-T> If you're using npm 5, you'll probably also see a `package-lock.json` file in your directory.
+T> If you're using npm 5+, you'll probably also see a `package-lock.json` file in your directory.
 
 W> Do not compile untrusted code with webpack. It could lead to execution of malicious code on your computer, remote servers, or in the Web browsers of the end users of your application.
 

--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -25,7 +25,7 @@ contributors:
   - anshumanv
 ---
 
-webpack is used to compile JavaScript modules. Once [installed](/guides/installation), you can interface with webpack either from its [CLI](/api/cli) or [API](/api/node). If you're still new to webpack, please read through the [core concepts](/concepts) and [this comparison](/comparison) to learn why you might use it over the other tools that are out in the community.
+webpack is used to compile JavaScript modules. Once [installed](/guides/installation), you can interact with webpack either from its [CLI](/api/cli) or [API](/api/node). If you're still new to webpack, please read through the [core concepts](/concepts) and [this comparison](/comparison) to learn why you might use it over the other tools that are out in the community.
 
 W> Since webpack v5.0.0-beta.1 the minimum Node.js version to run webpack is 10.13.0 (LTS)
 
@@ -75,8 +75,9 @@ __index.html__
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8" />
     <title>Getting Started</title>
-    <script src="https://unpkg.com/lodash@4.16.6"></script>
+    <script src="https://unpkg.com/lodash@4.17.20"></script>
   </head>
   <body>
     <script src="./src/index.js"></script>
@@ -104,10 +105,9 @@ __package.json__
     "author": "",
     "license": "ISC",
     "devDependencies": {
-      "webpack": "^4.20.2",
-      "webpack-cli": "^3.1.2"
-    },
-    "dependencies": {}
+      "webpack": "^5.2.0",
+      "webpack-cli": "^4.1.0"
+    }
   }
 ```
 
@@ -174,7 +174,7 @@ __dist/index.html__
   <html>
    <head>
      <title>Getting Started</title>
--    <script src="https://unpkg.com/lodash@4.16.6"></script>
+-    <script src="https://unpkg.com/lodash@4.17.20"></script>
    </head>
    <body>
 -    <script src="./src/index.js"></script>
@@ -189,11 +189,13 @@ With that said, let's run `npx webpack`, which will take our script at `src/inde
 
 ``` bash
 npx webpack
-
-...
-Built at: 13/06/2018 11:52:07
-  Asset      Size  Chunks             Chunk Names
-main.js  70.4 KiB       0  [emitted]  main
+[webpack-cli] Compilation finished
+asset main.js 69.3 KiB [emitted] [minimized] (name: main) 1 related asset
+runtime modules 1000 bytes 5 modules
+cacheable modules 530 KiB
+  ./src/index.js 257 bytes [built] [code generated]
+  ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
+webpack 5.2.0 compiled successfully in 2499 ms
 ...
 
 WARNING in configuration
@@ -287,11 +289,11 @@ __package.json__
     "author": "",
     "license": "ISC",
     "devDependencies": {
-      "webpack": "^4.20.2",
-      "webpack-cli": "^3.1.2"
+      "webpack": "^5.2.0",
+      "webpack-cli": "^4.1.0"
     },
     "dependencies": {
-      "lodash": "^4.17.5"
+      "lodash": "^4.17.20"
     }
   }
 ```
@@ -301,19 +303,20 @@ Now the `npm run build` command can be used in place of the `npx` command we use
 Now run the following command and see if your script alias works:
 
 ``` bash
-npm run build
+$ npm run build
 
 ...
-  Asset      Size  Chunks             Chunk Names
-main.js  70.4 KiB       0  [emitted]  main
-...
 
-WARNING in configuration
-The 'mode' option has not been set, webpack will fallback to 'production' for this value. Set 'mode' option to 'development' or 'production' to enable defaults for each environment.
-You can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/configuration/mode/.
+[webpack-cli] Compilation finished
+asset main.js 69.3 KiB [compared for emit] [minimized] (name: main) 1 related asset
+runtime modules 1000 bytes 5 modules
+cacheable modules 530 KiB
+  ./src/index.js 257 bytes [built] [code generated]
+  ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
+webpack 5.2.0 compiled successfully in 2255 ms
 ```
 
-T> Custom parameters can be passed to webpack by adding two dashes between the `npm run build` command and your parameters, e.g. `npm run build -- --colors`.
+T> Custom parameters can be passed to webpack by adding two dashes between the `npm run build` command and your parameters, e.g. `npm run build -- --color`.
 
 
 ## Conclusion

--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -40,19 +40,12 @@ npm init -y
 npm install webpack webpack-cli --save-dev
 ```
 
-Throughout the Guides we will use __`diff` blocks__ to show you what changes we're making to directories, files, and code. For instance:
+Throughout the Guides we will use __`diff`__  blocks to show you what changes we're making to directories, files, and code. For instance:
 
 ```diff
-+ this is a new line you should copy into your code
-- and this line should be removed from your code
-
-As the code might get long,
-  1. sometimes we only show part of it,
-  2. sometimes we use `// ...` to indicate those code folded
-
-Which means you should only care about those lines prefixing with `+`, `-` characters.
-
-Avoid copying the whole code block, otherwise your code might not work as expected
++ this is a new line you shall copy into your code
+- and this is a line to be removed from your code
+  and this is a line not to touch. 
 ```
 
 Now we'll create the following directory structure, files and their contents:
@@ -105,6 +98,7 @@ T> If you want to learn more about the inner workings of `package.json`, then we
 __package.json__
 
 ``` diff
+ {
    "name": "webpack-demo",
    "version": "1.0.0",
    "description": "",
@@ -113,6 +107,14 @@ __package.json__
    "scripts": {
      "test": "echo \"Error: no test specified\" && exit 1"
    },
+   "keywords": [],
+   "author": "",
+   "license": "ISC",
+   "devDependencies": {
+     "webpack": "^5.4.0",
+     "webpack-cli": "^4.2.0"
+   }
+ }
 ```
 
 In this example, there are implicit dependencies between the `<script>` tags. Our `index.js` file depends on `lodash` being included in the page before it runs. This is because `index.js` never explicitly declared a need for `lodash`; it just assumes that the global variable `_` exists.
@@ -164,6 +166,9 @@ __src/index.js__
    element.innerHTML = _.join(['Hello', 'webpack'], ' ');
  
    return element;
+ }
+ 
+ document.body.appendChild(component());
 ```
 
 Now, since we'll be bundling our scripts, we have to update our `index.html` file. Let's remove the lodash `<script>`, as we now `import` it, and modify the other `<script>` tag to load the bundle, instead of the raw `/src` file:
@@ -171,6 +176,8 @@ Now, since we'll be bundling our scripts, we have to update our `index.html` fil
 __dist/index.html__
 
 ``` diff
+ <!DOCTYPE html>
+ <html>
    <head>
      <meta charset="utf-8" />
      <title>Getting Started</title>
@@ -189,24 +196,18 @@ With that said, let's run `npx webpack`, which will take our script at `src/inde
 
 ``` bash
 $ npx webpack
-...
 [webpack-cli] Compilation finished
 asset main.js 69.3 KiB [emitted] [minimized] (name: main) 1 related asset
 runtime modules 1000 bytes 5 modules
 cacheable modules 530 KiB
-  ./src/index.js 258 bytes [built] [code generated]
+  ./src/index.js 257 bytes [built] [code generated]
   ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
-webpack 5.2.0 compiled successfully in 2419 ms
-...
-
-WARNING in configuration
-The 'mode' option has not been set, webpack will fallback to 'production' for this value. Set 'mode' option to 'development' or 'production' to enable defaults for each environment.
-You can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/configuration/mode/
+webpack 5.4.0 compiled successfully in 3619 ms
 ```
 
 T> Your output may vary a bit, but if the build is successful then you are good to go. Also, don't worry about the warning, we'll tackle that later.
 
-Open `index.html` from the `dist` directory in your browser and, if everything went right, you should see the following text: 'Hello webpack'.
+Open `index.html` from the `dist` directory in your browser and, if everything went right, you should see the following text: `'Hello webpack'`.
 
 W> If you are getting a syntax error in the middle of minified JavaScript when opening `index.html` in the browser, set [`development mode`](/configuration/mode/#mode-development) and run `npx webpack` again. This is related to running `npx webpack` on latest Node.js (v12.5+) instead of [LTS version](https://nodejs.org/en/).
 
@@ -215,7 +216,7 @@ W> If you are getting a syntax error in the middle of minified JavaScript when o
 
 The [`import`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) and [`export`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) statements have been standardized in [ES2015](https://babeljs.io/docs/en/learn/). They are supported in most of the browsers at this moment, however there are some browsers that don't recognize the new syntax. But don't worry, webpack does support them out of the box.
 
-Behind the scenes, webpack actually "transpiles" the code so that older browsers can also run it. If you inspect `dist/main.js`, you might be able to see how webpack does this, it's quite ingenious! Besides `import` and `export`, webpack supports various other module syntaxes as well, see [Module API](/api/module-methods) for more information.
+Behind the scenes, webpack actually "__transpiles__" the code so that older browsers can also run it. If you inspect `dist/main.js`, you might be able to see how webpack does this, it's quite ingenious! Besides `import` and `export`, webpack supports various other module syntaxes as well, see [Module API](/api/module-methods) for more information.
 
 Note that webpack will not alter any code other than `import` and `export` statements. If you are using other [ES2015 features](http://es6-features.org/), make sure to [use a transpiler](/loaders/#transpiling) such as [Babel](https://babeljs.io/) or [Bublé](https://buble.surge.sh/guide/) via webpack's [loader system](/concepts/loaders/).
 
@@ -253,14 +254,14 @@ module.exports = {
 Now, let's run the build again but instead using our new configuration file:
 
 ``` bash
-$ npx webpack --config webpack.config.js
+$ npx webpack --config webpack.config.js 
 [webpack-cli] Compilation finished
 asset main.js 69.3 KiB [compared for emit] [minimized] (name: main) 1 related asset
 runtime modules 1000 bytes 5 modules
 cacheable modules 530 KiB
-  ./src/index.js 258 bytes [built] [code generated]
+  ./src/index.js 257 bytes [built] [code generated]
   ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
-webpack 5.2.0 compiled successfully in 2448 ms
+webpack 5.4.0 compiled successfully in 3516 ms
 ```
 
 T> If a `webpack.config.js` is present, the `webpack` command picks it up by default. We use the `--config` option here only to show that you can pass a configuration of any name. This will be useful for more complex configurations that need to be split into multiple files.
@@ -275,6 +276,9 @@ Given it's not particularly fun to run a local copy of webpack from the CLI, we 
 __package.json__
 
 ``` diff
+{
+   "name": "webpack-demo",
+   "version": "1.0.0",
    "description": "",
    "private": true,
    "scripts": {
@@ -282,8 +286,17 @@ __package.json__
 +    "test": "echo \"Error: no test specified\" && exit 1",
 +    "build": "webpack"
    },
-   "repository": {
-     "type": "git",
+   "keywords": [],
+   "author": "",
+   "license": "ISC",
+   "devDependencies": {
+     "webpack": "^5.4.0",
+     "webpack-cli": "^4.2.0"
+   },
+   "dependencies": {
+     "lodash": "^4.17.20"
+   }
+ }
 ```
 
 Now the `npm run build` command can be used in place of the `npx` command we used earlier. Note that within `scripts` we can reference locally installed npm packages by name the same way we did with `npx`. This convention is the standard in most npm-based projects because it allows all contributors to use the same set of common scripts (each with flags like `--config` if necessary).
@@ -301,7 +314,7 @@ runtime modules 1000 bytes 5 modules
 cacheable modules 530 KiB
   ./src/index.js 257 bytes [built] [code generated]
   ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
-webpack 5.2.0 compiled successfully in 2255 ms
+webpack 5.4.0 compiled successfully in 3764 ms
 ```
 
 T> Custom parameters can be passed to webpack by adding two dashes between the `npm run build` command and your parameters, e.g. `npm run build -- --color`.

--- a/src/content/guides/output-management.md
+++ b/src/content/guides/output-management.md
@@ -47,24 +47,22 @@ And use that function in our `src/index.js` file:
 __src/index.js__
 
 ``` diff
-  import _ from 'lodash';
-+ import printMe from './print.js';
-
-  function component() {
-    const element = document.createElement('div');
-+   const btn = document.createElement('button');
-
-    element.innerHTML = _.join(['Hello', 'webpack'], ' ');
-
-+   btn.innerHTML = 'Click me and check the console!';
-+   btn.onclick = printMe;
+ import _ from 'lodash';
++import printMe from './print.js';
+ 
+ function component() {
+   const element = document.createElement('div');
++  const btn = document.createElement('button');
+ 
+   element.innerHTML = _.join(['Hello', 'webpack'], ' ');
+ 
++  btn.innerHTML = 'Click me and check the console!';
++  btn.onclick = printMe;
 +
-+   element.appendChild(btn);
-
-    return element;
-  }
-
-  document.body.appendChild(component());
++  element.appendChild(btn);
++
+   return element;
+ }
 ```
 
 Let's also update our `dist/index.html` file, in preparation for webpack to split out entries:
@@ -72,18 +70,18 @@ Let's also update our `dist/index.html` file, in preparation for webpack to spli
 __dist/index.html__
 
 ``` diff
-  <!doctype html>
-  <html>
-    <head>
--     <title>Asset Management</title>
-+     <title>Output Management</title>
-+     <script src="./print.bundle.js"></script>
-    </head>
-    <body>
--     <script src="./bundle.js"></script>
-+     <script src="./app.bundle.js"></script>
-    </body>
-  </html>
+ <html>
+   <head>
+     <meta charset="utf-8" />
+-    <title>Asset Management</title>
++    <title>Output Management</title>
++    <script src="./print.bundle.js"></script>
+   </head>
+   <body>
+-    <script src="bundle.js"></script>
++    <script src="./app.bundle.js"></script>
+   </body>
+ </html>
 ```
 
 Now adjust the config. We'll be adding our `src/print.js` as a new entry point (`print`) and we'll change the output as well, so that it will dynamically generate bundle names, based on the entry point names:
@@ -91,30 +89,35 @@ Now adjust the config. We'll be adding our `src/print.js` as a new entry point (
 __webpack.config.js__
 
 ``` diff
-  const path = require('path');
-
-  module.exports = {
--   entry: './src/index.js',
-+   entry: {
-+     app: './src/index.js',
-+     print: './src/print.js',
-+   },
-    output: {
--     filename: 'bundle.js',
-+     filename: '[name].bundle.js',
-      path: path.resolve(__dirname, 'dist'),
-    },
-  };
+ const path = require('path');
+ 
+ module.exports = {
+-  entry: './src/index.js',
++  entry: {
++    app: './src/index.js',
++    print: './src/print.js',
++  },
+   output: {
+-    filename: 'bundle.js',
++    filename: '[name].bundle.js',
+     path: path.resolve(__dirname, 'dist'),
+   },
+ };
 ```
 
 Let's run `npm run build` and see what this generates:
 
 ``` bash
 ...
-          Asset     Size  Chunks                    Chunk Names
-  app.bundle.js   545 kB    0, 1  [emitted]  [big]  app
-print.bundle.js  2.74 kB       1  [emitted]         print
-...
+[webpack-cli] Compilation finished
+asset app.bundle.js 69.5 KiB [emitted] [minimized] (name: app) 1 related asset
+asset print.bundle.js 316 bytes [emitted] [minimized] (name: print)
+runtime modules 1.36 KiB 7 modules
+cacheable modules 530 KiB
+  ./src/index.js 407 bytes [built] [code generated]
+  ./src/print.js 84 bytes [built] [code generated]
+  ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
+webpack 5.2.0 compiled successfully in 2245 ms
 ```
 
 We can see that webpack generates our `print.bundle.js` and `app.bundle.js` files, which we also specified in our `index.html` file. if you open `index.html` in your browser, you can see what happens when you click the button.
@@ -133,35 +136,38 @@ npm install --save-dev html-webpack-plugin
 __webpack.config.js__
 
 ``` diff
-  const path = require('path');
-+ const HtmlWebpackPlugin = require('html-webpack-plugin');
-
-  module.exports = {
-    entry: {
-      app: './src/index.js',
-      print: './src/print.js',
-    },
-+   plugins: [
-+     new HtmlWebpackPlugin({
-+       title: 'Output Management',
-+     }),
-+   ],
-    output: {
-      filename: '[name].bundle.js',
-      path: path.resolve(__dirname, 'dist'),
-    },
-  };
+ const path = require('path');
++const HtmlWebpackPlugin = require('html-webpack-plugin');
+ 
+ module.exports = {
+   entry: {
+     app: './src/index.js',
+     print: './src/print.js',
+   },
++  plugins: [
++    new HtmlWebpackPlugin({
++      title: 'Output Management',
++    }),
++  ],
+   output: {
+     filename: '[name].bundle.js',
+     path: path.resolve(__dirname, 'dist'),
 ```
 
 Before we do a build, you should know that the `HtmlWebpackPlugin` by default will generate its own `index.html` file, even though we already have one in the `dist/` folder. This means that it will replace our `index.html` file with a newly generated one. Let's see what happens when we do an `npm run build`:
 
 ``` bash
 ...
-           Asset       Size  Chunks                    Chunk Names
- print.bundle.js     544 kB       0  [emitted]  [big]  print
-   app.bundle.js    2.81 kB       1  [emitted]         app
-      index.html  249 bytes          [emitted]
-...
+[webpack-cli] Compilation finished
+asset app.bundle.js 69.5 KiB [compared for emit] [minimized] (name: app) 1 related asset
+asset print.bundle.js 316 bytes [compared for emit] [minimized] (name: print)
+asset index.html 251 bytes [emitted]
+runtime modules 1.36 KiB 7 modules
+cacheable modules 530 KiB
+  ./src/index.js 407 bytes [built] [code generated]
+  ./src/print.js 84 bytes [built] [code generated]
+  ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
+webpack 5.2.0 compiled successfully in 2397 ms
 ```
 
 If you open `index.html` in your code editor, you'll see that the `HtmlWebpackPlugin` has created an entirely new file for you and that all the bundles are automatically added.
@@ -183,26 +189,19 @@ npm install --save-dev clean-webpack-plugin
 __webpack.config.js__
 
 ``` diff
-  const path = require('path');
-  const HtmlWebpackPlugin = require('html-webpack-plugin');
-+ const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+ const path = require('path');
+ const HtmlWebpackPlugin = require('html-webpack-plugin');
++const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+ 
+ module.exports = {
+   entry: {
+   // ...
+   plugins: [
++    new CleanWebpackPlugin(),
+     new HtmlWebpackPlugin({
+       title: 'Output Management',
+     }),
 
-  module.exports = {
-    entry: {
-      app: './src/index.js',
-      print: './src/print.js',
-    },
-    plugins: [
-+     new CleanWebpackPlugin(),
-      new HtmlWebpackPlugin({
-        title: 'Output Management',
-      }),
-    ],
-    output: {
-      filename: '[name].bundle.js',
-      path: path.resolve(__dirname, 'dist'),
-    },
-  };
 ```
 
 Now run an `npm run build` and inspect the `/dist` folder. If everything went well you should now only see the files generated from the build and no more old files!
@@ -212,7 +211,7 @@ Now run an `npm run build` and inspect the `/dist` folder. If everything went we
 
 You might be wondering how webpack and its plugins seem to "know" what files are being generated. The answer is in the manifest that webpack keeps to track how all the modules map to the output bundles. If you're interested in managing webpack's [`output`](/configuration/output) in other ways, the manifest would be a good place to start.
 
-The manifest data can be extracted into a json file for easy consumption using the [`WebpackManifestPlugin`](https://github.com/danethurber/webpack-manifest-plugin).
+The manifest data can be extracted into a json file for easy consumption using the [`WebpackManifestPlugin`](https://github.com/shellscape/webpack-manifest-plugin).
 
 We won't go through a full example of how to use this plugin within your projects, but you can read up on [the concept page](/concepts/manifest) and the [caching guide](/guides/caching) to find out how this ties into long term caching.
 

--- a/src/content/guides/output-management.md
+++ b/src/content/guides/output-management.md
@@ -63,6 +63,8 @@ __src/index.js__
 +
    return element;
  }
+ 
+ document.body.appendChild(component());
 ```
 
 Let's also update our `dist/index.html` file, in preparation for webpack to split out entries:
@@ -70,6 +72,7 @@ Let's also update our `dist/index.html` file, in preparation for webpack to spli
 __dist/index.html__
 
 ``` diff
+ <!DOCTYPE html>
  <html>
    <head>
      <meta charset="utf-8" />
@@ -115,9 +118,9 @@ asset print.bundle.js 316 bytes [emitted] [minimized] (name: print)
 runtime modules 1.36 KiB 7 modules
 cacheable modules 530 KiB
   ./src/index.js 407 bytes [built] [code generated]
-  ./src/print.js 84 bytes [built] [code generated]
+  ./src/print.js 83 bytes [built] [code generated]
   ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
-webpack 5.2.0 compiled successfully in 2245 ms
+webpack 5.4.0 compiled successfully in 3410 ms
 ```
 
 We can see that webpack generates our `print.bundle.js` and `app.bundle.js` files, which we also specified in our `index.html` file. if you open `index.html` in your browser, you can see what happens when you click the button.
@@ -152,6 +155,8 @@ __webpack.config.js__
    output: {
      filename: '[name].bundle.js',
      path: path.resolve(__dirname, 'dist'),
+   },
+ };
 ```
 
 Before we do a build, you should know that the `HtmlWebpackPlugin` by default will generate its own `index.html` file, even though we already have one in the `dist/` folder. This means that it will replace our `index.html` file with a newly generated one. Let's see what happens when we do an `npm run build`:
@@ -165,9 +170,9 @@ asset index.html 251 bytes [emitted]
 runtime modules 1.36 KiB 7 modules
 cacheable modules 530 KiB
   ./src/index.js 407 bytes [built] [code generated]
-  ./src/print.js 84 bytes [built] [code generated]
+  ./src/print.js 83 bytes [built] [code generated]
   ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
-webpack 5.2.0 compiled successfully in 2397 ms
+webpack 5.4.0 compiled successfully in 5761 ms
 ```
 
 If you open `index.html` in your code editor, you'll see that the `HtmlWebpackPlugin` has created an entirely new file for you and that all the bundles are automatically added.
@@ -195,13 +200,20 @@ __webpack.config.js__
  
  module.exports = {
    entry: {
-   // ...
+     app: './src/index.js',
+     print: './src/print.js',
+   },
    plugins: [
 +    new CleanWebpackPlugin(),
      new HtmlWebpackPlugin({
        title: 'Output Management',
      }),
-
+   ],
+   output: {
+     filename: '[name].bundle.js',
+     path: path.resolve(__dirname, 'dist'),
+   },
+ };
 ```
 
 Now run an `npm run build` and inspect the `/dist` folder. If everything went well you should now only see the files generated from the build and no more old files!


### PR DESCRIPTION
closes https://github.com/webpack/webpack.js.org/issues/4090 fixes https://github.com/webpack/webpack.js.org/issues/4098

`Guide` section needs to be updated against webpack 5, I'll do it in this pull request.

PREVIEW URL: https://webpack-js-org-git-feature-update-guide-against-webpack5.webpack-docs.vercel.app/guides/getting-started/

- [x] update getting-started.md (code demo https://github.com/chenxsan/webpack-demo)
- [x] update asset-management.md (code demo https://github.com/chenxsan/webpack-demo/pull/2)
- [ ] update output-management.md (code demo https://github.com/chenxsan/webpack-demo/pull/3)