### PR TITLE
docs(configuration): fix CLI usage for devsServer.hotOnly

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -503,7 +503,7 @@ module.exports = {
 Usage via the CLI
 
 ```bash
-npx webpack serve --hot only
+npx webpack serve --hot-only
 ```
 
 ## `devServer.http2`


### PR DESCRIPTION
`--hot only` is not yet supported by CLI.

correct usage `webpack serve --hot-only`