### PR TITLE
docs(asset-modules): Fix syntax error

### DIFF
--- a/src/content/guides/asset-modules.md
+++ b/src/content/guides/asset-modules.md
@@ -416,8 +416,8 @@ module: {
     rules: [
     // ...
 +     {
-+       resourceQuery: /raw/
-+       type: 'asset/source'
++       resourceQuery: /raw/,
++       type: 'asset/source',
 +     }
     ]
   },
@@ -434,8 +434,8 @@ module: {
 +       resourceQuery: /^(?!\?raw$).*/,
 +     },
       {
-        resourceQuery: /raw/
-        type: 'asset/source'
+        resourceQuery: /raw/,
+        type: 'asset/source',
       }
     ]
   },


### PR DESCRIPTION
Added a missing comma. Used trailing comma to match prior rule.
