### PR TITLE
replace :emoji: with utf-8 emoji

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "remark": "^13.0.0",
     "remark-autolink-headings": "^6.0.1",
     "remark-custom-blockquotes": "1.0.0",
+    "remark-emoji": "^2.1.0",
     "remark-extract-anchors": "1.1.1",
     "remark-frontmatter": "^3.0.0",
     "remark-gfm": "^1.0.0",

--- a/src/utilities/content-tree-enhancers.js
+++ b/src/utilities/content-tree-enhancers.js
@@ -46,6 +46,7 @@ const enhance = (tree, options) => {
       .use(slug)
       .use(frontmatter)
       .use(gfm)
+      .use(require('remark-emoji'))
       .use(extractAnchors, { anchors, levels: 3 })
       .use(remarkHtml)
       .process(content, err => {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -7,6 +7,7 @@ const mdPlugins = [
   require('remark-gfm'),
   require('remark-slug'),
   remarkResponsiveTable,
+  require('remark-emoji'),
   [
     require('remark-custom-blockquotes'),
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5105,6 +5105,11 @@ emojis-list@^3.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
+emoticon@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/emoticon/-/emoticon-3.2.0.tgz#c008ca7d7620fac742fe1bf4af8ff8fed154ae7f"
+  integrity sha512-SNujglcLTTg+lDAcApPNgEdudaqQFiAbJCqzjNxJkvN9vAwCGi0uu8IUVvx+f16h+V44KCY6Y2yboroc9pilHg==
+
 encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
@@ -8572,6 +8577,11 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
+lodash.toarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
+  integrity sha1-JMS/zWsvuji/0FlNsRedjptlZWE=
+
 lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
@@ -9383,6 +9393,13 @@ no-case@^3.0.4:
   dependencies:
     lower-case "^2.0.2"
     tslib "^2.0.3"
+
+node-emoji@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.10.0.tgz#8886abd25d9c7bb61802a658523d1f8d2a89b2da"
+  integrity sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==
+  dependencies:
+    lodash.toarray "^4.4.0"
 
 node-fetch@^2.6.1:
   version "2.6.1"
@@ -11207,6 +11224,15 @@ remark-custom-blockquotes@1.0.0:
   integrity sha512-R6/tiD4RE7rIaPAmZcVdbddH35DJraxNiVWo8nwF4QIhjwthClAkrzDzKcRHzf2sHL3OlG5jOBtwvZX7Dwww/w==
   dependencies:
     unist-util-visit "1.3.1"
+
+remark-emoji@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/remark-emoji/-/remark-emoji-2.1.0.tgz#69165d1181b98a54ad5d9ef811003d53d7ebc7db"
+  integrity sha512-lDddGsxXURV01WS9WAiS9rO/cedO1pvr9tahtLhr6qCGFhHG4yZSJW3Ha4Nw9Uk1hLNmUBtPC0+m45Ms+xEitg==
+  dependencies:
+    emoticon "^3.2.0"
+    node-emoji "^1.10.0"
+    unist-util-visit "^2.0.2"
 
 remark-extract-anchors@1.1.1:
   version "1.1.1"
@@ -13498,7 +13524,7 @@ unist-util-visit@1.3.1:
   dependencies:
     unist-util-is "^2.1.1"
 
-unist-util-visit@2.0.3, unist-util-visit@^2.0.0, unist-util-visit@^2.0.3:
+unist-util-visit@2.0.3, unist-util-visit@^2.0.0, unist-util-visit@^2.0.2, unist-util-visit@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-2.0.3.tgz#c3703893146df47203bb8a9795af47d7b971208c"
   integrity sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==


### PR DESCRIPTION
It seems to me that github readme [supports those `:emoji:` syntax](https://github.com/webpack-contrib/eslint-webpack-plugin/blob/master/README.md):

![image](https://user-images.githubusercontent.com/1091472/103540482-b9aba800-4ed4-11eb-93bc-b4e6218972cb.png)

While webpack.js.org doesn't:

![image](https://user-images.githubusercontent.com/1091472/103540544-d47e1c80-4ed4-11eb-9ae6-1f4f4f737681.png)

This pull request should show those emojis. As it's run in the build stage, `remark-emoji` won't be included in the client side.

## Preview

https://webpack-js-org-git-fork-chenxsan-feature-enable-emoji-support.webpack-docs.vercel.app/plugins/eslint-webpack-plugin/