### PR TITLE
docs(configuration): remove `enforceModuleExtension` from resolve and resolveLoader

### DIFF
--- a/src/content/configuration/resolve.mdx
+++ b/src/content/configuration/resolve.mdx
@@ -662,22 +662,3 @@ module.exports = {
 ```
 
 T> Note that you can use alias here and other features familiar from resolve. For example `{ txt: 'raw-loader' }` would shim `txt!templates/demo.txt` to use `raw-loader`.
-
-### `resolveLoader.moduleExtensions`
-
-`[string]`
-
-W> Removed in webpack 5
-
-The extensions/suffixes that are used when resolving loaders. Since version two, we [strongly recommend](/migrate/3/#automatic--loader-module-name-extension-removed) using the full name, e.g. `example-loader`, as much as possible for clarity. However, if you really wanted to exclude the `-loader` bit, i.e. to only use `example`, you can use this option to do so:
-
-**webpack.config.js**
-
-```js
-module.exports = {
-  //...
-  resolveLoader: {
-    moduleExtensions: ['-loader'],
-  },
-};
-```

--- a/src/content/configuration/resolve.mdx
+++ b/src/content/configuration/resolve.mdx
@@ -226,25 +226,6 @@ module.exports = {
 };
 ```
 
-### `resolve.enforceModuleExtension`
-
-`boolean = false`
-
-W> Removed in webpack 5
-
-Tells webpack whether to require to use an extension for modules (e.g. loaders).
-
-**webpack.config.js**
-
-```js
-module.exports = {
-  //...
-  resolve: {
-    enforceModuleExtension: false,
-  },
-};
-```
-
 ### resolve.extensions
 
 `[string] = ['.js', '.json', '.wasm']`


### PR DESCRIPTION
Removed in webpack 5.
