### PR TITLE
exclude deprecated json5-loader

### DIFF
--- a/src/content/loaders/index.md
+++ b/src/content/loaders/index.md
@@ -25,7 +25,6 @@ Loaders are activated by using `loadername!` prefixes in `require()` statements,
 
 ## JSON
 
-- [`json5-loader`](/loaders/json5-loader) Loads and transpiles a [JSON 5](https://json5.org/) file
 - [`cson-loader`](https://github.com/awnist/cson-loader) Loads and transpiles a [CSON](https://github.com/bevry/cson#what-is-cson) file
 
 ## Transpiling

--- a/src/utilities/constants.js
+++ b/src/utilities/constants.js
@@ -16,6 +16,7 @@ const excludedLoaders = [
   'webpack-contrib/restyle-loader',
   'webpack-contrib/gzip-loader',
   'webpack-contrib/cache-loader',
+  'webpack-contrib/json5-loader',
 ];
 const excludedPlugins = [
   'webpack-contrib/component-webpack-plugin',


### PR DESCRIPTION
It's already deprecated under webpack 5 as per https://github.com/webpack-contrib/json5-loader.