### PR TITLE
docs(api): fix heading level

### DIFF
--- a/src/content/api/loaders.mdx
+++ b/src/content/api/loaders.mdx
@@ -605,7 +605,7 @@ W> The loader path in the error is displayed since webpack 4.12
 
 T> All the errors and warnings will be recorded into `stats`. Please see [Stats Data](/api/stats/#errors-and-warnings).
 
-### Inline matchResource
+## Inline matchResource
 
 A new inline request syntax was introduced in webpack v4. Prefixing `<match-resource>!=!` to a request will set the `matchResource` for this request.
 


### PR DESCRIPTION
`Inline matchResource` is not a child of `Error Reporting`:

![image](https://user-images.githubusercontent.com/1091472/114565321-be39e680-9ca3-11eb-84a9-d835c09fbfba.png)
