### PR TITLE
docs(api): add link for init

### DIFF
--- a/src/content/api/cli.md
+++ b/src/content/api/cli.md
@@ -82,6 +82,8 @@ Name of template to generate.
 
 To generate a project without questions. When enabled, default answer for each question will be used.
 
+Know more about the questions aksed by `init` [here](https://github.com/webpack/webpack-cli/blob/master/INIT.md#description-of-questions-asked-by-the-generator)
+
 ### Info
 
 Outputs information about your system.

--- a/src/content/api/cli.md
+++ b/src/content/api/cli.md
@@ -82,7 +82,7 @@ Name of template to generate.
 
 To generate a project without questions. When enabled, default answer for each question will be used.
 
-Know more about the questions aksed by `init` [here](https://github.com/webpack/webpack-cli/blob/master/INIT.md#description-of-questions-asked-by-the-generator)
+T> Click [here](https://github.com/webpack/webpack-cli/blob/master/INIT.md) to see the full documentation of webpack init command.
 
 ### Info
 


### PR DESCRIPTION
Add link for `init` - https://github.com/webpack/webpack-cli/blob/master/INIT.md#description-of-questions-asked-by-the-generator. 