### PR TITLE
chore: use yarn to run scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,29 +28,29 @@
     "clean-printable": "rimraf src/content/**/printable.md",
     "preclean": "run-s clean-dist clean-printable",
     "clean": "rimraf src/content/**/_*.md src/**/_*.json repositories/*.json",
-    "start": "npm run clean-dist && cross-env NODE_ENV=development webpack serve --config webpack.dev.js --env dev --progress",
+    "start": "yarn clean-dist && cross-env NODE_ENV=development webpack serve --config webpack.dev.js --env dev --progress",
     "content": "node src/scripts/build-content-tree.js ./src/content ./src/_content.json",
     "bundle-analyze": "run-s clean fetch printable content && cross-env NODE_ENV=production webpack --config webpack.ssg.js && run-s clean-printable content && cross-env NODE_ENV=production webpack --config webpack.prod.js  --profile --json > stats.json && webpack-bundle-analyzer stats.json",
     "fetch-repos": "node src/utilities/fetch-package-repos.js",
     "fetch": "run-p fetch:*",
     "fetch:readmes": "node src/utilities/fetch-package-readmes.js",
     "fetch:supporters": "node src/utilities/fetch-supporters.js",
-    "prebuild": "npm run clean",
+    "prebuild": "yarn clean",
     "build": "run-s fetch-repos fetch printable content && cross-env NODE_ENV=production webpack --config webpack.ssg.js && run-s clean-printable content && cross-env NODE_ENV=production webpack --config webpack.prod.js",
-    "postbuild": "npm run sitemap",
-    "build-test": "npm run build && http-server --port 4200 dist/",
-    "test": "npm run lint",
+    "postbuild": "yarn sitemap",
+    "build-test": "yarn build && http-server --port 4200 dist/",
+    "test": "yarn lint",
     "lint": "run-s lint:*",
-    "lint:js": "npm run lint-js .",
+    "lint:js": "yarn lint-js .",
     "lint-js": "eslint --cache --cache-location .cache/.eslintcache",
-    "lint:markdown": "npm run lint-markdown *.md ./src/content/**/*.md",
+    "lint:markdown": "yarn lint-markdown *.md ./src/content/**/*.md",
     "lint-markdown": "markdownlint --rules markdownlint-rule-emphasis-style --config ./.markdownlint.json --ignore './src/content/**/_*.md'",
     "lint:social": "alex . -q",
     "lint:prose": "vale --config='.vale.ini' src/content",
     "lint:links": "hyperlink -c 8 --root dist -r dist/index.html --canonicalroot https://webpack.js.org/ --internal --skip /plugins/extract-text-webpack-plugin/ --skip /printable --skip https:// --skip http:// --skip sw.js > internal-links.tap; cat internal-links.tap | tap-spot",
     "sitemap": "cd dist && sitemap-static --ignore-file=../sitemap-ignore.json --pretty --prefix=https://webpack.js.org/ > sitemap.xml",
-    "serve": "npm run build && sirv start ./dist --port 4000",
-    "preprintable": "npm run clean-printable",
+    "serve": "yarn build && sirv start ./dist --port 4000",
+    "preprintable": "yarn clean-printable",
     "printable": "node ./src/scripts/concatenate-docs.js",
     "jest": "jest",
     "cypress:open": "cypress open",
@@ -64,10 +64,10 @@
   },
   "lint-staged": {
     "*.{js,jsx,md}": [
-      "npm run lint-js"
+      "yarn lint-js"
     ],
     "*.md": [
-      "npm run lint-markdown"
+      "yarn lint-markdown"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
use `yarn` instead of `npm` to run scripts as the repository uses `yarn` and contributing docs says usage of `yarn` as well.