### PR TITLE
exclude closure-webpack-plugin

### DIFF
--- a/src/utilities/constants.js
+++ b/src/utilities/constants.js
@@ -28,6 +28,7 @@ const excludedPlugins = [
   'webpack-contrib/babel-minify-webpack-plugin',
   'webpack-contrib/uglifyjs-webpack-plugin',
   'webpack-contrib/zopfli-webpack-plugin',
+  'webpack-contrib/closure-webpack-plugin',
 ];
 
 module.exports = {


### PR DESCRIPTION
`closure-webpack-plugin` doesn't support webpack 5 at the moment as per https://github.com/webpack-contrib/closure-webpack-plugin/issues/161. We can add it back once it's webpack 5 ready.