### PR TITLE
Added Trusted Types section to CSP guide.

### DIFF
--- a/src/content/guides/csp.md
+++ b/src/content/guides/csp.md
@@ -44,4 +44,4 @@ For more information on CSP and `nonce` attribute, please refer to **Further Rea
 
 ## Trusted Types
 
-webpack is also capable of using Trusted Types to load dynamically constructed scripts, to adhere to CSP [`require-trusted-types-for`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for) directive restrictions. See [`output.trustedTypes`](/configuration/output/#outputtrustedtypes) configuration option.
+Webpack is also capable of using Trusted Types to load dynamically constructed scripts, to adhere to CSP [`require-trusted-types-for`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for) directive restrictions. See [`output.trustedTypes`](/configuration/output/#outputtrustedtypes) configuration option.

--- a/src/content/guides/csp.md
+++ b/src/content/guides/csp.md
@@ -5,6 +5,7 @@ contributors:
   - EugeneHlushko
   - probablyup
   - wizardofhogwarts
+  - koto
 related:
   - title: Nonce purpose explained
     url: https://stackoverflow.com/questions/42922784/what-s-the-purpose-of-the-html-nonce-attribute-for-script-and-style-elements
@@ -14,6 +15,8 @@ related:
     url: https://www.troyhunt.com/locking-down-your-website-scripts-with-csp-hashes-nonces-and-report-uri/
   - title: CSP on MDN
     url: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+  - title: Trusted Types
+    url: https://web.dev/trusted-types
 ---
 
 webpack is capable of adding `nonce` to all scripts that it loads. To activate the feature set a `__webpack_nonce__` variable needs to be included in your entry script. A unique hash based nonce should be generated and provided for each unique page view this is why `__webpack_nonce__` is specified in the entry file and not in the configuration. Please note that `nonce` should always be a base64-encoded string.
@@ -38,3 +41,7 @@ https://trusted.cdn.com;
 ```
 
 For more information on CSP and `nonce` attribute, please refer to **Further Reading** section at the bottom of this page.
+
+## Trusted Types
+
+webpack is also capable of using Trusted Types to load dynamically constructed scripts, to adhere to CSP [`require-trusted-types-for`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for) directive restrictions. See [`output.trustedTypes`](/configuration/output/#outputtrustedtypes) configuration option.


### PR DESCRIPTION
Added Trusted Types section to the Content Security Policies Guide (since Trusted Types restrictions are controlled by CSP, some users might be looking for Trusted Types info in the CSP guide). The section simply refers the users to the `output.trustedTypes` option documentation added in https://github.com/webpack/webpack.js.org/pull/4961. 
