### PR TITLE
fix process-readme for html code

### DIFF
--- a/src/utilities/process-readme.js
+++ b/src/utilities/process-readme.js
@@ -92,10 +92,6 @@ function getMatches(string, regex) {
 
 module.exports = function processREADME(body, options = {}) {
   let processingString = body
-    .replace(/[^]*?<div align="center">([^]*?)<\/div>/, (match, content) => {
-      let parsed = content.match(/<p>([^]*?)<\/?p>/);
-      return parsed ? parsed[1] : '';
-    })
     // Replace lone h1 formats
     .replace(/<h1.*?>.+?<\/h1>/, '')
     .replace(/^# .+/m, '')


### PR DESCRIPTION
See https://webpack.js.org/plugins/image-minimizer-webpack-plugin/:

![image](https://user-images.githubusercontent.com/1091472/121774592-a6081a00-cbb5-11eb-83f0-b2cad09f677d.png)

Generally I don't think it's necessary to replace [this html](https://raw.githubusercontent.com/webpack-contrib/image-minimizer-webpack-plugin/master/README.md):

```html
<!--lint disable no-html-->

<div align="center">
  <a href="https://github.com/webpack/webpack">
    <img width="200" height="200" hspace="10"
      src="https://cdn.rawgit.com/webpack/media/e7485eb2/logo/icon.svg">
  </a>
  <h1>Imagemin Webpack</h1>
  <p>
    Plugin and Loader for <a href="http://webpack.js.org/">webpack</a> to optimize (compress) all images using <a href="https://github.com/imagemin/imagemin">imagemin</a>.
    Do not worry about size of images, now they are always optimized/compressed.
  </p>
</div>

<!--lint enable no-html-->
```