### PR TITLE
Added the necessary import 'webpack-dev-server' to configuration-languages for typescript

### DIFF
--- a/src/content/configuration/configuration-languages.md
+++ b/src/content/configuration/configuration-languages.md
@@ -33,7 +33,7 @@ __webpack.config.ts__
 ```typescript
 import * as path from 'path';
 import * as webpack from 'webpack';
-// and, if using webpack-dev-server
+// just in case you run into any typescript error when configuring `devServer`
 import 'webpack-dev-server';
 
 const config: webpack.Configuration = {

--- a/src/content/configuration/configuration-languages.md
+++ b/src/content/configuration/configuration-languages.md
@@ -33,6 +33,8 @@ __webpack.config.ts__
 ```typescript
 import * as path from 'path';
 import * as webpack from 'webpack';
+// and, if using webpack-dev-server
+import 'webpack-dev-server';
 
 const config: webpack.Configuration = {
   mode: 'production',


### PR DESCRIPTION
Improved the example in configuration languages for typescript to include the necessary “import 'webpack-dev-server';”. 
This one line would have saved me some time. I hope it will help someone else.
