### PR TITLE
docs(configuration): update devServer.setup warning

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -1273,7 +1273,7 @@ module.exports = {
 
 `function (app, server)`
 
-W> This option is **deprecated** in favor of [`devServer.before`](#devserverbefore) and will be removed in v3.0.0.
+W> This option is **deprecated** in favor of [`devServer.before`](#devserverbefore) and will be removed in v4.0.0.
 
 Here you can access the Express app object and add your own custom middleware to it.
 For example, to define custom handlers for some paths:


### PR DESCRIPTION
v3 still support `setup`. dropped in `v4`

https://github.com/webpack/webpack-dev-server/blob/v3/lib/options.json#L334