### PR TITLE
docs(api): document WEBPACK_BUNDLE

### DIFF
--- a/src/content/api/cli.md
+++ b/src/content/api/cli.md
@@ -454,6 +454,7 @@ NODE_OPTIONS="--max-old-space-size=4096 -r /path/to/preload/file.js" webpack
 | -------------------- | -------------------------------------------- |
 | `WEBPACK_SERVE`      | `true` if `serve\|s` is being used.          |
 | `WEBPACK_BUILD`      | `true` if `build\|bundle\|b` is being used.  |
+| `WEBPACK_BUNDLE`     | `true` if `build\|bundle\|b` is being used.  |
 | `WEBPACK_WATCH`      | `true` if `--watch\|watch\|w` is being used. |
 
 You can use the above environment variables inside your webpack configuration:


### PR DESCRIPTION
Just noticed there's a [`WEBPACK_BUNDLE`](https://github.com/webpack/webpack-cli/blob/d20714f9fc47d2f20ecbbb553956fcadd947c316/packages/webpack-cli/lib/webpack-cli.js#L1942).