### PR TITLE
fix(app): Deprecated Sass api

### DIFF
--- a/src/components/Markdown/Markdown.scss
+++ b/src/components/Markdown/Markdown.scss
@@ -66,7 +66,7 @@ $topHeightMobileWithBanner: $bannerHeight + $topHeightMobile;
     font-weight: 600;
     line-height: 1.4;
     margin: 0 0 0.25em;
-    color: color.adjust(getColor(fiord), $lightness: -10);
+    color: color.adjust(getColor(fiord), $lightness: -10%);
     word-break: break-word;
 
     tt,


### PR DESCRIPTION
See the changelog of `sass` here https://github.com/webpack/webpack.js.org/pull/4402:

> Deprecate passing non-% numbers as lightness and saturation to hsl(), hsla(), color.adjust(), and color.change(). This matches the CSS specification, which also requires % for all lightness and saturation parameters. See [the Sass website][color-units] for more details.