### PR TITLE
docs(configuration): sort options alphabetically

### DIFF
--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -217,6 +217,67 @@ module.exports = {
 };
 ```
 
+## output.clean
+
+<Badge text="5.20.0+" />
+
+`boolean` `{ dry?: boolean, keep?: RegExp | string | ((filename: string) => boolean) }`
+
+```javascript
+module.exports = {
+  //...
+  output: {
+    clean: true, // Clean the output directory before emit.
+  },
+};
+```
+
+```javascript
+module.exports = {
+  //...
+  output: {
+    clean: {
+      dry: true, // Log the assets that should be removed instead of deleting them.
+    },
+  },
+};
+```
+
+```javascript
+module.exports = {
+  //...
+  output: {
+    clean: {
+      keep: /ignored\/dir\//, // Keep these assets under 'ignored/dir'.
+    },
+  },
+};
+
+// or
+
+module.exports = {
+  //...
+  output: {
+    clean: {
+      keep(asset) {
+        return asset.includes('ignored/dir');
+      },
+    },
+  },
+};
+```
+
+You can also use it with hook:
+
+```javascript
+webpack.CleanPlugin.getCompilationHooks(compilation).keep.tap(
+  'Test',
+  (asset) => {
+    if (/ignored\/dir\//.test(asset)) return true;
+  }
+);
+```
+
 ## `output.enabledChunkLoadingTypes`
 
 `[string: 'jsonp' | 'import-scripts' | 'require' | 'async-node' | <any string>]`
@@ -2174,64 +2235,3 @@ module.exports = {
 ```
 
 W> `output.module` is an experimental feature and can only be enabled by setting [`experiments.outputModule`](/configuration/experiments/#experiments) to `true`.
-
-## output.clean
-
-<Badge text="5.20.0+" />
-
-`boolean` `{ dry?: boolean, keep?: RegExp | string | ((filename: string) => boolean) }`
-
-```javascript
-module.exports = {
-  //...
-  output: {
-    clean: true, // Clean the output directory before emit.
-  },
-};
-```
-
-```javascript
-module.exports = {
-  //...
-  output: {
-    clean: {
-      dry: true, // Log the assets that should be removed instead of deleting them.
-    },
-  },
-};
-```
-
-```javascript
-module.exports = {
-  //...
-  output: {
-    clean: {
-      keep: /ignored\/dir\//, // Keep these assets under 'ignored/dir'.
-    },
-  },
-};
-
-// or
-
-module.exports = {
-  //...
-  output: {
-    clean: {
-      keep(asset) {
-        return asset.includes('ignored/dir');
-      },
-    },
-  },
-};
-```
-
-You can also use it with hook:
-
-```javascript
-webpack.CleanPlugin.getCompilationHooks(compilation).keep.tap(
-  'Test',
-  (asset) => {
-    if (/ignored\/dir\//.test(asset)) return true;
-  }
-);
-```

--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -278,6 +278,23 @@ webpack.CleanPlugin.getCompilationHooks(compilation).keep.tap(
 );
 ```
 
+## output.crossOriginLoading
+
+`boolean = false` `string: 'anonymous' | 'use-credentials'`
+
+Tells webpack to enable [cross-origin](https://developer.mozilla.org/en/docs/Web/HTML/Element/script#attr-crossorigin) loading of chunks. Only takes effect when [`target`](/configuration/target/) is set to `'web'`, which uses JSONP for loading on-demand chunks, by adding script tags.
+
+- `'anonymous'` - Enable cross-origin loading **without credentials**
+- `'use-credentials'` - Enable cross-origin loading **with credentials**
+
+## `output.devtoolFallbackModuleFilenameTemplate`
+
+`string` `function (info)`
+
+A fallback used when the template string or function above yields duplicates.
+
+See [`output.devtoolModuleFilenameTemplate`](#outputdevtoolmodulefilenametemplate).
+
 ## `output.enabledChunkLoadingTypes`
 
 `[string: 'jsonp' | 'import-scripts' | 'require' | 'async-node' | <any string>]`
@@ -295,23 +312,6 @@ module.exports = {
   },
 };
 ```
-
-## `output.crossOriginLoading`
-
-`boolean = false` `string: 'anonymous' | 'use-credentials'`
-
-Tells webpack to enable [cross-origin](https://developer.mozilla.org/en/docs/Web/HTML/Element/script#attr-crossorigin) loading of chunks. Only takes effect when [`target`](/configuration/target/) is set to `'web'`, which uses JSONP for loading on-demand chunks, by adding script tags.
-
-- `'anonymous'` - Enable cross-origin loading **without credentials**
-- `'use-credentials'` - Enable cross-origin loading **with credentials**
-
-## `output.devtoolFallbackModuleFilenameTemplate`
-
-`string` `function (info)`
-
-A fallback used when the template string or function above yields duplicates.
-
-See [`output.devtoolModuleFilenameTemplate`](#outputdevtoolmodulefilenametemplate).
 
 ## `output.devtoolModuleFilenameTemplate`
 


### PR DESCRIPTION
A follow-up of https://github.com/webpack/webpack.js.org/pull/5141.

Two options are moved in this pull request: 

1. `output.clean`
2. `output.crossOriginLoading`