### PR TITLE
docs: fix link

### DIFF
--- a/repositories/README.md
+++ b/repositories/README.md
@@ -1,3 +1,3 @@
 # webpack documentation repositories
 
-The files in this directory are auto generated from `src/utils/fetch-package-repos.js` and should not be edited by hand. Any manual changes will be overwritten by the automation next time it runs.
+The files in this directory are auto generated from `src/utilities/fetch-package-repos.js` and should not be edited by hand. Any manual changes will be overwritten by the automation next time it runs.


### PR DESCRIPTION
Fixes #4298
The link mentioned in repositories/README.md is wrong, `utils` is used instead of `utilities`, but `utils` do not exist in the repo
