### PR TITLE
optimize Badge style

### DIFF
--- a/src/components/Badge/Badge.scss
+++ b/src/components/Badge/Badge.scss
@@ -1,8 +1,8 @@
 .badge {
   background-color: #1d78c1;
-  padding: 0 6px;
-  border-radius: 2px;
+  padding: 0 4px;
   color: #fff;
   position: relative;
   top: -4px;
+  font-size: 14px;
 }


### PR DESCRIPTION
The current `Badge` is too large compared to other body texts when we use it a lot:

<img width='630' src='https://user-images.githubusercontent.com/1091472/106698902-bebb5e80-661c-11eb-876c-22f615c5b043.png' />


## After

<img width='564' src='https://user-images.githubusercontent.com/1091472/106698771-73a14b80-661c-11eb-9016-9ad39767fc12.png' />

