### PR TITLE
docs(examples): fix StackBlitz example for module federation

### DIFF
--- a/examples/module-federation/.stackblitzrc
+++ b/examples/module-federation/.stackblitzrc
@@ -1,3 +1,0 @@
-{
-  "startCommand": "npm start"
-}

--- a/src/content/concepts/module-federation.mdx
+++ b/src/content/concepts/module-federation.mdx
@@ -25,7 +25,7 @@ Multiple separate builds should form a single application. These separate builds
 This is often known as Micro-Frontends, but is not limited to that.
 
 <StackBlitzPreview
-  example="module-federation?terminal="
+  example="module-federation?terminal=start&terminal="
   description="Check out this live module federation example on StackBlitz."
 />
 

--- a/src/content/plugins/module-federation-plugin.mdx
+++ b/src/content/plugins/module-federation-plugin.mdx
@@ -11,7 +11,7 @@ related:
 The `ModuleFederationPlugin` allows a build to provide or consume modules with other independent builds at runtime.
 
 <StackBlitzPreview
-  example="module-federation?terminal="
+  example="module-federation?terminal=start&terminal="
   description="Check out this live module federation example on StackBlitz."
 />
 


### PR DESCRIPTION
This PR fixes the link when clicking on the StackBlitz button. It will install the dependencies, run the `npm start` command and open a second blank terminal.

I also removed the `.stackblitzrc` because it's covered by the query parameters and allows more flexibility like opening a second or third terminal and what not. So in this case, the `.stackblitzrc` is not needed.
