### PR TITLE
Remove outdated example for compiler hook usage

### DIFF
--- a/src/content/api/compiler-hooks.md
+++ b/src/content/api/compiler-hooks.md
@@ -17,10 +17,6 @@ with all the options passed through the [CLI](/api/cli) or [Node API](/api/node)
 `Tapable` class in order to register and call plugins. Most user facing plugins
 are first registered on the `Compiler`.
 
-T> This module is exposed as `webpack.Compiler` and can be used directly. See
-[this example](https://github.com/pksjce/webpack-internal-examples/tree/master/compiler-example)
-for more information.
-
 When developing a plugin for webpack, you might want to know where each hook is called. To learn this, search for `hooks.<hook name>.call` across the webpack source
 
 ## Watching


### PR DESCRIPTION
Addresses issue #4813 where we identified that a compiler hook example was referencing stale code from a private repository.
As discussed in the issue, it was advised to remove the link from the docs.

- [X] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [X] Make sure your PR complies with the [writer's guide][2].
- [X] Review the diff carefully as sometimes this can reveal issues.

[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
