### PR TITLE
fix: entry path in doc

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -242,7 +242,7 @@ As of version 4, webpack doesn't require any configuration, but most projects wi
 const path = require('path');
 
 module.exports = {
-  entry: './src/index.js',
+  entry: path.resolve(__dirname, 'src', 'index.js'),
   output: {
     filename: 'main.js',
     path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
`entry` path currently isn't platform-independent. This change will fix it.

