### PR TITLE
optimize action

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,9 +1,6 @@
 name: Ensure PR
 
 on:
-  push:
-    branches-ignore:
-      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
Currently the action would run twice for branches on this repository, one for `push`, another for `pull_request`, the former is not necessary as the latter should fulfill our demand:

![actions](https://user-images.githubusercontent.com/1091472/128439168-6b1d831d-2635-474f-aa62-332ab209f64c.png)

Note that it's not a problem for pull requests from forked repositories.