### PR TITLE
Fix processAssets stage example

### DIFF
--- a/src/content/api/compilation-hooks.md
+++ b/src/content/api/compilation-hooks.md
@@ -9,6 +9,7 @@ contributors:
   - wizardofhogwarts
   - EugeneHlushko
   - chenxsan
+  - liorgreenb
 ---
 
 The `Compilation` module is used by the `Compiler` to create new compilations
@@ -494,7 +495,7 @@ Here's an example:
 compilation.hooks.processAssets.tap(
   {
     name: 'MyPlugin',
-    stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
+    stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
   },
   (assets) => {
     // code here


### PR DESCRIPTION
The example uses:
`PROCESS_ASSETS_STAGE_ADDITIONS`

which doesn't exist, i suppose it was meant to use PROCESS_ASSETS_STAGE_ADDITIONAL

