### PR TITLE
docs(api): add example with multiple `=` for `--env`

### DIFF
--- a/src/content/api/cli.md
+++ b/src/content/api/cli.md
@@ -449,6 +449,7 @@ The `--env` argument accepts multiple values:
 | `npx webpack --env prod`                                         | `{ prod: true }`                               |
 | `npx webpack --env prod --env min`                               | `{ prod: true, min: true }`                    |
 | `npx webpack --env platform=app --env production`                | `{ platform: "app", production: true }`        |
+| `npx webpack --env foo=bar=app`                                  | `{ foo: "bar=app"}`                            |
 | `npx webpack --env app.platform="staging" --env app.name="test"` | `{ app: { platform: "staging", name: "test" }` |
 
 T> See the [environment variables](/guides/environment-variables/) guide for more information on its usage.


### PR DESCRIPTION
Add an advanced usage example. This will clarify --env only split from first `=`