### PR TITLE
Update noParse docs

### DIFF
--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -194,13 +194,18 @@ The `'relative'` value for `module.parser.javascript.url` is available since web
 
 Prevent webpack from parsing any files matching the given regular expression(s). Ignored files **should not** have calls to `import`, `require`, `define` or any other importing mechanism. This can boost build performance when ignoring large libraries.
 
+`noParse` can be also used as a way to deliberately prevent  expansion of all `import`, `require`, `define` etc. calls, if you're sure those calls are unreachable at runtime.
+For example, when building a project for browser target, and using a third-party library that was prebuilt as a dual browser/nodejs lib, and requires some nodejs built-ins, like `require('os')`.
+
+Note the need to use `[\\/]` in regex to match `\` on Windows and `/` on Mac/Linux.
+
 **webpack.config.js**
 
 ```javascript
 module.exports = {
   //...
   module: {
-    noParse: /jquery|lodash/,
+    noParse: /jquery|lodash|src[\\/]vendor[\\/]somelib/,
   },
 };
 ```
@@ -209,7 +214,7 @@ module.exports = {
 module.exports = {
   //...
   module: {
-    noParse: (content) => /jquery|lodash/.test(content),
+    noParse: (content) => /jquery|lodash|src[\\/]vendor[\\/]somelib/.test(content),
   },
 };
 ```


### PR DESCRIPTION
1) Warn about `[\\/]` for portability (`/` does not match on Windows)
2) Document `noParse` x `require`.

I had an issue like described with 3rd-party lib (webpack 4 was expanding `require('os')`, `require('http')` with shims).

An alternative way to prevent expansion of `require`-s would be defining `externals`, one by one, but I think `noParse` is a better solution - I just tell webpack to bundle the file as-is, instead of going through all the code and all those requires.

```
externals: {
    os: 'var {}',
    http: 'var {}',
    https: 'var {}',
},
```