### PR TITLE
docs(configuration): sort output configurations alphabetically

### DIFF
--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -31,6 +31,12 @@ contributors:
 
 The top-level `output` key contains set of options instructing webpack on how and where it should output your bundles, assets and anything else you bundle or load with webpack.
 
+## `output.assetModuleFilename`
+
+`string = '[hash][ext][query]'`
+
+The same as [`output.filename`](#outputfilename) but for [Asset Modules](/guides/asset-modules/).
+
 ## `output.auxiliaryComment`
 
 W> Prefer to use [`output.library.auxiliaryComment`](#outputlibraryauxiliarycomment) instead.
@@ -139,29 +145,11 @@ module.exports = {
 };
 ```
 
-## `output.chunkLoadTimeout`
+## `output.chunkFormat`
 
-`number = 120000`
+`false` `string: 'array-push' | 'commonjs' | <any string>`
 
-Number of milliseconds before chunk request expires. This option is supported since webpack 2.6.0.
-
-**webpack.config.js**
-
-```javascript
-module.exports = {
-  //...
-  output: {
-    //...
-    chunkLoadTimeout: 30000,
-  },
-};
-```
-
-## `output.chunkLoadingGlobal`
-
-`string = 'webpackChunkwebpack'`
-
-The global variable used by webpack for loading of chunks.
+The format of chunks (formats included by default are 'array-push' (web/WebWorker), 'commonjs' (node.js), but others might be added by plugins).
 
 **webpack.config.js**
 
@@ -170,7 +158,7 @@ module.exports = {
   //...
   output: {
     //...
-    chunkLoadingGlobal: 'myCustomFunc',
+    chunkFormat: 'commonjs',
   },
 };
 ```
@@ -193,11 +181,11 @@ module.exports = {
 };
 ```
 
-## `output.chunkFormat`
+## `output.chunkLoadingGlobal`
 
-`false` `string: 'array-push' | 'commonjs' | <any string>`
+`string = 'webpackChunkwebpack'`
 
-The format of chunks (formats included by default are 'array-push' (web/WebWorker), 'commonjs' (node.js), but others might be added by plugins).
+The global variable used by webpack for loading of chunks.
 
 **webpack.config.js**
 
@@ -206,16 +194,16 @@ module.exports = {
   //...
   output: {
     //...
-    chunkFormat: 'commonjs',
+    chunkLoadingGlobal: 'myCustomFunc',
   },
 };
 ```
 
-## `output.enabledChunkLoadingTypes`
+## `output.chunkLoadTimeout`
 
-`[string: 'jsonp' | 'import-scripts' | 'require' | 'async-node' | <any string>]`
+`number = 120000`
 
-List of chunk loading types enabled for use by entry points. Will be automatically filled by webpack. Only needed when using a function as entry option and returning chunkLoading option from there.
+Number of milliseconds before chunk request expires. This option is supported since webpack 2.6.0.
 
 **webpack.config.js**
 
@@ -224,7 +212,85 @@ module.exports = {
   //...
   output: {
     //...
-    enabledChunkLoadingTypes: ['jsonp', 'require'],
+    chunkLoadTimeout: 30000,
+  },
+};
+```
+
+## output.clean
+
+<Badge text="5.20.0+" />
+
+`boolean` `{ dry?: boolean, keep?: RegExp | string | ((filename: string) => boolean) }`
+
+```javascript
+module.exports = {
+  //...
+  output: {
+    clean: true, // Clean the output directory before emit.
+  },
+};
+```
+
+```javascript
+module.exports = {
+  //...
+  output: {
+    clean: {
+      dry: true, // Log the assets that should be removed instead of deleting them.
+    },
+  },
+};
+```
+
+```javascript
+module.exports = {
+  //...
+  output: {
+    clean: {
+      keep: /ignored\/dir\//, // Keep these assets under 'ignored/dir'.
+    },
+  },
+};
+
+// or
+
+module.exports = {
+  //...
+  output: {
+    clean: {
+      keep(asset) {
+        return asset.includes('ignored/dir');
+      },
+    },
+  },
+};
+```
+
+You can also use it with hook:
+
+```javascript
+webpack.CleanPlugin.getCompilationHooks(compilation).keep.tap(
+  'Test',
+  (asset) => {
+    if (/ignored\/dir\//.test(asset)) return true;
+  }
+);
+```
+
+## `output.compareBeforeEmit`
+
+`boolean = true`
+
+Tells webpack to check if to be emitted file already exists and has the same content before writing to the output file system.
+
+W> webpack will not write output file when file already exists on disk with the same content.
+
+```javascript
+module.exports = {
+  //...
+  output: {
+    compareBeforeEmit: false,
   },
 };
 ```
@@ -301,6 +367,81 @@ If multiple modules would result in the same name, [`output.devtoolFallbackModul
 This option determines the modules namespace used with the [`output.devtoolModuleFilenameTemplate`](#outputdevtoolmodulefilenametemplate). When not specified, it will default to the value of: [`output.library`](#outputlibrary). It's used to prevent source file path collisions in sourcemaps when loading multiple libraries built with webpack.
 
 For example, if you have 2 libraries, with namespaces `library1` and `library2`, which both have a file `./src/index.js` (with potentially different contents), they will expose these files as `webpack://library1/./src/index.js` and `webpack://library2/./src/index.js`.
+
+## `output.enabledChunkLoadingTypes`
+
+`[string: 'jsonp' | 'import-scripts' | 'require' | 'async-node' | <any string>]`
+
+List of chunk loading types enabled for use by entry points. Will be automatically filled by webpack. Only needed when using a function as entry option and returning chunkLoading option from there.
+
+**webpack.config.js**
+
+```javascript
+module.exports = {
+  //...
+  output: {
+    //...
+    enabledChunkLoadingTypes: ['jsonp', 'require'],
+  },
+};
+```
+
+## `output.enabledLibraryTypes`
+
+`[string]`
+
+List of library types enabled for use by entry points.
+
+```javascript
+module.exports = {
+  //...
+  output: {
+    enabledLibraryTypes: ['module'],
+  },
+};
+```
+
+## `output.enabledWasmLoadingTypes`
+
+`[string]`
+
+List of wasm loading types enabled for use by entry points.
+
+```javascript
+module.exports = {
+  //...
+  output: {
+    enabledWasmLoadingTypes: ['fetch'],
+  },
+};
+```
+
+## `output.environment`
+
+Tell webpack what kind of ES-features may be used in the generated runtime-code.
+
+```javascript
+module.exports = {
+  output: {
+    environment: {
+      // The environment supports arrow functions ('() => { ... }').
+      arrowFunction: true,
+      // The environment supports BigInt as literal (123n).
+      bigIntLiteral: false,
+      // The environment supports const and let for variable declarations.
+      const: true,
+      // The environment supports destructuring ('{ a, b } = obj').
+      destructuring: true,
+      // The environment supports an async import() function to import EcmaScript modules.
+      dynamicImport: false,
+      // The environment supports 'for of' iteration ('for (const x of array) { ... }').
+      forOf: true,
+      // The environment supports ECMAScript Module syntax to import ECMAScript modules (import ... from '...').
+      module: false,
+    },
+  },
+};
+```
 
 ## `output.filename`
 
@@ -396,7 +537,7 @@ Note this option is called filename but you are still allowed to use something l
 
 Note this option does not affect output files for on-demand-loaded chunks. It only affects output files that are initially loaded. For on-demand-loaded chunk files the [`output.chunkFilename`](#outputchunkfilename) option is used. Files created by loaders also aren't affected. In this case you would have to try the specific loader's available options.
 
-## Template strings
+### Template strings
 
 The following substitutions are available in template strings (via webpack's internal [`TemplatedPathPlugin`](https://github.com/webpack/webpack/blob/master/lib/TemplatedPathPlugin.js)):
 
@@ -488,11 +629,22 @@ type ModulePathData = {
 
 T> In some context properties will use JavaScript code expressions instead of raw values. In these cases the `WithLength` variant is available and should be used instead of slicing the original value.
 
-## `output.assetModuleFilename`
+## `output.futureEmitAssets`
 
-`string = '[hash][ext][query]'`
+`boolean = false`
 
-The same as [`output.filename`](#outputfilename) but for [Asset Modules](/guides/asset-modules/)
+Tells webpack to use the future version of asset emitting logic, which allows freeing memory of assets after emitting. It could break plugins which assume that assets are still readable after they were emitted.
+
+W> `output.futureEmitAssets` option will be removed in webpack v5.0.0 and this behaviour will become the new default.
+
+```javascript
+module.exports = {
+  //...
+  output: {
+    futureEmitAssets: true,
+  },
+};
+```
 
 ## `output.globalObject`
 
@@ -512,27 +664,6 @@ module.exports = {
     libraryTarget: 'umd',
     filename: 'myLib.js',
     globalObject: 'this',
-  },
-};
-```
-
-## `output.uniqueName`
-
-`string`
-
-A unique name of the webpack build to avoid multiple webpack runtimes to conflict when using globals. It defaults to [`output.library`](/configuration/output/#outputlibrary) name or the package name from `package.json` in the context, if both aren't found, it is set to an `''`.
-
-`output.uniqueName` will be used to generate unique globals for:
-
-- [`output.chunkLoadingGlobal`](/configuration/output/#outputchunkloadingglobal)
-
-**webpack.config.js**
-
-```javascript
-module.exports = {
-  // ...
-  output: {
-    uniqueName: 'my-package-xyz',
   },
 };
 ```
@@ -608,6 +739,38 @@ For details see [`output.chunkLoadingGlobal`](#outputchunkloadingglobal).
 Customize the main hot update filename. `[fullhash]` and `[runtime]` are available as placeholder.
 
 T> Typically you don't need to change `output.hotUpdateMainFilename`.
+
+## `output.iife`
+
+`boolean = true`
+
+Tells webpack to add [IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE) wrapper around emitted code.
+
+```javascript
+module.exports = {
+  //...
+  output: {
+    iife: true,
+  },
+};
+```
+
+## `output.importFunctionName`
+
+`string = 'import'`
+
+The name of the native `import()` function. Can be used for polyfilling, e.g. with [`dynamic-import-polyfill`](https://github.com/GoogleChromeLabs/dynamic-import-polyfill).
+
+**webpack.config.js**
+
+```javascript
+module.exports = {
+  //...
+  output: {
+    importFunctionName: '__import__',
+  },
+};
+```
 
 ## output.library
 
@@ -1714,22 +1877,29 @@ MyLibrary(_entry_return_);
 
 The dependencies for your library will be defined by the [`externals`](/configuration/externals/) config.
 
-## `output.importFunctionName`
+## `output.module`
 
-`string = 'import'`
+`boolean = false`
 
-The name of the native `import()` function. Can be used for polyfilling, e.g. with [`dynamic-import-polyfill`](https://github.com/GoogleChromeLabs/dynamic-import-polyfill).
+Output JavaScript files as module type. Disabled by default as it's an experimental feature.
 
-**webpack.config.js**
+When enabled, webpack will set [`output.iife`](#outputiife) to `false`, [`output.scriptType`](#outputscripttype) to `'module'` and `terserOptions.module` to `true` internally.
+
+If you're using webpack to compile a library to be consumed by others, make sure to set [`output.libraryTarget`](#librarytarget-module) to `'module'` when `output.module` is `true`.
 
 ```javascript
 module.exports = {
   //...
+  experiments: {
+    outputModule: true,
+  },
   output: {
-    importFunctionName: '__import__',
+    module: true,
   },
 };
 ```
+
+W> `output.module` is an experimental feature and can only be enabled by setting [`experiments.outputModule`](/configuration/experiments/#experiments) to `true`.
 
 ## `output.path`
 
@@ -2006,97 +2176,23 @@ module.exports = {
 };
 ```
 
-## `output.workerChunkLoading`
+## `output.uniqueName`
 
-`string: 'require' | 'import-scripts' | 'async-node' | 'import' | 'universal'` `boolean: false`
+`string`
 
-The new option `workerChunkLoading` controls the chunk loading of workers.
+A unique name of the webpack build to avoid multiple webpack runtimes to conflict when using globals. It defaults to [`output.library`](/configuration/output/#outputlibrary) name or the package name from `package.json` in the context, if both aren't found, it is set to an `''`.
 
-T> The default value of this option is depending on the `target` setting. For more details, search for `"workerChunkLoading"`: [in the webpack defaults](https://github.com/webpack/webpack/blob/master/lib/config/defaults.js).
+`output.uniqueName` will be used to generate unique globals for:
+
+- [`output.chunkLoadingGlobal`](/configuration/output/#outputchunkloadingglobal)
 
 **webpack.config.js**
 
 ```javascript
 module.exports = {
-  //...
+  // ...
   output: {
-    workerChunkLoading: false,
-  },
-};
-```
-
-## `output.enabledLibraryTypes`
-
-`[string]`
-
-List of library types enabled for use by entry points.
-
-```javascript
-module.exports = {
-  //...
-  output: {
-    enabledLibraryTypes: ['module'],
-  },
-};
-```
-
-## `output.futureEmitAssets`
-
-`boolean = false`
-
-Tells webpack to use the future version of asset emitting logic, which allows freeing memory of assets after emitting. It could break plugins which assume that assets are still readable after they were emitted.
-
-W> `output.futureEmitAssets` option will be removed in webpack v5.0.0 and this behaviour will become the new default.
-
-```javascript
-module.exports = {
-  //...
-  output: {
-    futureEmitAssets: true,
-  },
-};
-```
-
-## `output.environment`
-
-Tell webpack what kind of ES-features may be used in the generated runtime-code.
-
-```javascript
-module.exports = {
-  output: {
-    environment: {
-      // The environment supports arrow functions ('() => { ... }').
-      arrowFunction: true,
-      // The environment supports BigInt as literal (123n).
-      bigIntLiteral: false,
-      // The environment supports const and let for variable declarations.
-      const: true,
-      // The environment supports destructuring ('{ a, b } = obj').
-      destructuring: true,
-      // The environment supports an async import() function to import EcmaScript modules.
-      dynamicImport: false,
-      // The environment supports 'for of' iteration ('for (const x of array) { ... }').
-      forOf: true,
-      // The environment supports ECMAScript Module syntax to import ECMAScript modules (import ... from '...').
-      module: false,
-    },
-  },
-};
-```
-
-## `output.compareBeforeEmit`
-
-`boolean = true`
-
-Tells webpack to check if to be emitted file already exists and has the same content before writing to the output file system.
-
-W> webpack will not write output file when file already exists on disk with the same content.
-
-```javascript
-module.exports = {
-  //...
-  output: {
-    compareBeforeEmit: false,
+    uniqueName: 'my-package-xyz',
   },
 };
 ```
@@ -2121,117 +2217,21 @@ module.exports = {
 };
 ```
 
-## `output.enabledWasmLoadingTypes`
+## `output.workerChunkLoading`
 
-`[string]`
+`string: 'require' | 'import-scripts' | 'async-node' | 'import' | 'universal'` `boolean: false`
 
-List of wasm loading types enabled for use by entry points.
+The new option `workerChunkLoading` controls the chunk loading of workers.
 
-```javascript
-module.exports = {
-  //...
-  output: {
-    enabledWasmLoadingTypes: ['fetch'],
-  },
-};
-```
+T> The default value of this option is depending on the `target` setting. For more details, search for `"workerChunkLoading"`: [in the webpack defaults](https://github.com/webpack/webpack/blob/master/lib/config/defaults.js).
 
-## `output.iife`
-
-`boolean = true`
-
-Tells webpack to add [IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE) wrapper around emitted code.
+**webpack.config.js**
 
 ```javascript
 module.exports = {
   //...
   output: {
-    iife: true,
+    workerChunkLoading: false,
   },
 };
-```
-
-## `output.module`
-
-`boolean = false`
-
-Output JavaScript files as module type. Disabled by default as it's an experimental feature.
-
-When enabled, webpack will set [`output.iife`](#outputiife) to `false`, [`output.scriptType`](#outputscripttype) to `'module'` and `terserOptions.module` to `true` internally.
-
-If you're using webpack to compile a library to be consumed by others, make sure to set [`output.libraryTarget`](#librarytarget-module) to `'module'` when `output.module` is `true`.
-
-```javascript
-module.exports = {
-  //...
-  experiments: {
-    outputModule: true,
-  },
-  output: {
-    module: true,
-  },
-};
-```
-
-W> `output.module` is an experimental feature and can only be enabled by setting [`experiments.outputModule`](/configuration/experiments/#experiments) to `true`.
-
-## output.clean
-
-<Badge text="5.20.0+" />
-
-`boolean` `{ dry?: boolean, keep?: RegExp | string | ((filename: string) => boolean) }`
-
-```javascript
-module.exports = {
-  //...
-  output: {
-    clean: true, // Clean the output directory before emit.
-  },
-};
-```
-
-```javascript
-module.exports = {
-  //...
-  output: {
-    clean: {
-      dry: true, // Log the assets that should be removed instead of deleting them.
-    },
-  },
-};
-```
-
-```javascript
-module.exports = {
-  //...
-  output: {
-    clean: {
-      keep: /ignored\/dir\//, // Keep these assets under 'ignored/dir'.
-    },
-  },
-};
-
-// or
-
-module.exports = {
-  //...
-  output: {
-    clean: {
-      keep(asset) {
-        return asset.includes('ignored/dir');
-      },
-    },
-  },
-};
-```
-
-You can also use it with hook:
-
-```javascript
-webpack.CleanPlugin.getCompilationHooks(compilation).keep.tap(
-  'Test',
-  (asset) => {
-    if (/ignored\/dir\//.test(asset)) return true;
-  }
-);
 ```


### PR DESCRIPTION
Sort configurations alphabetically.

## Before

<img width="150" alt="CleanShot 2021-06-25 at 20 22 19@2x" src="https://user-images.githubusercontent.com/1091472/123424170-1326a100-d5f3-11eb-9c94-08928834a334.png">

## After

<img width="150" alt="CleanShot 2021-06-25 at 20 23 42@2x" src="https://user-images.githubusercontent.com/1091472/123424319-4406d600-d5f3-11eb-86ed-7eee9fab9670.png">

FYI @QC-L @YukJiSoo as this one might bring a lot of changes to the downstream translation repository. Or maybe I should split this pull request into some small ones?  Let me know what you think here.

