### PR TITLE
Fix https settings for own certs

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -582,10 +582,11 @@ With the above setting, a self-signed certificate is used, but you can provide y
 module.exports = {
   //...
   devServer: {
-    https: true,
-    key: fs.readFileSync('/path/to/server.key'),
-    cert: fs.readFileSync('/path/to/server.crt'),
-    ca: fs.readFileSync('/path/to/ca.pem'),
+    https: {
+      key: fs.readFileSync('/path/to/server.key'),
+      cert: fs.readFileSync('/path/to/server.crt'),
+      ca: fs.readFileSync('/path/to/ca.pem'),
+    },
   },
 };
 ```


### PR DESCRIPTION
Hi! If you want to use own https certificate for hmr with devServer you should pass cert & key in the devServer.https object not just root devServer object.
