### PR TITLE
docs(dev-server): clarify root path for generated files

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -20,11 +20,14 @@ contributors:
   - g100g
   - anikethsaha
   - snitin315
+  - maxloh
 ---
 
 [webpack-dev-server](https://github.com/webpack/webpack-dev-server) can be used to quickly develop an application. See the [development guide](/guides/development/) to get started.
 
 This page describes the options that affect the behavior of webpack-dev-server (short: dev-server).
+
+T> dev-server uses `output.path` instead of current working directory to be the root path for serving generated files, which might not work on your project structure (e.g. if you reference output files with relative path). See the [development guide](/guides/development#using-webpack-dev-server) for more information on adjusting webpack configuration to work with dev-server.
 
 T> Options that are compatible with [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware) have 🔑 next to them.
 

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -20,14 +20,11 @@ contributors:
   - g100g
   - anikethsaha
   - snitin315
-  - maxloh
 ---
 
 [webpack-dev-server](https://github.com/webpack/webpack-dev-server) can be used to quickly develop an application. See the [development guide](/guides/development/) to get started.
 
 This page describes the options that affect the behavior of webpack-dev-server (short: dev-server).
-
-T> dev-server uses `output.path` instead of current working directory to be the root path for serving generated files, which might not work on your project structure (e.g. if you reference output files with relative path). See the [development guide](/guides/development/#using-webpack-dev-server) for more information on adjusting webpack configuration to work with dev-server.
 
 T> Options that are compatible with [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware) have 🔑 next to them.
 

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -27,7 +27,7 @@ contributors:
 
 This page describes the options that affect the behavior of webpack-dev-server (short: dev-server).
 
-T> dev-server uses `output.path` instead of current working directory to be the root path for serving generated files, which might not work on your project structure (e.g. if you reference output files with relative path). See the [development guide](/guides/development#using-webpack-dev-server) for more information on adjusting webpack configuration to work with dev-server.
+T> dev-server uses `output.path` instead of current working directory to be the root path for serving generated files, which might not work on your project structure (e.g. if you reference output files with relative path). See the [development guide](/guides/development/#using-webpack-dev-server) for more information on adjusting webpack configuration to work with dev-server.
 
 T> Options that are compatible with [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware) have 🔑 next to them.
 

--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -266,7 +266,8 @@ __webpack.config.js__
 
 This tells `webpack-dev-server` to serve the files from the `dist` directory on `localhost:8080`.
 
->T `webpack-dev-server` serves bundled files from the directory of [`output.path`](/configuration/output/#outputpath), i.e., files will be available under `http://[devServer.host]:[devServer.port]/[output.publicPath]/[output.filename]`.
+T> `webpack-dev-server` serves bundled files from the directory defined in [`output.path`](/configuration/output/#outputpath), i.e., files will be available under `http://[devServer.host]:[devServer.port]/[output.publicPath]/[output.filename]`.
+
 W> webpack-dev-server doesn't write any output files after compiling. Instead, it keeps bundle files in memory and serves them as if they were real files mounted at the server's root path. If your page expects to find the bundle files on a different path, you can change this with the [`publicPath`](/configuration/dev-server/#devserverpublicpath-) option in the dev server's configuration.
 
 Let's add a script to easily run the dev server as well:

--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -266,34 +266,7 @@ __webpack.config.js__
 
 This tells `webpack-dev-server` to serve the files from the `dist` directory on `localhost:8080`.
 
-`webpack-dev-server` uses `output.path` as the root path for serving generated files. Generated files will be available under `http://localhost:[devServer.port]/[output.publicPath]/[output.filename]`. If you want to serve generated files under a specific directory on dev server, e.g. under the `assets` directory (`http://localhost:8080/assets/bundle.js`), you will need to set output directory with `output.filename` instead of `output.path`, or configure `output.publicPath`.
-
-__webpack.config.js__
-
-``` diff
- const path = require('path');
-
- module.exports = {
-   // Set output directory with output.filename instead of output.path
-   output: {
--    filename: 'bundle.js',
-+    filename: 'assets/bundle.js',
--    path: path.resolve('assets'),
-+    path: path.resolve(),
-   },
- };
-
- // Or
-
- module.exports = {
-   output: {
-     filename: 'bundle.js',
-     path: path.resolve('assets'), // Keep this line intact to specify output directory for building
-+    publicPath: '/assets/', // Tell webpack-dev-server to serve generated files under assets directory
-   },
- };
-```
-
+>T `webpack-dev-server` serves bundled files from the directory of [`output.path`](/configuration/output/#outputpath), i.e., files will be available under `http://[devServer.host]:[devServer.port]/[output.publicPath]/[output.filename]`.
 W> webpack-dev-server doesn't write any output files after compiling. Instead, it keeps bundle files in memory and serves them as if they were real files mounted at the server's root path. If your page expects to find the bundle files on a different path, you can change this with the [`publicPath`](/configuration/dev-server/#devserverpublicpath-) option in the dev server's configuration.
 
 Let's add a script to easily run the dev server as well:

--- a/src/content/guides/development.md
+++ b/src/content/guides/development.md
@@ -14,6 +14,7 @@ contributors:
   - trivikr
   - aholzner
   - chenxsan
+  - maxloh
 ---
 
 T> This guide extends on code examples found in the [Output Management](/guides/output-management) guide.
@@ -264,6 +265,34 @@ __webpack.config.js__
 ```
 
 This tells `webpack-dev-server` to serve the files from the `dist` directory on `localhost:8080`.
+
+`webpack-dev-server` uses `output.path` as the root path for serving generated files. Generated files will be available under `http://localhost:[devServer.port]/[output.publicPath]/[output.filename]`. If you want to serve generated files under a specific directory on dev server, e.g. under the `assets` directory (`http://localhost:8080/assets/bundle.js`), you will need to set output directory with `output.filename` instead of `output.path`, or configure `output.publicPath`.
+
+__webpack.config.js__
+
+``` diff
+ const path = require('path');
+
+ module.exports = {
+   // Set output directory with output.filename instead of output.path
+   output: {
+-    filename: 'bundle.js',
++    filename: 'assets/bundle.js',
+-    path: path.resolve('assets'),
++    path: path.resolve(),
+   },
+ };
+
+ // Or
+
+ module.exports = {
+   output: {
+     filename: 'bundle.js',
+     path: path.resolve('assets'), // Keep this line intact to specify output directory for building
++    publicPath: '/assets/', // Tell webpack-dev-server to serve generated files under assets directory
+   },
+ };
+```
 
 W> webpack-dev-server doesn't write any output files after compiling. Instead, it keeps bundle files in memory and serves them as if they were real files mounted at the server's root path. If your page expects to find the bundle files on a different path, you can change this with the [`publicPath`](/configuration/dev-server/#devserverpublicpath-) option in the dev server's configuration.
 


### PR DESCRIPTION
Clarify root path for generated files

Related: https://github.com/webpack/webpack-dev-server/issues/2982