### PR TITLE
docs(api): clarify `webpackExports`' function

### DIFF
--- a/src/content/api/module-methods.md
+++ b/src/content/api/module-methods.md
@@ -12,6 +12,7 @@ contributors:
   - EugeneHlushko
   - chenxsan
   - jamesgeorge007
+  - WofWca
 related:
   - title: CommonJS Wikipedia
     url: https://en.wikipedia.org/wiki/CommonJS
@@ -163,7 +164,7 @@ T> Note that all options can be combined like so `/* webpackMode: "lazy-once", w
 
 T> Note that `webpackInclude` and `webpackExclude` options do not interfere with the prefix. eg: `./locale`.
 
-`webpackExports`: tells webpack to only bundle the used exports of a module when using dynamic imports. It can decrease the output size of a chunk. Available since [webpack 5.0.0-beta.18](https://github.com/webpack/webpack/releases/tag/v5.0.0-beta.18).
+`webpackExports`: tells webpack to only bundle the specified exports of a module. It can decrease the output size of a chunk. Available since [webpack 5.0.0-beta.18](https://github.com/webpack/webpack/releases/tag/v5.0.0-beta.18).
 
 
 ## CommonJS

--- a/src/content/api/module-methods.md
+++ b/src/content/api/module-methods.md
@@ -164,7 +164,7 @@ T> Note that all options can be combined like so `/* webpackMode: "lazy-once", w
 
 T> Note that `webpackInclude` and `webpackExclude` options do not interfere with the prefix. eg: `./locale`.
 
-`webpackExports`: tells webpack to only bundle the specified exports of a module. It can decrease the output size of a chunk. Available since [webpack 5.0.0-beta.18](https://github.com/webpack/webpack/releases/tag/v5.0.0-beta.18).
+`webpackExports`: tells webpack to only bundle the specified exports of a dynamically `import()`ed module. It can decrease the output size of a chunk. Available since [webpack 5.0.0-beta.18](https://github.com/webpack/webpack/releases/tag/v5.0.0-beta.18).
 
 
 ## CommonJS


### PR DESCRIPTION
1. "when using dynamic imports" – "dynamic" is assumed for `import()` isn't it?
2. You have to manually specify which imports are to be bundled, not just tell it not to bundle unused exports.
