### PR TITLE
doc(plugins):  Fix splitChunks.name

### DIFF
--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -213,15 +213,13 @@ The difference between `maxInitialSize` and `maxSize` is that `maxInitialSize` w
 
 Also available for each cacheGroup: `splitChunks.cacheGroups.{cacheGroup}.name`.
 
-The name of the split chunk. Providing `false` will keep the same name of the chunks so it doesn't change names unnecessarily.
+The name of the split chunk. Providing `false` will keep the same name of the chunks so it doesn't change names unnecessarily. It is the recommended value for production builds.
 
 Providing a string or a function allows you to use a custom name. Specifying either a string or a function that always returns the same string will merge all common modules and vendors into a single chunk. This might lead to bigger initial downloads and slow down page loads.
 
 If you choose to specify a function, you may find the `chunk.name` and `chunk.hash` properties (where `chunk` is an element of the `chunks` array) particularly useful in choosing a name for your chunk.
 
 If the `splitChunks.name` matches an [entry point](/configuration/entry-context/#entry) name, the entry point will be removed.
-
-T> It is recommended to set `splitChunks.name` to `false` for production builds so that it doesn't change names unnecessarily.
 
 __main.js__
 

--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -209,11 +209,11 @@ The difference between `maxInitialSize` and `maxSize` is that `maxInitialSize` w
 
 ### `splitChunks.name`
 
-`boolean = true` `function (module, chunks, cacheGroupKey) => string` `string`
+`boolean = false` `function (module, chunks, cacheGroupKey) => string` `string`
 
 Also available for each cacheGroup: `splitChunks.cacheGroups.{cacheGroup}.name`.
 
-The name of the split chunk. Providing `true` will automatically generate a name based on chunks and cache group key.
+The name of the split chunk. Providing `false` will keep the same name of the chunks so it doesn't change names unnecessarily.
 
 Providing a string or a function allows you to use a custom name. Specifying either a string or a function that always returns the same string will merge all common modules and vendors into a single chunk. This might lead to bigger initial downloads and slow down page loads.
 


### PR DESCRIPTION
What kind of change does this PR introduce?


[SplitChunksPlugin.optimization.splitChunks.name: true ](https://webpack.js.org/plugins/split-chunks-plugin/#splitchunksname) is not allowed for webpack-5 (see changelog here https://webpack.js.org/blog/2020-10-10-webpack-5-release/#changes-to-the-structure:~:text=Automatic%20names%20are%20no%20longer%20supported).

Does this PR introduce a breaking change?
No
