### PR TITLE
docs: add public path in entry descriptor

### DIFF
--- a/src/content/concepts/entry-points.md
+++ b/src/content/concepts/entry-points.md
@@ -84,7 +84,7 @@ An object with entry point description. You can specify the following properties
 - `import`: Module(s) that are loaded upon startup.
 - `library`: Specify [library options](/configuration/output/#outputlibrary) to bundle a library from current entry.
 - `runtime`: The name of the runtime chunk. If set, a runtime chunk with this name is created otherwise an existing entry point is used as runtime.
-- `publicPath`: Specify base path for assets for this entry. Also see [output.publicPath](/configuration/output/#outputpublicpath).
+- `publicPath`: Specify a public URL address for the output files of this entry when they are referenced in a browser. Also see [output.publicPath](/configuration/output/#outputpublicpath).
 
 **webpack.config.js**
 

--- a/src/content/concepts/entry-points.md
+++ b/src/content/concepts/entry-points.md
@@ -10,6 +10,7 @@ contributors:
   - Zearin
   - chenxsan
   - adyjs
+  - anshumanv
 ---
 
 As mentioned in [Getting Started](/guides/getting-started/#using-a-configuration), there are multiple ways to define the `entry` property in your webpack configuration. We will show you the ways you **can** configure the `entry` property, in addition to explaining why it may be useful to you.
@@ -83,6 +84,7 @@ An object with entry point description. You can specify the following properties
 - `import`: Module(s) that are loaded upon startup.
 - `library`: Specify [library options](/configuration/output/#outputlibrary) to bundle a library from current entry.
 - `runtime`: The name of the runtime chunk. If set, a runtime chunk with this name is created otherwise an existing entry point is used as runtime.
+- `publicPath`: Specifies the public URL address of the output files when referenced in a browser for this entry. Also see [output.publicPath](/configuration/output/#outputpublicpath).
 
 **webpack.config.js**
 

--- a/src/content/concepts/entry-points.md
+++ b/src/content/concepts/entry-points.md
@@ -84,7 +84,7 @@ An object with entry point description. You can specify the following properties
 - `import`: Module(s) that are loaded upon startup.
 - `library`: Specify [library options](/configuration/output/#outputlibrary) to bundle a library from current entry.
 - `runtime`: The name of the runtime chunk. If set, a runtime chunk with this name is created otherwise an existing entry point is used as runtime.
-- `publicPath`: Specifies the public URL address of the output files when referenced in a browser for this entry. Also see [output.publicPath](/configuration/output/#outputpublicpath).
+- `publicPath`: Specify base path for assets for this entry. Also see [output.publicPath](/configuration/output/#outputpublicpath).
 
 **webpack.config.js**
 


### PR DESCRIPTION
Fix https://github.com/webpack/webpack.js.org/issues/4873

Should we also add some example? Already linked to `output.publicPath` which contains a ton

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].
- **Remove these instructions from your PR as they are for your eyes only.**

[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
