### PR TITLE
docs(api): fix typo

### DIFF
--- a/src/content/api/hot-module-replacement.md
+++ b/src/content/api/hot-module-replacement.md
@@ -68,7 +68,7 @@ module.hot.decline(
 );
 ```
 
-Flag a dependency as not-update-able. This makes sense when changing exports of this dependency can be handled or handling is not implemented yet. Depending on your HMR management code, an update to these dependencies (or unaccepted dependencies of it) usually causes a full-reload of the page.
+Flag a dependency as not-update-able. This makes sense when changing exports of this dependency can't be handled or handling is not implemented yet. Depending on your HMR management code, an update to these dependencies (or unaccepted dependencies of it) usually causes a full-reload of the page.
 
 ### `decline` (self)
 


### PR DESCRIPTION
I believe it should be `can't be handled` instead of `can be handled` as we were talking about `decline` of HMR api.