### PR TITLE
remove shadow from contributor name

### DIFF
--- a/src/components/Contributors/Contributors.scss
+++ b/src/components/Contributors/Contributors.scss
@@ -35,7 +35,6 @@
     overflow-wrap: break-word;
     hyphens: auto;
     color: getColor(fiord);
-    box-shadow: 0 0 2px rgba(0, 0, 0, 0.3);
     background: transparentize(getColor(white), 0.05);
     transition: color 0.1s;
   }


### PR DESCRIPTION
## Before

<img width="300" alt="CleanShot 2021-06-30 at 22 23 26@2x" src="https://user-images.githubusercontent.com/1091472/123977712-d04d3a80-d9f1-11eb-8bd7-f9a3484e4cfa.png">

## After

<img width="300" alt="CleanShot 2021-06-30 at 22 23 39@2x" src="https://user-images.githubusercontent.com/1091472/123977744-d80cdf00-d9f1-11eb-8b32-19ee06a86408.png">

The later one would be much cleaner.