### PR TITLE
fix scroll edge case

### DIFF
--- a/cypress/integration/click-menu-scroll-top_spec.js
+++ b/cypress/integration/click-menu-scroll-top_spec.js
@@ -8,7 +8,7 @@ describe('Click menu', () => {
 
     cy.get(selector).click();
     cy.window().then((win) => {
-      expect(win.scrollY).toBe(0);
+      expect(win.scrollY).to.equal(0);
     });
   });
 });

--- a/cypress/integration/click-menu-scroll-top_spec.js
+++ b/cypress/integration/click-menu-scroll-top_spec.js
@@ -2,6 +2,7 @@ describe('Click menu', () => {
   it('scroll to top when menu clicked', () => {
     cy.visit('/concepts/plugins/');
     // scroll to Contributors section
+    // note that there's no hash in url
     cy.get('.contributors__section').scrollIntoView();
 
     const selector = '.sidebar-item__title[href="/concepts/plugins/"]';

--- a/cypress/integration/click-menu-scroll-top_spec.js
+++ b/cypress/integration/click-menu-scroll-top_spec.js
@@ -1,0 +1,14 @@
+describe('Click menu', () => {
+  it('scroll to top when menu clicked', () => {
+    cy.visit('/concepts/plugins/');
+    // scroll to Contributors section
+    cy.get('.contributors__section').scrollIntoView();
+
+    const selector = '.sidebar-item__title[href="/concepts/plugins/"]';
+
+    cy.get(selector).click();
+    cy.window().then((win) => {
+      expect(win.scrollY).toBe(0);
+    });
+  });
+});

--- a/cypress/integration/pr_4435_spec.js
+++ b/cypress/integration/pr_4435_spec.js
@@ -1,7 +1,7 @@
 // set scrollBehavior to false
 // because we don't want cypress to scroll itself
 describe('Open page in new tab', { scrollBehavior: false }, () => {
-  it('should not scroll to top', () => {
+  it('should not scroll to top when right clicked', () => {
     cy.visit('/concepts/plugins/', {
       onBeforeLoad: (win) => {
         cy.stub(win, 'scrollTo');
@@ -17,8 +17,8 @@ describe('Open page in new tab', { scrollBehavior: false }, () => {
     // we click the menu
     cy.get(selector).click();
     cy.window().then((win) => {
-      // since no pathname changed, so no scrollTo called again
-      expect(win.scrollTo).to.be.calledOnce;
+      // we don't know whether user has scrolled the page or not although no pathname changed
+      expect(win.scrollTo).to.be.calledTwice;
     });
 
     if (Cypress.platform === 'darwin') {
@@ -27,7 +27,7 @@ describe('Open page in new tab', { scrollBehavior: false }, () => {
       });
       // no scrollTo should be called
       cy.window().then((win) => {
-        expect(win.scrollTo).to.be.calledOnce;
+        expect(win.scrollTo).to.be.calledTwice;
       });
     } else if (Cypress.platform === 'win32' || Cypress.platform === 'linux') {
       // win32, linux
@@ -36,14 +36,14 @@ describe('Open page in new tab', { scrollBehavior: false }, () => {
       });
       // no scrollTo should be called
       cy.window().then((win) => {
-        expect(win.scrollTo).to.be.calledOnce;
+        expect(win.scrollTo).to.be.calledTwice;
       });
     }
 
     // we click the menu again
     cy.get(selector).click();
     cy.window().then((win) => {
-      expect(win.scrollTo).to.be.calledOnce;
+      expect(win.scrollTo).to.be.calledTwice;
     });
   });
 });

--- a/cypress/integration/pr_4435_spec.js
+++ b/cypress/integration/pr_4435_spec.js
@@ -40,10 +40,10 @@ describe('Open page in new tab', { scrollBehavior: false }, () => {
       });
     }
 
-    // we click the menu again
+    // we click the menu again, scroll to top again
     cy.get(selector).click();
     cy.window().then((win) => {
-      expect(win.scrollTo).to.be.calledTwice;
+      expect(win.scrollTo).to.be.calledThrice;
     });
   });
 });

--- a/src/components/SidebarItem/SidebarItem.jsx
+++ b/src/components/SidebarItem/SidebarItem.jsx
@@ -24,10 +24,11 @@ export default class SidebarItem extends Component {
     // 1. location.pathname or location.hash changes which will be handled by useEffect in Page.jsx
     // 2. location.pathname and location.hash doesn't change at all
     if (window.location.hash !== '') {
-      // hash will change after click, handled by useEffect in Page.jsx
+      // case 1
       return;
     }
     if (!event.metaKey && !event.ctrlKey) {
+      // case 2
       window.scrollTo(0, 0);
     }
   }

--- a/src/components/SidebarItem/SidebarItem.jsx
+++ b/src/components/SidebarItem/SidebarItem.jsx
@@ -19,6 +19,19 @@ export default class SidebarItem extends Component {
     open: this._isOpen(this.props),
   };
 
+  scrollTop(event) {
+    // there're two cases
+    // 1. location.pathname or location.hash changes which will be handled by useEffect in Page.jsx
+    // 2. location.pathname and location.hash doesn't change at all
+    if (window.location.hash !== '') {
+      // hash will change after click, handled by useEffect in Page.jsx
+      return;
+    }
+    if (!event.metaKey && !event.ctrlKey) {
+      window.scrollTo(0, 0);
+    }
+  }
+
   renderAnchors(anchors) {
     return (
       <ul className={`${block}__anchors`}>
@@ -70,6 +83,7 @@ export default class SidebarItem extends Component {
           key={this.props.url}
           className={`${block}__title`}
           to={this.props.url}
+          onClick={this.scrollTop}
         >
           {title}
         </NavLink>


### PR DESCRIPTION
Regression in https://github.com/webpack/webpack.js.org/pull/4613 and https://github.com/webpack/webpack.js.org/pull/4613 combined.

Say we open https://webpack.js.org/concepts/plugins/ and scroll to page end, click the `Plugins` menu item should scroll page to top.

Another case is already handled by `useEffect` in [`Page.jsx`](https://github.com/webpack/webpack.js.org/blob/master/src/components/Page/Page.jsx#L49), i.e., open https://webpack.js.org/concepts/plugins/#usage, and click the `Plugins` menu item should scroll page to top.