### PR TITLE
docs(configuration): fix liveReload cli usage

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -751,6 +751,7 @@ Usage via the CLI
 ```bash
 npx webpack serve --liveReload
 ```
+Notice that there's no way to disable it from CLI.
 
 ## `devServer.mimeTypes` 🔑
 

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -750,7 +750,7 @@ Usage via the CLI
 
 ```bash
 npx webpack serve --liveReload
-```
+
 Notice that there's no way to disable it from CLI.
 
 ## `devServer.mimeTypes` 🔑

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -749,7 +749,7 @@ module.exports = {
 Usage via the CLI
 
 ```bash
-npx webpack serve --no-live-reload
+npx webpack serve --liveReload
 ```
 
 ## `devServer.mimeTypes` 🔑


### PR DESCRIPTION
`--no-live-reload` is an invalid option. Only `--liveReload` is allowed.
