### PR TITLE
doc(writers-guide): linkfix

### DIFF
--- a/src/content/contribute/writers-guide.md
+++ b/src/content/contribute/writers-guide.md
@@ -223,4 +223,4 @@ An example can be found on the [`options` section of the EvalSourceMapDevToolPlu
 
 ### Adding links
 
-Please use relative URLs (/concepts/mode/) to link our own content instead of absolute URLs (https://webpack.js.org/concepts/mode/).
+Please use relative URLs (such as `/concepts/mode/`) to link our own content instead of absolute URLs (such as `https://webpack.js.org/concepts/mode/`).


### PR DESCRIPTION
Rationale: The link is currently rendered including the `)`, see https://webpack.js.org/contribute/writers-guide/#adding-links