### PR TITLE
Make clearer browserslist feature

### DIFF
--- a/src/content/migrate/5.md
+++ b/src/content/migrate/5.md
@@ -136,7 +136,13 @@ Consider removing defaults:
 ### Need to support an older browser like IE 11?
 
 - By default, webpack 5 will use your `browserslist` config to decide which code style to emit for the runtime code.
-- Without a `browserslist` webpack's runtime code uses ES2015 syntax (e.g., arrow function) to build smaller bundles. If your build targets environments that don't support ES2015 syntax (like IE11), you'll need to set `target: ['web', 'es5']` to use ES5 syntax.
+
+T> You should set `target: 'browserslist'` or remove this setting.
+
+- Without a `browserslist` webpack's runtime code uses ES2015 syntax (e.g., arrow function) to build smaller bundles.
+
+T> If your build targets environments that don't support ES2015 syntax (like IE11), you'll need to set `target: ['web', 'es5']` to use ES5 syntax.
+
 - For Node.js, builds include the supported Node.js version in the `target` option and webpack will automatically figure out which syntax is supported, e.g. `target: 'node8.6'`.
 
 ### Cleanup the code

--- a/src/content/migrate/5.md
+++ b/src/content/migrate/5.md
@@ -135,14 +135,14 @@ Consider removing defaults:
 
 ### Need to support an older browser like IE 11?
 
-- By default, webpack 5 will use your `browserslist` config to decide which code style to emit for the runtime code.
+- If you have [browserslist](https://github.com/browserslist/browserslist) enabled for your project, webpack 5 will reuse your `browserslist` config to decide which code style to emit for the runtime code.
 
-T> You should set `target: 'browserslist'` or remove this setting.
+  Just make sure to:
 
-- Without a `browserslist` webpack's runtime code uses ES2015 syntax (e.g., arrow function) to build smaller bundles.
+  1. set [`target`](/configuration/target/#root) to `browserslist` or remove `target` letting webpack set `browserslist` automatically for you.
+  2. add a `IE 11` to your browserslist configuration.
 
-T> If your build targets environments that don't support ES2015 syntax (like IE11), you'll need to set `target: ['web', 'es5']` to use ES5 syntax.
-
+- Without a `browserslist` webpack's runtime code uses ES2015 syntax (e.g., arrow function) to build smaller bundles. Hence you'll need to set `target: ['web', 'es5']` to use the ES5 syntax for browsers (like IE11) which don't support ES2015 syntax .
 - For Node.js, builds include the supported Node.js version in the `target` option and webpack will automatically figure out which syntax is supported, e.g. `target: 'node8.6'`.
 
 ### Cleanup the code


### PR DESCRIPTION
I tried to make more clear and obvious `browserslist` feature. I did it because after reading the guide I did not remove `target: 'web'` in my config, because I thought, that `browserslist` will apply automatically in this case. But it did not happen and my service crashed in ie11. So I hope that with my tip people will check this setting in their projects.

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].
- **Remove these instructions from your PR as they are for your eyes only.**

[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
