### PR TITLE
docs(guides): fix misleading content

### DIFF
--- a/src/content/guides/web-workers.mdx
+++ b/src/content/guides/web-workers.mdx
@@ -50,4 +50,4 @@ import { Worker } from 'worker_threads';
 new Worker(new URL('./worker.js', import.meta.url));
 ```
 
-Note that this is only available in ESM. CommonJS is not supported by neither webpack nor Node.js.
+Note that this is only available in ESM. `Worker` in CommonJS syntax is not supported by neither webpack nor Node.js.


### PR DESCRIPTION
It's sort of misleading to say `CommonJS is not supported by neither webpack nor Node.js.`. Thanks @QC-L for heads-up.