### PR TITLE
docs(guides): explain why index.html is in dist/

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -143,6 +143,9 @@ __project__
     |- index.js
 ```
 
+T> The observant among you may have noticed that `index.html` is created manually, even though it is now placed in the `dist` directory. Later on in this guide, we will generate `index.html` rather than edit it manually. Once this is done, it should be safe to empty the `dist` directory and to regenerate all the files within it.
+
+
 To bundle the `lodash` dependency with `index.js`, we'll need to install the library locally:
 
 ``` bash


### PR DESCRIPTION
In the getting started guide, I was confused why a file that was written manually would be included in the `dist/` directory. This pull request explains that eventually `dist/index.html` will be generated manually.