### PR TITLE
docs: remove deprecation of the loader this._compilation api

### DIFF
--- a/src/content/api/loaders.md
+++ b/src/content/api/loaders.md
@@ -454,6 +454,18 @@ Read in which [`mode`](/configuration/mode/) webpack is running.
 
 Possible values: `'production'`, `'development'`, `'none'`
 
+## Webpack specific properties
+
+The loader interface provides all module relate information. However in rare cases you might need access to the compiler api itself. 
+
+W> Please note that using these webpack specific properties will have a negative impact on your loaders compatibility.
+
+Therefore you should only use them as a last resort. Using them will reduce the portability of your loader. 
+
+### `this._compilation`
+
+Access to the current Compilation object of webpack.
+
 ## Deprecated context properties
 
 W> The usage of these properties is highly discouraged since we are planning to remove them from the context. They are still listed here for documentation purposes.
@@ -473,10 +485,6 @@ A boolean flag. It is set when in debug mode.
 ### `this.minimize`
 
 Tells if result should be minimized.
-
-### `this._compilation`
-
-Hacky access to the Compilation object of webpack.
 
 ### `this._compiler`
 


### PR DESCRIPTION
According to @sokra `this._compilation` should not be deprecated.
Therefore I moved it into the "webpack specific properties" section

[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
