### PR TITLE
docs: add output.publicPath: 'auto'

### DIFF
--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -1135,7 +1135,7 @@ module.exports = {
   //...
   output: {
     // One of the below
-    publicPath: 'auto', // It automatically determines the publicPath from `import.meta.url`, `document.currentScript`, `<script/>` or `self.location`.
+    publicPath: 'auto', // It automatically determines the public path from either `import.meta.url`, `document.currentScript`, `<script />` or `self.location`.
     publicPath: 'https://cdn.example.com/assets/', // CDN (always HTTPS)
     publicPath: '//cdn.example.com/assets/', // CDN (same protocol)
     publicPath: '/assets/', // server-relative
@@ -1156,7 +1156,7 @@ __webpack_public_path__ = myRuntimePublicPath;
 
 See [this discussion](https://github.com/webpack/webpack/issues/2776#issuecomment-233208623) for more information on `__webpack_public_path__`.
 
-T> output.publicPath defaults to `'auto'` with `web` and `web-worker` targets.
+T> `output.publicPath` defaults to `'auto'` with `web` and `web-worker` targets.
 
 ## `output.sourceMapFilename`
 

--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -1135,6 +1135,7 @@ module.exports = {
   //...
   output: {
     // One of the below
+    publicPath: 'auto', // It automatically determines the publicPath from <script> tag. Only works with web and web-worker targets.
     publicPath: 'https://cdn.example.com/assets/', // CDN (always HTTPS)
     publicPath: '//cdn.example.com/assets/', // CDN (same protocol)
     publicPath: '/assets/', // server-relative

--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -1135,7 +1135,7 @@ module.exports = {
   //...
   output: {
     // One of the below
-    publicPath: 'auto', // It automatically determines the publicPath from <script> tag. Only works with web and web-worker targets.
+    publicPath: 'auto', // It automatically determines the publicPath from `import.meta.url`, `document.currentScript`, `<script/>` or `self.location`.
     publicPath: 'https://cdn.example.com/assets/', // CDN (always HTTPS)
     publicPath: '//cdn.example.com/assets/', // CDN (same protocol)
     publicPath: '/assets/', // server-relative
@@ -1156,6 +1156,7 @@ __webpack_public_path__ = myRuntimePublicPath;
 
 See [this discussion](https://github.com/webpack/webpack/issues/2776#issuecomment-233208623) for more information on `__webpack_public_path__`.
 
+T> output.publicPath defaults to `'auto'` with `web` and `web-worker` targets.
 
 ## `output.sourceMapFilename`
 

--- a/src/content/guides/public-path.md
+++ b/src/content/guides/public-path.md
@@ -60,4 +60,4 @@ import './public-path';
 import './app';
 ```
 
-T> When using `web` or `web-worker` target, `publicPath` defaults to `'auto'` which will automatically determines the public path from either `import.meta.url`, `document.currentScript`, `<script />` or `self.location`.
+T> When using `web` or `web-worker` target, `publicPath` defaults to `'auto'` which will automatically determine the public path from either `import.meta.url`, `document.currentScript`, `<script />` or `self.location`.

--- a/src/content/guides/public-path.md
+++ b/src/content/guides/public-path.md
@@ -60,4 +60,4 @@ import './public-path';
 import './app';
 ```
 
-T> You can also set `publicPath: 'auto'`. It automatically determines the `publicPath` from `<script>` tag. It only works with `web` and `web-worker` targets.
+T> You can also set `publicPath: 'auto'`. It automatically determines the publicPath from `import.meta.url`, `document.currentScript`, `<script/>` or `self.location`. It only works with `web` and `web-worker` targets.

--- a/src/content/guides/public-path.md
+++ b/src/content/guides/public-path.md
@@ -59,3 +59,5 @@ W> Be aware that if you use ES6 module imports in your entry file the `__webpack
 import './public-path';
 import './app';
 ```
+
+T> You can also set `publicPath: 'auto'`. It automatically determines the `publicPath` from `<script>` tag. It only works with `web` and `web-worker` targets.

--- a/src/content/guides/public-path.md
+++ b/src/content/guides/public-path.md
@@ -60,4 +60,4 @@ import './public-path';
 import './app';
 ```
 
-T> You can also set `publicPath: 'auto'`. It automatically determines the publicPath from `import.meta.url`, `document.currentScript`, `<script/>` or `self.location`. It only works with `web` and `web-worker` targets.
+T> When using `web` or `web-worker` target, `publicPath` defaults to `'auto'` which will automatically determines the public path from either `import.meta.url`, `document.currentScript`, `<script />` or `self.location`.


### PR DESCRIPTION
fixes https://github.com/webpack/webpack.js.org/issues/4491

add `output.publicPath: 'auto'`