### PR TITLE
docs(api): add beforeModuleHash compilation hook

### DIFF
--- a/src/content/api/compilation-hooks.mdx
+++ b/src/content/api/compilation-hooks.mdx
@@ -296,7 +296,7 @@ Called before the compilation is hashed.
 
 `SyncHook`
 
-Called after the hashes of modules are created
+Called after the hashes of modules are created.
 
 ### `afterHash`
 

--- a/src/content/api/compilation-hooks.mdx
+++ b/src/content/api/compilation-hooks.mdx
@@ -9,6 +9,7 @@ contributors:
   - wizardofhogwarts
   - EugeneHlushko
   - chenxsan
+  - jamesgeorge007
 ---
 
 The `Compilation` module is used by the `Compiler` to create new compilations
@@ -285,11 +286,17 @@ Store chunk info to the records. This is only triggered if [`shouldRecord`](#sho
 
 - Callback Parameters: `chunks` `records`
 
-### `beforeHash`
+### `beforeModuleHash`
 
 `SyncHook`
 
 Called before the compilation is hashed.
+
+### `beforeHash`
+
+`SyncHook`
+
+Called after the hashes of modules are created
 
 ### `afterHash`
 


### PR DESCRIPTION
https://webpack.js.org/blog/2020-10-10-webpack-5-release/#other-minor-changes