### PR TITLE
docs(configuration): add warning for `liveReload`

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -746,7 +746,7 @@ npx webpack serve --liveReload
 
 Notice that there's no way to disable it from CLI.
 
-W> Live reloading does not work with non-web targets like `node`, `async-node` etc.
+W> Live reloading works only with web related [targets](/configuration/target/#string) like `web`, `webworker`, `electron-renderer` and `node-webkit`.
 
 ## `devServer.mimeTypes` 🔑
 

--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -746,6 +746,8 @@ npx webpack serve --liveReload
 
 Notice that there's no way to disable it from CLI.
 
+W> Live reloading does not work with non-web targets like `node`, `async-node` etc.
+
 ## `devServer.mimeTypes` 🔑
 
 `object`


### PR DESCRIPTION
Add warning that `liveReload` doesn't work with non-web targets. 

For new webpack users who don't have much idea about the configuration -

https://github.com/webpack/webpack-dev-server/issues/2026#issuecomment-502450338

