### PR TITLE
Fix optimization.moduleIds setting in 5.mdx

### DIFF
--- a/src/content/migrate/5.mdx
+++ b/src/content/migrate/5.mdx
@@ -52,12 +52,12 @@ Set `mode` to either [`production`](/configuration/mode/#mode-production) or [`d
 
 Update the following options to their new version (if used):
 
-- `optimization.hashedModuleIds: true` → `optimization.moduleIds: 'deterministic'`
+- `optimization.hashedModuleIds: true` → `optimization.moduleIds: 'hashed'`
 - `optimization.namedChunks: true` → `optimization.chunkIds: 'named'`
 - `optimization.namedModules: true` → `optimization.moduleIds: 'named'`
 - `NamedModulesPlugin` → `optimization.moduleIds: 'named'`
 - `NamedChunksPlugin` → `optimization.chunkIds: 'named'`
-- `HashedModuleIdsPlugin` → `optimization.moduleIds: 'deterministic'`
+- `HashedModuleIdsPlugin` → `optimization.moduleIds: 'hashed'`
 - `optimization.noEmitOnErrors: false` → `optimization.emitOnErrors: true`
 - `optimization.occurrenceOrder: true` → `optimization: { chunkIds: 'total-size', moduleIds: 'size' }`
 - `optimization.splitChunks.cacheGroups.vendors` → `optimization.splitChunks.cacheGroups.defaultVendors`


### PR DESCRIPTION
**Upgrade webpack to 5** is the next step, and we can only use `optimization.moduleIds: 'hashed'` in v4

![2021-08-13_18-47](https://user-images.githubusercontent.com/16360246/129371077-0c104c81-de7c-4bd8-a590-dc3370ad7a61.png)

