### PR TITLE
docs(plugins): fix invalid option in IgnorePlugin

### DIFF
--- a/src/content/plugins/ignore-plugin.md
+++ b/src/content/plugins/ignore-plugin.md
@@ -43,7 +43,7 @@ As of [moment](https://momentjs.com/) 2.18, all locales are bundled together wit
 The `resourceRegExp` parameter passed to `IgnorePlugin` is not tested against the resolved file names or absolute module names being imported or required, but rather against the _string_ passed to `require` or `import` _within the source code where the import is taking place_. For example, if you're trying to exclude `node_modules/moment/locale/*.js`, this won't work:
 
 ```diff
--new webpack.IgnorePlugin({requestRegExp: /moment\/locale\//});
+-new webpack.IgnorePlugin({ resourceRegExp: /moment\/locale\// });
 ```
 
 Rather, because `moment` imports with this code:


### PR DESCRIPTION
Replace invalid IgnorePlugin option `requestRegExp` with `resourceRegExp`.

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].

[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
