### PR TITLE
docs(configuration): remove --info for dev server

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -632,16 +632,6 @@ module.exports = {
 };
 ```
 
-## `devServer.info` - CLI only
-
-`boolean`
-
-Output cli information. It is enabled by default.
-
-```bash
-npx webpack serve --info false
-```
-
 ## `devServer.injectClient`
 
 `boolean = false` `function (compilerConfig) => boolean`


### PR DESCRIPTION
No longer supported in `webpack-dev-server@latest`.

https://github.com/webpack/webpack-cli/issues/2606
