### PR TITLE
docs(plugins): fix broken link

### DIFF
--- a/src/content/plugins/index.md
+++ b/src/content/plugins/index.md
@@ -35,7 +35,7 @@ webpack has a rich plugin interface. Most of the features within webpack itself 
 | [`MiniCssExtractPlugin`](/plugins/mini-css-extract-plugin)                      | creates a CSS file per JS file which requires CSS                                      |
 | [`NoEmitOnErrorsPlugin`](/configuration/optimization/#optimizationemitonerrors) | Skip the emitting phase when there are compilation errors                              |
 | [`NormalModuleReplacementPlugin`](/plugins/normal-module-replacement-plugin)    | Replace resource(s) that matches a regexp                                              |
-| [`NpmInstallWebpackPlugin`](/plugins/npm-install-webpack-plugin)                | Auto-install missing dependencies during development                                   |
+| [`NpmInstallWebpackPlugin`](/plugins/install-webpack-plugin)                    | Auto-install missing dependencies during development                                   |
 | [`ProgressPlugin`](/plugins/progress-plugin)                                    | Report compilation progress                                                            |
 | [`ProvidePlugin`](/plugins/provide-plugin)                                      | Use modules without having to use import/require                                       |
 | [`SourceMapDevToolPlugin`](/plugins/source-map-dev-tool-plugin)                 | Enables a more fine grained control of source maps                                     |


### PR DESCRIPTION
Someone changed the url from `https://github.com/webpack-contrib/npm-install-webpack-plugin` to `https://github.com/webpack-contrib/install-webpack-plugin`, causing [the CI failure](https://github.com/webpack/webpack.js.org/pull/5060/checks?check_run_id=2798702524#step:9:8).