### PR TITLE
Migration guide should link to Asset Modules guide

### DIFF
--- a/src/content/migrate/5.md
+++ b/src/content/migrate/5.md
@@ -33,7 +33,7 @@ If you are using webpack version less than 4 please see the [webpack 4 migration
 
 Some Plugins and Loaders might have a beta version that has to be used in order to be compatible with webpack 5.
 
-W> Check related Plugins and Loaders migration guide when upgrading across major versions.  Several commonly-used loaders like `raw-loader`, `url-loader`, and `file-loader` should be replaced using the new built-in [Asset Modules](/guides/asset-modules/) feature.
+W> Check related Plugins and Loaders migration guide when upgrading across major versions. Several commonly-used loaders like `raw-loader`, `url-loader`, and `file-loader` should be replaced using the new built-in [Asset Modules](/guides/asset-modules/) feature.
 
 W>  ExtendedAPIPlugin is removed and the logic is merged into [`APIPlugin`](https://github.com/webpack/webpack/blob/master/lib/APIPlugin.js).
 

--- a/src/content/migrate/5.md
+++ b/src/content/migrate/5.md
@@ -33,7 +33,7 @@ If you are using webpack version less than 4 please see the [webpack 4 migration
 
 Some Plugins and Loaders might have a beta version that has to be used in order to be compatible with webpack 5.
 
-W> Check related Plugins and Loaders migration guide when upgrading across major versions.
+W> Check related Plugins and Loaders migration guide when upgrading across major versions.  Several commonly-used loaders like `raw-loader`, `url-loader`, and `file-loader` should be replaced using the new built-in [Asset Modules](/guides/asset-modules/) feature.
 
 W>  ExtendedAPIPlugin is removed and the logic is merged into [`APIPlugin`](https://github.com/webpack/webpack/blob/master/lib/APIPlugin.js).
 
@@ -109,6 +109,7 @@ Yarn: `yarn add webpack@next -D`
 - If you are using `IgnorePlugin` with a regular expression as argument, it takes an `options` object now: `new IgnorePlugin({ resourceRegExp: /regExp/ })`.
 - If you are using `node.something: 'empty'` replace it with `resolve.fallback.something: false`.
 - If you are using `watch: true` in webpack Node.js API, remove it. There's no need to set it as it's indicated by the compiler method you call, either `true` for `watch()` or `false` for `run()`.
+- If you have `rules` defined for loading assets using `raw-loader`, `url-loader`, or `file-loader`, these should be configured as [Asset Modules](/guides/asset-modules/) instead.
 
 If you were using WebAssembly via import, you should follow this two step process:
 


### PR DESCRIPTION
Link to new Asset Modules guide in appropriate places.  Per the guide,

> When using the old assets loaders (i.e. file-loader/url-loader/raw-loader) along with Asset Module in webpack 5, you might want to stop Asset Module from processing your assets again as that would result in asset duplication

This means that certain configurations can break under 4->5 migration if they aren't aware of the new Asset Module behavior.