### PR TITLE
docs: add info about the parallelism with multiple configurations

### DIFF
--- a/src/content/configuration/configuration-types.md
+++ b/src/content/configuration/configuration-types.md
@@ -97,10 +97,16 @@ T> If you pass a name to [`--config-name`](/api/cli/#config-name) flag, webpack 
 
 In case you export multiple configurations, you can use `parallelism` option on the configuration array to specify the maximum number of compilers that will compile in parallel.
 
+**webpack.config.js**
+
 ```javascript
   module.exports = [
-    { ... },
-    { ... }
+    { 
+      //config-1 
+    },
+    { 
+      //config-2 
+    }
   ];
   module.exports.parallelism = 1;
 ```

--- a/src/content/configuration/configuration-types.md
+++ b/src/content/configuration/configuration-types.md
@@ -90,3 +90,17 @@ module.exports = [
 ```
 
 T> If you pass a name to [`--config-name`](/api/cli/#config-name) flag, webpack will only build that specific configuration.
+
+### parallelism
+
+`number`
+
+In case you export multiple configurations, you can use `parallelism` option on the configuration array to specify the maximum number of compilers that will compile in parallel.
+
+```javascript
+  module.exports = [
+    { ... },
+    { ... }
+  ];
+  module.exports.parallelism = 1;
+```

--- a/src/content/configuration/configuration-types.md
+++ b/src/content/configuration/configuration-types.md
@@ -100,13 +100,13 @@ In case you export multiple configurations, you can use `parallelism` option on 
 **webpack.config.js**
 
 ```javascript
-  module.exports = [
-    { 
-      //config-1 
-    },
-    { 
-      //config-2 
-    }
-  ];
-  module.exports.parallelism = 1;
+module.exports = [
+  { 
+    //config-1 
+  },
+  { 
+    //config-2 
+  }
+];
+module.exports.parallelism = 1;
 ```


### PR DESCRIPTION
Refers https://github.com/webpack/webpack.js.org/issues/4587

Add information about the `parallelism` option on the configuration array.