### PR TITLE
docs: clarify asset handling

### DIFF
--- a/src/content/guides/asset-modules.md
+++ b/src/content/guides/asset-modules.md
@@ -27,6 +27,9 @@ Asset Modules type replaces all of these loaders by adding 4 new module types:
 - `asset` automatically chooses between exporting a data URI and emitting a separate file. Previously achievable by using `url-loader` with asset size limit.
 
 When using the old assets loaders (i.e. `file-loader`/`url-loader`/`raw-loader`) along with Asset Module in webpack 5, you might want to stop Asset Module from processing your assets again as that would result in asset duplication. This can be done by setting asset's module type to `'javascript/auto'`.
+
+__webpack.config.js__
+
 ``` diff
 module.exports = {
   module: {
@@ -48,6 +51,9 @@ module.exports = {
 }
 ```
 To exclude assets that came from new URL calls from the asset loaders add `dependency: { not: ['url'] }` to the loader configuration.
+
+__webpack.config.js__
+
 ``` diff
 module.exports = {
   module: {

--- a/src/content/guides/asset-modules.md
+++ b/src/content/guides/asset-modules.md
@@ -26,7 +26,51 @@ Asset Modules type replaces all of these loaders by adding 4 new module types:
 - `asset/source` exports the source code of the asset. Previously achievable by using `raw-loader`.
 - `asset` automatically chooses between exporting a data URI and emitting a separate file. Previously achievable by using `url-loader` with asset size limit.
 
-W>When using the old assets loaders in webpack 5 you might want to exclude them from the assets module processing to prevent asset duplication. This can be done by overriding the asset configuration for that asset type by setting it's module type to "javascript/auto". To exclude assets that came from new URL calls from the asset loaders add dependency: { not: "url" } to the loader configuration.
+When using the old assets loaders (i.e. `file-loader`/`url-loader`/`raw-loader`) in webpack 5 you might want to exclude them from the assets module processing to prevent asset duplication. This can be done by overriding the asset configuration for that asset type by setting it's module type to 'javascript/auto'.
+``` diff
+module.exports = {
+  module: {
+   rules: [
+      {
+        test: /\.(png|jpg|gif)$/i,
+        use: [
+          {
+            loader: 'url-loader',
+            options: {
+              limit: 8192,
+            }
+          },
+        ],
+      },
++     {
++       test: /\.png/,
++       type: 'javascript/auto'
++     }
+   ]
+  },
+}
+```
+To exclude assets that came from new URL calls from the asset loaders add `dependency: { not: 'url' }` to the loader configuration.
+``` diff
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.(png|jpg|gif)$/i,
+        use: [
+          {
+            loader: 'url-loader',
+            options: {
+              limit: 8192,
+            },
++           dependency: { not: 'url' }
+          },
+        ],
+      },
+    ],
+  }
+}
+```
 
 ## Resource assets
 

--- a/src/content/guides/asset-modules.md
+++ b/src/content/guides/asset-modules.md
@@ -50,6 +50,7 @@ module.exports = {
   },
 }
 ```
+
 To exclude assets that came from new URL calls from the asset loaders add `dependency: { not: ['url'] }` to the loader configuration.
 
 __webpack.config.js__

--- a/src/content/guides/asset-modules.md
+++ b/src/content/guides/asset-modules.md
@@ -26,7 +26,7 @@ Asset Modules type replaces all of these loaders by adding 4 new module types:
 - `asset/source` exports the source code of the asset. Previously achievable by using `raw-loader`.
 - `asset` automatically chooses between exporting a data URI and emitting a separate file. Previously achievable by using `url-loader` with asset size limit.
 
-When using the old assets loaders (i.e. `file-loader`/`url-loader`/`raw-loader`) in webpack 5 you might want to exclude them from the assets module processing to prevent asset duplication. This can be done by overriding the asset configuration for that asset type by setting it's module type to 'javascript/auto'.
+When using the old assets loaders (i.e. `file-loader`/`url-loader`/`raw-loader`) along with Asset Module in webpack 5, you might want to stop Asset Module from processing your assets again as that would result in asset duplication. This can be done by setting asset's module type to `'javascript/auto'`.
 ``` diff
 module.exports = {
   module: {
@@ -41,29 +41,26 @@ module.exports = {
             }
           },
         ],
-      },
-+     {
-+       test: /\.png/,
 +       type: 'javascript/auto'
-+     }
+      },
    ]
   },
 }
 ```
-To exclude assets that came from new URL calls from the asset loaders add `dependency: { not: 'url' }` to the loader configuration.
+To exclude assets that came from new URL calls from the asset loaders add `dependency: { not: ['url'] }` to the loader configuration.
 ``` diff
 module.exports = {
   module: {
     rules: [
       {
         test: /\.(png|jpg|gif)$/i,
++       dependency: { not: ['url'] }, 
         use: [
           {
             loader: 'url-loader',
             options: {
               limit: 8192,
             },
-+           dependency: { not: 'url' }
           },
         ],
       },

--- a/src/content/guides/asset-modules.md
+++ b/src/content/guides/asset-modules.md
@@ -26,6 +26,8 @@ Asset Modules type replaces all of these loaders by adding 4 new module types:
 - `asset/source` exports the source code of the asset. Previously achievable by using `raw-loader`.
 - `asset` automatically chooses between exporting a data URI and emitting a separate file. Previously achievable by using `url-loader` with asset size limit.
 
+W>When using the old assets loaders in webpack 5 you might want to exclude them from the assets module processing to prevent asset duplication. This can be done by overriding the asset configuration for that asset type by setting it's module type to "javascript/auto". To exclude assets that came from new URL calls from the asset loaders add dependency: { not: "url" } to the loader configuration.
+
 ## Resource assets
 
 __webpack.config.js__


### PR DESCRIPTION
closes https://github.com/webpack/webpack.js.org/issues/4127

Added a paragraph for using asset modules and old asset loaders
