### PR TITLE
update cname

### DIFF
--- a/src/CNAME
+++ b/src/CNAME
@@ -1,1 +1,1 @@
-webpack.js.org
+v4.webpack.js.org


### PR DESCRIPTION
The v4 version is hosted on `v4.webpack.js.org` instead of `webpack.js.org`, thus the change.