### PR TITLE
fix service worker not refreshing all pages

### DIFF
--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -103,6 +103,12 @@ function Site(props) {
   };
 
   useEffect(() => {
+    navigator.serviceWorker.addEventListener('controllerchange', () => {
+      window.location.reload();
+    });
+  }, []);
+
+  useEffect(() => {
     if (isClient) {
       if (process.env.NODE_ENV === 'production') {
         // only register sw.js in production
@@ -120,12 +126,6 @@ function Site(props) {
                 "A new service worker has installed, but it can't activate until all tabs running the current version have been unloaded"
               );
               setList([true]);
-            });
-
-            // listen to `controlling`
-            // https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-window.Workbox#event:controlling
-            wb.addEventListener('controlling', () => {
-              window.location.reload();
             });
 
             // register the service worker


### PR DESCRIPTION
When I open two or more pages, clicking `UPDATE` button will only refresh the current page, while I expect all pages to be refreshed. This pull request should hopefully fix it.