### PR TITLE
docs(configuration): document generator publicPath

### DIFF
--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -603,6 +603,31 @@ module.exports = {
 };
 ```
 
+### Rule.generator.emit
+
+Opt out of writing assets from [Asset Modules](/guides/asset-modules/), you might want to use it in Server side rendering cases.
+
+- Type: `boolean = true`
+- Available: 5.25.0+
+- Example:
+
+  ```js
+  module.exports = {
+    // …
+    module: {
+      rules: [
+        {
+          test: /\.png$/i,
+          type: 'asset/resource',
+          generator: {
+            emit: false,
+          },
+        },
+      ],
+    },
+  };
+  ```
+
 ### Rule.generator.filename
 
 The same as [`output.assetModuleFilename`](/configuration/output/#outputassetmodulefilename) but for specific rule. Overrides `output.assetModuleFilename` and works only with `asset` and `asset/resource` module types.
@@ -632,31 +657,6 @@ module.exports = {
   },
 };
 ```
-
-### Rule.generator.emit
-
-Opt out of writing assets from [Asset Modules](/guides/asset-modules/), you might want to use it in Server side rendering cases.
-
-- Type: `boolean = true`
-- Available: 5.25.0+
-- Example:
-
-  ```js
-  module.exports = {
-    // …
-    module: {
-      rules: [
-        {
-          test: /\.png$/i,
-          type: 'asset/resource',
-          generator: {
-            emit: false,
-          },
-        },
-      ],
-    },
-  };
-  ```
 
 ## `Rule.resource`
 

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -669,7 +669,7 @@ module.exports = {
 Customize `publicPath` for specific Asset Modules.
 
 - Type: `string | ((pathData: PathData, assetInfo?: AssetInfo) => string)`
-- Available: 5.28.0+
+- Available: <Badge text='5.28.0+' />
 
 ```js
 module.exports = {

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -38,12 +38,18 @@ module.exports = {
     generator: {
       asset: {
         // Generator options for asset modules
+
+        // Customize publicPath for asset modules, available since webpack 5.28.0
+        publicPath: 'assets/',
       },
       'asset/inline': {
         // Generator options for asset/inline modules
       },
       'asset/resource': {
         // Generator options for asset/resource modules
+
+        // Customize publicPath for asset/resource modules, available since webpack 5.28.0
+        publicPath: 'assets/',
       },
       javascript: {
         // No generator options are supported for this module type yet
@@ -651,6 +657,33 @@ module.exports = {
         type: 'asset/resource',
         generator: {
           filename: 'static/[hash][ext]',
+        },
+      },
+    ],
+  },
+};
+```
+
+### Rule.generator.publicPath
+
+Customize `publicPath` for specific Asset Modules.
+
+- Type: `string | ((pathData: PathData, assetInfo?: AssetInfo) => string)`
+- Available: 5.28.0+
+
+```js
+module.exports = {
+  //...
+  output: {
+    publicPath: 'static/',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.png$/i,
+        type: 'asset/resource',
+        generator: {
+          publicPath: 'assets/',
         },
       },
     ],

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -614,7 +614,7 @@ module.exports = {
 Opt out of writing assets from [Asset Modules](/guides/asset-modules/), you might want to use it in Server side rendering cases.
 
 - Type: `boolean = true`
-- Available: 5.25.0+
+- Available: <Badge text='5.25.0+' />
 - Example:
 
   ```js


### PR DESCRIPTION
Document the new `generator.publicPath` config introduced in webpack 5.28.0 https://github.com/webpack/webpack/releases/tag/v5.28.0, related pull request https://github.com/webpack/webpack/pull/12902