### PR TITLE
docs(configuration): fix tip for mode option

### DIFF
--- a/src/content/configuration/mode.md
+++ b/src/content/configuration/mode.md
@@ -42,7 +42,7 @@ The following string values are supported:
 
 If not set, webpack sets `production` as the default value for `mode`.
 
-T> Please remember that setting `NODE_ENV` doesn't automatically set `mode`.
+T> If `mode` is not provided via configuration or CLI, CLI will check if `NODE_ENV` is set to any of the accepted values for `mode` and will use it to set `mode`.
 
 ### Mode: development
 

--- a/src/content/configuration/mode.md
+++ b/src/content/configuration/mode.md
@@ -42,7 +42,7 @@ The following string values are supported:
 
 If not set, webpack sets `production` as the default value for `mode`.
 
-T> If `mode` is not provided via configuration or CLI, CLI will check if `NODE_ENV` is set to any of the accepted values for `mode` and will use it to set `mode`.
+T> If `mode` is not provided via configuration or CLI, CLI will check if `NODE_ENV` is set to any of the accepted values for `mode` and will automatically use it to set `mode`.
 
 ### Mode: development
 

--- a/src/content/configuration/mode.md
+++ b/src/content/configuration/mode.md
@@ -42,7 +42,7 @@ The following string values are supported:
 
 If not set, webpack sets `production` as the default value for `mode`.
 
-T> If `mode` is not provided via configuration or CLI, CLI will check if `NODE_ENV` is set to any of the accepted values for `mode` and will automatically use it to set `mode`.
+T> If `mode` is not provided via configuration or CLI, CLI will use any valid `NODE_ENV` value for `mode`.
 
 ### Mode: development
 


### PR DESCRIPTION
fix tip.

`NODE_ENV` can automatically set `mode`.

Reference -  https://github.com/webpack/webpack-cli/blob/4c786e39f342414948c9620f128f67f8b1e821e2/packages/webpack-cli/lib/webpack-cli.js#L1527-L1536