### PR TITLE
Don't scroll to top if link was opened in new tab

### DIFF
--- a/cypress/integration/pr_4435_spec.js
+++ b/cypress/integration/pr_4435_spec.js
@@ -1,0 +1,48 @@
+// set scrollBehavior to false
+// because we don't want cypress to scroll itself
+describe('Open page in new tab', { scrollBehavior: false }, () => {
+  it('', () => {
+    cy.visit('/concepts/plugins/', {
+      onBeforeLoad: (win) => {
+        cy.stub(win, 'scrollTo');
+      },
+    });
+    // there's one call in Page.jsx when componentDidMount
+    cy.window().then((win) => {
+      expect(win.scrollTo).to.be.calledOnce;
+    });
+
+    const selector = '.sidebar-item__title[href="/concepts/plugins/"]';
+
+    // we click the menu
+    cy.get(selector).click();
+    cy.window().then((win) => {
+      expect(win.scrollTo).to.be.calledTwice;
+    });
+
+    if (Cypress.platform === 'darwin') {
+      cy.get(selector).click({
+        metaKey: true,
+      });
+      // no scrollTo should be called
+      cy.window().then((win) => {
+        expect(win.scrollTo).to.be.calledTwice;
+      });
+    } else if (Cypress.platform === 'win32' || Cypress.platform === 'linux') {
+      // win32, linux
+      cy.get(selector).click({
+        ctrlKey: true,
+      });
+      // no scrollTo should be called
+      cy.window().then((win) => {
+        expect(win.scrollTo).to.be.calledTwice;
+      });
+    }
+
+    // we click the menu again
+    cy.get(selector).click();
+    cy.window().then((win) => {
+      expect(win.scrollTo).to.be.calledThrice;
+    });
+  });
+});

--- a/cypress/integration/pr_4435_spec.js
+++ b/cypress/integration/pr_4435_spec.js
@@ -1,7 +1,7 @@
 // set scrollBehavior to false
 // because we don't want cypress to scroll itself
 describe('Open page in new tab', { scrollBehavior: false }, () => {
-  it('', () => {
+  it('should not scroll to top', () => {
     cy.visit('/concepts/plugins/', {
       onBeforeLoad: (win) => {
         cy.stub(win, 'scrollTo');

--- a/src/components/SidebarItem/SidebarItem.jsx
+++ b/src/components/SidebarItem/SidebarItem.jsx
@@ -37,7 +37,7 @@ export default class SidebarItem extends Component {
   }
 
   scrollTop(event) {
-    if (!event.metaKey) {
+    if (!event.metaKey && !event.ctrlKey) {
         window.scrollTo(0, 0);
     }
   }

--- a/src/components/SidebarItem/SidebarItem.jsx
+++ b/src/components/SidebarItem/SidebarItem.jsx
@@ -36,8 +36,10 @@ export default class SidebarItem extends Component {
     );
   }
 
-  scrollTop() {
-    window.scrollTo(0, 0);
+  scrollTop(event) {
+    if (!event.metaKey) {
+        window.scrollTo(0, 0);
+    }
   }
 
   render() {


### PR DESCRIPTION
If user cmd+clicks (or ctrl+clicks) a link in the sidebar, the linked page opens in a new page, and the current tab should not scroll to the top.