### PR TITLE
fix bug for Support

### DIFF
--- a/src/components/Support/Support.jsx
+++ b/src/components/Support/Support.jsx
@@ -141,14 +141,16 @@ export default class Support extends Component {
     }
 
     if (typeof random === 'number') {
-      // Pick n random items
-      for (let i = 0; i < random; i++) {
-        const other = Math.floor(Math.random() * (supporters.length - i));
-        const temp = supporters[other];
-        supporters[other] = supporters[i];
-        supporters[i] = temp;
+      if (supporters.length >= random) {
+        // Pick n random items
+        for (let i = 0; i < random; i++) {
+          const other = Math.floor(Math.random() * (supporters.length - i));
+          const temp = supporters[other];
+          supporters[other] = supporters[i];
+          supporters[i] = temp;
+        }
+        supporters = supporters.slice(0, random);
       }
-      supporters = supporters.slice(0, random);
     }
 
     // resort to keep order


### PR DESCRIPTION
There're chances `supporters.length` would be smaller than `random`, which would causing `undefined` value in `supporters` array. For example, I would create an empty `_supporters.json` because I don't want to fetch supporters data when developing locally, which then cause error:

![image](https://user-images.githubusercontent.com/1091472/104172375-1eb84e00-543f-11eb-8e34-b5c2dac79b0d.png)
