### PR TITLE
hide 404 contributors from page

### DIFF
--- a/src/components/Contributors/404.js
+++ b/src/components/Contributors/404.js
@@ -1,0 +1,7 @@
+// contributors 404
+export const contributorsNotFound = [
+  'bartushek',
+  'rynclark',
+  'henriquea',
+  'makuzaverite',
+];

--- a/src/components/Contributors/Contributors.jsx
+++ b/src/components/Contributors/Contributors.jsx
@@ -3,6 +3,7 @@ import VisibilitySensor from 'react-visibility-sensor';
 import SmallIcon from '../../assets/icon-square-small-slack.png';
 import './Contributors.scss';
 import PropTypes from 'prop-types';
+import { contributorsNotFound } from './404.js';
 
 export default class Contributors extends Component {
   static propTypes = {
@@ -36,23 +37,25 @@ export default class Contributors extends Component {
       >
         <div className="contributors">
           <div className="contributors__list">
-            {contributors.map((contributor) => (
-              <a
-                key={contributor}
-                className="contributor"
-                href={`https://github.com/${contributor}`}
-              >
-                <img
-                  alt={contributor}
-                  src={
-                    inView
-                      ? `https://github.com/${contributor}.png?size=90`
-                      : SmallIcon
-                  }
-                />
-                <span className="contributor__name"> {contributor}</span>
-              </a>
-            ))}
+            {contributors
+              .filter((c) => contributorsNotFound.includes(c) === false)
+              .map((contributor) => (
+                <a
+                  key={contributor}
+                  className="contributor"
+                  href={`https://github.com/${contributor}`}
+                >
+                  <img
+                    alt={contributor}
+                    src={
+                      inView
+                        ? `https://github.com/${contributor}.png?size=90`
+                        : SmallIcon
+                    }
+                  />
+                  <span className="contributor__name"> {contributor}</span>
+                </a>
+              ))}
           </div>
         </div>
       </VisibilitySensor>


### PR DESCRIPTION
Some contributors are 404 on github now, it would be better to hide them from the webpage,

![CleanShot 2021-07-01 at 08 10 07@2x](https://user-images.githubusercontent.com/1091472/124046167-e5eb5000-da43-11eb-80d6-3add24efd4d1.png)

Note that we're still keeping them in the source file.