### PR TITLE
docs(api): fix tip for entry

### DIFF
--- a/src/content/api/cli.md
+++ b/src/content/api/cli.md
@@ -216,7 +216,7 @@ npx webpack ./first-entry.js ./other-entry.js
 npx webpack --entry ./first-entry.js ./other-entry.js
 ```
 
-T> Use `webpack [command] [entries...] [option]` syntax because some options can accept multiple values so `webpack --target node ./entry.js` means `target: ['node', './file.js']`
+T> Use `webpack [command] [entries...] [option]` syntax because some options can accept multiple values so `webpack --target node ./entry.js` means `target: ['node', './entry.js']`
 
 **`<output>`**
 


### PR DESCRIPTION
Fix tip.

`webpack --target node ./entry.js` =>  `target: ['node', './entry.js']`