### PR TITLE
docs(migrate): improve webpack 5 migration guide

### DIFF
--- a/src/content/migrate/5.md
+++ b/src/content/migrate/5.md
@@ -16,68 +16,55 @@ This guide aims to help you migrating to webpack 5 when using webpack directly. 
 
 ## Preparations
 
-webpack 5 requires at least Node.js 10.13.0 (LTS).
+Webpack 5 requires at least Node.js 10.13.0 (LTS), so make sure you upgrade your Node.js if you're still running an older one.
 
-T> Using newer Node.js version can improve build performance.
+## Upgrade webpack 4 and its plugins/loaders
 
-### Upgrade webpack and its dependencies
+1. Upgrade `webpack` 4 to the latest available version.
 
-#### Upgrade webpack 4 to the latest available version
+    - When using webpack >= 4, upgrading to the latest webpack 4 version should not require additional guidance.
+    
+    - If you are using webpack version less than 4 please see the [webpack 4 migration guide](/migrate/4/).
 
-When using webpack >= 4, upgrading to the latest webpack 4 version should not require additional guidance.
-If you are using webpack version less than 4 please see the [webpack 4 migration guide](/migrate/4/).
+2. Upgrade `webpack-cli` to the latest available version (when used)
 
-#### Upgrade webpack-cli to the latest available version (when used)
+3. Upgrade all used Plugins and Loaders to the latest available version
 
-#### Upgrade all used Plugins and Loaders to the latest available version
+    Some Plugins and Loaders might have a beta version that has to be used in order to be compatible with webpack 5.
 
-Some Plugins and Loaders might have a beta version that has to be used in order to be compatible with webpack 5.
+### Make sure your build has no errors or warnings
 
-W> Check related Plugins and Loaders migration guide when upgrading across major versions. Several commonly-used loaders like `raw-loader`, `url-loader`, and `file-loader` should be replaced using the new built-in [Asset Modules](/guides/asset-modules/) feature.
+There might be new errors or warnings because of the upgraded versions of `webpack`, `webpack-cli`, Plugins and Loaders. Keep an eye for deprecation warnings during the build.
 
