### PR TITLE
upgrade minimist

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "markdownlint-cli": "^0.25.0",
     "markdownlint-rule-emphasis-style": "^1.0.0",
     "mini-css-extract-plugin": "^1.3.2",
-    "minimist": "1.2.3",
     "mkdirp": "^1.0.4",
     "modularscale-sass": "^3.0.3",
     "node-fetch": "^2.6.1",
@@ -172,6 +171,7 @@
     "webpack.vote": "https://github.com/webpack/voting-app.git"
   },
   "resolutions": {
-    "remark-responsive-tables": "git://github.com/chenxsan/remark-responsive-tables.git#bugfix/fix-empty-head"
+    "remark-responsive-tables": "git://github.com/chenxsan/remark-responsive-tables.git#bugfix/fix-empty-head",
+    "sitemap-static/minimist": "1.2.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9190,17 +9190,7 @@ minimalistic-assert@^1.0.0:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
-
-minimist@1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.3.tgz#3db5c0765545ab8637be71f333a104a965a9ca3f"
-  integrity sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==
-
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@~1.2.5:
+minimist@1.2.0, minimist@1.2.5, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@~1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==


### PR DESCRIPTION
`sitemap-static` depends on a lower version `minimist` which has vulnerabilities, fixed with yarn's `resolutions`.