### PR TITLE
New way to invoke onListening

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -797,7 +797,7 @@ module.exports = {
   //...
   devServer: {
     onListening: function (server) {
-      const port = server.listeningApp.address().port;
+      const port = server.server.address().port;
       console.log('Listening on port:', port);
     },
   },


### PR DESCRIPTION
You need to call server.server.address() since server.listeningApp is no longer available in webpack-dev-server 4.0.0+
