### PR TITLE
Revert "ui(page): show icon for external links (#4802)"

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -52,11 +52,6 @@ button.as-link {
   &:hover {
     color: darken(getColor(denim), 5%);
   }
-
-  .page &[href^='http']::after {
-    color: transparentize($text-color-highlight, 0.65);
-    content: ' \25F3';
-  }
 }
 
 ::selection {


### PR DESCRIPTION
This reverts commit 9f175182784a08d1f6f8c917657bda48cb6c689c.

Generally I think it's a good idea to differentiate external links from internal ones, however the current solution introduced problems like below:

![image](https://user-images.githubusercontent.com/1091472/113721929-84f0fc00-9722-11eb-93fc-59eaf4ecc0ca.png)

![image](https://user-images.githubusercontent.com/1091472/113722000-963a0880-9722-11eb-941a-5ca0303306da.png)

Hence I'm reverting it at the moment until we figure out a much better solution.