### PR TITLE
Remove `webpack-dev-middleware` note from stats documentation

### DIFF
--- a/src/content/configuration/stats.md
+++ b/src/content/configuration/stats.md
@@ -16,6 +16,7 @@ contributors:
   - pixel-ray
   - snitin315
   - u01jmg3
+  - grrizzly
 ---
 
 `object` `string`
@@ -23,8 +24,6 @@ contributors:
 The `stats` option lets you precisely control what bundle information gets displayed. This can be a nice middle ground if you don't want to use `quiet` or `noInfo` because you want some bundle information, but not all of it.
 
 T> For webpack-dev-server, this property needs to be in the [`devServer` configuration object](/configuration/dev-server/#devserverstats-).
-
-T> For [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware), this property needs to be in the webpack-dev-middleware's `options` object.
 
 W> This option does not have any effect when using the Node.js API.
 


### PR DESCRIPTION
In previous versions of `webpack-dev-middleware`, the documentation was correct in expecting `stats` to be passed in the options.

Starting with 4.0.0, this is no longer true. Their [changelog](https://github.com/webpack/webpack-dev-middleware/releases/tag/v4.0.0-rc.0) indicates that the `stats` option is now honored from the main configuration. 

In fact, using their latest package will fail to compile in Typescript if you follow the official webpack docs. This PR opts to remove this advice in accordance with modern usage.