### PR TITLE
fix custom blockquote

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "redirect-webpack-plugin": "^1.0.0",
     "remark": "^13.0.0",
     "remark-autolink-headings": "^6.0.1",
-    "remark-custom-blockquotes": "1.0.1",
+    "remark-custom-blockquotes": "1.0.0",
     "remark-extract-anchors": "1.1.1",
     "remark-frontmatter": "^3.0.0",
     "remark-gfm": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11264,10 +11264,10 @@ remark-autolink-headings@^6.0.1:
     extend "^3.0.0"
     unist-util-visit "^2.0.0"
 
-remark-custom-blockquotes@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/remark-custom-blockquotes/-/remark-custom-blockquotes-1.0.1.tgz#4b1e2ee844d75a6b76d64710c96b575821886ca3"
-  integrity sha512-Fqnl7vN1d5Gvxx5lc/C/XoPaLVJ2A0Jw+gGkJqO/pQ8qBp4DLuuLb3iUb+7wiOFpRTopAqGRe4fW7qx8omrJ+w==
+remark-custom-blockquotes@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/remark-custom-blockquotes/-/remark-custom-blockquotes-1.0.0.tgz#82ed4cebf45255a0d07ba81696f909c23b1d749d"
+  integrity sha512-R6/tiD4RE7rIaPAmZcVdbddH35DJraxNiVWo8nwF4QIhjwthClAkrzDzKcRHzf2sHL3OlG5jOBtwvZX7Dwww/w==
   dependencies:
     unist-util-visit "1.3.1"
 


### PR DESCRIPTION
Seems like 1.0.1 has bug causing issues like below:

![image](https://user-images.githubusercontent.com/1091472/101476239-69e6c900-3988-11eb-8eac-e08f89800fb9.png)

By the way, we should consider eliminating those exotic packages as the code are not in control of this repository.