### PR TITLE
Update module.mdx

### DIFF
--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -380,8 +380,10 @@ module.exports = {
       {
         //...
         generator: {
-          encoding: 'base64',
-          mimetype: 'mimetype/png'
+          dataUrl: {
+            encoding: 'base64',
+            mimetype: 'mimetype/png'
+          }
         }
       }
     ]


### PR DESCRIPTION
The text in the `rules.generator.dataUrl` section is correct, but the example given is not.  There is no `generator.mimetype` option, it's supposed to be `generator.dataUrl.mimetype`.

See types here https://github.com/webpack/webpack/blob/master/declarations/plugins/AssetModulesPluginGenerator.d.ts#L19