### PR TITLE
fix a wrong reference in MF plugin example

### DIFF
--- a/src/content/plugins/module-federation-plugin.mdx
+++ b/src/content/plugins/module-federation-plugin.mdx
@@ -104,7 +104,7 @@ module.exports = {
         // version is inferred from package.json
         // it will always use the shared version, but print a warning when the shared lodash is < 4.17 or >= 5
         react: {
-          requiredVersion: deps.lodash,
+          requiredVersion: deps.react,
           singleton: true,
         },
       },


### PR DESCRIPTION
Fix a wrong reference in MF plugin example.
The example is about sharing react, but refer incorrectly to deps.lodash instead of deps.react.
