### PR TITLE
docs(configuration): remove warning regarding cache properties usage

### DIFF
--- a/src/content/configuration/other-options.mdx
+++ b/src/content/configuration/other-options.mdx
@@ -355,8 +355,6 @@ module.exports = {
 };
 ```
 
-W> `cache.idleTimeout` is only available when [`cache.store`](#cachestore) is set to `'pack'`
-
 ### cache.idleTimeoutForInitialStore
 
 `number = 0`
@@ -373,8 +371,6 @@ module.exports = {
   },
 };
 ```
-
-W> `cache.idleTimeoutForInitialStore` is only available when [`cache.store`](#cachestore) is set to `'pack'`
 
 ## dependencies
 


### PR DESCRIPTION
`pack` is the only supported mode for `cache.store` since webpack `5.0.x`.
#3393