### PR TITLE
Fix invalid optimization.splitChunks config

### DIFF
--- a/src/content/plugins/split-chunks-plugin.md
+++ b/src/content/plugins/split-chunks-plugin.md
@@ -61,9 +61,8 @@ module.exports = {
   optimization: {
     splitChunks: {
       chunks: 'async',
-      minSize: 0,
+      minSize: 20000,
       minRemainingSize: 0,
-      maxSize: 20000,
       minChunks: 1,
       maxAsyncRequests: 30,
       maxInitialRequests: 30,


### PR DESCRIPTION
`minSize` and `maxSize` in the previous configuration is obviously wrong, when executed it shows:

```
WARNING in SplitChunksPlugin
Fallback cache group
Configured minSize (19.5 KiB) is bigger than maxSize (0 bytes).
This seem to be a invalid optimization.splitChunks configuration.
```