### PR TITLE
add a link to privacy policy

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -15,6 +15,9 @@ const Footer = () => (
         <Link className="footer__link" to="/comparison/">
           Comparison
         </Link>
+        <Link className="footer__link" to="https://privacy-policy.openjsf.org/">
+          Privacy Policy
+        </Link>
       </section>
 
       <section className="footer__middle">


### PR DESCRIPTION
The usage of Google Analytics requires a privacy policy. Since webpack is an openjs foundation project, we can just add a link to its privacy policy instead of creating one ourselves.