### PR TITLE
docs(guides): document data urls support in new url

### DIFF
--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -751,7 +751,7 @@ T> See [`Nested rules`](#nested-rules) for more information.
 
 ## Rule.scheme
 
-Matche the used schema, e.g., `data`, `http`.
+Match the used schema, e.g., `data`, `http`.
 
 - Type: `string | RegExp | ((value: string) => boolean) | RuleSetLogicalConditions | RuleSetCondition[]`
 - Available: <Badge text='5.38.0+' />

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -749,6 +749,28 @@ An array of [`Rules`](#rule) that is also used when the Rule matches.
 
 T> See [`Nested rules`](#nested-rules) for more information.
 
+## Rule.scheme
+
+Matche the used schema, e.g., `data`, `http`.
+
+- Type: `string | RegExp | ((value: string) => boolean) | RuleSetLogicalConditions | RuleSetCondition[]`
+- Available: <Badge text='5.38.0+' />
+
+**webpack.config.js**
+
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        scheme: 'data',
+        type: 'asset/resource',
+      },
+    ],
+  },
+};
+```
+
 ## `Rule.sideEffects`
 
 `bool`

--- a/src/content/guides/asset-modules.md
+++ b/src/content/guides/asset-modules.md
@@ -339,6 +339,17 @@ new URL(
 );
 ```
 
+As of webpack 5.38.0, [Data URLs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) are supported in `new URL()` as well:
+
+**src/index.js**
+
+```js
+const url = new URL('data:,', import.meta.url);
+console.log(url.href === 'data:,');
+console.log(url.protocol === 'data:');
+console.log(url.pathname === ',');
+```
+
 ## General asset type
 
 **webpack.config.js**


### PR DESCRIPTION
Closes https://github.com/webpack/webpack.js.org/issues/4996