### PR TITLE
fix ci failure

### DIFF
--- a/src/utilities/fetch-supporters.js
+++ b/src/utilities/fetch-supporters.js
@@ -17,14 +17,10 @@ const absoluteFilename = path.resolve(
   filename
 );
 
-let graphqlEndpoint = 'https://api.opencollective.com/graphql/v2';
+const graphqlEndpoint = 'https://api.opencollective.com/graphql/v2';
 
 // https://github.com/opencollective/opencollective-api/blob/master/server/graphql/v2/query/TransactionsQuery.ts#L81
 const graphqlPageSize = 1000;
-
-if (process.env && process.env.CI && process.env.OPENCOLLECTIVE_API_KEY) {
-  graphqlEndpoint = graphqlEndpoint + `/${process.env.OPENCOLLECTIVE_API_KEY}`;
-}
 
 const membersGraphqlQuery = `query account($limit: Int, $offset: Int) {
   account(slug: "webpack") {
@@ -106,7 +102,7 @@ const getAllNodes = async (graphqlQuery, getNodes) => {
       return allNodes;
     } else {
       // sleep for a while
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await new Promise((resolve) => setTimeout(resolve, 6500));
     }
   }
 };

--- a/src/utilities/fetch-supporters.js
+++ b/src/utilities/fetch-supporters.js
@@ -42,7 +42,7 @@ const membersGraphqlQuery = `query account($limit: Int, $offset: Int) {
 }`;
 
 // only query transactions in last year
-const transactionsGraphqlQuery = `query transactions($dateFrom: ISODateTime, $limit: Int, $offset: Int) {
+const transactionsGraphqlQuery = `query transactions($dateFrom: DateTime, $limit: Int, $offset: Int) {
   transactions(account: {
     slug: "webpack"
   }, dateFrom: $dateFrom, limit: $limit, offset: $offset, includeIncognitoTransactions: false) {
@@ -95,6 +95,8 @@ const getAllNodes = async (graphqlQuery, getNodes) => {
         'Content-Type': 'application/json',
       },
     }).then((response) => response.json());
+    console.log(result);
+    if (result.errors) throw new Error(result.errors[0].message);
     const nodes = getNodes(result.data);
     allNodes = [...allNodes, ...nodes];
     body.variables.offset += graphqlPageSize;

--- a/src/utilities/fetch-supporters.js
+++ b/src/utilities/fetch-supporters.js
@@ -102,7 +102,7 @@ const getAllNodes = async (graphqlQuery, getNodes) => {
       return allNodes;
     } else {
       // sleep for a while
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await new Promise((resolve) => setTimeout(resolve, 650));
     }
   }
 };

--- a/src/utilities/fetch-supporters.js
+++ b/src/utilities/fetch-supporters.js
@@ -102,7 +102,7 @@ const getAllNodes = async (graphqlQuery, getNodes) => {
       return allNodes;
     } else {
       // sleep for a while
-      await new Promise((resolve) => setTimeout(resolve, 650));
+      await new Promise((resolve) => setTimeout(resolve, 6500));
     }
   }
 };

--- a/src/utilities/fetch-supporters.js
+++ b/src/utilities/fetch-supporters.js
@@ -17,10 +17,14 @@ const absoluteFilename = path.resolve(
   filename
 );
 
-const graphqlEndpoint = 'https://api.opencollective.com/graphql/v2';
+let graphqlEndpoint = 'https://api.opencollective.com/graphql/v2';
 
 // https://github.com/opencollective/opencollective-api/blob/master/server/graphql/v2/query/TransactionsQuery.ts#L81
 const graphqlPageSize = 1000;
+
+if (process.env && process.env.CI && process.env.OPENCOLLECTIVE_API_KEY) {
+  graphqlEndpoint = graphqlEndpoint + `/${process.env.OPENCOLLECTIVE_API_KEY}`;
+}
 
 const membersGraphqlQuery = `query account($limit: Int, $offset: Int) {
   account(slug: "webpack") {
@@ -102,7 +106,7 @@ const getAllNodes = async (graphqlQuery, getNodes) => {
       return allNodes;
     } else {
       // sleep for a while
-      await new Promise((resolve) => setTimeout(resolve, 6500));
+      await new Promise((resolve) => setTimeout(resolve, 100));
     }
   }
 };

--- a/src/utilities/fetch-supporters.js
+++ b/src/utilities/fetch-supporters.js
@@ -104,7 +104,7 @@ const getAllNodes = async (graphqlQuery, getNodes) => {
       return allNodes;
     } else {
       // sleep for a while
-      await new Promise((resolve) => setTimeout(resolve, 6500));
+      await new Promise((resolve) => setTimeout(resolve, 6000));
     }
   }
 };


### PR DESCRIPTION
We don't use any api key for opencollective at the moment, which means it's easy to hit the api limit defined here https://github.com/opencollective/opencollective-api/blob/main/server/routes.js#L75:

> // 10 requests / minute / ip for anonymous requests

And it's failing the CI now https://github.com/webpack/webpack.js.org/actions/runs/1083925129.

This pull request would query its api less often to avoid hitting the api limit.