### PR TITLE
Remove --open flag

### DIFF
--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -280,7 +280,7 @@ __package.json__
    "scripts": {
      "test": "echo \"Error: no test specified\" && exit 1",
      "watch": "webpack --watch",
-+    "start": "webpack serve --open",
++    "start": "webpack serve",
      "build": "webpack"
    },
    "keywords": [],


### PR DESCRIPTION
The `--open` flag throws (in my case at least) with this message:
```
error: option '--open <value>' argument missing
error Command failed with exit code 1.
```
Eliminating the flag had the dev server running successfully.
