### PR TITLE
Revert "build(deps-dev): bump cypress from 7.2.0 to 7.3.0 (#4964)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "copy-webpack-plugin": "^8.1.1",
     "css-loader": "^5.2.4",
     "css-minimizer-webpack-plugin": "^2.0.0",
-    "cypress": "^7.3.0",
+    "cypress": "^7.2.0",
     "directory-tree": "^2.2.9",
     "directory-tree-webpack-plugin": "^1.0.2",
     "duplexer": "^0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4346,10 +4346,10 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-cypress@^7.3.0:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-7.3.0.tgz#17345b8d18681c120f033e7d8fd0f0271e9d0d51"
-  integrity sha512-aseRCH1tRVCrM6oEfja6fR/bo5l6e4SkHRRSATh27UeN4f/ANC8U7tGIulmrISJVy9xuOkOdbYKbUb2MNM+nrw==
+cypress@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-7.2.0.tgz#6a3364e18972f898fff1fb12c1ff747939e45ddc"
+  integrity sha512-lHHGay+YsffDn4M0bkkwezylBVHUpwwhtqte4LNPrFRCHy77X38+1PUe3neFb3glVTM+rbILtTN6FhO2djcOuQ==
   dependencies:
     "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"


### PR DESCRIPTION
Something wrong with the cypress 7.3.0 as vercel failed to download it:

![image](https://user-images.githubusercontent.com/1091472/117811545-41def700-b293-11eb-996a-1b4e72c86fc3.png)

See a report here https://github.com/cypress-io/cypress/issues/16435