### PR TITLE
chore: use bash instead of sh

### DIFF
--- a/src/content/api/cli.md
+++ b/src/content/api/cli.md
@@ -110,13 +110,13 @@ See [configuration](/configuration) for the options in the configuration file.
 
 ### Without configuration file
 
-```sh
+```bash
 webpack <entry> [<entry>] -o <output-path>
 ```
 
 __example__
 
-```sh
+```bash
 webpack --entry ./first.js --entry ./second.js --output-path /build
 ```
 
@@ -284,7 +284,7 @@ T> See the [environment variables](/guides/environment-variables/) guide for mor
 
 You can also use `webpack-bundle-analyzer` to analyze your output bundles emitted by webpack. You can use `--analyze` flag to invoke it via CLI.
 
-```sh
+```bash
 webpack --analyze
 ```
 


### PR DESCRIPTION
As per https://github.com/webpack/webpack.js.org/pull/4132#discussion_r519162726

seems `cli.md` is the only file using `sh` - https://github.com/webpack/webpack.js.org/search?q=%60%60%60sh