### PR TITLE
docs(api): update --version info

### DIFF
--- a/src/content/api/cli.md
+++ b/src/content/api/cli.md
@@ -213,6 +213,7 @@ This will output the following result:
 webpack 5.11.1
 webpack-cli 4.3.1
 ```
+
 If installed it will output the version of `webpack-dev-server` as well:
 
 ```bash

--- a/src/content/api/cli.md
+++ b/src/content/api/cli.md
@@ -214,7 +214,7 @@ webpack 5.11.1
 webpack-cli 4.3.1
 ```
 
-If installed it will output the version of `webpack-dev-server` as well:
+It will output the version of `webpack-dev-server` as well if you have it installed:
 
 ```bash
 webpack 5.11.1

--- a/src/content/api/cli.md
+++ b/src/content/api/cli.md
@@ -210,8 +210,15 @@ npx webpack --version
 This will output the following result:
 
 ```bash
-webpack-cli 4.2.0
-webpack 5.4.0
+webpack 5.11.1
+webpack-cli 4.3.1
+```
+If installed it will output the version of `webpack-dev-server` as well:
+
+```bash
+webpack 5.11.1
+webpack-cli 4.3.1
+webpack-dev-server 3.11.1
 ```
 
 To inspect the version of any `webpack-cli` sub-package (like `@webpack-cli/init`) just run command similar to the following:


### PR DESCRIPTION
now `--version` will show the version of `webpack-dev-server` as well.