### PR TITLE
customize Link for mdx

### DIFF
--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -29,6 +29,7 @@ import PageNotFound from '../PageNotFound/PageNotFound';
 import Vote from '../Vote/Vote';
 import Organization from '../Organization/Organization';
 import Badge from '../Badge/Badge.js';
+import {default as LinkComponent} from '../mdxComponents/Link';
 
 // Load Styling
 import '../../styles/index';
@@ -152,9 +153,8 @@ function Site(props) {
   return (
     <MDXProvider
       components={{
-        Badge: function Comp(props) {
-          return <Badge {...props} />;
-        },
+        Badge: Badge,
+        a: LinkComponent
       }}
     >
       <div className="site">

--- a/src/components/mdxComponents/Link.js
+++ b/src/components/mdxComponents/Link.js
@@ -1,0 +1,13 @@
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+LinkComponent.propTypes = {
+  href: PropTypes.string.isRequired,
+};
+export default function LinkComponent(props) {
+  // if it's internal link
+  // use Link instead
+  if (props.href.startsWith('/')) {
+    return <Link {...props} to={props.href} />;
+  }
+  return <a {...props}></a>;
+}


### PR DESCRIPTION
Improve website performance.

## Why?

Let's take this page for example https://webpack.js.org/api/node/.

Open devtools and click the link in the screenshot below:

![image](https://user-images.githubusercontent.com/1091472/104084121-bcfdb580-527f-11eb-986e-bd454e3bbdf9.png)

Here's the network panel:

![image](https://user-images.githubusercontent.com/1091472/104084144-ec142700-527f-11eb-9a14-22bfec798b83.png)

Even with service worker, we still have a lot of requests.

Now let's open the preview of this pull request https://webpack-js-org-git-fork-chenxsan-feature-use-react-route-5aabb7.webpack-docs.vercel.app/api/node/, and click the same link:

![image](https://user-images.githubusercontent.com/1091472/104084221-5036eb00-5280-11eb-8a28-2b1ea1d3d25e.png)

That's impressive isn't it?

## What's going on

This website is a Single Page React Application with precompiled HTML, but links in body are rendered as `<a>` elements, which would cause browser to load a whole new html page. When we render them as `Link` from `react-router`, it would dynamic load the needed part instead of loading a new html page, and it's possible with `MDX`. Guess this is a good reason to migrate from `.md` to `.mdx`  because we have so many internal links.