### PR TITLE
fix(docs): expose errors details in loader example

### DIFF
--- a/src/content/contribute/writing-a-loader.md
+++ b/src/content/contribute/writing-a-loader.md
@@ -351,7 +351,7 @@ export default (fixture, options = {}) => {
   return new Promise((resolve, reject) => {
     compiler.run((err, stats) => {
       if (err) reject(err);
-      if (stats.hasErrors()) reject(new Error(stats.toJson().errors));
+      if (stats.hasErrors()) reject(stats.toJson().errors);
 
       resolve(stats);
     });


### PR DESCRIPTION
## Before:
### errors detail not exposed:
![loader-err-2](https://user-images.githubusercontent.com/14243906/104816294-35064580-5855-11eb-802d-f54409a352e5.png)

## After:
### errors detail exposed clearly:
![loader-err-1](https://user-images.githubusercontent.com/14243906/104816323-5b2be580-5855-11eb-8d42-bcd347722253.png)
