### PR TITLE
docs(output): remove leading slash

### DIFF
--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -1434,7 +1434,7 @@ module.exports = {
   //...
   output: {
     clean: {
-      keep: /\/ignored\/dir\//, // Keep these assets.
+      keep: /ignored\/dir\//, // Keep these assets.
     },
   },
 };

--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -1434,7 +1434,7 @@ module.exports = {
   //...
   output: {
     clean: {
-      keep: /ignored\/dir\//, // Keep these assets.
+      keep: /ignored\/dir\//, // Keep these assets under 'ignored/dir'.
     },
   },
 };

--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -1459,7 +1459,7 @@ You can also use it with hook:
 webpack.CleanPlugin.getCompilationHooks(compilation).keep.tap(
   'Test',
   (asset) => {
-    if (/\/ignored\/dir\//.test(asset)) return true;
+    if (/ignored\/dir\//.test(asset)) return true;
   }
 );
 ```


### PR DESCRIPTION
I believe that the leading slash in the `keep` property does not prevent the directory from being deleted. 
I didn't test the *hook* option.

