### PR TITLE
Fix a typo in `output` option

### DIFF
--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -1392,7 +1392,7 @@ If you're using webpack to compile a library to be consumed by others, make sure
 ```javascript
 module.exports = {
   //...
-  experimentals: {
+  experiments: {
     outputModule: true,
   },
   output: {


### PR DESCRIPTION
There was a typo. There is no `output.experimentals`. It must be `output.experiments`.