### PR TITLE
hide blog from sub navbar

### DIFF
--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -169,6 +169,9 @@ function Site(props) {
           (item) => item.type !== 'directory' && item.url !== '/'
         )
   );
+
+  // not to show in sub navbar
+  const excludeItems = ['contribute', 'blog'];
   return (
     <MDXProvider
       components={{
@@ -194,7 +197,9 @@ function Site(props) {
                     url
                   ),
                 children: _strip(
-                  sections.filter((item) => item.name !== 'contribute')
+                  sections.filter(
+                    ({ name }) => excludeItems.includes(name) === false
+                  )
                 ),
               },
               { content: 'Contribute', url: '/contribute/' },


### PR DESCRIPTION
No need to duplicate `blog` link:

![image](https://user-images.githubusercontent.com/1091472/106991460-36ba8d80-67b1-11eb-8882-9091df8443e6.png)
