### PR TITLE
docs(configuration): fix typo

### DIFF
--- a/src/content/configuration/externals.md
+++ b/src/content/configuration/externals.md
@@ -427,7 +427,7 @@ Option   | Description                                      | Input Type
 `node`     | Treat node.js built-in modules like `fs`, `path` or `vm` as external and load them via `require()` when used.| boolean
 `nwjs`    | Treat `NW.js` legacy `nw.gui` module as external and load it via `require()` when used.| boolean
 `web`     | Treat references to `http(s)://...` and `std:...` as external and load them via `import` when used. __(Note that this changes execution order as externals are executed before any other code in the chunk)__.| boolean
-`webAsync`     | Treat references to 'http(s)://...' and 'std:...' as external and load them via `async import()` when used __(Note that this external type is an `async` module, which has various effects on the execution)__.| boolean
+`webAsync`     | Treat references to `http(s)://...` and `std:...` as external and load them via `async import()` when used __(Note that this external type is an `async` module, which has various effects on the execution)__.| boolean
 
 
 __Example__


### PR DESCRIPTION
To keep consistency with the one above.