### PR TITLE
docs(api): add afterModuleHash

### DIFF
--- a/src/content/api/compilation-hooks.mdx
+++ b/src/content/api/compilation-hooks.mdx
@@ -290,13 +290,19 @@ Store chunk info to the records. This is only triggered if [`shouldRecord`](#sho
 
 `SyncHook`
 
-Called before the compilation is hashed.
+Called before modules are hashed.
+
+### `afterModuleHash`
+
+`syncHook`
+
+Called after modules are hashed.
 
 ### `beforeHash`
 
 `SyncHook`
 
-Called after the hashes of modules are created.
+Called before the compilation is hashed.
 
 ### `afterHash`
 


### PR DESCRIPTION
1. Add `afterModuleHash` hook
2. Fix misleading description