### PR TITLE
enable eslint-plugin-react-hooks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
     jest: true,
     'cypress/globals': true,
   },
-  plugins: ['markdown', 'cypress'],
+  plugins: ['markdown', 'cypress', 'react-hooks'],
   globals: {
     __DEV__: true,
   },
@@ -19,6 +19,8 @@ module.exports = {
     quotes: ['error', 'single'],
     'react/jsx-uses-react': 'off', // no longer needed with new jsx transform
     'react/react-in-jsx-scope': 'off', // ditto
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
   },
   settings: {
     react: {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "eslint-plugin-cypress": "^2.11.2",
     "eslint-plugin-markdown": "^2.0.0",
     "eslint-plugin-react": "^7.22.0",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "front-matter": "^4.0.2",
     "html-loader": "^1.3.0",
     "html-webpack-plugin": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4897,6 +4897,11 @@ eslint-plugin-markdown@^2.0.0:
     remark-parse "^5.0.0"
     unified "^6.1.2"
 
+eslint-plugin-react-hooks@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
+  integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
+
 eslint-plugin-react@^7.22.0:
   version "7.22.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.22.0.tgz#3d1c542d1d3169c45421c1215d9470e341707269"


### PR DESCRIPTION
We're likely to have many hook usages, hence enable the[ eslint plugin](https://reactjs.org/docs/hooks-rules.html#eslint-plugin) to catch potential issues.