### PR TITLE
docs(api): update `init` link

### DIFF
--- a/src/content/api/cli.md
+++ b/src/content/api/cli.md
@@ -82,7 +82,7 @@ Name of template to generate.
 
 To generate a project without questions. When enabled, default answer for each question will be used.
 
-T> Click [here](https://github.com/webpack/webpack-cli/blob/master/INIT.md) to see the full documentation of webpack init command.
+T> [Click here](https://github.com/webpack/webpack-cli/blob/master/packages/generators/INIT.md) to see the full documentation of webpack init command.
 
 ### Info
 

--- a/src/content/api/cli.md
+++ b/src/content/api/cli.md
@@ -82,7 +82,7 @@ Name of template to generate.
 
 To generate a project without questions. When enabled, default answer for each question will be used.
 
-T> [Click here](https://github.com/webpack/webpack-cli/blob/master/packages/generators/INIT.md) to see the full documentation of webpack init command.
+T> See the [full documentation of `webpack init` command](https://github.com/webpack/webpack-cli/blob/master/packages/generators/INIT.md).
 
 ### Info
 


### PR DESCRIPTION
`INIT.md` was moved.

New link - https://github.com/webpack/webpack-cli/blob/master/packages/generators/INIT.md