### PR TITLE
Update author-librairies.md

### DIFF
--- a/src/content/guides/author-libraries.md
+++ b/src/content/guides/author-libraries.md
@@ -32,11 +32,11 @@ The basic project structure would look like this:
 +    |- ref.json
 ```
 
-Initialize the project with npm, then install `webpack` and `lodash`:
+Initialize the project with npm, then install `webpack`, `webpack-cli` and `lodash`:
 
 ```bash
 npm init -y
-npm install --save-dev webpack lodash
+npm install --save-dev webpack wepack-cli lodash
 ```
 
 We install `lodash` as `devDependencies` instead of `dependencies` because we don't want to bundle it into our library, or our library could be easily bloated.

--- a/src/content/guides/author-libraries.md
+++ b/src/content/guides/author-libraries.md
@@ -36,7 +36,7 @@ Initialize the project with npm, then install `webpack`, `webpack-cli` and `loda
 
 ```bash
 npm init -y
-npm install --save-dev webpack wepack-cli lodash
+npm install --save-dev webpack webpack-cli lodash
 ```
 
 We install `lodash` as `devDependencies` instead of `dependencies` because we don't want to bundle it into our library, or our library could be easily bloated.


### PR DESCRIPTION
_describe your changes..._


[Website] Webpack Authoring Libraries Guide require CLI for Webpack
<!-- Please don't delete this template because we'll close your issue -->
<!-- Before creating an issue please make sure you are using the latest version of webpack. -->

# Bug report

<!-- Please ask questions on StackOverflow or the webpack Gitter. -->
<!-- https://stackoverflow.com/questions/ask?tags=webpack -->
<!-- https://gitter.im/webpack/webpack -->
<!-- Issues which contain questions or support requests will be closed. -->

**What is the current behavior?**

Following Webpack Guide for Authoring Libraries on the official website output an error:

```
CLI for webpack must be installed.
  webpack-cli (https://github.com/webpack/webpack-cli)

We will use "npm" to install the CLI via "npm install -D webpack-cli".
Do you want to install 'webpack-cli' (yes/no): no
You need to install 'webpack-cli' to use webpack via CLI.
You can also install the CLI manually.
```

**If the current behavior is a bug, please provide the steps to reproduce.**

Following the [Authoring Libraires Guide](https://webpack.js.org/guides/author-libraries): 
after [Expose the Library](https://webpack.js.org/guides/author-libraries/#expose-the-library) section and running  `npx webpack`

<!-- A great way to do this is to provide your configuration via a GitHub repository -->
<!-- The most helpful is a minimal reproduction with instructions on how to reproduce -->
<!-- Repositories with too many files or large `webpack.config.js` files are not suitable -->
<!-- Please only add small code snippets directly into this issue -->
<!-- https://gist.github.com is a good place for longer code snippets -->
<!-- If your issue is caused by a plugin or loader, please create an issue on the loader/plugin repository instead -->

**What is the expected behavior?**

At the beginning of the guide if we change the snippet code


_Initialize the project with npm, then install webpack and lodash:_
```
npm init -y
npm install --save-dev webpack lodash
```
by

_Initialize the project with npm, then install webpack, webpack-cli and lodash:_
```
npm init -y
npm install --save-dev webpack webpack-cli lodash
```

The expected behavior is the build of the project in order to find that a largish bundle is created. ([according to the guide](https://webpack.js.org/guides/author-libraries/#externalize-lodash))


<!-- "It should work" is not a helpful explanation -->
<!-- Explain exactly how it should behave -->

**Other relevant information:**
webpack version:  5.35.0
Node.js version: 15.14.0
Operating System: macOS X Big Sur
Additional tools:
