### PR TITLE
docs(api): correct type of --name flag

### DIFF
--- a/src/content/api/cli.md
+++ b/src/content/api/cli.md
@@ -58,7 +58,7 @@ Note: These are the flags with webpack v4, starting v5 CLI also supports [core f
 | `--entry`           | string[]        | The entry point(s) of your application e.g. `./src/main.js`                                                    |
 | `--config, -c`      | string[]        | Provide path to a webpack configuration file e.g. `./webpack.config.js`                                        |
 | `--config-name`     | string[]        | Name of the configuration to use                                                                               |
-| `--name`            | string[]        | Name of the configuration. Used when loading multiple configurations                                           |
+| `--name`            | string          | Name of the configuration. Used when loading multiple configurations                                           |
 | `--color`           | boolean         | Enable colors on console                                                                                       |
 | `--merge, -m`       | boolean         | Merge two or more configurations using webpack-merge e.g. `-c ./webpack.config.js -c ./webpack.test.config.js` |
 | `--env`             | string[]        | Environment passed to the configuration when it is a function                                                  |


### PR DESCRIPTION
`--name` can accept only string value.

https://github.com/webpack/webpack-cli/blob/53ed92616bd6050dccbc07a4a77010faceacc508/packages/webpack-cli/lib/utils/cli-flags.js#L235

https://webpack.js.org/configuration/other-options/#name