### PR TITLE
Fix typos

### DIFF
--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -55,7 +55,7 @@ module.exports = {
 
 `boolean` `function (module)`
 
-Cache the resolution of module requests. There are couple of defaults for `module.unsafeCache`:
+Cache the resolution of module requests. There are a couple of defaults for `module.unsafeCache`:
 
 - `false` if [`cache`](/configuration/other-options/#cache) is disabled.
 - `true` if [`cache`](/configuration/other-options/#cache) is enabled and the module appears to come from node modules, `false` otherwise.
@@ -167,7 +167,7 @@ import { b } from  '-!./file2.js';
 import { c } from  '!!./file3.js';
 ```
 
-Inline loaders and `!` prefixes should not be used as they are non-standard. They may be use by loader generated code.
+Inline loaders and `!` prefixes should not be used as they are non-standard. They may be used by loader generated code.
 
 
 ## `Rule.exclude`

--- a/src/content/configuration/optimization.md
+++ b/src/content/configuration/optimization.md
@@ -224,7 +224,7 @@ W> `moduleIds: total-size` has been removed in webpack 5.
 
 `boolean = false` `string: 'natural' | 'named' | 'size' | 'total-size' | 'deterministic' `
 
-Tells webpack which algorithm to use when choosing chunk ids. Setting `optimization.chunkIds` to `false` tells webpack that none of built-in algorithms should be used, as custom one can be provided via plugin. There are couple of defaults for `optimization.chunkIds`:
+Tells webpack which algorithm to use when choosing chunk ids. Setting `optimization.chunkIds` to `false` tells webpack that none of built-in algorithms should be used, as custom one can be provided via plugin. There are a couple of defaults for `optimization.chunkIds`:
 
 - Also if the environment is development then `optimization.chunkIds` is set to `'named'`, while in production it is set to `'deterministic'`
 - if none of the above, `optimization.chunkIds` will be defaulted to `'natural'`


### PR DESCRIPTION
This fixes a few typos in the modules section of the rules docs.
