### PR TITLE
highlight current menu

### DIFF
--- a/src/components/SidebarItem/SidebarItem.jsx
+++ b/src/components/SidebarItem/SidebarItem.jsx
@@ -1,10 +1,10 @@
 import { Component } from 'react';
-import Link from '../Link/Link';
 import './SidebarItem.scss';
 import list2Tree from '../../utilities/list2Tree';
 import ChevronRightIcon from '../../styles/icons/chevron-right.svg';
 import BarIcon from '../../styles/icons/vertical-bar.svg';
 import PropTypes from 'prop-types';
+import { NavLink } from 'react-router-dom';
 
 const block = 'sidebar-item';
 
@@ -63,13 +63,14 @@ export default class SidebarItem extends Component {
           <BarIcon className={`${block}__toggle`} width={15} height={17} fill="#175d96" />
         )}
 
-        <Link
+        <NavLink
+          exact
           key={this.props.url}
           className={`${block}__title`}
           to={this.props.url}
           onClick={this.scrollTop}>
           {title}
-        </Link>
+        </NavLink>
 
         {anchors.length > 0 ? this.renderAnchors(tree) : null}
       </div>

--- a/src/components/SidebarItem/SidebarItem.scss
+++ b/src/components/SidebarItem/SidebarItem.scss
@@ -26,6 +26,10 @@
     color: getColor(elephant);
     max-width: 85%;
     @include control-overflow;
+    &.active {
+      font-weight: 600;
+      color: #1d78c1;
+    }
   }
 
   &__anchors {

--- a/src/components/SidebarItem/SidebarItem.scss
+++ b/src/components/SidebarItem/SidebarItem.scss
@@ -28,7 +28,7 @@
     @include control-overflow;
     &.active {
       font-weight: 600;
-      color: #1d78c1;
+      color: #333;
     }
   }
 

--- a/src/styles/dark.scss
+++ b/src/styles/dark.scss
@@ -70,6 +70,9 @@
   .sidebar-item__anchor a {
     color: #b8b8b8;
   }
+  .sidebar-item__title.active {
+    color: #fff;
+  }
   .navigation-sub__link.navigation-sub__link--active {
     color: #fff;
   }


### PR DESCRIPTION
As I mentioned in https://github.com/webpack/webpack.js.org/pull/4413:

> The Bold style can be used for highlighting active menu item later.

![image](https://user-images.githubusercontent.com/1091472/106536989-6e68d180-6534-11eb-8e53-7f4b6d3b6091.png)
