### PR TITLE
docs: expand on the 'one entry point tip' tip

### DIFF
--- a/src/content/concepts/entry-points.md
+++ b/src/content/concepts/entry-points.md
@@ -141,4 +141,4 @@ __What does this do?__ We are telling webpack that we would like 3 separate depe
 
 __Why?__ In a multi-page application, the server is going to fetch a new HTML document for you. The page reloads this new document and assets are redownloaded. However, this gives us the unique opportunity to do things like using [`optimization.splitChunks`](/configuration/optimization/#optimizationsplitchunks) to create bundles of shared application code between each page. Multi-page applications that reuse a lot of code/modules between entry points can greatly benefit from these techniques, as the number of entry points increases.
 
-T> As a rule of thumb: Use exactly one entry point for each HTML document.
+T> As a rule of thumb: Use exactly one entry point for each HTML document. See the issue [described here](https://bundlers.tooling.report/code-splitting/multi-entry/) for more details.

--- a/src/content/concepts/entry-points.md
+++ b/src/content/concepts/entry-points.md
@@ -141,4 +141,4 @@ __What does this do?__ We are telling webpack that we would like 3 separate depe
 
 __Why?__ In a multi-page application, the server is going to fetch a new HTML document for you. The page reloads this new document and assets are redownloaded. However, this gives us the unique opportunity to do things like using [`optimization.splitChunks`](/configuration/optimization/#optimizationsplitchunks) to create bundles of shared application code between each page. Multi-page applications that reuse a lot of code/modules between entry points can greatly benefit from these techniques, as the number of entry points increases.
 
-T> As a rule of thumb: Use exactly one entry point for each HTML document. See the issue [described here](https://bundlers.tooling.report/code-splitting/multi-entry/) for more details.
+T> As a rule of thumb: Use exactly one entry point for each HTML document. See the issue [described here](https://bundlers.tooling.report/code-splitting/multi-entry/#webpack) for more details.


### PR DESCRIPTION
Hi there! I was stuck on an issue related to having multi entries in the same HTML document, until I stumbled on this line in the docs and wonder why. A google search yield a link to [tooling.report](https://bundlers.tooling.report/code-splitting/multi-entry/#webpack), which finally helped me resolve my issue.

It'd be nice to have this link directly in the tip, or alternatively add a few words explain why; or link to another section of the docs. I found [this section in the code-splitting guide](https://webpack.js.org/guides/code-splitting/#prevent-duplication) relevant, but it did not address the issue as directly as tooling.report.