### PR TITLE
docs(typescript guide) set "moduleResolution" to "node" in tsconfig.json

### DIFF
--- a/src/content/guides/typescript.md
+++ b/src/content/guides/typescript.md
@@ -52,7 +52,7 @@ Let's set up a simple configuration to support JSX and compile TypeScript down t
     "target": "es5",
     "jsx": "react",
     "allowJs": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
   }
 }
 ```
@@ -140,7 +140,7 @@ To enable source maps, we must configure TypeScript to output inline source maps
       "target": "es5",
       "jsx": "react",
       "allowJs": true,
-      "moduleResolution": "node"
+      "moduleResolution": "node",
     }
   }
 ```

--- a/src/content/guides/typescript.md
+++ b/src/content/guides/typescript.md
@@ -51,7 +51,8 @@ Let's set up a simple configuration to support JSX and compile TypeScript down t
     "module": "es6",
     "target": "es5",
     "jsx": "react",
-    "allowJs": true
+    "allowJs": true,
+    "moduleResolution": "node"
   }
 }
 ```
@@ -138,7 +139,8 @@ To enable source maps, we must configure TypeScript to output inline source maps
       "module": "commonjs",
       "target": "es5",
       "jsx": "react",
-      "allowJs": true
+      "allowJs": true,
+      "moduleResolution": "node"
     }
   }
 ```


### PR DESCRIPTION
This is about the example tsconfig.json file used in the webpack typescript guide.

By default, "moduleResolution" is set to "classic". When using "module": "es6", this does not allow importing lodash (or any module) in the way described in this guide. Setting it to "node" instead fixes the issue (and I double checked - this is compatible with "module": "commonjs" as well). This setting is the industry standard; https://www.typescriptlang.org/docs/handbook/module-resolution.html

P.S. webpack is awesome, and the docs are great, many thanks!