### PR TITLE
docs: update devServer.allowedHosts

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -139,7 +139,7 @@ module.exports = {
 };
 ```
 
-To use this option with the CLI pass the `--allowed-hosts` option a comma-delimited string.
+To use this option with the CLI pass the `--allowed-hosts` as following:
 
 ```bash
 npx webpack serve --entry ./entry/file --output-path ./output/path --allowed-hosts .host.com --allowed-hosts host2.com


### PR DESCRIPTION
Update documentation for `devServer.allowedHosts`,

I see comma-delimited string was accepted by old cli version.