### PR TITLE
docs(configuration): sort `performance` options

### DIFF
--- a/src/content/configuration/performance.mdx
+++ b/src/content/configuration/performance.mdx
@@ -86,21 +86,6 @@ module.exports = {
 
 An error will be displayed notifying you of a large asset. We recommend using `hints: "error"` during production builds to help prevent deploying production bundles that are too large, impacting webpage performance.
 
-## `performance.maxEntrypointSize`
-
-`number = 250000`
-
-An entry point represents all assets that would be utilized during initial load time for a specific entry. This option controls when webpack should emit performance hints based on the maximum entry point size in bytes.
-
-```js
-module.exports = {
-  //...
-  performance: {
-    maxEntrypointSize: 400000,
-  },
-};
-```
-
 ## `performance.maxAssetSize`
 
 `number = 250000`
@@ -112,6 +97,21 @@ module.exports = {
   //...
   performance: {
     maxAssetSize: 100000,
+  },
+};
+```
+
+## `performance.maxEntrypointSize`
+
+`number = 250000`
+
+An entry point represents all assets that would be utilized during initial load time for a specific entry. This option controls when webpack should emit performance hints based on the maximum entry point size in bytes.
+
+```js
+module.exports = {
+  //...
+  performance: {
+    maxEntrypointSize: 400000,
   },
 };
 ```

--- a/src/content/configuration/performance.mdx
+++ b/src/content/configuration/performance.mdx
@@ -18,6 +18,33 @@ This feature was inspired by the idea of [webpack Performance Budgets](https://g
 
 Configure how performance hints are shown. For example if you have an asset that is over 250kb, webpack will emit a warning notifying you of this.
 
+## `performance.assetFilter`
+
+`function(assetFilename) => boolean`
+
+This property allows webpack to control what files are used to calculate performance hints. The default function is:
+
+```js
+function assetFilter(assetFilename) {
+  return !/\.map$/.test(assetFilename);
+}
+```
+
+You can override this property by passing your own function in:
+
+```js
+module.exports = {
+  //...
+  performance: {
+    assetFilter: function (assetFilename) {
+      return assetFilename.endsWith('.js');
+    },
+  },
+};
+```
+
+The example above will only give you performance hints based on `.js` files.
+
 ## `performance.hints`
 
 `string = 'warning': 'error' | 'warning'` `boolean: false`
@@ -88,30 +115,3 @@ module.exports = {
   },
 };
 ```
-
-## `performance.assetFilter`
-
-`function(assetFilename) => boolean`
-
-This property allows webpack to control what files are used to calculate performance hints. The default function is:
-
-```js
-function assetFilter(assetFilename) {
-  return !/\.map$/.test(assetFilename);
-}
-```
-
-You can override this property by passing your own function in:
-
-```js
-module.exports = {
-  //...
-  performance: {
-    assetFilter: function (assetFilename) {
-      return assetFilename.endsWith('.js');
-    },
-  },
-};
-```
-
-The example above will only give you performance hints based on `.js` files.

--- a/src/content/configuration/performance.mdx
+++ b/src/content/configuration/performance.mdx
@@ -18,7 +18,7 @@ This feature was inspired by the idea of [webpack Performance Budgets](https://g
 
 Configure how performance hints are shown. For example if you have an asset that is over 250kb, webpack will emit a warning notifying you of this.
 
-## `performance.assetFilter`
+### performance.assetFilter
 
 `function(assetFilename) => boolean`
 
@@ -45,7 +45,7 @@ module.exports = {
 
 The example above will only give you performance hints based on `.js` files.
 
-## `performance.hints`
+### performance.hints
 
 `string = 'warning': 'error' | 'warning'` `boolean: false`
 
@@ -86,7 +86,7 @@ module.exports = {
 
 An error will be displayed notifying you of a large asset. We recommend using `hints: "error"` during production builds to help prevent deploying production bundles that are too large, impacting webpage performance.
 
-## `performance.maxAssetSize`
+### performance.maxAssetSize
 
 `number = 250000`
 
@@ -101,7 +101,7 @@ module.exports = {
 };
 ```
 
-## `performance.maxEntrypointSize`
+### performance.maxEntrypointSize
 
 `number = 250000`
 


### PR DESCRIPTION
Sort `performance` options and fix heading levels