### PR TITLE
docs(configuration): output.library.umdNamedDefine example fix

### DIFF
--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -1305,9 +1305,11 @@ When using `output.library.type: "umd"`, setting `output.library.umdNamedDefine`
 module.exports = {
   //...
   output: {
-    name: 'MyLibrary',
-    type: 'umd',
-    umdNamedDefine: true,
+    library: {
+      name: 'MyLibrary',
+      type: 'umd',
+      umdNamedDefine: true,
+    },
   },
 };
 ```


### PR DESCRIPTION
Related PR #4691.

Preview URL: https://webpack-js-org-git-fork-vsn4ik-output-library-umd-named-508c51.vercel.app/configuration/output/#outputlibraryumdnameddefine