### PR TITLE
fix Navigation for external url

### DIFF
--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -34,12 +34,26 @@ function NavigationItem({ children, url, isActive }) {
       isActive,
     };
   }
+  const classes =
+    'text-gray-100 dark:text-gray-100 text-sm font-light uppercase hover:text-blue-200';
+  if (url.startsWith('http') || url.startsWith('//')) {
+    return (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={classes}
+      >
+        {children}
+      </a>
+    );
+  }
   return (
     <NavLink
       {...obj}
       activeClassName="active-menu"
       to={url}
-      className="text-gray-100 dark:text-gray-100 text-sm font-light uppercase hover:text-blue-200"
+      className={classes}
     >
       {children}
     </NavLink>


### PR DESCRIPTION
Seems the `NavLink` won't work with external url https://github.com/ReactTraining/react-router/issues/1147, although our repository doesn't use any external urls in navigation, the downstream translation repositories might use it. Thus it's better to fix it here.