### PR TITLE
NODE_ENV should not be used for `env`

### DIFF
--- a/src/content/guides/environment-variables.md
+++ b/src/content/guides/environment-variables.md
@@ -8,16 +8,13 @@ contributors:
   - legalcodes
   - byzyk
   - jceipek
-related:
-  - title: The Fine Art of the webpack 3 Config
-    url: https://blog.flennik.com/the-fine-art-of-the-webpack-2-config-dc4d19d7f172#d60a
 ---
 
 To disambiguate in your `webpack.config.js` between [development](/guides/development) and [production builds](/guides/production) you may use environment variables.
 
 T> webpack's environment variables are different from the [environment variables](https://en.wikipedia.org/wiki/Environment_variable) of operating system shells like `bash` and `CMD.exe`
 
-The webpack command line [environment option](/api/cli/#environment-options) `--env` allows you to pass in as many environment variables as you like. Environment variables will be made accessible in your `webpack.config.js`. For example, `--env production` or `--env NODE_ENV=local` (`NODE_ENV` is conventionally used to define the environment type, see [here](https://dzone.com/articles/what-you-should-know-about-node-env).)
+The webpack command line [environment option](/api/cli/#environment-options) `--env` allows you to pass in as many environment variables as you like. Environment variables will be made accessible in your `webpack.config.js`. For example, `--env production` or `--env goal=local`.
 
 ```bash
 npx webpack --env NODE_ENV=local --env production --progress
@@ -34,7 +31,7 @@ const path = require('path');
 
 module.exports = (env) => {
   // Use env.<YOUR VARIABLE> here:
-  console.log('NODE_ENV: ', env.NODE_ENV); // 'local'
+  console.log('Goal: ', env.goal); // 'local'
   console.log('Production: ', env.production); // true
 
   return {


### PR DESCRIPTION
This leads to confusion with `process.env` resp env variables, which is not the same
