### PR TITLE
docs(configuration): use `--stats-colors`

### DIFF
--- a/src/content/configuration/stats.mdx
+++ b/src/content/configuration/stats.mdx
@@ -452,7 +452,7 @@ module.exports = {
 It is also available as a CLI flag:
 
 ```bash
-webpack-cli --stats-colors
+npx webpack --stats-colors
 ```
 
 You can specify your own terminal output colors using [ANSI escape sequences](https://en.wikipedia.org/wiki/ANSI_escape_code)

--- a/src/content/configuration/stats.mdx
+++ b/src/content/configuration/stats.mdx
@@ -452,7 +452,7 @@ module.exports = {
 It is also available as a CLI flag:
 
 ```bash
-webpack-cli --colors
+webpack-cli --stats-colors
 ```
 
 You can specify your own terminal output colors using [ANSI escape sequences](https://en.wikipedia.org/wiki/ANSI_escape_code)

--- a/src/content/configuration/stats.mdx
+++ b/src/content/configuration/stats.mdx
@@ -455,6 +455,12 @@ It is also available as a CLI flag:
 npx webpack --stats-colors
 ```
 
+To disable:
+
+```bash
+npx webpack --no-stats-colors
+```
+
 You can specify your own terminal output colors using [ANSI escape sequences](https://en.wikipedia.org/wiki/ANSI_escape_code)
 
 ```js


### PR DESCRIPTION
`--colors` is no longer valid. `--stats-colors` is the latest option.