### PR TITLE
docs(configuration): fix a misspelled `output.sourcePrefix`'s description.

### DIFF
--- a/src/content/configuration/index.mdx
+++ b/src/content/configuration/index.mdx
@@ -269,7 +269,7 @@ module.exports = {
       hotUpdateGlobal: "hmrUpdateFunction", // string
       // the name of the global variable used to load hot update chunks
       sourcePrefix: "\t", // string
-      // prefix module sources in bundle for better readablitity
+      // prefix module sources in bundle for better readability
       // but breaks multi-line template strings
       hashFunction: "md4", // string (default)
       // hash function used in general


### PR DESCRIPTION
as-is
```
sourcePrefix: "\t"
// prefix module sources in bundle for better readablitity
```

to-be
```
sourcePrefix: "\t"
// prefix module sources in bundle for better readability
```
