### PR TITLE
replace Geomanist with Source Serif Pro

### DIFF
--- a/src/components/Markdown/Markdown.scss
+++ b/src/components/Markdown/Markdown.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @import 'vars';
 @import 'functions';
 @import 'prism-theme';
@@ -65,7 +66,7 @@ $topHeightMobileWithBanner: $bannerHeight + $topHeightMobile;
     font-weight: 600;
     line-height: 1.4;
     margin: 0 0 0.25em;
-    color: getColor(fiord);
+    color: color.adjust(getColor(fiord), $lightness: -10);
     word-break: break-word;
 
     tt,

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -1,7 +1,0 @@
-@font-face {
-  font-family: 'Geomanist';
-  src: url('../assets/geomanist-medium.woff2') format('woff2'), url('../assets/geomanist-medium.woff') format('woff');
-  font-weight: 600;
-  font-style: normal;
-  font-display: swap;
-}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,7 +1,6 @@
-@import url('https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600&family=Source+Sans+Pro:ital,wght@0,400;0,600;1,400&family=Source+Serif+Pro:wght@600&display=swap');
 
 @import 'vars';
-@import 'fonts';
 @import 'functions';
 @import 'mixins';
 

--- a/src/styles/partials/_vars.scss
+++ b/src/styles/partials/_vars.scss
@@ -19,7 +19,7 @@ $screens: (
 );
 
 $font-stack-body: 'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
-$font-stack-heading: Geomanist, sans-serif;
+$font-stack-heading: 'Source Serif Pro', ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
 $font-stack-code: 'Source Code Pro', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
 $text-color-highlight: lighten(map-get($colors, denim), 5%);


### PR DESCRIPTION
Currently we have `Geomanist` for headings, `Source Sans Pro` for body texts, and `Source Code Pro` for code, all of the three fonts are sans-serif, which makes the page boring, and there's not enough contrast between body texts and headings.