### PR TITLE
docs(configuration): fix openPage usage

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -877,7 +877,7 @@ Usage via the CLI
 npx webpack serve --open --open-page different/page
 ```
 
-W> You do not need to add `/` in starting webpack-dev-server adds it automatically for you else the browser will open `http://localhost:8080//different/page`
+W> Do not prepend `/` for the page as webpack-dev-server will do it automatically, otherwise the browser will open urls like `http://localhost:8080//different/page`.
 
 If you wish to specify multiple pages to open in the browser.
 

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -892,7 +892,7 @@ module.exports = {
 Usage via the CLI
 
 ```bash
-npx webpack serve --open-page /different/page1,/different/page2
+npx webpack serve --open-page /different/page1 --open-page /different/page2
 ```
 
 ## `devServer.overlay`

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -865,6 +865,7 @@ Specify a page to navigate to when opening the browser.
 module.exports = {
   //...
   devServer: {
+    open: true,
     openPage: 'different/page',
   },
 };
@@ -886,6 +887,7 @@ If you wish to specify multiple pages to open in the browser.
 module.exports = {
   //...
   devServer: {
+    open: true,
     openPage: ['different/page1', 'different/page2'],
   },
 };

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -865,7 +865,7 @@ Specify a page to navigate to when opening the browser.
 module.exports = {
   //...
   devServer: {
-    openPage: '/different/page',
+    openPage: 'different/page',
   },
 };
 ```
@@ -873,8 +873,10 @@ module.exports = {
 Usage via the CLI
 
 ```bash
-npx webpack serve --open-page /different/page
+npx webpack serve --open --open-page different/page
 ```
+
+W> You do not need to add `/` in starting webpack-dev-server adds it automatically for you else the browser will open `http://localhost:8080//different/page`
 
 If you wish to specify multiple pages to open in the browser.
 
@@ -884,7 +886,7 @@ If you wish to specify multiple pages to open in the browser.
 module.exports = {
   //...
   devServer: {
-    openPage: ['/different/page1', '/different/page2'],
+    openPage: ['different/page1', 'different/page2'],
   },
 };
 ```
@@ -892,7 +894,7 @@ module.exports = {
 Usage via the CLI
 
 ```bash
-npx webpack serve --open-page /different/page1 --open-page /different/page2
+npx webpack serve --open --open-page different/page1 --open-page different/page2
 ```
 
 ## `devServer.overlay`


### PR DESCRIPTION
Valid - `npx webpack serve --open --open-page different/page1 --open-page different/page2`