### PR TITLE
fix: Gracefully handle browsers that do not support service workers.

### DIFF
--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -103,9 +103,11 @@ function Site(props) {
   };
 
   useEffect(() => {
-    navigator.serviceWorker.addEventListener('controllerchange', () => {
-      window.location.reload();
-    });
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.addEventListener('controllerchange', () => {
+        window.location.reload();
+      });
+    }
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
Fixes #4364.

Firefox's private browsing mode does not set the serviceWorker property on the Navigator object. Attempting to use that property without checking for its existence first will cause the entire site to fail to load.

I tested this by running the development server locally and checking that it loads in Firefox's private browsing mode after I added this guard.