### PR TITLE
docs(api): clean obsolete hook

### DIFF
--- a/src/content/api/parser.md
+++ b/src/content/api/parser.md
@@ -7,6 +7,7 @@ contributors:
   - DeTeam
   - misterdev
   - EugeneHlushko
+  - chenxsan
 ---
 
 The `parser` instance, found in the `compiler`, is used to parse each module
@@ -518,23 +519,6 @@ const a = this;
 
 parser.hooks.expression.for('this').tap('MyPlugin', expression => {});
 ```
-
-
-### expressionAnyMember
-
-`SyncBailHook`
-
-Executed when parsing a `MemberExpression`.
-
-- Hook Parameters: `identifier`
-- Callback Parameters: `expression`
-
-```js
-const a = process.env;
-
-parser.hooks.expressionAnyMember.for('process').tap('MyPlugin', expression => {});
-```
-
 
 ### expressionConditionalOperator
 


### PR DESCRIPTION
I believe `expressionAnyMember` hook was removed in this commit https://github.com/webpack/webpack/pull/9203/files#diff-313038f65941a3a6c139ebe61a484045ace246a429e31975f3606afdd95d977fL97