### PR TITLE
docs(api): update `init` command usage

### DIFF
--- a/src/content/api/cli.md
+++ b/src/content/api/cli.md
@@ -37,18 +37,18 @@ Read the [installation guide](/guides/installation) if you don't already have we
 
 webpack-cli offers a variety of commands to make working with webpack easy. By default webpack ships with
 
-| Command                               | Usage                                     | Description                                                                     |
-| ------------------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------- |
-| `build`                               | `build\|bundle\|b [entries...] [options]` | Run webpack (default command, can be omitted).                                  |
-| [`configtest`](#configtest)           | `configtest\|t [config-path]`             | Validate a webpack configuration.                                               |
-| [`help`](#help)                       | `help\|h [command] [option]`              | Display help for commands and options.                                          |
-| [`info`](#info)                       | `info\|i [options]`                       | Outputs information about your system.                                          |
-| [`init`](#init)                       | `init\|c [generation-path] [options]`     | Initialize a new webpack project.                                               |
-| `loader`                              | `loader\|l [output-path]`                 | Scaffold a loader.                                                              |
-| `plugin`                              | `plugin\|p [output-path]`                 | Scaffold a plugin.                                                              |
-| [`serve`](/configuration/dev-server/) | `serve\|s [options]`                      | Run the `webpack-dev-server`.                                                   |
-| [`version`](#version)                 | `version\|v [commands...]`                | Output the version number of `webpack`, `webpack-cli` and `webpack-dev-server`. |
-| `watch`                               | `watch\|w [entries...] [options]`         | Run webpack and watch for files changes.                                        |
+| Command                               | Usage                                                 | Description                                                                     |
+| ------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `build`                               | `build\|bundle\|b [entries...] [options]`             | Run webpack (default command, can be omitted).                                  |
+| [`configtest`](#configtest)           | `configtest\|t [config-path]`                         | Validate a webpack configuration.                                               |
+| [`help`](#help)                       | `help\|h [command] [option]`                          | Display help for commands and options.                                          |
+| [`info`](#info)                       | `info\|i [options]`                                   | Outputs information about your system.                                          |
+| [`init`](#init)                       | `init\|create\|new\|c\|n [generation-path] [options]` | Initialize a new webpack project.                                               |
+| `loader`                              | `loader\|l [output-path]`                             | Scaffold a loader.                                                              |
+| `plugin`                              | `plugin\|p [output-path]`                             | Scaffold a plugin.                                                              |
+| [`serve`](/configuration/dev-server/) | `serve\|s [options]`                                  | Run the `webpack-dev-server`.                                                   |
+| [`version`](#version)                 | `version\|v [commands...]`                            | Output the version number of `webpack`, `webpack-cli` and `webpack-dev-server`. |
+| `watch`                               | `watch\|w [entries...] [options]`                     | Run webpack and watch for files changes.                                        |
 
 ### Init
 
@@ -72,7 +72,7 @@ Location of where to generate the configuration. Defaults to `process.cwd()`.
 
 **`--template`**
 
-`string = default`
+`string = 'default'`
 
 Name of template to generate.
 


### PR DESCRIPTION
add more aliases - `create`, `c`, `new`, `n`

Refers https://github.com/webpack/webpack-cli/pull/2616

To be merged after new release.