### PR TITLE
remove dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    labels:
-      - "dependencies"


### PR DESCRIPTION
We all agree it's important to keep dependencies up-to-date. However, we did have different opinions on how often to do it.

I prefer to upgrade dependencies when there's an update available, thus I've enabled the [dependabot](https://github.com/apps/dependabot) which could notify me with a pull request when there's an update.

Take the `sass` for example, I can check the  [changelog right in the pull request](https://github.com/webpack/webpack.js.org/pull/4402) instead of checking its [changelog page](https://github.com/sass/dart-sass/releases/tag/1.32.2), it could save a lot of our time when their are many dependencies to be updated.

However, @montogeek thought those pull requests from the dependabot were sort of spam. And he prefers to do the upgrades every week https://github.com/webpack/webpack.js.org/pull/4276#issuecomment-754491343. My problem with this way is you have to read quite a lot of changelogs when you do the upgrades every week, and it could be challenging to pinpoint the problem if you confront one.

Anyway, I'd like to see how things will work when dependencies are upgraded every week, so let's remove dependabot first.