### PR TITLE
fix position of list marker for safari

### DIFF
--- a/src/components/Markdown/Markdown.scss
+++ b/src/components/Markdown/Markdown.scss
@@ -42,6 +42,7 @@ $topHeightMobileWithBanner: $bannerHeight + $topHeightMobile;
   h5,
   h6 {
     &:before {
+      position: absolute; // a hack for safari
       content: '';
       display: block;
       visibility: hidden;


### PR DESCRIPTION
We used a hack in this pull request https://github.com/webpack/webpack.js.org/pull/3901 to work around visibility problem of headers' anchor under safari. However I found that it caused a problem when the headings are used inside list under safari:

![image](https://user-images.githubusercontent.com/1091472/111019434-2c1b9580-83fa-11eb-99ae-d2f9682ec5de.png)


This pull request introduced a hack to fix the problem.

Preview url: https://webpack-js-org-git-fork-chenxsan-bugfix-fix-safari-list-87fc48.vercel.app/configuration/output/#expose-a-variable