-W>  ExtendedAPIPlugin is removed and the logic is merged into [`APIPlugin`](https://github.com/webpack/webpack/blob/master/lib/APIPlugin.js).
-
-#### Make sure your build has no errors or warnings
-
-There might be new errors or warnings because of the upgraded versions of webpack, webpack-cli, Plugins and Loaders. Keep an eye for deprecation warnings during the build.
-
-You can invoke webpack this way to get stack traces for deprecation warnings to figure out which Plugins and Loaders are responsible.
+You can invoke `webpack` this way to get stack traces for deprecation warnings to figure out which Plugins and Loaders are responsible.
 
 ```bash
 node --trace-deprecation node_modules/webpack/bin/webpack.js
 ```
 
-W> webpack 5 removes all deprecated features. In order to proceed, there should be no webpack deprecation warnings during the build.
+As webpack 5 removes all deprecated features, make sure there's no webpack deprecation warnings during the build in order to proceed.
 
-#### Make sure you are using entry point information from stats
+### Make sure to use `mode`
 
-T> If you are using [HtmlWebpackPlugin](/plugins/html-webpack-plugin/) skip this step.
+Set `mode` to either [`production`](/configuration/mode/#mode-production) or [`development`](/configuration/mode/#mode-development) to make sure that corresponding defaults are set.
 
-When using static HTML or creating HTML in other way, make sure to use entry points from stats JSON to generate `<script>`, `<style>` and `<link>` tags.
-
-If this is not possible, avoid setting `splitChunks.chunks: 'all'` and `splitChunks.maxSize` later in this guide. Note that this is sub-optimal and a workaround.
-
-#### Make sure to use `mode`
-
-Set mode to either [`production`](/configuration/mode/#mode-production) or [`development`](/configuration/mode/#mode-development) to make sure that corresponding defaults are set.
-
-#### Update outdated options
+### Update outdated options
 
 Update the following options to their new version (if used):
 
-- `optimization.hashedModuleIds: true` ↦ `optimization.moduleIds: 'deterministic'`
-- `optimization.namedChunks: true` ↦ `optimization.chunkIds: 'named'`
-- `optimization.namedModules: true` ↦ `optimization.moduleIds: 'named'`
-- `NamedModulesPlugin` ↦ `optimization.moduleIds: 'named'`
-- `NamedChunksPlugin` ↦ `optimization.chunkIds: 'named'`
-- `HashedModuleIdsPlugin` ↦ `optimization.moduleIds: 'deterministic'`
-- `optimization.noEmitOnErrors: false` ↦ `optimization.emitOnErrors: true`
-- `optimization.occurrenceOrder: true` ↦ `optimization: { chunkIds: 'total-size', moduleIds: 'size' }`
-- `optimization.splitChunks.cacheGroups.vendors` ↦ `optimization.splitChunks.cacheGroups.defaultVendors`
-- `Compilation.entries` ↦ `Compilation.entryDependencies`
-- `serve` ↦ `serve` is removed in favor of [`DevServer`](/configuration/dev-server/)
+- `optimization.hashedModuleIds: true` → `optimization.moduleIds: 'deterministic'`
+- `optimization.namedChunks: true` → `optimization.chunkIds: 'named'`
+- `optimization.namedModules: true` → `optimization.moduleIds: 'named'`
+- `NamedModulesPlugin` → `optimization.moduleIds: 'named'`
+- `NamedChunksPlugin` → `optimization.chunkIds: 'named'`
+- `HashedModuleIdsPlugin` → `optimization.moduleIds: 'deterministic'`
+- `optimization.noEmitOnErrors: false` → `optimization.emitOnErrors: true`
+- `optimization.occurrenceOrder: true` → `optimization: { chunkIds: 'total-size', moduleIds: 'size' }`
+- `optimization.splitChunks.cacheGroups.vendors` → `optimization.splitChunks.cacheGroups.defaultVendors`
+- `Compilation.entries` → `Compilation.entryDependencies`
+- `serve` → `serve` is removed in favor of [`DevServer`](/configuration/dev-server/)
 
-#### Test webpack 5 compatibility
+### Test webpack 5 compatibility
 
 Try to set the following options in your webpack 4 configuration and check if build still works correctly.
 
@@ -91,25 +78,27 @@ module.exports = {
 };
 ```
 
-T> webpack 5 removes these options from the configuration schema and will always use `false`.
-
 You have to remove these options again when upgrading your configuration for webpack 5.
 
-#### Upgrade webpack version
+T> webpack 5 removes these options from the configuration schema and will always use `false`.
 
-npm: `npm install webpack@latest --dev`
+## Upgrade webpack to 5
 
-Yarn: `yarn add webpack@latest -D`
+Now let's upgrade webpack to version 5:
 
-#### Clean up configuration
+- npm: `npm install webpack@latest --dev`
+
+- Yarn: `yarn add webpack@latest -D`
+
+### Clean up configuration
 
 - Consider removing `optimization.moduleIds` and `optimization.chunkIds` from your webpack configuration. The defaults could be better, because they support long term caching in [`production mode`](/configuration/mode/#mode-production) and debugging in [`development` mode](/configuration/mode/#mode-development).
 - When using `[hash]` placeholder in webpack configuration, consider changing it to `[contenthash]`. It is not the same, but proven to be more effective.
 - If you are using Yarn's PnP and the `pnp-webpack-plugin`, we have good news: it is supported by default now. You have to remove it from the configuration.
 - If you are using `IgnorePlugin` with a regular expression as argument, it takes an `options` object now: `new IgnorePlugin({ resourceRegExp: /regExp/ })`.
-- If you are using `node.something: 'empty'` replace it with `resolve.fallback.something: false`.
+- If you are using something like `node.fs: 'empty'` replace it with `resolve.fallback.fs: false`.
 - If you are using `watch: true` in webpack Node.js API, remove it. There's no need to set it as it's indicated by the compiler method you call, either `true` for `watch()` or `false` for `run()`.
-- If you have `rules` defined for loading assets using `raw-loader`, `url-loader`, or `file-loader`, these should be configured as [Asset Modules](/guides/asset-modules/) instead.
+- If you have `rules` defined for loading assets using `raw-loader`, `url-loader`, or `file-loader`, please use [Asset Modules](/guides/asset-modules/) instead as they're going to be deprecated in near future.
 - If you have `target` set to a function, update it to `false` and apply that function within `plugins` option. See example below:
     
     ```json
@@ -144,22 +133,38 @@ Consider removing defaults:
 - Using `output.path: path.resolve(__dirname, 'dist')`: you can omit it, that's the default.
 - Using `output.filename: '[name].js'`: you can omit it, that's the default.
 
-Need to support an older browser?
+### Need to support an older browser like IE 11?
 
-- By default, webpack will use your browserslist config to decide which code style to emit.
-- Without a browserslist it would emit ES6 style. You can use `target: ["web", "es5"]` to change it to ES5.
+- By default, webpack 5 will use your `browserslist` config to decide which code style to emit for the runtime code.
+- Without a `browserslist` webpack's runtime code uses ES2015 syntax (e.g., arrow function) to build smaller bundles. If your build targets environments that don't support ES2015 syntax (like IE11), you'll need to set `target: ['web', 'es5']` to revert to ES5 syntax.
 - For Node.js, builds include the supported Node.js version in the `target` option and webpack will automatically figure out which syntax is supported, e.g. `target: 'node8.6'`.
 
-#### Cleanup the code
+### Cleanup the code
 
-Using `/* webpackChunkName: '...' */`: Make sure to understand the intention:
+#### Using `/* webpackChunkName: '...' */`
+
+Make sure to understand the intention:
 
 - The chunk's name here is intended to be public.
 - It's not a development-only name.
-- webpack will use it to name files in production and development modes.
-- webpack 5 will automatically assign useful file names in `development` mode even when not using `webpackChunkName`.
+- Webpack will use it to name files in production and development modes.
+- Webpack 5 will automatically assign useful file names in `development` mode even when not using `webpackChunkName`.
 
-Using named exports from JSON modules: this is not supported by the new specification and you will get a warning. Instead of `import { version } from './package.json'; console.log(version);` use `import package from './package.json'; console.log(package.version);`
+#### Using named exports from JSON modules
+
+This is not supported by the new specification and you will get a warning. Instead of:
+
+```js
+import { version } from './package.json';
+console.log(version);
+```
+
+use:
+
+```js
+import pkg from './package.json';
+console.log(pkg.version);
+```
 
 #### Cleanup the build code
 
@@ -167,35 +172,56 @@ Using named exports from JSON modules: this is not supported by the new specific
     - This doesn't apply to the `webpack(..., callback)` form which automatically closes.
     - This is optional if you use webpack in watching mode until the user ends the process. The idle phases in watch mode will be used for this kind of work.
 
-#### Run a single build and follow advises
+### Run a single build and follow advises
 
-Please make sure to read errors/warnings carefully.
+Please make sure to read the building errors/warnings carefully. If there is no corresponding advise, please create an issue and we will try to resolve it. 
 
-If there is no corresponding advise? Please create an issue and we will try to resolve it. Repeat this step until you solved at least level 3 or 4:
+Repeat the following steps until you solved at least level 3 or 4:
 
-- Level 1: Schema validation fails. Configuration options have changed. There should be a validation error with a `BREAKING CHANGE:` note, or a hint which option should be used instead.
-- Level 2: webpack exits with an error. The error message should tell you what needs to be changed.
-- Level 3: Build Errors. The error message should have a `BREAKING CHANGE:` note.
-- Level 4: Build Warnings. The warning message should tell you what can be improved.
-- Level 5: Runtime Errors. This is tricky. You probably have to debug to find the problem. A general advise is difficult here.
-- Level 6: Deprecation Warnings. You probably get a lot of deprecation warnings. This is not directly a problem. Plugins need time to catch up with core changes. Please report these deprecations to the plugins. These deprecations are only warnings and the build will still work with only minor drawbacks (like less performance).
-- Level 7: Performance issues. Usually performance should improve with webpack 5, but there are also a few cases where performance get worse.
+- Level 1: __Schema validation fails__.
+    
+    Configuration options have changed. There should be a validation error with a `BREAKING CHANGE:` note, or a hint which option should be used instead.
 
-- Regarding Runtime Errors:
+- Level 2: __Webpack exits with an error__.
+    
+    The error message should tell you what needs to be changed.
+
+- Level 3: __Build Errors__.
+
+    The error message should have a `BREAKING CHANGE:` note.
+
+- Level 4: __Build Warnings__.
+    
+    The warning message should tell you what can be improved.
+
+- Level 5: __Runtime Errors__.
+
+    This is tricky. You probably have to debug to find the problem. A general advise is difficult here. But we do list some common advices below regarding Runtime Errors:
+
     - `process` is not defined.
         - webpack 5 does no longer include a polyfill for this Node.js variable. Avoid using it in the frontend code.
         - Want to support frontend and browser usage? Use the `exports` or `imports` package.json field to use different code depending on the environment.
-            - Also use the `browser` field to support older bundlers,.
+            - Also use the `browser` field to support older bundlers.
             - Alternative: Wrap code blocks with the `typeof process` checks. Note that this will have a negative impact on the bundle size.
         - Want to use environment variables with `process.env.VARIABLE`? You need to use the `DefinePlugin` or `EnvironmentPlugin` to define these variables in the configuration.
             - Consider using `VARIABLE` instead and make sure to check `typeof VARIABLE !== 'undefined'` too. `process.env` is Node.js specific and should be avoided in frontend code.
     - 404 errors pointing to URLs containing `auto`
         - Not all ecosystem tooling is ready for the new default automatic `publicPath` via `output.publicPath: "auto"`
             - Use a static `output.publicPath: ""` instead.
-- Regarding Deprecation Warnings:
+
+- Level 6: __Deprecation Warnings__.
+
+    You probably get a lot of deprecation warnings. This is not directly a problem. Plugins need time to catch up with core changes. Please report these deprecations to the plugins. These deprecations are only warnings and the build will still work with only minor drawbacks (like less performance).
+
     - You can hide deprecation warnings by running node with `--no-deprecation` flag, e.g.: `node --no-deprecation node_modules/webpack/bin/webpack.js`. This should only be a temporary workaround.
     - Plugins and Loaders contributors can follow the advises in the deprecation messages to improve the code.
-- Regarding Performance issues:
+
+- Level 7: __Performance issues__.
+
+    Usually performance should improve with webpack 5, but there are also a few cases where performance get worse.
+
+    And here are something you can do to improve the situation:
+
     - Profile where the time is spend.
         - `--profile --progress` displays a simple performance profile now
         - `node --inspect-brk node_modules/webpack/bin/webpack.js` + [`chrome://inspect`](chrome://inspect) / [`edge://inspect`](edge://inspect) (see profiler tab).
@@ -212,21 +238,17 @@ If there is no corresponding advise? Please create an issue and we will try to r
         - Persistent Caching can help to improve the repetitive full builds.
         - Module Federation allows to split the application into multiple smaller builds.
 
-#### Turn off ES2015 syntax in runtime code, if necessary
-
-By default, webpack's runtime code uses ES2015 syntax to build smaller bundles. If your build targets environments that don't support this syntax (like IE11), you'll need to set `target: ['web', 'es5']` to revert to ES5 syntax (`'web'` if target environment is browser).
-
-#### Everything works?
+## Everything works?
 
 Please tweet that you have successfully migrated to webpack 5. [Tweet it](https://twitter.com/intent/tweet?source=https://webpack.js.org/migrate/5/&text=I%20just%20migrated%20to%20webpack%205%20using%20its%20migration%20guide!%20&via=webpack&hashtags=webpack,webpack5)
 
-#### It is not working?
+## It is not working?
 
 Create an [issue](https://github.com/webpack/webpack/issues/new?template=Bug_report.md) and tell us about the issues you have encountered during the migration.
 
-#### Something missing in this guide?
+## Something missing in this guide?
 
-Please open a Pull Request to help the next person using this guide.
+Please open a [Pull Request](https://github.com/webpack/webpack.js.org/edit/master/src/content/migrate/5.md) to help the next person using this guide.
 
 ## Changes to internals
 
@@ -239,6 +261,6 @@ The changes to webpack internals such as: adding types, refactoring code and met
 webpack 5 ships with built-in [`this.getOptions`](/api/loaders/#thisgetoptionsschema) method available in loader context. This is a breaking change for loaders that had been using `getOptions` method from previously preferred [schema-utils](https://github.com/webpack/schema-utils):
 
 - `this.getOptions` is available since webpack 5
-- Instead of JSON5 it supports JSON as a query string: `?{arg:true}` ↦ `?{"arg":true}`. Using JSON5 should be considered and documented as deprecated in favor of JSON in respective Loader's documentation.
+- Instead of JSON5 it supports JSON as a query string: `?{arg:true}` → `?{"arg":true}`. Using JSON5 should be considered and documented as deprecated in favor of JSON in respective Loader's documentation.
 - [`loader-utils`](https://github.com/webpack/loader-utils) has specific behavior for parsing query strings (`true`, `false` and `null` won't be parsed as `string` but as a primitive value). This is no longer the case for the new built-in `this.getOptions` method, which uses native [`querystring`](https://nodejs.org/api/querystring.html) parsing (ships with Node.js). It is still possible to add custom behavior for these cases in the Loader's code after getting the options by using `this.getOptions` method.
 - Schema argument is optional for the new `this.getOptions` method, but we strongly advise to add schema validation for your Loader's options. The `title` field in the schema, can be used to customize the validation error message e.g. `"title": "My Loader ooooptions"` will result in displaying errors this way: `Invalid ooooptions object. My Loader has been initialised using an ooooptions object that does not match the API schema. - ooooptions.foo.bar.baz should be a string.`

--- a/src/content/migrate/5.md
+++ b/src/content/migrate/5.md
@@ -136,7 +136,7 @@ Consider removing defaults:
 ### Need to support an older browser like IE 11?
 
 - By default, webpack 5 will use your `browserslist` config to decide which code style to emit for the runtime code.
-- Without a `browserslist` webpack's runtime code uses ES2015 syntax (e.g., arrow function) to build smaller bundles. If your build targets environments that don't support ES2015 syntax (like IE11), you'll need to set `target: ['web', 'es5']` to revert to ES5 syntax.
+- Without a `browserslist` webpack's runtime code uses ES2015 syntax (e.g., arrow function) to build smaller bundles. If your build targets environments that don't support ES2015 syntax (like IE11), you'll need to set `target: ['web', 'es5']` to use ES5 syntax.
 - For Node.js, builds include the supported Node.js version in the `target` option and webpack will automatically figure out which syntax is supported, e.g. `target: 'node8.6'`.
 
 ### Cleanup the code

--- a/src/content/migrate/5.md
+++ b/src/content/migrate/5.md
@@ -200,7 +200,7 @@ Repeat the following steps until you solved at least level 3 or 4:
 
     - `process` is not defined.
         - webpack 5 does no longer include a polyfill for this Node.js variable. Avoid using it in the frontend code.
-        - Want to support frontend and browser usage? Use the `exports` or `imports` package.json field to use different code depending on the environment.
+        - Want to support browser usage? Use the `exports` or `imports` package.json field to use different code depending on the environment.
             - Also use the `browser` field to support older bundlers.
             - Alternative: Wrap code blocks with the `typeof process` checks. Note that this will have a negative impact on the bundle size.
         - Want to use environment variables with `process.env.VARIABLE`? You need to use the `DefinePlugin` or `EnvironmentPlugin` to define these variables in the configuration.

--- a/src/content/migrate/5.md
+++ b/src/content/migrate/5.md
@@ -180,7 +180,7 @@ Repeat the following steps until you solved at least level 3 or 4:
 
 - Level 1: __Schema validation fails__.
     
-    Configuration options have changed. There should be a validation error with a `BREAKING CHANGE:` note, or a hint which option should be used instead.
+    Configuration options have changed. There should be a validation error with a `BREAKING CHANGE:` note, or a hint of which option should be used instead.
 
 - Level 2: __Webpack exits with an error__.
     
@@ -218,7 +218,7 @@ Repeat the following steps until you solved at least level 3 or 4:
 
 - Level 7: __Performance issues__.
 
-    Usually performance should improve with webpack 5, but there are also a few cases where performance get worse.
+    Usually, performance should improve with webpack 5, but there are also a few cases where performance gets worse.
 
     And here are something you can do to improve the situation:
 
@@ -261,6 +261,6 @@ The changes to webpack internals such as: adding types, refactoring code and met
 webpack 5 ships with built-in [`this.getOptions`](/api/loaders/#thisgetoptionsschema) method available in loader context. This is a breaking change for loaders that had been using `getOptions` method from previously preferred [schema-utils](https://github.com/webpack/schema-utils):
 
 - `this.getOptions` is available since webpack 5
-- Instead of JSON5 it supports JSON as a query string: `?{arg:true}` → `?{"arg":true}`. Using JSON5 should be considered and documented as deprecated in favor of JSON in respective Loader's documentation.
+- Instead of JSON5 it supports JSON as a query string: `?{arg:true}` → `?{"arg":true}`. Using JSON5 should be considered and documented as deprecated in favor of JSON in the respective Loader's documentation.
 - [`loader-utils`](https://github.com/webpack/loader-utils) has specific behavior for parsing query strings (`true`, `false` and `null` won't be parsed as `string` but as a primitive value). This is no longer the case for the new built-in `this.getOptions` method, which uses native [`querystring`](https://nodejs.org/api/querystring.html) parsing (ships with Node.js). It is still possible to add custom behavior for these cases in the Loader's code after getting the options by using `this.getOptions` method.
 - Schema argument is optional for the new `this.getOptions` method, but we strongly advise to add schema validation for your Loader's options. The `title` field in the schema, can be used to customize the validation error message e.g. `"title": "My Loader ooooptions"` will result in displaying errors this way: `Invalid ooooptions object. My Loader has been initialised using an ooooptions object that does not match the API schema. - ooooptions.foo.bar.baz should be a string.`


### PR DESCRIPTION
The current migration guide for webpack 5 is sort of intimidating:

![image](https://user-images.githubusercontent.com/1091472/103592308-af69c800-4f2d-11eb-9eb6-3ded01fc55d8.png)


 I've made some improvements to it in this pull request:

![image](https://user-images.githubusercontent.com/1091472/103592323-bd1f4d80-4f2d-11eb-8e51-cec3cfdddd46.png)

## Preview

https://webpack-js-org-git-fork-chenxsan-feature-migrate-5.webpack-docs.vercel.app/migrate/5/