### PR TITLE
docs(plugin): add EntryPlugin

### DIFF
--- a/src/content/plugins/internal-plugins.mdx
+++ b/src/content/plugins/internal-plugins.mdx
@@ -57,9 +57,9 @@ Saves and restores module and chunk ids from records.
 
 Plugins, which add entry chunks to the compilation.
 
-### SingleEntryPlugin
+### EntryPlugin
 
-`SingleEntryPlugin(context, request, chunkName)`
+`EntryPlugin(context, request, chunkName)`
 
 Adds an entry chunk on compilation. The chunk is named `chunkName` and contains only one module (plus dependencies). The module is resolved from `request` in `context` (absolute path).
 


### PR DESCRIPTION
`SingleEntryPlugin` is deprecated and also renamed to `EntryPlugin`.

https://github.com/webpack/webpack/blob/32bd1a2ff53c6b7fbf99d0e473d6db98f9e3a3f2/lib/index.js#L248