### PR TITLE
docs(guides): correct bash command in environment-variables.md

### DIFF
--- a/src/content/guides/environment-variables.md
+++ b/src/content/guides/environment-variables.md
@@ -20,10 +20,10 @@ T> webpack's environment variables are different from the [environment variables
 The webpack command line [environment option](/api/cli/#environment-options) `--env` allows you to pass in as many environment variables as you like. Environment variables will be made accessible in your `webpack.config.js`. For example, `--env.production` or `--env.NODE_ENV=local` (`NODE_ENV` is conventionally used to define the environment type, see [here](https://dzone.com/articles/what-you-should-know-about-node-env).)
 
 ```bash
-webpack --env.NODE_ENV=local --env.production --progress
+webpack --env NODE_ENV=local --env production --progress
 ```
 
-T> Setting up your `env` variable without assignment, `--env.production` sets `--env.production` to `true` by default. There are also other syntaxes that you can use. See the [webpack CLI](/api/cli/#environment-options) documentation for more information.
+T> Setting up your `env` variable without assignment, `--env production` sets `--env production` to `true` by default. There are also other syntaxes that you can use. See the [webpack CLI](/api/cli/#environment-options) documentation for more information.
 
 There is one change that you will have to make to your webpack config. Typically, `module.exports` points to the configuration object. To use the `env` variable, you must convert `module.exports` to a function:
 


### PR DESCRIPTION
Hello, these days I upgrade my project into webpack 5 (currently 5.3.1), and I found a little change in environment variables.
According to the issue [#1216](https://github.com/webpack/webpack-cli/issues/1216) and [pull request](https://github.com/webpack/webpack-cli/pull/1939), `--env.foo=bar` should be changed to `--env foo=bar`, so I created this pull request.
