### PR TITLE
Bugfix/fix postcss

### DIFF
--- a/.postcssrc.js
+++ b/.postcssrc.js
@@ -1,5 +1,0 @@
-module.exports = {
-  plugins: [
-    require('autoprefixer')
-  ]
-}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: [require('autoprefixer')],
+};

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -97,7 +97,8 @@ module.exports = () => ({
         test: /\.css$/,
         use: [
           MiniCssExtractPlugin.loader,
-          'css-loader'
+          'css-loader',
+          'postcss-loader'
         ]
       },
       {
@@ -105,16 +106,7 @@ module.exports = () => ({
         use: [
           MiniCssExtractPlugin.loader,
           'css-loader',
-          {
-            loader: 'postcss-loader',
-            options: {
-              postcssOptions: {
-                plugins: () => [
-                  require('autoprefixer')
-                ],
-              }
-            }
-          },
+          'postcss-loader',
           {
             loader: 'sass-loader',
             options: {


### PR DESCRIPTION
1. `postcss.config.js` is recommended over `.postcssrc.js`
2. we should apply `autoprefixer` to `.css` too, not just `.scss`.
3. `postcss-loader` could read its configuration from `postcss.config.js`, hence no need to specify inline configurations again.