### PR TITLE
📝 Clarified point about requiring webpack-cli under Installation

### DIFF
--- a/src/content/guides/installation.md
+++ b/src/content/guides/installation.md
@@ -32,7 +32,7 @@ npm install --save-dev webpack@<version>
 
 T> Whether to use `--save-dev` or not depends on your use cases. Say you're using webpack only for bundling, then it's suggested that you install it with `--save-dev` option since you're not going to include webpack in your production build. Otherwise you can ignore `--save-dev`.
 
-If you're using webpack v4 or later, you'll also need to install the [CLI](/api/cli/).
+If you're using webpack v4 or later and want to call `webpack` from the command line, you'll also need to install the [CLI](/api/cli/).
 
 ```bash
 npm install --save-dev webpack-cli


### PR DESCRIPTION
There's a point in the docs about installing Webpack-CLI. I've never installed this nor is it required. It's my understanding this is only required if you're running `webpack` in the command line rather than calling `webpack(config)` directly in Node.js.

As a separate piece, there _is_ a bug where, for every config I pass to `webpack()`, it outputs this message to `stats`:
```sh
-----
CLI for webpack must be installed.
  webpack-cli (https://github.com/webpack/webpack-cli)


-----
-----
We will use "yarn" to install the CLI via "yarn add -D webpack-cli".

-----
-----
Do you want to install 'webpack-cli' (yes/no):
-----
```

That's a separate issue.
