### PR TITLE
use NavLink for SidebarItem

### DIFF
--- a/cypress/integration/pr_4435_spec.js
+++ b/cypress/integration/pr_4435_spec.js
@@ -17,6 +17,7 @@ describe('Open page in new tab', { scrollBehavior: false }, () => {
     // we click the menu
     cy.get(selector).click();
     cy.window().then((win) => {
+      console.log('click the menu');
       expect(win.scrollTo).to.be.calledTwice;
     });
 

--- a/cypress/integration/pr_4435_spec.js
+++ b/cypress/integration/pr_4435_spec.js
@@ -17,7 +17,6 @@ describe('Open page in new tab', { scrollBehavior: false }, () => {
     // we click the menu
     cy.get(selector).click();
     cy.window().then((win) => {
-      console.log('click the menu');
       expect(win.scrollTo).to.be.calledTwice;
     });
 

--- a/src/components/Page/Page.jsx
+++ b/src/components/Page/Page.jsx
@@ -27,7 +27,7 @@ export default function Page(props) {
   const [content, setContent] = useState(
     isDynamicContent
       ? PlaceholderString()
-      : props.content.default || props.content
+      : () => props.content.default || props.content
   );
   const [contentLoaded, setContentLoaded] = useState(
     isDynamicContent ? false : true
@@ -48,7 +48,7 @@ export default function Page(props) {
 
   useEffect(() => {
     if (contentLoaded) {
-      const hash = window.location.hash;
+      const hash = location.hash;
       if (hash) {
         const element = document.querySelector(hash);
         if (element) {

--- a/src/components/Page/Page.jsx
+++ b/src/components/Page/Page.jsx
@@ -36,8 +36,8 @@ export default function Page(props) {
   useEffect(() => {
     if (props.content instanceof Promise) {
       props.content
-        .then((module) => {
-          setContent(() => module.default || module);
+        .then((mod) => {
+          setContent(() => mod.default || mod);
           setContentLoaded(true);
         })
         .catch(() => setContent('Error loading content.'));

--- a/src/components/Page/Page.jsx
+++ b/src/components/Page/Page.jsx
@@ -1,6 +1,7 @@
 // Import External Dependencies
-import { Children, isValidElement, Component } from 'react';
+import { Children, isValidElement, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import { useLocation } from 'react-router-dom';
 
 // Import Components
 import PageLinks from '../PageLinks/PageLinks';
@@ -12,146 +13,128 @@ import AdjacentPages from './AdjacentPages';
 
 // Load Styling
 import './Page.scss';
+export default function Page(props) {
+  const {
+    title,
+    contributors = [],
+    related = [],
+    previous,
+    next,
+    ...rest
+  } = props;
 
-class Page extends Component {
-  static propTypes = {
-    title: PropTypes.string,
-    contributors: PropTypes.array,
-    related: PropTypes.array,
-    previous: PropTypes.object,
-    next: PropTypes.object,
-    content: PropTypes.oneOfType([
-      PropTypes.shape({
-        then: PropTypes.func.isRequired,
-        default: PropTypes.string,
-      }),
-    ]),
-  };
-  constructor(props) {
-    super(props);
+  const isDynamicContent = props.content instanceof Promise;
+  const [content, setContent] = useState(
+    isDynamicContent
+      ? PlaceholderString()
+      : props.content.default || props.content
+  );
+  const [contentLoaded, setContentLoaded] = useState(
+    isDynamicContent ? false : true
+  );
 
-    const { content } = props;
-    const isDynamicContent = content instanceof Promise;
-
-    this.state = {
-      content: isDynamicContent
-        ? PlaceholderString()
-        : content.default || content,
-      contentLoaded: isDynamicContent ? false : true,
-    };
-  }
-
-  componentDidMount() {
-    const { content } = this.props;
-
-    if (content instanceof Promise) {
-      content
-        .then((module) =>
-          this.setState(
-            {
-              content: module.default || module,
-              contentLoaded: true,
-            },
-            () => {
-              const hash = window.location.hash;
-              if (hash) {
-                const element = document.querySelector(hash);
-                if (element) {
-                  element.scrollIntoView();
-                }
-              } else {
-                window.scrollTo(0, 0);
-              }
-            }
-          )
-        )
-        .catch(() =>
-          this.setState({
-            content: 'Error loading content.',
-          })
-        );
+  useEffect(() => {
+    if (props.content instanceof Promise) {
+      props.content
+        .then((module) => {
+          setContent(() => module.default || module);
+          setContentLoaded(true);
+        })
+        .catch(() => setContent('Error loading content.'));
     }
-  }
+  }, [props.content]);
 
-  render() {
-    const {
-      title,
-      contributors = [],
-      related = [],
-      previous,
-      next,
-      ...rest
-    } = this.props;
+  const location = useLocation();
 
-    const { contentLoaded } = this.state;
-    const loadRelated = contentLoaded && related && related.length !== 0;
-    const loadContributors =
-      contentLoaded && contributors && contributors.length !== 0;
-
-    const { content } = this.state;
-
-    let contentRender;
-
-    if (typeof content === 'function') {
-      contentRender = content({}).props.children.slice(4); // Cut frontmatter information
-      contentRender = Children.map(contentRender, (child) => {
-        if (isValidElement(child)) {
-          if (child.props.mdxType === 'pre') {
-            // eslint-disable-next-line
-            return <Pre children={child.props.children} />;
-          }
+  useEffect(() => {
+    if (contentLoaded) {
+      const hash = window.location.hash;
+      if (hash) {
+        const element = document.querySelector(hash);
+        if (element) {
+          element.scrollIntoView();
         }
-
-        return child;
-      });
-    } else {
-      contentRender = (
-        <div
-          dangerouslySetInnerHTML={{
-            __html: this.state.content,
-          }}
-        />
-      );
+      } else {
+        window.scrollTo(0, 0);
+      }
     }
+  }, [contentLoaded, location]);
 
-    return (
-      <section className="page">
-        <PageLinks page={rest} />
+  const loadRelated = contentLoaded && related && related.length !== 0;
+  const loadContributors =
+    contentLoaded && contributors && contributors.length !== 0;
 
-        <Markdown>
-          <h1>{title}</h1>
+  let contentRender;
 
-          {contentRender}
+  if (typeof content === 'function') {
+    contentRender = content({}).props.children.slice(4); // Cut frontmatter information
+    contentRender = Children.map(contentRender, (child) => {
+      if (isValidElement(child)) {
+        if (child.props.mdxType === 'pre') {
+          // eslint-disable-next-line
+          return <Pre children={child.props.children} />;
+        }
+      }
 
-          {(previous || next) && (
-            <AdjacentPages previous={previous} next={next} />
-          )}
-
-          {loadRelated && (
-            <div className="related__section">
-              <hr />
-              <h3>Further Reading</h3>
-              <ul>
-                {related.map((link, index) => (
-                  <li key={index}>
-                    <a href={link.url}>{link.title}</a>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-
-          {loadContributors && (
-            <div className="contributors__section">
-              <hr />
-              <h3>Contributors</h3>
-              <Contributors contributors={contributors} />
-            </div>
-          )}
-        </Markdown>
-      </section>
+      return child;
+    });
+  } else {
+    contentRender = (
+      <div
+        dangerouslySetInnerHTML={{
+          __html: content,
+        }}
+      />
     );
   }
-}
+  return (
+    <section className="page">
+      <PageLinks page={rest} />
 
-export default Page;
+      <Markdown>
+        <h1>{title}</h1>
+
+        {contentRender}
+
+        {(previous || next) && (
+          <AdjacentPages previous={previous} next={next} />
+        )}
+
+        {loadRelated && (
+          <div className="related__section">
+            <hr />
+            <h3>Further Reading</h3>
+            <ul>
+              {related.map((link, index) => (
+                <li key={index}>
+                  <a href={link.url}>{link.title}</a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {loadContributors && (
+          <div className="contributors__section">
+            <hr />
+            <h3>Contributors</h3>
+            <Contributors contributors={contributors} />
+          </div>
+        )}
+      </Markdown>
+    </section>
+  );
+}
+Page.propTypes = {
+  title: PropTypes.string,
+  contributors: PropTypes.array,
+  related: PropTypes.array,
+  previous: PropTypes.object,
+  next: PropTypes.object,
+  content: PropTypes.oneOfType([
+    PropTypes.shape({
+      then: PropTypes.func.isRequired,
+      default: PropTypes.string,
+    }),
+  ]),
+};

--- a/src/components/SidebarItem/SidebarItem.jsx
+++ b/src/components/SidebarItem/SidebarItem.jsx
@@ -38,12 +38,6 @@ export default class SidebarItem extends Component {
     );
   }
 
-  scrollTop(event) {
-    if (!event.metaKey && !event.ctrlKey) {
-      window.scrollTo(0, 0);
-    }
-  }
-
   render() {
     let { title, anchors = [] } = this.props;
     let openMod = this.state.open ? `${block}--open` : '';
@@ -76,7 +70,6 @@ export default class SidebarItem extends Component {
           key={this.props.url}
           className={`${block}__title`}
           to={this.props.url}
-          onClick={this.scrollTop}
         >
           {title}
         </NavLink>

--- a/src/components/SidebarItem/SidebarItem.jsx
+++ b/src/components/SidebarItem/SidebarItem.jsx
@@ -28,7 +28,9 @@ export default class SidebarItem extends Component {
             className={`${block}__anchor`}
             title={anchor.title}
           >
-            <a href={this._generateAnchorURL(anchor)}>{anchor.title}</a>
+            <NavLink to={this._generateAnchorURL(anchor)}>
+              {anchor.title}
+            </NavLink>
             {anchor.children && this.renderAnchors(anchor.children)}
           </li>
         ))}


### PR DESCRIPTION
This website is a Single Page React Application with precompiled HTML, but links in sidebar are rendered as [`<a>`](https://github.com/webpack/webpack.js.org/blob/master/src/components/SidebarItem/SidebarItem.jsx#L31) elements at the moment, which would cause browser to load a whole new html page. When we render them as `NavLink`, it would dynamic load the needed part instead of loading a new html page which could load the page faster.