### PR TITLE
Fix regexs related to extensions /\\./ > /\./

### DIFF
--- a/src/content/concepts/loaders.mdx
+++ b/src/content/concepts/loaders.mdx
@@ -36,8 +36,8 @@ __webpack.config.js__
 module.exports = {
   module: {
     rules: [
-      { test: /\\.css$/, use: 'css-loader' },
-      { test: /\\.ts$/, use: 'ts-loader' }
+      { test: /\.css$/, use: 'css-loader' },
+      { test: /\.ts$/, use: 'ts-loader' }
     ]
   }
 };
@@ -65,7 +65,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\\.css$/,
+        test: /\.css$/,
         use: [
           // [style-loader](/loaders/style-loader)
           { loader: 'style-loader' },

--- a/src/content/configuration/index.mdx
+++ b/src/content/configuration/index.mdx
@@ -145,7 +145,7 @@ module.exports = {
         /* Expert output configuration (on own risk) */
       </default>
       devtoolLineToLine: {
-        test: /\\.jsx$/
+        test: /\.jsx$/
       },
       // use a simple 1:1 mapped SourceMaps for these modules (faster)
       hotUpdateMainFilename: "[hash].hot-update.json", // string
@@ -161,7 +161,7 @@ module.exports = {
     rules: [
       // rules for modules (configure loaders, parser options, etc.)
       {
-        test: /\\.jsx?$/,
+        test: /\.jsx?$/,
         include: [
           path.resolve(__dirname, "app")
         ],
@@ -188,7 +188,7 @@ module.exports = {
         // options for the loader
       },
       {
-        test: /\\.html$/,
+        test: /\.html$/,
         use: [
           // apply multiple loaders and options
           "htmllint-loader",

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -239,7 +239,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\\.css$/,
+        test: /\.css$/,
         oneOf: [
           {
             resourceQuery: /inline/, // foo.css?inline
@@ -459,7 +459,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\\.css$/,
+        test: /\.css$/,
         resourceQuery: /inline/,
         use: 'url-loader'
       }
@@ -531,7 +531,7 @@ module.exports = {
     rules: [
       //...
       {
-        test: /\\.json$/,
+        test: /\.json$/,
         type: 'javascript/auto',
         loader: 'custom-json-loader'
       }
@@ -720,7 +720,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\\.css$/,
+        test: /\.css$/,
         include: [
           path.resolve(__dirname, 'app/styles'),
           path.resolve(__dirname, 'vendor/styles')


### PR DESCRIPTION
I found incorrect regexs in the document about loader's concepts. I think /\\.css/ should be replaced with /\.css/.