### PR TITLE
reduce scroll effect

### DIFF
--- a/cypress/integration/pr_4435_spec.js
+++ b/cypress/integration/pr_4435_spec.js
@@ -17,7 +17,8 @@ describe('Open page in new tab', { scrollBehavior: false }, () => {
     // we click the menu
     cy.get(selector).click();
     cy.window().then((win) => {
-      expect(win.scrollTo).to.be.calledTwice;
+      // since no pathname changed, so no scrollTo called again
+      expect(win.scrollTo).to.be.calledOnce;
     });
 
     if (Cypress.platform === 'darwin') {
@@ -26,7 +27,7 @@ describe('Open page in new tab', { scrollBehavior: false }, () => {
       });
       // no scrollTo should be called
       cy.window().then((win) => {
-        expect(win.scrollTo).to.be.calledTwice;
+        expect(win.scrollTo).to.be.calledOnce;
       });
     } else if (Cypress.platform === 'win32' || Cypress.platform === 'linux') {
       // win32, linux
@@ -35,14 +36,14 @@ describe('Open page in new tab', { scrollBehavior: false }, () => {
       });
       // no scrollTo should be called
       cy.window().then((win) => {
-        expect(win.scrollTo).to.be.calledTwice;
+        expect(win.scrollTo).to.be.calledOnce;
       });
     }
 
     // we click the menu again
     cy.get(selector).click();
     cy.window().then((win) => {
-      expect(win.scrollTo).to.be.calledThrice;
+      expect(win.scrollTo).to.be.calledOnce;
     });
   });
 });

--- a/src/components/Page/Page.jsx
+++ b/src/components/Page/Page.jsx
@@ -44,11 +44,10 @@ export default function Page(props) {
     }
   }, [props.content]);
 
-  const location = useLocation();
+  const { hash, pathname } = useLocation();
 
   useEffect(() => {
     if (contentLoaded) {
-      const hash = location.hash;
       if (hash) {
         const element = document.querySelector(hash);
         if (element) {
@@ -58,7 +57,7 @@ export default function Page(props) {
         window.scrollTo(0, 0);
       }
     }
-  }, [contentLoaded, location]);
+  }, [contentLoaded, pathname, hash]);
 
   const loadRelated = contentLoaded && related && related.length !== 0;
   const loadContributors =


### PR DESCRIPTION
When we click the same menu item on sidebar again and again, the `key` value of `location` changes all the time which would cause the page to invoke unnecessary scroll effect.