### PR TITLE
Fix typo

### DIFF
--- a/src/content/concepts/entry-points.md
+++ b/src/content/concepts/entry-points.md
@@ -102,7 +102,7 @@ __webpack.prod.js__
 ```javascript
 module.exports = {
   output: {
-    filename: '[name].[contentHash].bundle.js'
+    filename: '[name].[contenthash].bundle.js'
   }
 };
 ```


### PR DESCRIPTION
The example usage is not working, substitutions has to be in lowercase
