### PR TITLE
docs(guides): fix condition

### DIFF
--- a/src/content/guides/asset-modules.md
+++ b/src/content/guides/asset-modules.md
@@ -431,7 +431,7 @@ module: {
     // ...
 +     {
 +       test: /\.m?js$/,
-+       resourceQuery: { not: /raw/ },
++       resourceQuery: { not: [/raw/] },
 +       use: [ ... ]
 +     },
       {


### PR DESCRIPTION
According to https://github.com/webpack/webpack/blob/c876b0ee4ec9d1e6dbdcc9e3eecf1db9824fbade/types.d.ts#L9637, the type of `not` should be `RuleSetCondition[]`.