### PR TITLE
docs(configuration): avoid using headings in list

### DIFF
--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -696,46 +696,46 @@ T> Note that `_entry_return_` in the example code below is the value returned by
 
 These options assign the return value of the entry point (e.g. whatever the entry point exported) to the name provided by [`output.library`](#outputlibrary) at whatever scope the bundle was included at.
 
-- #### `libraryTarget: 'var'`
+#### `libraryTarget: 'var'`
 
-  When your library is loaded, the **return value of your entry point** will be assigned to a variable:
+When your library is loaded, the **return value of your entry point** will be assigned to a variable:
 
-  ```javascript
-  var MyLibrary = _entry_return_;
+```javascript
+var MyLibrary = _entry_return_;
 
-  // In a separate script...
-  MyLibrary.doSomething();
-  ```
+// In a separate script...
+MyLibrary.doSomething();
+```
 
-- #### `libraryTarget: 'assign'`
+#### `libraryTarget: 'assign'`
 
-  This will generate an implied global which has the potential to reassign an existing value (use with caution):
+This will generate an implied global which has the potential to reassign an existing value (use with caution):
 
-  ```javascript
-  MyLibrary = _entry_return_;
-  ```
+```javascript
+MyLibrary = _entry_return_;
+```
 
-  Be aware that if `MyLibrary` isn't defined earlier your library will be set in global scope.
+Be aware that if `MyLibrary` isn't defined earlier your library will be set in global scope.
 
-- #### `libraryTarget: 'assign-properties'` <Badge text='5.16.0+' />
+#### `libraryTarget: 'assign-properties'` <Badge text='5.16.0+' />
 
-  Copy the return value to a target object if it exists, otherwise create the target object first:
+Copy the return value to a target object if it exists, otherwise create the target object first:
 
-  ```js
-  // create the target object if it doesn't exist
-  MyLibrary = typeof MyLibrary === 'undefined' ? {} : MyLibrary;
-  // then copy the return value to MyLibrary
-  // just like what Object.assign does
+```js
+// create the target object if it doesn't exist
+MyLibrary = typeof MyLibrary === 'undefined' ? {} : MyLibrary;
+// then copy the return value to MyLibrary
+// just like what Object.assign does
 
-  // for instance, you export a `hello` function in your entry as follow
-  export function hello(name) {
-    console.log(`Hello ${name}`);
-  }
+// for instance, you export a `hello` function in your entry as follow
+export function hello(name) {
+  console.log(`Hello ${name}`);
+}
 
-  // In another script running MyLibrary
-  // you can run `hello` function like so
-  MyLibrary.hello('World');
-  ```
+// In another script running MyLibrary
+// you can run `hello` function like so
+MyLibrary.hello('World');
+```
 
 W> An empty string for [`output.library`](#outputlibrary) is invalid, make sure you specify a valid identifier that could be assigned.
 
@@ -755,261 +755,261 @@ If `output.library` is not assigned a non-empty string, the default behavior is 
 
 W> Note that not setting a `output.library` will cause all properties returned by the entry point to be assigned to the given object; there are no checks against existing property names.
 
-- #### `libraryTarget: 'this'`
+#### `libraryTarget: 'this'`
 
-  The **return value of your entry point** will be assigned to this under the property named by `output.library`. The meaning of `this` is up to you:
+The **return value of your entry point** will be assigned to this under the property named by `output.library`. The meaning of `this` is up to you:
 
-  ```javascript
-  this['MyLibrary'] = _entry_return_;
+```javascript
+this['MyLibrary'] = _entry_return_;
 
-  // In a separate script...
-  this.MyLibrary.doSomething();
-  MyLibrary.doSomething(); // if this is window
-  ```
+// In a separate script...
+this.MyLibrary.doSomething();
+MyLibrary.doSomething(); // if this is window
+```
 
-- #### `libraryTarget: 'window'`
+#### `libraryTarget: 'window'`
 
-  The **return value of your entry point** will be assigned to the `window` object using the `output.library` value.
+The **return value of your entry point** will be assigned to the `window` object using the `output.library` value.
 
-  ```javascript
-  window['MyLibrary'] = _entry_return_;
+```javascript
+window['MyLibrary'] = _entry_return_;
 
-  window.MyLibrary.doSomething();
-  ```
+window.MyLibrary.doSomething();
+```
 
-- #### `libraryTarget: 'global'`
+#### `libraryTarget: 'global'`
 
-  The **return value of your entry point** will be assigned to the `global` object using the `output.library` value.
+The **return value of your entry point** will be assigned to the `global` object using the `output.library` value.
 
-  ```javascript
-  global['MyLibrary'] = _entry_return_;
+```javascript
+global['MyLibrary'] = _entry_return_;
 
-  global.MyLibrary.doSomething();
-  ```
+global.MyLibrary.doSomething();
+```
 
-- #### `libraryTarget: 'commonjs'`
+#### `libraryTarget: 'commonjs'`
 
-  The **return value of your entry point** will be assigned to the `exports` object using the `output.library` value. As the name implies, this is used in CommonJS environments.
+The **return value of your entry point** will be assigned to the `exports` object using the `output.library` value. As the name implies, this is used in CommonJS environments.
 
-  ```javascript
-  exports['MyLibrary'] = _entry_return_;
+```javascript
+exports['MyLibrary'] = _entry_return_;
 
-  require('MyLibrary').doSomething();
-  ```
+require('MyLibrary').doSomething();
+```
 
 ### Module Definition Systems
 
 These options will result in a bundle that comes with a complete header to ensure compatibility with various module systems. The `output.library` option will take on a different meaning under the following `output.libraryTarget` options.
 
-- #### `libraryTarget: 'module'`
+#### `libraryTarget: 'module'`
 
-  Output ES Module. Make sure to enable [experiments.outputModule](/configuration/experiments/) beforehand.
+Output ES Module. Make sure to enable [experiments.outputModule](/configuration/experiments/) beforehand.
 
-  Note that this feature is not fully supported yet, please track the progress in [this thread](https://github.com/webpack/webpack/issues/2933#issuecomment-774253975).
+Note that this feature is not fully supported yet, please track the progress in [this thread](https://github.com/webpack/webpack/issues/2933#issuecomment-774253975).
 
-- #### `libraryTarget: 'commonjs2'`
+#### `libraryTarget: 'commonjs2'`
 
-  The **return value of your entry point** will be assigned to the `module.exports`. As the name implies, this is used in CommonJS environments:
+The **return value of your entry point** will be assigned to the `module.exports`. As the name implies, this is used in CommonJS environments:
 
-  ```javascript
-  module.exports = _entry_return_;
+```javascript
+module.exports = _entry_return_;
 
-  require('MyLibrary').doSomething();
-  ```
+require('MyLibrary').doSomething();
+```
 
-  Note that `output.library` can't be used with this particular `output.libraryTarget`, for further details, please [read this issue](https://github.com/webpack/webpack/issues/11800).
+Note that `output.library` can't be used with this particular `output.libraryTarget`, for further details, please [read this issue](https://github.com/webpack/webpack/issues/11800).
 
-  T> Wondering the difference between CommonJS and CommonJS2 is? While they are similar, there are some subtle differences between them that are not usually relevant in the context of webpack. (For further details, please [read this issue](https://github.com/webpack/webpack/issues/1114).)
+T> Wondering the difference between CommonJS and CommonJS2 is? While they are similar, there are some subtle differences between them that are not usually relevant in the context of webpack. (For further details, please [read this issue](https://github.com/webpack/webpack/issues/1114).)
 
-- #### `libraryTarget: 'amd'`
+#### `libraryTarget: 'amd'`
 
-  This will expose your library as an AMD module.
+This will expose your library as an AMD module.
 
-  AMD modules require that the entry chunk (e.g. the first script loaded by the `<script>` tag) be defined with specific properties, such as `define` and `require` which is typically provided by RequireJS or any compatible loaders (such as almond). Otherwise, loading the resulting AMD bundle directly will result in an error like `define is not defined`.
+AMD modules require that the entry chunk (e.g. the first script loaded by the `<script>` tag) be defined with specific properties, such as `define` and `require` which is typically provided by RequireJS or any compatible loaders (such as almond). Otherwise, loading the resulting AMD bundle directly will result in an error like `define is not defined`.
 
-  So, with the following configuration...
+So, with the following configuration...
 
-  ```javascript
-  module.exports = {
-    //...
-    output: {
-      library: 'MyLibrary',
-      libraryTarget: 'amd',
+```javascript
+module.exports = {
+  //...
+  output: {
+    library: 'MyLibrary',
+    libraryTarget: 'amd',
+  },
+};
+```
+
+The generated output will be defined with the name "MyLibrary", i.e.
+
+```javascript
+define('MyLibrary', [], function () {
+  return _entry_return_;
+});
+```
+
+The bundle can be included as part of a script tag, and the bundle can be invoked like so:
+
+```javascript
+require(['MyLibrary'], function (MyLibrary) {
+  // Do something with the library...
+});
+```
+
+If `output.library` is undefined, the following is generated instead.
+
+```javascript
+define([], function () {
+  return _entry_return_;
+});
+```
+
+This bundle will not work as expected, or not work at all (in the case of the almond loader) if loaded directly with a `<script>` tag. It will only work through a RequireJS compatible asynchronous module loader through the actual path to that file, so in this case, the `output.path` and `output.filename` may become important for this particular setup if these are exposed directly on the server.
+
+#### `libraryTarget: 'amd-require'`
+
+This packages your output with an immediately-executed AMD `require(dependencies, factory)` wrapper.
+
+The `'amd-require'` target allows for the use of AMD dependencies without needing a separate later invocation. As with the `'amd'` target, this depends on the appropriate [`require` function](https://github.com/amdjs/amdjs-api/blob/master/require.md) being available in the environment in which the webpack output is loaded.
+
+With this target, the library name is ignored.
+
+#### `libraryTarget: 'umd'`
+
+This exposes your library under all the module definitions, allowing it to work with CommonJS, AMD and as global variable. Take a look at the [UMD Repository](https://github.com/umdjs/umd) to learn more.
+
+In this case, you need the `library` property to name your module:
+
+```javascript
+module.exports = {
+  //...
+  output: {
+    library: 'MyLibrary',
+    libraryTarget: 'umd',
+  },
+};
+```
+
+And finally the output is:
+
+```javascript
+(function webpackUniversalModuleDefinition(root, factory) {
+  if (typeof exports === 'object' && typeof module === 'object')
+    module.exports = factory();
+  else if (typeof define === 'function' && define.amd) define([], factory);
+  else if (typeof exports === 'object') exports['MyLibrary'] = factory();
+  else root['MyLibrary'] = factory();
+})(typeof self !== 'undefined' ? self : this, function () {
+  return _entry_return_;
+});
+```
+
+Note that omitting `library` will result in the assignment of all properties returned by the entry point be assigned directly to the root object, as documented under the [object assignment section](#expose-via-object-assignment). Example:
+
+```javascript
+module.exports = {
+  //...
+  output: {
+    libraryTarget: 'umd',
+  },
+};
+```
+
+The output will be:
+
+```javascript
+(function webpackUniversalModuleDefinition(root, factory) {
+  if (typeof exports === 'object' && typeof module === 'object')
+    module.exports = factory();
+  else if (typeof define === 'function' && define.amd) define([], factory);
+  else {
+    var a = factory();
+    for (var i in a) (typeof exports === 'object' ? exports : root)[i] = a[i];
+  }
+})(typeof self !== 'undefined' ? self : this, function () {
+  return _entry_return_;
+});
+```
+
+Since webpack 3.1.0, you may specify an object for `library` for differing names per targets:
+
+```javascript
+module.exports = {
+  //...
+  output: {
+    library: {
+      root: 'MyLibrary',
+      amd: 'my-library',
+      commonjs: 'my-common-library',
+    },
+    libraryTarget: 'umd',
+  },
+};
+```
+
+#### `libraryTarget: 'system'`
+
+This will expose your library as a [`System.register`](https://github.com/systemjs/systemjs/blob/master/docs/system-register.md) module. This feature was first released in [webpack 4.30.0](https://github.com/webpack/webpack/releases/tag/v4.30.0).
+
+System modules require that a global variable `System` is present in the browser when the webpack bundle is executed. Compiling to `System.register` format allows you to `System.import('/bundle.js')` without additional configuration and have your webpack bundle loaded into the System module registry.
+
+```javascript
+module.exports = {
+  //...
+  output: {
+    libraryTarget: 'system',
+  },
+};
+```
+
+Output:
+
+```javascript
+System.register([], function (_export) {
+  return {
+    setters: [],
+    execute: function () {
+      // ...
     },
   };
-  ```
+});
+```
 
-  The generated output will be defined with the name "MyLibrary", i.e.
+By adding `output.library` to configuration in addition to having `output.libraryTarget` set to `system`, the output bundle will have the library name as an argument to `System.register`:
 
-  ```javascript
-  define('MyLibrary', [], function () {
-    return _entry_return_;
-  });
-  ```
-
-  The bundle can be included as part of a script tag, and the bundle can be invoked like so:
-
-  ```javascript
-  require(['MyLibrary'], function (MyLibrary) {
-    // Do something with the library...
-  });
-  ```
-
-  If `output.library` is undefined, the following is generated instead.
-
-  ```javascript
-  define([], function () {
-    return _entry_return_;
-  });
-  ```
-
-  This bundle will not work as expected, or not work at all (in the case of the almond loader) if loaded directly with a `<script>` tag. It will only work through a RequireJS compatible asynchronous module loader through the actual path to that file, so in this case, the `output.path` and `output.filename` may become important for this particular setup if these are exposed directly on the server.
-
-- #### `libraryTarget: 'amd-require'`
-
-  This packages your output with an immediately-executed AMD `require(dependencies, factory)` wrapper.
-
-  The `'amd-require'` target allows for the use of AMD dependencies without needing a separate later invocation. As with the `'amd'` target, this depends on the appropriate [`require` function](https://github.com/amdjs/amdjs-api/blob/master/require.md) being available in the environment in which the webpack output is loaded.
-
-  With this target, the library name is ignored.
-
-- #### `libraryTarget: 'umd'`
-
-  This exposes your library under all the module definitions, allowing it to work with CommonJS, AMD and as global variable. Take a look at the [UMD Repository](https://github.com/umdjs/umd) to learn more.
-
-  In this case, you need the `library` property to name your module:
-
-  ```javascript
-  module.exports = {
-    //...
-    output: {
-      library: 'MyLibrary',
-      libraryTarget: 'umd',
+```javascript
+System.register('my-library', [], function (_export) {
+  return {
+    setters: [],
+    execute: function () {
+      // ...
     },
   };
-  ```
+});
+```
 
-  And finally the output is:
+You can access [SystemJS context](https://github.com/systemjs/systemjs/blob/master/docs/system-register.md#format-definition) via `__system_context__`:
 
-  ```javascript
-  (function webpackUniversalModuleDefinition(root, factory) {
-    if (typeof exports === 'object' && typeof module === 'object')
-      module.exports = factory();
-    else if (typeof define === 'function' && define.amd) define([], factory);
-    else if (typeof exports === 'object') exports['MyLibrary'] = factory();
-    else root['MyLibrary'] = factory();
-  })(typeof self !== 'undefined' ? self : this, function () {
-    return _entry_return_;
-  });
-  ```
+```javascript
+// Log the URL of the current SystemJS module
+console.log(__system_context__.meta.url);
 
-  Note that omitting `library` will result in the assignment of all properties returned by the entry point be assigned directly to the root object, as documented under the [object assignment section](#expose-via-object-assignment). Example:
-
-  ```javascript
-  module.exports = {
-    //...
-    output: {
-      libraryTarget: 'umd',
-    },
-  };
-  ```
-
-  The output will be:
-
-  ```javascript
-  (function webpackUniversalModuleDefinition(root, factory) {
-    if (typeof exports === 'object' && typeof module === 'object')
-      module.exports = factory();
-    else if (typeof define === 'function' && define.amd) define([], factory);
-    else {
-      var a = factory();
-      for (var i in a) (typeof exports === 'object' ? exports : root)[i] = a[i];
-    }
-  })(typeof self !== 'undefined' ? self : this, function () {
-    return _entry_return_;
-  });
-  ```
-
-  Since webpack 3.1.0, you may specify an object for `library` for differing names per targets:
-
-  ```javascript
-  module.exports = {
-    //...
-    output: {
-      library: {
-        root: 'MyLibrary',
-        amd: 'my-library',
-        commonjs: 'my-common-library',
-      },
-      libraryTarget: 'umd',
-    },
-  };
-  ```
-
-- #### `libraryTarget: 'system'`
-
-  This will expose your library as a [`System.register`](https://github.com/systemjs/systemjs/blob/master/docs/system-register.md) module. This feature was first released in [webpack 4.30.0](https://github.com/webpack/webpack/releases/tag/v4.30.0).
-
-  System modules require that a global variable `System` is present in the browser when the webpack bundle is executed. Compiling to `System.register` format allows you to `System.import('/bundle.js')` without additional configuration and have your webpack bundle loaded into the System module registry.
-
-  ```javascript
-  module.exports = {
-    //...
-    output: {
-      libraryTarget: 'system',
-    },
-  };
-  ```
-
-  Output:
-
-  ```javascript
-  System.register([], function (_export) {
-    return {
-      setters: [],
-      execute: function () {
-        // ...
-      },
-    };
-  });
-  ```
-
-  By adding `output.library` to configuration in addition to having `output.libraryTarget` set to `system`, the output bundle will have the library name as an argument to `System.register`:
-
-  ```javascript
-  System.register('my-library', [], function (_export) {
-    return {
-      setters: [],
-      execute: function () {
-        // ...
-      },
-    };
-  });
-  ```
-
-  You can access [SystemJS context](https://github.com/systemjs/systemjs/blob/master/docs/system-register.md#format-definition) via `__system_context__`:
-
-  ```javascript
-  // Log the URL of the current SystemJS module
-  console.log(__system_context__.meta.url);
-
-  // Import a SystemJS module, with the current SystemJS module's url as the parentUrl
-  __system_context__.import('./other-file.js').then((m) => {
-    console.log(m);
-  });
-  ```
+// Import a SystemJS module, with the current SystemJS module's url as the parentUrl
+__system_context__.import('./other-file.js').then((m) => {
+  console.log(m);
+});
+```
 
 ### Other Targets
 
-- #### `libraryTarget: 'jsonp'`
+#### `libraryTarget: 'jsonp'`
 
-  This will wrap the return value of your entry point into a jsonp wrapper.
+This will wrap the return value of your entry point into a jsonp wrapper.
 
-  ```javascript
-  MyLibrary(_entry_return_);
-  ```
+```javascript
+MyLibrary(_entry_return_);
+```
 
-  The dependencies for your library will be defined by the [`externals`](/configuration/externals/) config.
+The dependencies for your library will be defined by the [`externals`](/configuration/externals/) config.
 
 ## `output.importFunctionName`
 


### PR DESCRIPTION
We used a hack in this pull request https://github.com/webpack/webpack.js.org/pull/3901 to work around visibility problem of headers' anchor under safari. However I found that it caused a problem when the headings are used inside list under safari:

![image](https://user-images.githubusercontent.com/1091472/111019434-2c1b9580-83fa-11eb-99ae-d2f9682ec5de.png)

This pull request moves the headings out of list to work around the problem, it's not a real fix, and I don't think there's one until safari fix it.