### PR TITLE
upgrade actions/setup-node@v2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,21 +18,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: yarn
 
       - run: yarn --frozen-lockfile
       - name: Build site
@@ -47,4 +36,3 @@ jobs:
           BRANCH: gh-pages
           FOLDER: dist
           CLEAN: true
-

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,18 +21,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: yarn
 
       - run: yarn --frozen-lockfile
       - run: yarn lint:js

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -57,28 +57,9 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: yarn
 
       - run: yarn
-
-      - uses: actions/cache@v2
-        id: build-cache
-        with:
-          path: .cache
-          key: build-${{ hashFiles('webpack.*.js') }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            build-${{ hashFiles('webpack.*.js') }}-
 
       - name: Build site
         run: yarn build
@@ -100,26 +81,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - uses: actions/cache@v2
-        id: build-cache
-        with:
-          path: .cache
-          key: build-e2e-${{ hashFiles('webpack.*.js') }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            build-e2e-${{ hashFiles('webpack.*.js') }}-
+          cache: yarn
 
       - run: |
           yarn


### PR DESCRIPTION
1. upgrade to `actions/setup-node@v2`
2. use its built-in `cache` option which should fulfill our demand without the complexity of `actions/cache@v2`.