### PR TITLE
docs(configuration): fix `--useLocalIp` usage

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -1515,7 +1515,7 @@ module.exports = {
 Usage via the CLI
 
 ```bash
-npx webpack serve --use-local-ip
+npx webpack serve --useLocalIp
 ```
 
 ## `devServer.watchContentBase`


### PR DESCRIPTION
Refer https://github.com/webpack/webpack-dev-server/blob/v3/bin/cli-flags.js#L67