### PR TITLE
docs(configuration): add version

### DIFF
--- a/src/content/configuration/configuration-types.mdx
+++ b/src/content/configuration/configuration-types.mdx
@@ -93,20 +93,21 @@ T> If you pass a name to [`--config-name`](/api/cli/#config-name) flag, webpack 
 
 ### parallelism
 
-`number`
-
 In case you export multiple configurations, you can use `parallelism` option on the configuration array to specify the maximum number of compilers that will compile in parallel.
+
+- Type: `number`
+- Available: 5.22.0+
 
 **webpack.config.js**
 
 ```javascript
 module.exports = [
-  { 
-    //config-1 
+  {
+    //config-1
   },
-  { 
-    //config-2 
-  }
+  {
+    //config-2
+  },
 ];
 module.exports.parallelism = 1;
 ```


### PR DESCRIPTION
Follows-up of https://github.com/webpack/webpack.js.org/pull/4593 as it's a feature available in webpack 5.22.0.