### PR TITLE
Revert "fix position of list marker for safari (#4713)"

### DIFF
--- a/src/components/Markdown/Markdown.scss
+++ b/src/components/Markdown/Markdown.scss
@@ -42,7 +42,6 @@ $topHeightMobileWithBanner: $bannerHeight + $topHeightMobile;
   h5,
   h6 {
     &:before {
-      position: absolute; // a hack for safari
       content: '';
       display: block;
       visibility: hidden;


### PR DESCRIPTION
This reverts commit 8b39b6915879603c26ec776a2c1a7eb32de0d7f7.

Unfortunately the latest commit introduced the visibility problem for headings' anchor again. I'll file an issue to track the problem as I don't know how to fix it for safari now. We might have to avoid using headings in list item.
