### PR TITLE
docs(api): update orders of compiler hooks

### DIFF
--- a/src/content/api/compiler-hooks.md
+++ b/src/content/api/compiler-hooks.md
@@ -50,6 +50,19 @@ Depending on the hook type, `tapAsync` and `tapPromise` may also be available.
 
 For the description of hook types, see [the Tapable docs](https://github.com/webpack/tapable#tapable).
 
+### `environment`
+
+`SyncHook`
+
+Called while preparing the compiler environment, right after initializing the plugins in the configuration file.
+
+
+### `afterEnvironment`
+
+`SyncHook`
+
+Called right after the `environment` hook, when the compiler environment setup is complete.
+
 
 ### `entryOption`
 
@@ -64,8 +77,6 @@ compiler.hooks.entryOption.tap('MyPlugin', (context, entry) => {
   /* ... */
 });
 ```
-
-Parameters: `context`, `entry`
 
 ### `afterPlugins`
 
@@ -83,20 +94,6 @@ Called after setting up initial set of internal plugins.
 Triggered after resolver setup is complete.
 
 - Callback Parameters: `compiler`
-
-
-### `environment`
-
-`SyncHook`
-
-Called while preparing the compiler environment, right after initializing the plugins in the configuration file.
-
-
-### `afterEnvironment`
-
-`SyncHook`
-
-Called right after the `environment` hook, when the compiler environment setup is complete.
 
 
 ### `beforeRun`

--- a/src/content/api/compiler-hooks.md
+++ b/src/content/api/compiler-hooks.md
@@ -110,12 +110,6 @@ Adds a hook right before running the compiler.
 
 - Callback Parameters: `compiler`
 
-### `additionalPass`
-
-`AsyncSeriesHook`
-
-This hook allows you to do a one more additional pass of the build.
-
 
 ### `run`
 
@@ -285,6 +279,12 @@ compiler.hooks.assetEmitted.tap(
 Executed when the compilation has completed.
 
 - Callback Parameters: `stats`
+
+### `additionalPass`
+
+`AsyncSeriesHook`
+
+This hook allows you to do a one more additional pass of the build.
 
 
 ### `failed`

--- a/src/content/api/compiler-hooks.md
+++ b/src/content/api/compiler-hooks.md
@@ -95,6 +95,12 @@ Triggered after resolver setup is complete.
 
 - Callback Parameters: `compiler`
 
+### `initialize`
+
+`SyncHook`
+
+Called when a compiler object is initialized.
+
 
 ### `beforeRun`
 
@@ -145,13 +151,6 @@ Called after a `NormalModuleFactory` is created.
 Runs a plugin after a `ContextModuleFactory` is created.
 
 - Callback Parameters: `contextModuleFactory`
-
-
-### `initialize`
-
-`SyncHook`
-
-Called when a compiler object is initialized.
 
 
 ### `beforeCompile`


### PR DESCRIPTION
From the source code, I believe [`environment`](https://github.com/webpack/webpack/blob/master/lib/webpack.js#L74) and [`afterEnvironment`](https://github.com/webpack/webpack/blob/master/lib/webpack.js#L75) hooks are called before [`entryOptions`](https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsApply.js#L247), [`afterPlugins`](https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsApply.js#L545) and [`afterResolvers`](https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsApply.js#L571). Although it's not a big deal, I still think it's better to keep the order right since user might take it for granted that the former one runs before the latter .