### PR TITLE
fix(docs): Allow the scrolling of the Sidebar

### DIFF
--- a/src/components/Sidebar/Sidebar.scss
+++ b/src/components/Sidebar/Sidebar.scss
@@ -16,9 +16,7 @@
 .sidebar__inner {
   padding: 1.5em;
   position: sticky;
-  top: -1px;
   overflow: scroll;
-  max-height: 100vh;
   // To hide scrollbar in Firefox
   scrollbar-width: none;
   // To hide scrollbar in Chrome


### PR DESCRIPTION
Removed the CSS styling that prevents the scrolling of the Sidebar component. 

When long content is displayed in the Sidebar component, for example https://webpack.js.org/guides/tree-shaking/ with some of the tree options opened, the end of the Sidebar menu is inaccessible as it doesn't scroll with the page.
