### PR TITLE
Update lazy-loading.md

### DIFF
--- a/src/content/guides/lazy-loading.md
+++ b/src/content/guides/lazy-loading.md
@@ -39,6 +39,31 @@ webpack-demo
 |- /node_modules
 ```
 
+__webpack.config.js__
+
+``` diff
+  const path = require("path");
++ const { CleanWebpackPlugin } = require("clean-webpack-plugin");
++ const HtmlWebpackPlugin = require("html-webpack-plugin");
+
+  module.exports = {
+  mode: "development",
+    entry: {
+      index: "./src/index.js",
+    },
++   plugins: [
++     new CleanWebpackPlugin(),
++     new HtmlWebpackPlugin({
++       title: "Production",
++     }),
++   ],
+    output: {
+        filename: "[name].bundle.js",
+        path: path.resolve(__dirname, "dist"),
+    },
+};
+```
+
 __src/print.js__
 
 ``` js


### PR DESCRIPTION
I had to add the CleanWebpackPlugin and the HtmlWebpackPlugin in the webpack.config.js file in order to get the same results that were shown in the example after the npm run build command was ran.  These two plugins were not present in the Code Splitting subsection of the Guides section.

_describe your changes..._

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
