### PR TITLE
Corrected Jest code for Loader Writer's Guide.

### DIFF
--- a/src/content/contribute/writing-a-loader.md
+++ b/src/content/contribute/writing-a-loader.md
@@ -370,9 +370,9 @@ import compiler from './compiler.js';
 
 test('Inserts name and outputs JavaScript', async () => {
   const stats = await compiler('example.txt', { name: 'Alice' });
-  const output = stats.toJson().modules[0].source;
+  const output = stats.toJson({source: true}).modules[0].source;
 
-  expect(output).toBe('export default "Hey Alice!\"');
+  expect(output).toBe('export default "Hey Alice!\\n"');
 });
 ```
 


### PR DESCRIPTION
closes https://github.com/webpack/webpack.js.org/issues/4112

The [Jest testing example](https://webpack.js.org/contribute/writing-a-loader/#testing) of the Loader Writer's Guide needs the following for Webpack5.

* The `stats.toJson()` method now requires `{source: true}` as a parameter in order to populate the `source` property of the `module` object.
* If people create the `example.txt` with a line ending, then the expected output should also have a line ending.

I verified that with these changes the Jest test passes as coded in the document of my pull request.