### PR TITLE
fix dev-server start script

### DIFF
--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -280,7 +280,7 @@ __package.json__
    "scripts": {
      "test": "echo \"Error: no test specified\" && exit 1",
      "watch": "webpack --watch",
-+    "start": "webpack serve --open",
++    "start": "webpack serve --open true",
      "build": "webpack"
    },
    "keywords": [],
@@ -403,7 +403,7 @@ __package.json__
    "scripts": {
      "test": "echo \"Error: no test specified\" && exit 1",
      "watch": "webpack --watch",
-     "start": "webpack serve --open",
+     "start": "webpack serve --open true",
 +    "server": "node server.js",
      "build": "webpack"
    },


### PR DESCRIPTION
error was

```
$ npm run start

> webpack serve --open

error: option '--open <value>' argument missing
 ERROR  Command failed with exit code 1.
```

command should be `webpack serve --open true`


https://webpack.js.org/configuration/dev-server/#devserveropen


alternative: move to config file

```js
module.exports = {
  //...
  devServer: {
    open: true
  }
};
```
