### PR TITLE
docs: add `debug` and `level` default for `infrastructureLogging`

### DIFF
--- a/src/content/configuration/other-options.mdx
+++ b/src/content/configuration/other-options.mdx
@@ -207,9 +207,9 @@ module.exports = {
 
 ### debug
 
-`string` `RegExp` `function(name) => boolean` `[string, RegExp, function(name) => boolean]`
+`string` `boolean = false` `RegExp` `function(name) => boolean` `[string, RegExp, function(name) => boolean]`
 
-Enable debug information of specified loggers such as plugins or loaders. Similar to [`stats.loggingDebug`](/configuration/stats/#statsloggingdebug) option but for infrastructure. No default value is given.
+Enable debug information of specified loggers such as plugins or loaders. Similar to [`stats.loggingDebug`](/configuration/stats/#statsloggingdebug) option but for infrastructure. Defaults to `false`.
 
 **webpack.config.js**
 
@@ -225,9 +225,9 @@ module.exports = {
 
 ### level
 
-`string`
+`string = 'info' : 'none' | 'error' | 'warn' | 'info' | 'log' | 'verbose'`
 
-Enable infrastructure logging output. Similar to [`stats.logging`](/configuration/stats/#statslogging) option but for infrastructure. No default value is given.
+Enable infrastructure logging output. Similar to [`stats.logging`](/configuration/stats/#statslogging) option but for infrastructure. Defaults to `'info'`.
 
 Possible values:
 


### PR DESCRIPTION
Add defaults as per -
https://github.com/webpack/webpack/blob/400a0f94ab45ca20b10f219c8311e87d3d3f108c/lib/config/defaults.js#L1173