### PR TITLE
docs(api): fix default value for `template` option

### DIFF
--- a/src/content/api/cli.md
+++ b/src/content/api/cli.md
@@ -72,7 +72,7 @@ Location of where to generate the configuration. Defaults to `process.cwd()`.
 
 **`--template`**
 
-`string = default`
+`string = 'default'`
 
 Name of template to generate.
 


### PR DESCRIPTION
It should be `'default'`
