### PR TITLE
docs(api): add pages for NormalModuleFactory and ContextModuleFactory Hooks

### DIFF
--- a/src/content/api/compiler-hooks.md
+++ b/src/content/api/compiler-hooks.md
@@ -133,7 +133,7 @@ Executes a plugin during watch mode after a new compilation is triggered but bef
 
 `SyncHook`
 
-Called after a `NormalModuleFactory` is created.
+Called after a [NormalModuleFactory](/api/normalmodulefactory-hooks) is created.
 
 - Callback Parameters: `normalModuleFactory`
 
@@ -142,7 +142,7 @@ Called after a `NormalModuleFactory` is created.
 
 `SyncHook`
 
-Runs a plugin after a `ContextModuleFactory` is created.
+Runs a plugin after a [ContextModuleFactory](/api/contextmodulefactory-hooks) is created.
 
 - Callback Parameters: `contextModuleFactory`
 

--- a/src/content/api/contextmodulefactory-hooks.md
+++ b/src/content/api/contextmodulefactory-hooks.md
@@ -1,0 +1,55 @@
+---
+title: ContextModuleFactory Hooks
+group: Plugins
+sort: 11
+contributors:
+  - iguessitsokay
+---
+
+The `ContextModuleFactory` module is used by the `Compiler` to generate dependencies from webpack specific [require.context](/api/module-methods/#requirecontext) API. It resolves the requested directory, generates requests for each file and filters against passed regExp. Matching dependencies then passes through [NormalModuleFactory](/api/normalmodulefactory-hooks).
+
+The `ContextModuleFactory` class extends `Tapable` and provides the following
+lifecycle hooks. They can be tapped the same way as compiler hooks:
+
+``` js
+ContextModuleFactory.hooks.someHook.tap(/* ... */);
+```
+
+As with the `compiler`, `tapAsync` and `tapPromise` may also be available
+depending on the type of hook.
+
+
+### `beforeResolve`
+
+`AsyncSeriesWaterfallHook`
+
+Fired before resolving the requested directory. The request can be ignored by returning `false`.
+
+- Callback Parameters: `data`
+
+
+### `afterResolve`
+
+`AsyncSeriesWaterfallHook`
+
+Fired after resolving the requested directory.
+
+- Callback Parameters: `data`
+
+
+### `contextModuleFiles`
+
+`SyncWaterfallHook`
+
+Fired after directory contents are read. On recursive mode, fires for each sub-directory as well. Callback parameter is an array of all file and folder names in each directory.
+
+- Callback Parameters: `fileNames`
+
+
+### `alternativeRequests`
+
+`AsyncSeriesWaterfallHook`
+
+Fired for each file after the request is created but before filtering against regExp.
+
+- Callback Parameters: `request` `options`

--- a/src/content/api/contextmodulefactory-hooks.md
+++ b/src/content/api/contextmodulefactory-hooks.md
@@ -19,37 +19,37 @@ As with the `compiler`, `tapAsync` and `tapPromise` may also be available
 depending on the type of hook.
 
 
-### `beforeResolve`
+### beforeResolve
 
 `AsyncSeriesWaterfallHook`
 
-Fired before resolving the requested directory. The request can be ignored by returning `false`.
+Called before resolving the requested directory. The request can be ignored by returning `false`.
 
 - Callback Parameters: `data`
 
 
-### `afterResolve`
+### afterResolve
 
 `AsyncSeriesWaterfallHook`
 
-Fired after resolving the requested directory.
+Called after the requested directory resolved.
 
 - Callback Parameters: `data`
 
 
-### `contextModuleFiles`
+### contextModuleFiles
 
 `SyncWaterfallHook`
 
-Fired after directory contents are read. On recursive mode, fires for each sub-directory as well. Callback parameter is an array of all file and folder names in each directory.
+Called after directory contents are read. On recursive mode, calls for each sub-directory as well. Callback parameter is an array of all file and folder names in each directory.
 
 - Callback Parameters: `fileNames`
 
 
-### `alternativeRequests`
+### alternativeRequests
 
 `AsyncSeriesWaterfallHook`
 
-Fired for each file after the request is created but before filtering against regExp.
+Called for each file after the request is created but before filtering against regExp.
 
 - Callback Parameters: `request` `options`

--- a/src/content/api/normalmodulefactory-hooks.md
+++ b/src/content/api/normalmodulefactory-hooks.md
@@ -25,81 +25,81 @@ As with the `compiler`, `tapAsync` and `tapPromise` may also be available
 depending on the type of hook.
 
 
-### `beforeResolve`
+### beforeResolve
 
 `AsyncSeriesBailHook`
 
-Fired when a new dependency request is encountered. A dependency can be ignored by returning `false`. Otherwise, it should return undefined to proceed.
+Called when a new dependency request is encountered. A dependency can be ignored by returning `false`. Otherwise, it should return `undefined` to proceed.
 
 - Callback Parameters: `ResolveData`
 
 
-### `factorize`
+### factorize
 
 `AsyncSeriesBailHook`
 
-Fired before initiating resolve. It should return undefined to proceed.
+Called before initiating resolve. It should return `undefined` to proceed.
 
 - Callback Parameters: `resolveData`
 
 
-### `resolve`
+### resolve
 
 `AsyncSeriesBailHook`
 
-Fired before the request is resolved. A dependency can be ignored by returning `false`. Returning a Module instance would finalize the process. Otherwise, it should return undefined to proceed.
+Called before the request is resolved. A dependency can be ignored by returning `false`. Returning a Module instance would finalize the process. Otherwise, it should return `undefined` to proceed.
 
 - Callback Parameters: `resolveData`
 
 
-### `resolveForScheme`
+### resolveForScheme
 
 `AsyncSeriesBailHook`
 
-Fired before a request with scheme (URI) is resolved.
+Called before a request with scheme (URI) is resolved.
 
 - Callback Parameters: `resolveData`
 
 
-### `afterResolve`
+### afterResolve
 
 `AsyncSeriesBailHook`
 
-Fired after the request is resolved.
+Called after the request is resolved.
 
 - Callback Parameters: `resolveData`
 
 
-### `createModule`
+### createModule
 
 `AsyncSeriesBailHook`
 
-Fired before a `Module` instance is created.
+Called before a `NormalModule` instance is created.
 
 - Callback Parameters: `createData` `resolveData`
 
 
-### `module`
+### module
 
 `SyncWaterfallHook`
 
-Fired after a `Module` instance is created.
+Called after a `NormalModule` instance is created.
 
 - Callback Parameters: `module` `createData` `resolveData`
 
 
-### `createParser`
+### createParser
 
 `HookMap<SyncBailHook>`
 
-Fired before a `Parser` instance is created. `parserOptions` is options in [module.parser](/configuration/module/#moduleparser) for the corresponding identifier or an empty object.
+Called before a `Parser` instance is created. `parserOptions` is options in [module.parser](/configuration/module/#moduleparser) for the corresponding identifier or an empty object.
 
 - Hook Parameters: `identifier`
 
 - Callback Parameters: `parserOptions`
 
 
-### `parser`
+### parser
 
 `HookMap<SyncHook>`
 
@@ -109,28 +109,44 @@ Fired after a `Parser` instance is created.
 
 - Callback Parameters: `parser` `parserOptions`
 
-Possible default identifiers: `javascript/auto` `javascript/dynamic` `javascript/esm` `json` `webassembly/sync` `webassembly/async` `asset`
+Possible default identifiers: 
+
+1. `javascript/auto`
+2. `javascript/dynamic`
+3. `javascript/esm`
+4. `json`
+5. `webassembly/sync`
+6. `webassembly/async`
+7. `asset`
 
 
-### `createGenerator`
+### createGenerator
 
 `HookMap<SyncBailHook>`
 
-Fired before a `Generator` instance is created. `generatorOptions` is options in [module.parser](/configuration/module/#modulegenerator) for the corresponding identifier or an empty object.
+Called before a `Generator` instance is created. `generatorOptions` is options in [module.parser](/configuration/module/#modulegenerator) for the corresponding identifier or an empty object.
 
 - Hook Parameters: `identifier`
 
 - Callback Parameters: `generatorOptions`
 
 
-### `generator`
+### generator
 
 `HookMap<SyncHook>`
 
-Fired after a `Generator` instance is created.
+Called after a `Generator` instance is created.
 
 - Hook Parameters: `identifier`
 
 - Callback Parameters: `generator` `generatorOptions`
 
-Possible default identifiers: `json` `webassembly/sync` `webassembly/async` `asset` `asset/source` `asset/resource` `asset/inline`
+Possible default identifiers:
+
+1. `json`
+2. `webassembly/sync`
+3. `webassembly/async`
+4. `asset`
+5. `asset/source`
+6. `asset/resource`
+7. `asset/inline`

--- a/src/content/api/normalmodulefactory-hooks.md
+++ b/src/content/api/normalmodulefactory-hooks.md
@@ -1,0 +1,136 @@
+---
+title: NormalModuleFactory Hooks
+group: Plugins
+sort: 13
+contributors:
+  - iguessitsokay
+---
+
+The `NormalModuleFactory` module is used by the `Compiler` to generate modules. Starting with entry points, it resolves each request, parses the content to find further requests, and keeps crawling through files by resolving all and parsing any new files. At last stage, each dependency becomes a Module instance.
+
+The `NormalModuleFactory` class extends `Tapable` and provides the following
+lifecycle hooks. They can be tapped the same way as compiler hooks:
+
+``` js
+NormalModuleFactory.hooks.someHook.tap(/* ... */);
+```
+
+NormaleModuleFactory creates `Parser` and `Generator` instances which can be accessed by HookMaps. Identifier must be passed to tap into these:
+
+``` js
+NormalModuleFactory.hooks.someHook.for('identifier').tap(/* ... */);
+```
+
+As with the `compiler`, `tapAsync` and `tapPromise` may also be available
+depending on the type of hook.
+
+
+### `beforeResolve`
+
+`AsyncSeriesBailHook`
+
+Fired when a new dependency request is encountered. A dependency can be ignored by returning `false`. Otherwise, it should return undefined to proceed.
+
+- Callback Parameters: `ResolveData`
+
+
+### `factorize`
+
+`AsyncSeriesBailHook`
+
+Fired before initiating resolve. It should return undefined to proceed.
+
+- Callback Parameters: `resolveData`
+
+
+### `resolve`
+
+`AsyncSeriesBailHook`
+
+Fired before the request is resolved. A dependency can be ignored by returning `false`. Returning a Module instance would finalize the process. Otherwise, it should return undefined to proceed.
+
+- Callback Parameters: `resolveData`
+
+
+### `resolveForScheme`
+
+`AsyncSeriesBailHook`
+
+Fired before a request with scheme (URI) is resolved.
+
+- Callback Parameters: `resolveData`
+
+
+### `afterResolve`
+
+`AsyncSeriesBailHook`
+
+Fired after the request is resolved.
+
+- Callback Parameters: `resolveData`
+
+
+### `createModule`
+
+`AsyncSeriesBailHook`
+
+Fired before a `Module` instance is created.
+
+- Callback Parameters: `createData` `resolveData`
+
+
+### `module`
+
+`SyncWaterfallHook`
+
+Fired after a `Module` instance is created.
+
+- Callback Parameters: `module` `createData` `resolveData`
+
+
+### `createParser`
+
+`HookMap<SyncBailHook>`
+
+Fired before a `Parser` instance is created. `parserOptions` is options in [module.parser](/configuration/module/#moduleparser) for the corresponding identifier or an empty object.
+
+- Hook Parameters: `identifier`
+
+- Callback Parameters: `parserOptions`
+
+
+### `parser`
+
+`HookMap<SyncHook>`
+
+Fired after a `Parser` instance is created.
+
+- Hook Parameters: `identifier`
+
+- Callback Parameters: `parser` `parserOptions`
+
+Possible default identifiers: `javascript/auto` `javascript/dynamic` `javascript/esm` `json` `webassembly/sync` `webassembly/async` `asset`
+
+
+### `createGenerator`
+
+`HookMap<SyncBailHook>`
+
+Fired before a `Generator` instance is created. `generatorOptions` is options in [module.parser](/configuration/module/#modulegenerator) for the corresponding identifier or an empty object.
+
+- Hook Parameters: `identifier`
+
+- Callback Parameters: `generatorOptions`
+
+
+### `generator`
+
+`HookMap<SyncHook>`
+
+Fired after a `Generator` instance is created.
+
+- Hook Parameters: `identifier`
+
+- Callback Parameters: `generator` `generatorOptions`
+
+Possible default identifiers: `json` `webassembly/sync` `webassembly/async` `asset` `asset/source` `asset/resource` `asset/inline`

--- a/src/content/api/parser.md
+++ b/src/content/api/parser.md
@@ -1,7 +1,7 @@
 ---
 title: JavascriptParser Hooks
 group: Plugins
-sort: 11
+sort: 12
 contributors:
   - byzyk
   - DeTeam
@@ -15,7 +15,7 @@ being processed by webpack. The `parser` is yet another webpack class that
 extends `tapable` and provides a variety of `tapable` hooks that can be used by
 plugin authors to customize the parsing process.
 
-The `parser` is found within [module factories](/api/compiler-hooks/#normalmodulefactory) and therefore takes little
+The `parser` is found within [NormalModuleFactory](/api/compiler-hooks/#normalmodulefactory) and therefore takes little
 more work to access:
 
 ``` js

--- a/src/content/api/plugins.md
+++ b/src/content/api/plugins.md
@@ -1,7 +1,7 @@
 ---
 title: Plugin API
 group: Plugins
-sort: 12
+sort: 14
 contributors:
   - thelarkinn
   - pksjce

--- a/src/content/api/resolvers.md
+++ b/src/content/api/resolvers.md
@@ -1,7 +1,7 @@
 ---
 title: Resolvers
 group: Plugins
-sort: 13
+sort: 15
 contributors:
   - EugeneHlushko
   - chenxsan


### PR DESCRIPTION
- Add pages NormalModuleFactory Hooks and ContextModuleFactory Hooks.
- Add links to new pages in Compiler Hooks.
- Update Sort values to keep alphabetical order within Plugin sub-menu.

I am ready to work further on any bugs/improvements.