### PR TITLE
docs(api): update module variable usage info

### DIFF
--- a/src/content/api/module-variables.mdx
+++ b/src/content/api/module-variables.mdx
@@ -165,7 +165,7 @@ Access to the internal object of all modules.
 
 ### `__webpack_hash__` (webpack-specific)
 
-This variable is only available with the `HotModuleReplacementPlugin` or the `ExtendedAPIPlugin`. It provides access to the hash of the compilation.
+It provides access to the hash of the compilation.
 
 ### `__non_webpack_require__` (webpack-specific)
 


### PR DESCRIPTION
`__webpack_hash__` can always be used, and runtime code is injected where needed.

https://webpack.js.org/blog/2020-10-10-webpack-5-release/#minor-changes