### PR TITLE
Revert "detect all broken links (#5284)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lint:markdown": "npm run lint-markdown *.md ./src/content/**/*.md",
     "lint-markdown": "markdownlint --config ./.markdownlint.json --ignore './src/content/**/_*.md' --ignore '.vale/**/*.md' --ignore '.github/**/*.md'",
     "lint:prose": "vale --config='.vale.ini' src/content",
-    "lint:links": "hyperlink -c 8 --root dist -r dist/index.html --canonicalroot https://webpack.js.org/ --skip /plugins/extract-text-webpack-plugin/ --skip /printable --skip https:// --skip http:// --skip sw.js > internal-links.tap; cat internal-links.tap | tap-spot",
+    "lint:links": "hyperlink -c 8 --root dist -r dist/index.html --canonicalroot https://webpack.js.org/ --internal --skip /plugins/extract-text-webpack-plugin/ --skip /printable --skip https:// --skip http:// --skip sw.js > internal-links.tap; cat internal-links.tap | tap-spot",
     "sitemap": "cd dist && sitemap-static --ignore-file=../sitemap-ignore.json --pretty --prefix=https://webpack.js.org/ > sitemap.xml",
     "serve": "npm run build && sirv start ./dist --port 4000",
     "preprintable": "npm run clean-printable",


### PR DESCRIPTION
Enabling external links detection would take us [more than 11m](https://github.com/webpack/webpack.js.org/pull/5285/checks?check_run_id=3290319887) to finish the CI, I don't think it's a good idea. We have to manually review the pr https://github.com/webpack/webpack.js.org/pull/5275.