### PR TITLE
docs(guides): add tip about CLI env vars

### DIFF
--- a/src/content/guides/environment-variables.md
+++ b/src/content/guides/environment-variables.md
@@ -47,4 +47,4 @@ module.exports = (env) => {
 };
 ```
 
-T> webpack CLI offers some built-in environment variables which you can access inside a wbpack configuration. Know more about them [here](/api/cli/#environment-variables)
+T> Webpack CLI offers some [built-in environment variables](/api/cli/#environment-variables) which you can access inside a webpack configuration.

--- a/src/content/guides/environment-variables.md
+++ b/src/content/guides/environment-variables.md
@@ -46,3 +46,5 @@ module.exports = (env) => {
   };
 };
 ```
+
+T> webpack CLI offers some built in environment variables which you can access inside a wbpack configuration. Know more about them [here](/api/cli/#environment-variables)

--- a/src/content/guides/environment-variables.md
+++ b/src/content/guides/environment-variables.md
@@ -47,4 +47,4 @@ module.exports = (env) => {
 };
 ```
 
-T> webpack CLI offers some built in environment variables which you can access inside a wbpack configuration. Know more about them [here](/api/cli/#environment-variables)
+T> webpack CLI offers some built-in environment variables which you can access inside a wbpack configuration. Know more about them [here](/api/cli/#environment-variables)


### PR DESCRIPTION
Update environment-variables guide.

Add tip about built-in env variables offered by webpack-cli