### PR TITLE
deploy to gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: deploy-with-github-actions
+          BRANCH: gh-pages
           FOLDER: dist
           CLEAN: true
 


### PR DESCRIPTION
I've merged a pr here https://github.com/webpack/webpack.js.org/pull/4206, and it deployed our built `dist` to target branch https://github.com/webpack/webpack.js.org/tree/deploy-with-github-actions successfully, which means deploying to `gh-pages` branch should work as well.

After this PR, we'll have two deployments running simultaneously, one from travis, another from github actions, I'm going to monitor both for a while before removing all those travis related code.