### PR TITLE
Docs(blog) : compilation.cache is deprecated now

### DIFF
--- a/src/content/blog/2020-10-10-webpack-5-release.md
+++ b/src/content/blog/2020-10-10-webpack-5-release.md
@@ -1251,6 +1251,7 @@ These dependencies are cheaper to process and webpack uses them when possible
 - `ChunkGraph` added
 - `ChunkGroup.setParents` removed
 - `ChunkGroup.containsModule` removed
+- `compilation.cache` is deprecated now
 - `ChunkGroup.remove` no longer disconnected the group from block
 - `ChunkGroup.compareTo` signature changed
 - `ChunkGroup.getChildrenByOrders` signature changed

--- a/src/content/blog/2020-10-10-webpack-5-release.md
+++ b/src/content/blog/2020-10-10-webpack-5-release.md
@@ -1251,7 +1251,7 @@ These dependencies are cheaper to process and webpack uses them when possible
 - `ChunkGraph` added
 - `ChunkGroup.setParents` removed
 - `ChunkGroup.containsModule` removed
-- `compilation.cache` is deprecated now
+- `Compilation.cache` was removed in favor of `Compilation.getCache()`
 - `ChunkGroup.remove` no longer disconnected the group from block
 - `ChunkGroup.compareTo` signature changed
 - `ChunkGroup.getChildrenByOrders` signature changed


### PR DESCRIPTION
Docs(blog) : compilation.cache is deprecated now

Related issue https://github.com/webpack/webpack.js.org/issues/3843