### PR TITLE
update node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/webpack/webpack.js.org/issues"
   },
   "engines": {
-    "node": ">=8.9.4"
+    "node": ">=10.13.0"
   },
   "scripts": {
     "clean-dist": "rimraf ./dist",


### PR DESCRIPTION
The minimum supported Node.js version for [webpack 5 is 10.13.0(LTS)](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#minimum-nodejs-version).