### PR TITLE
docs(configuration): use consistent format

### DIFF
--- a/src/content/configuration/other-options.mdx
+++ b/src/content/configuration/other-options.mdx
@@ -271,7 +271,7 @@ Define the lifespan of unused cache entries in the memory cache.
 
 - `cache.maxGenerations: Infinity`: Cache entries are kept forever.
 
-`cache.maxGenerations` option is only available when [`cache.type`](#cachetype) is set to `memory`.
+`cache.maxGenerations` option is only available when [`cache.type`](#cachetype) is set to `'memory'`.
 
 **webpack.config.js**
 


### PR DESCRIPTION
Use consistent formatting.