### PR TITLE
Update 5.md

### DIFF
--- a/src/content/migrate/5.md
+++ b/src/content/migrate/5.md
@@ -88,7 +88,7 @@ Now let's upgrade webpack to version 5:
 
 - npm: `npm install webpack@latest`
 
-- Yarn: `yarn add webpack@latest -D`
+- Yarn: `yarn add webpack@latest`
 
 ### Clean up configuration
 

--- a/src/content/migrate/5.md
+++ b/src/content/migrate/5.md
@@ -86,7 +86,7 @@ T> webpack 5 removes these options from the configuration schema and will always
 
 Now let's upgrade webpack to version 5:
 
-- npm: `npm install webpack@latest --dev`
+- npm: `npm install webpack@latest`
 
 - Yarn: `yarn add webpack@latest -D`
 


### PR DESCRIPTION
`--dev` is deprecated. npm 6 suggest to use `--also=dev` and npm 7 suggests to use `--include=dev`. I simply suggest to remove that flag because if webpack is already in devDependencies, it will be updated in any case.

Even using `--save-dev` works but it will also move webpack from `dependencies` to `devDependencies`, and maybe it's not always what the developer wants.