### PR TITLE
transform data for docsearch

### DIFF
--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -21,6 +21,7 @@ export default class Navigation extends React.Component {
 
     return (
       <Banner
+        onSearch={() => {}}
         blockName="navigation"
         logo={ <Logo light={ true } /> }
         url={ pathname }
@@ -68,7 +69,16 @@ export default class Navigation extends React.Component {
       DocSearch({
         apiKey: 'fac401d1a5f68bc41f01fb6261661490',
         indexName: 'webpack-js-org',
-        inputSelector: '.navigation-search__input'
+        inputSelector: '.navigation-search__input',
+        transformData: (data) => {
+          return data.map(({url, ...others}) => {
+            const { origin } = new URL(url);
+            return {
+              ...others,
+              url: url.replace(new RegExp(`^${origin}`), ''),
+            };
+          });
+        }
       });
     }
   }


### PR DESCRIPTION
Closes https://github.com/webpack/webpack.js.org/issues/4824

Just a workaround as I don't receive any response so far regarding who owns the algolia account for webpack documentation.

The search result won't be redirected to webpack.js.org now, however since the it's searching from webpack v5 document instead of v4, the result might be wrong sometimes. But better than now as far as I see.