### PR TITLE
docs: remove excess backslash escapes

### DIFF
--- a/src/content/api/node.mdx
+++ b/src/content/api/node.mdx
@@ -11,6 +11,7 @@ contributors:
   - toshihidetagami
   - chenxsan
   - jamesgeorge007
+  - textbook
 ---
 
 webpack provides a Node.js API which can be used directly in Node.js runtime.
@@ -278,7 +279,7 @@ webpack([
   { entry: './index1.js', output: { filename: 'bundle1.js' } },
   { entry: './index2.js', output: { filename: 'bundle2.js' } }
 ], (err, stats) => { // [Stats Object](#stats-object)
-  process.stdout.write(stats.toString() + '\\n');
+  process.stdout.write(stats.toString() + '\n');
 })
 ```
 

--- a/src/content/concepts/loaders.mdx
+++ b/src/content/concepts/loaders.mdx
@@ -16,6 +16,7 @@ contributors:
   - lukasgeiter
   - furkle
   - jamesgeorge007
+  - textbook
 ---
 
 Loaders are transformations that are applied to the source code of a module. They allow you to pre-process files as you `import` or “load” them. Thus, loaders are kind of like “tasks” in other build tools and provide a powerful way to handle front-end build steps. Loaders can transform files from a different language (like TypeScript) to JavaScript or load inline images as data URLs. Loaders even allow you to do things like `import` CSS files directly from your JavaScript modules!
@@ -36,8 +37,8 @@ __webpack.config.js__
 module.exports = {
   module: {
     rules: [
-      { test: /\\.css$/, use: 'css-loader' },
-      { test: /\\.ts$/, use: 'ts-loader' }
+      { test: /\.css$/, use: 'css-loader' },
+      { test: /\.ts$/, use: 'ts-loader' }
     ]
   }
 };
@@ -65,7 +66,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\\.css$/,
+        test: /\.css$/,
         use: [
           // [style-loader](/loaders/style-loader)
           { loader: 'style-loader' },

--- a/src/content/configuration/index.mdx
+++ b/src/content/configuration/index.mdx
@@ -17,6 +17,7 @@ contributors:
   - EugeneHlushko
   - bigdawggi
   - anshumanv
+  - textbook
 ---
 
 Out of the box, webpack won't require you to use a configuration file. However, it will assume the entry point of your project is `src/index.js` and will output the result in `dist/main.js` minified and optimized for production.
@@ -267,7 +268,7 @@ module.exports = {
       // filename template for HMR chunks
       hotUpdateGlobal: "hmrUpdateFunction", // string
       // the name of the global variable used to load hot update chunks
-      sourcePrefix: "\\t", // string
+      sourcePrefix: "\t", // string
       // prefix module sources in bundle for better readablitity
       // but breaks multi-line template strings
       hashFunction: "md4", // string (default)
@@ -286,7 +287,7 @@ module.exports = {
       // rules for modules (configure loaders, parser options, etc.)
       {
         // Conditions:
-        test: /\\.jsx?$/,
+        test: /\.jsx?$/,
         include: [
           path.resolve(__dirname, "app")
         ],
@@ -302,18 +303,18 @@ module.exports = {
         // - Try to avoid exclude and prefer include
         // Each condition can also receive an object with "and", "or" or "not" properties
         // which are an array of conditions.
-        issuer: /\\.css$/,
+        issuer: /\.css$/,
         issuer: path.resolve(__dirname, "app"),
-        issuer: { and: [ /\\.css$/, path.resolve(__dirname, "app") ] },
-        issuer: { or: [ /\\.css$/, path.resolve(__dirname, "app") ] },
-        issuer: { not: [ /\\.css$/ ] },
-        issuer: [ /\\.css$/, path.resolve(__dirname, "app") ], // like "or"
+        issuer: { and: [ /\.css$/, path.resolve(__dirname, "app") ] },
+        issuer: { or: [ /\.css$/, path.resolve(__dirname, "app") ] },
+        issuer: { not: [ /\.css$/ ] },
+        issuer: [ /\.css$/, path.resolve(__dirname, "app") ], // like "or"
         // conditions for the issuer (the origin of the import)
         <advancedConditions "#">
           <default>
             /* Advanced conditions (click to show) */
           </default>
-          resource: /\\.css$/,
+          resource: /\.css$/,
           // matches the resource of the module, behaves equal to "test" and "include"
           compiler: /html-webpack-plugin/,
           // matches the name of the child compilation
@@ -329,7 +330,7 @@ module.exports = {
           // matches information from the package.json
           mimetype: "text/javascript",
           // matches the mimetype in DataUris
-          realResource: /\\.css$/,
+          realResource: /\.css$/,
           // matches the resource but ignores when resource was been renamed
           resourceFragment: "#blah",
           // matches the fragment part of the resource request
@@ -402,15 +403,15 @@ module.exports = {
         /* Advanced module configuration (click to show) */
       </default>
       noParse: [
-        /special-library\\.js$/
+        /special-library\.js$/
       ],
       // do not parse this module
       unknownContextRequest: ".",
       unknownContextRecursive: true,
-      unknownContextRegExp: /^\\.\\/.*$/,
+      unknownContextRegExp: /^\.\/.*$/,
       unknownContextCritical: true,
       exprContextRequest: ".",
-      exprContextRegExp: /^\\.\\/.*$/,
+      exprContextRegExp: /^\.\/.*$/,
       exprContextRecursive: true,
       exprContextCritical: true,
       wrappedContextRegExp: /.*/,
@@ -482,7 +483,7 @@ module.exports = {
       mainFields: ["main"],
       // properties that are read from description file
       // when a folder is requested
-      restrictions: [ /\\.js$/, path.resolve(__dirname, "app") ],
+      restrictions: [ /\.js$/, path.resolve(__dirname, "app") ],
       // To successful resolve the result must match these criteria
       cache: true, // boolean
       // enable safe caching of resolving
@@ -597,7 +598,7 @@ module.exports = {
       externals: ["react", /^@angular/],
     </default>
     externals: "react", // string (exact match)
-    externals: /^[a-z\\-]+($|\\/)/, // Regex
+    externals: /^[a-z\-]+($|\/)/, // Regex
     externals: { // object
       angular: "this angular", // this["angular"]
       react: { // UMD
@@ -720,7 +721,7 @@ module.exports = {
       // number of asset lines to display
       cachedAssets: false,
       // show assets that are caching in output
-      excludeAssets: /\\.png$/,
+      excludeAssets: /\.png$/,
       // hide some assets
       groupAssetsByPath: true,
       // group assets by their path in the output directory
@@ -786,7 +787,7 @@ module.exports = {
       // show modules that were cached
       orphanModules: true,
       // show modules that are not referenced in optimized graph anymore
-      excludeModules: /\\.css$/,
+      excludeModules: /\.css$/,
       // hide some modules
       reasons: true,
       // show the reasons why modules are included
@@ -945,7 +946,7 @@ module.exports = {
         "my-name": {
           // define groups of modules with specific
           // caching behavior
-          test: /\\.sass$/,
+          test: /\.sass$/,
           type: "css/mini-extract",
 
           <cacheGroupAdvancedSelectors "#">


### PR DESCRIPTION
These had previously been introduced for *.mdx files (see #2917) but seem to no longer be needed. As a result, the rendered output includes redundant escapes that would break file matching, e.g.:

```js
module.exports = {
  module: {
    rules: [
      { test: /\\.css$/, use: 'css-loader' },
      { test: /\\.ts$/, use: 'ts-loader' }
    ]
  }
};
```

See e.g. [this Stack Overflow question](https://stackoverflow.com/q/64882726/3001761) for resulting confusion.