### PR TITLE
apply travis only for master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,56 +10,10 @@ cache:
     - repositories
 
 stages:
-  - Lint
-  - Test
   - Build
 
 jobs:
   fast_finish: true
-
-  include:
-    - stage: Lint
-      name: Lint
-      env: CACHE_TYPE=lint
-      script:
-        - yarn lint:js || travis_terminate 1
-        - yarn lint:markdown || travis_terminate 1
-        - yarn lint:social || travis_terminate 1
-
-    - stage: Lint
-      name: Proselint
-      language: python
-      env: CACHE_TYPE=proselint
-      python: 3.6
-      cache:
-        yarn: false
-        npm: false
-        pip: true
-        directories:
-          - $HOME/.cache
-      install: pip install -r requirements.txt
-      script: cp .proselintrc ~/ && proselint src/content
-
-    - stage: Test
-      name: Cypress
-      env: CACHE_TYPE=lint
-      node_js: "10"
-      install:
-        - yarn
-        - yarn cypress install
-        - yarn cypress verify
-      script:
-        - yarn fetch:supporters
-        - yarn fetch:starter-kits
-        - yarn cypress:ci || travis_terminate 1
-
-    - stage: Build
-      name: Build
-      if: branch != master OR type NOT IN (push, cron)
-      env: CACHE_TYPE=build
-      script:
-        - yarn build || travis_terminate 1
-        - yarn lint:links || travis_terminate 1
 
     - stage: Build
       name: Build and Deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ stages:
 jobs:
   fast_finish: true
 
+  include:
     - stage: Build
       name: Build and Deploy
       if: branch = master AND type IN (push, cron)


### PR DESCRIPTION
I've enabled the github actions for Pull Requests here https://github.com/webpack/webpack.js.org/blob/master/.github/workflows/testing.yml, and we'll monitor it for a while before migrating those travis jobs running against pull requests to github actions.

As you can see in this PR that I'm currently keeping the job of master branch building to travis as it won't run frequently. Hopefully we can migrate it too in near future.