### PR TITLE
Suggest removing watch arg from config

### DIFF
--- a/src/content/migrate/5.md
+++ b/src/content/migrate/5.md
@@ -108,6 +108,7 @@ Yarn: `yarn add webpack@next -D`
 - If you are using Yarn's PnP and the `pnp-webpack-plugin`, we have good news: it is supported by default now. You have to remove it from the configuration.
 - If you are using `IgnorePlugin` with a regular expression as argument, it takes an `options` object now: `new IgnorePlugin({ resourceRegExp: /regExp/ })`.
 - If you are using `node.something: 'empty'` replace it with `resolve.fallback.something: false`.
+- If you are using `watch: true`, remove it. Watching is handled by the CLI or calling `compiler.watch` in node.
 
 If you were using WebAssembly via import, you should follow this two step process:
 

--- a/src/content/migrate/5.md
+++ b/src/content/migrate/5.md
@@ -108,7 +108,7 @@ Yarn: `yarn add webpack@next -D`
 - If you are using Yarn's PnP and the `pnp-webpack-plugin`, we have good news: it is supported by default now. You have to remove it from the configuration.
 - If you are using `IgnorePlugin` with a regular expression as argument, it takes an `options` object now: `new IgnorePlugin({ resourceRegExp: /regExp/ })`.
 - If you are using `node.something: 'empty'` replace it with `resolve.fallback.something: false`.
-- If you are using `watch: true`, remove it. Watching is handled by the CLI or calling `compiler.watch` in node.
+- If you are using `watch: true` in webpack Node.js API, remove it. There's no need to set it as it's indicated by the compiler method you call, either `true` for `watch()` or `false` for `run()`.
 
 If you were using WebAssembly via import, you should follow this two step process:
 


### PR DESCRIPTION
The watch argument is deprecated & the runtime error doesn't directly tell you to remove it. 
See https://github.com/webpack/webpack/issues/12218 for context.
