### PR TITLE
fix dark mode bug

### DIFF
--- a/cypress/integration/toggle-dark-mode_spec.js
+++ b/cypress/integration/toggle-dark-mode_spec.js
@@ -1,0 +1,13 @@
+describe('Toggle dark mode', () => {
+  it('should toggle .dark class for html element', () => {
+    cy.visit('/');
+
+    const selector = '[data-testid="hello-darkness"]';
+
+    cy.get(selector).click();
+    cy.get('html').should('have.class', 'dark');
+
+    cy.get(selector).click();
+    cy.get('html').should('not.have.class', 'dark');
+  });
+});

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -124,6 +124,7 @@ function Navigation({
                 cursor: 'pointer',
               }}
               onClick={themeSwitcher}
+              data-testid="hello-darkness"
             >
               {theme === DARK ? '🌙' : '☀️'}
             </button>

--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -68,7 +68,11 @@ function Site(props) {
 
   const applyTheme = (theme) => {
     document.documentElement.setAttribute('data-theme', theme);
-    document.documentElement.classList.add(theme);
+    if (theme === THEME.DARK) {
+      document.documentElement.classList.add(THEME.DARK);
+    } else {
+      document.documentElement.classList.remove(THEME.DARK);
+    }
   };
   useEffect(() => {
     applyTheme(theme);


### PR DESCRIPTION
There's a bug in the dark mode. Here's how to reproduce,

1. open webpack.js.org in incognito mode
2. click the dark mode toggle button twice
3. now you should see:

<img width="337" alt="CleanShot 2021-07-01 at 20 47 53@2x" src="https://user-images.githubusercontent.com/1091472/124126812-a0636d00-daad-11eb-8210-d7b738f9feb0.png">

Here's the culprit:

![CleanShot 2021-07-01 at 20 48 09@2x](https://user-images.githubusercontent.com/1091472/124126883-b3763d00-daad-11eb-8b0f-8317998e3810.png)

`dark` class should be removed on second click.

