### PR TITLE
clean up action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,6 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENCOLLECTIVE_API_KEY: ${{ secrets.OPENCOLLECTIVE_API_KEY }}
           BRANCH: gh-pages
           FOLDER: dist
           CLEAN: true


### PR DESCRIPTION
The api key was introduced in https://github.com/webpack/webpack.js.org/pull/4214, but it's no longer used.