### PR TITLE
docs(watch): Update `watchOptions` types

### DIFF
--- a/src/content/configuration/watch.md
+++ b/src/content/configuration/watch.md
@@ -70,9 +70,9 @@ module.exports = {
 
 ## `watchOptions.ignored`
 
-`RegExp` [`anymatch`](https://github.com/micromatch/anymatch)
+`RegExp` `string` [`string`]
 
-For some systems, watching many file systems can result in a lot of CPU or memory usage. It is possible to exclude a huge folder like `node_modules`:
+For some systems, watching many files can result in a lot of CPU or memory usage. It is possible to exclude a huge folder like `node_modules` using a regular expression:
 
 __webpack.config.js__
 
@@ -85,7 +85,20 @@ module.exports = {
 };
 ```
 
-It is also possible to have and use multiple [anymatch](https://github.com/micromatch/anymatch) patterns:
+Alternatively, a glob pattern may be used:
+
+__webpack.config.js__
+
+```javascript
+module.exports = {
+  //...
+  watchOptions: {
+    ignored: 'node_modules/**'
+  }
+};
+```
+
+It is also possible to use multiple glob patterns:
 
 __webpack.config.js__
 

--- a/src/content/configuration/watch.md
+++ b/src/content/configuration/watch.md
@@ -70,7 +70,7 @@ module.exports = {
 
 ## `watchOptions.ignored`
 
-`RegExp` `string` [`string`]
+`RegExp` `string` `[string]`
 
 For some systems, watching many files can result in a lot of CPU or memory usage. It is possible to exclude a huge folder like `node_modules` using a regular expression:
 


### PR DESCRIPTION
The `ignored` property of `watchOptions` no longer accepts an array of `anymatch` patterns, and instead accepts an array of string glob patterns.

This PR updates the `watchOptions.ignored` types to reflect this change. Also adds an additional example.

Closes #11903
