### PR TITLE
docs: avoid code in heading

### DIFF
--- a/src/content/api/compilation-hooks.mdx
+++ b/src/content/api/compilation-hooks.mdx
@@ -450,7 +450,7 @@ The assets have been optimized.
 
 - Callback Parameters: `assets`
 
-###processAssets
+### processAssets
 
 `AsyncSeriesHook`
 

--- a/src/content/api/compilation-hooks.mdx
+++ b/src/content/api/compilation-hooks.mdx
@@ -145,7 +145,7 @@ Called at the beginning of the chunk optimization phase. A plugin can tap into t
 
 - Callback Parameters: `chunks`
 
-## afterOptimizeChunks
+### afterOptimizeChunks
 
 `SyncHook`
 
@@ -153,7 +153,7 @@ Fired after chunk optimization has completed.
 
 - Callback Parameters: `chunks`
 
-## optimizeTree
+### optimizeTree
 
 `AsyncSeriesHook`
 
@@ -169,7 +169,7 @@ Called after the dependency tree optimization has completed with success.
 
 - Callback Parameters: `chunks` `modules`
 
-### optimizeChunkModule
+### optimizeChunkModules
 
 `SyncBailHook`
 

--- a/src/content/api/compilation-hooks.mdx
+++ b/src/content/api/compilation-hooks.mdx
@@ -63,7 +63,7 @@ Run when a module build has failed.
 
 - Callback Parameters: `module` `error`
 
-### succeedModul
+### succeedModule
 
 `SyncHook`
 
@@ -145,7 +145,7 @@ Called at the beginning of the chunk optimization phase. A plugin can tap into t
 
 - Callback Parameters: `chunks`
 
-##afterOptimizeChun
+## afterOptimizeChunks
 
 `SyncHook`
 
@@ -153,7 +153,7 @@ Fired after chunk optimization has completed.
 
 - Callback Parameters: `chunks`
 
-##optimizeTr
+## optimizeTree
 
 `AsyncSeriesHook`
 
@@ -161,7 +161,7 @@ Called before optimizing the dependency tree. A plugin can tap into this hook to
 
 - Callback Parameters: `chunks` `modules`
 
-###afterOptimizeTre
+### afterOptimizeTree
 
 `SyncHook`
 
@@ -169,7 +169,7 @@ Called after the dependency tree optimization has completed with success.
 
 - Callback Parameters: `chunks` `modules`
 
-###optimizeChunkModule
+### optimizeChunkModule
 
 `SyncBailHook`
 

--- a/src/content/api/compilation-hooks.mdx
+++ b/src/content/api/compilation-hooks.mdx
@@ -30,7 +30,7 @@ compilation.hooks.someHook.tap(/* ... */);
 As with the `compiler`, `tapAsync` and `tapPromise` may also be available
 depending on the type of hook.
 
-### `buildModule`
+### buildModule
 
 `SyncHook`
 
@@ -47,7 +47,7 @@ compilation.hooks.buildModule.tap(
 );
 ```
 
-### `rebuildModule`
+### rebuildModule
 
 `SyncHook`
 
@@ -55,7 +55,7 @@ Fired before rebuilding a module.
 
 - Callback Parameters: `module`
 
-### `failedModule`
+### failedModule
 
 `SyncHook`
 
@@ -63,7 +63,7 @@ Run when a module build has failed.
 
 - Callback Parameters: `module` `error`
 
-### `succeedModule`
+### succeedModul
 
 `SyncHook`
 
@@ -71,7 +71,7 @@ Executed when a module has been built successfully.
 
 - Callback Parameters: `module`
 
-### `finishModules`
+### finishModules
 
 `AsyncSeriesHook`
 
@@ -79,7 +79,7 @@ Called when all modules have been built without errors.
 
 - Callback Parameters: `modules`
 
-### `finishRebuildingModule`
+### finishRebuildingModule
 
 `SyncHook`
 
@@ -87,19 +87,19 @@ Executed when a module has been rebuilt, in case of both success or with errors.
 
 - Callback Parameters: `module`
 
-### `seal`
+### seal
 
 `SyncHook`
 
 Fired when the compilation stops accepting new modules.
 
-### `unseal`
+### unseal
 
 `SyncHook`
 
 Fired when a compilation begins accepting new modules.
 
-### `optimizeDependencies`
+### optimizeDependencies
 
 `SyncBailHook`
 
@@ -107,7 +107,7 @@ Fired at the beginning of dependency optimization.
 
 - Callback Parameters: `modules`
 
-### `afterOptimizeDependencies`
+### afterOptimizeDependencies
 
 `SyncHook`
 
@@ -115,13 +115,13 @@ Fired after the dependency optimization.
 
 - Callback Parameters: `modules`
 
-### `optimize`
+### optimize
 
 `SyncHook`
 
 Triggered at the beginning of the optimization phase.
 
-### `optimizeModules`
+### optimizeModules
 
 `SyncBailHook`
 
@@ -129,7 +129,7 @@ Called at the beginning of the module optimization phase. A plugin can tap into 
 
 - Callback Parameters: `modules`
 
-### `afterOptimizeModules`
+### afterOptimizeModules
 
 `SyncHook`
 
@@ -137,7 +137,7 @@ Called after modules optimization has completed.
 
 - Callback Parameters: `modules`
 
-### `optimizeChunks`
+### optimizeChunks
 
 `SyncBailHook`
 
@@ -145,7 +145,7 @@ Called at the beginning of the chunk optimization phase. A plugin can tap into t
 
 - Callback Parameters: `chunks`
 
-### `afterOptimizeChunks`
+##afterOptimizeChun
 
 `SyncHook`
 
@@ -153,7 +153,7 @@ Fired after chunk optimization has completed.
 
 - Callback Parameters: `chunks`
 
-### `optimizeTree`
+##optimizeTr
 
 `AsyncSeriesHook`
 
@@ -161,7 +161,7 @@ Called before optimizing the dependency tree. A plugin can tap into this hook to
 
 - Callback Parameters: `chunks` `modules`
 
-### `afterOptimizeTree`
+###afterOptimizeTre
 
 `SyncHook`
 
@@ -169,7 +169,7 @@ Called after the dependency tree optimization has completed with success.
 
 - Callback Parameters: `chunks` `modules`
 
-### `optimizeChunkModules`
+###optimizeChunkModule
 
 `SyncBailHook`
 
@@ -177,7 +177,7 @@ Called after the tree optimization, at the beginning of the chunk modules optimi
 
 - Callback Parameters: `chunks` `modules`
 
-### `afterOptimizeChunkModules`
+### afterOptimizeChunkModules
 
 `SyncHook`
 
@@ -185,13 +185,13 @@ Called after the chunkmodules optimization has completed successfully.
 
 - Callback Parameters: `chunks` `modules`
 
-### `shouldRecord`
+### shouldRecord
 
 `SyncBailHook`
 
 Called to determine whether or not to store records. Returning anything `!== false` will prevent every other "record" hook from being executed ([`record`](#record), [`recordModules`](#recordmodules), [`recordChunks`](#recordchunks) and [`recordHash`](#recordhash)).
 
-### `reviveModules`
+### reviveModules
 
 `SyncHook`
 
@@ -199,7 +199,7 @@ Restore module information from records.
 
 - Callback Parameters: `modules` `records`
 
-### `beforeModuleIds`
+### beforeModuleIds
 
 `SyncHook`
 
@@ -207,7 +207,7 @@ Executed before assigning an `id` to each module.
 
 - Callback Parameters: `modules`
 
-### `moduleIds`
+### moduleIds
 
 `SyncHook`
 
@@ -215,7 +215,7 @@ Called to assign an `id` to each module.
 
 - Callback Parameters: `modules`
 
-### `optimizeModuleIds`
+### optimizeModuleIds
 
 `SyncHook`
 
@@ -223,7 +223,7 @@ Called at the beginning of the modules `id` optimization.
 
 - Callback Parameters: `modules`
 
-### `afterOptimizeModuleIds`
+### afterOptimizeModuleIds
 
 `SyncHook`
 
@@ -231,7 +231,7 @@ Called when the modules `id` optimization phase has completed.
 
 - Callback Parameters: `modules`
 
-### `reviveChunks`
+### reviveChunks
 
 `SyncHook`
 
@@ -239,7 +239,7 @@ Restore chunk information from records.
 
 - Callback Parameters: `chunks` `records`
 
-### `beforeChunkIds`
+### beforeChunkIds
 
 `SyncHook`
 
@@ -247,7 +247,7 @@ Executed before assigning an `id` to each chunk.
 
 - Callback Parameters: `chunks`
 
-### `chunkIds`
+### chunkIds
 
 `SyncHook`
 
@@ -255,7 +255,7 @@ Called to assign an `id` to each chunk.
 
 - Callback Parameters: `chunks`
 
-### `optimizeChunkIds`
+### optimizeChunkIds
 
 `SyncHook`
 
@@ -263,7 +263,7 @@ Called at the beginning of the chunks `id` optimization phase.
 
 - Callback Parameters: `chunks`
 
-### `afterOptimizeChunkIds`
+### afterOptimizeChunkIds
 
 `SyncHook`
 
@@ -271,7 +271,7 @@ Triggered after chunk `id` optimization has finished.
 
 - Callback Parameters: `chunks`
 
-### `recordModules`
+### recordModules
 
 `SyncHook`
 
@@ -279,7 +279,7 @@ Store module info to the records. This is triggered if [`shouldRecord`](#shouldr
 
 - Callback Parameters: `modules` `records`
 
-### `recordChunks`
+### recordChunks
 
 `SyncHook`
 
@@ -287,31 +287,31 @@ Store chunk info to the records. This is only triggered if [`shouldRecord`](#sho
 
 - Callback Parameters: `chunks` `records`
 
-### `beforeModuleHash`
+### beforeModuleHash
 
 `SyncHook`
 
 Called before modules are hashed.
 
-### `afterModuleHash`
+### afterModuleHash
 
 `syncHook`
 
 Called after modules are hashed.
 
-### `beforeHash`
+### beforeHash
 
 `SyncHook`
 
 Called before the compilation is hashed.
 
-### `afterHash`
+### afterHash
 
 `SyncHook`
 
 Called after the compilation is hashed.
 
-### `recordHash`
+### recordHash
 
 `SyncHook`
 
@@ -319,7 +319,7 @@ Store information about record hash to the `records`. This is only triggered if 
 
 - Callback Parameters: `records`
 
-### `record`
+### record
 
 `SyncHook`
 
@@ -327,13 +327,13 @@ Store information about the `compilation` to the `records`. This is only trigger
 
 - Callback Parameters: `compilation` `records`
 
-### `beforeModuleAssets`
+### beforeModuleAssets
 
 `SyncHook`
 
 Executed before module assets creation.
 
-### `additionalChunkAssets`
+### additionalChunkAssets
 
 `SyncHook`
 
@@ -343,19 +343,19 @@ Create additional assets for the chunks.
 
 - Callback Parameters: `chunks`
 
-### `shouldGenerateChunkAssets`
+### shouldGenerateChunkAssets
 
 `SyncBailHook`
 
 Called to determine whether or not generate chunks assets. Returning anything `!== false` will allow chunk assets generation.
 
-### `beforeChunkAssets`
+### beforeChunkAssets
 
 `SyncHook`
 
 Executed before creating the chunks assets.
 
-### `additionalAssets`
+### additionalAssets
 
 `AsyncSeriesHook`
 
@@ -377,7 +377,7 @@ compilation.hooks.additionalAssets.tapAsync('MyPlugin', (callback) => {
 });
 ```
 
-### `optimizeChunkAssets`
+### optimizeChunkAssets
 
 `AsyncSeriesHook`
 
@@ -410,7 +410,7 @@ compilation.hooks.optimizeChunkAssets.tapAsync(
 );
 ```
 
-### `afterOptimizeChunkAssets`
+### afterOptimizeChunkAssets
 
 `SyncHook`
 
@@ -434,7 +434,7 @@ compilation.hooks.afterOptimizeChunkAssets.tap('MyPlugin', (chunks) => {
 });
 ```
 
-### `optimizeAssets`
+### optimizeAssets
 
 `AsyncSeriesHook`
 
@@ -442,7 +442,7 @@ Optimize all assets stored in `compilation.assets`.
 
 - Callback Parameters: `assets`
 
-### `afterOptimizeAssets`
+### afterOptimizeAssets
 
 `SyncHook`
 
@@ -450,7 +450,7 @@ The assets have been optimized.
 
 - Callback Parameters: `assets`
 
-### `processAssets`
+###processAssets
 
 `AsyncSeriesHook`
 
@@ -561,25 +561,25 @@ compilation.hooks.processAssets.tap(
 );
 ```
 
-### `afterProcessAssets`
+### afterProcessAssets
 
 `SyncHook`
 
 Called after the [`processAssets`](#processassets) hook had finished without error.
 
-### `needAdditionalSeal`
+### needAdditionalSeal
 
 `SyncBailHook`
 
 Called to determine if the compilation needs to be unsealed to include other files.
 
-### `afterSeal`
+### afterSeal
 
 `AsyncSeriesHook`
 
 Executed right after `needAdditionalSeal`.
 
-### `chunkHash`
+### chunkHash
 
 `SyncHook`
 
@@ -587,7 +587,7 @@ Triggered to emit the hash for each chunk.
 
 - Callback Parameters: `chunk` `chunkHash`
 
-### `moduleAsset`
+### moduleAsset
 
 `SyncHook`
 
@@ -595,7 +595,7 @@ Called when an asset from a module was added to the compilation.
 
 - Callback Parameters: `module` `filename`
 
-### `chunkAsset`
+### chunkAsset
 
 `SyncHook`
 
@@ -603,7 +603,7 @@ Triggered when an asset from a chunk was added to the compilation.
 
 - Callback Parameters: `chunk` `filename`
 
-### `assetPath`
+### assetPath
 
 `SyncWaterfallHook`
 
@@ -611,13 +611,13 @@ Called to determine the path of an asset.
 
 - Callback Parameters: `path` `options`
 
-### `needAdditionalPass`
+### needAdditionalPass
 
 `SyncBailHook`
 
 Called to determine if an asset needs to be processed further after being emitted.
 
-### `childCompiler`
+### childCompiler
 
 `SyncHook`
 
@@ -625,6 +625,6 @@ Executed after setting up a child compiler.
 
 - Callback Parameters: `childCompiler` `compilerName` `compilerIndex`
 
-### `normalModuleLoader`
+### normalModuleLoader
 
 Since webpack v5 `normalModuleLoader` hook was removed. Now to access the loader use `NormalModule.getCompilationHooks(compilation).loader` instead.

--- a/src/content/api/compiler-hooks.mdx
+++ b/src/content/api/compiler-hooks.mdx
@@ -44,19 +44,19 @@ Depending on the hook type, `tapAsync` and `tapPromise` may also be available.
 
 For the description of hook types, see [the Tapable docs](https://github.com/webpack/tapable#tapable).
 
-### `environment`
+### environment
 
 `SyncHook`
 
 Called while preparing the compiler environment, right after initializing the plugins in the configuration file.
 
-### `afterEnvironment`
+### afterEnvironment
 
 `SyncHook`
 
 Called right after the `environment` hook, when the compiler environment setup is complete.
 
-### `entryOption`
+### entryOption
 
 `SyncBailHook`
 
@@ -70,7 +70,7 @@ compiler.hooks.entryOption.tap('MyPlugin', (context, entry) => {
 });
 ```
 
-### `afterPlugins`
+### afterPlugins
 
 `SyncHook`
 
@@ -78,7 +78,7 @@ Called after setting up initial set of internal plugins.
 
 - Callback Parameters: `compiler`
 
-### `afterResolvers`
+### afterResolvers
 
 `SyncHook`
 
@@ -86,13 +86,13 @@ Triggered after resolver setup is complete.
 
 - Callback Parameters: `compiler`
 
-### `initialize`
+### initialize
 
 `SyncHook`
 
 Called when a compiler object is initialized.
 
-### `beforeRun`
+### beforeRun
 
 `AsyncSeriesHook`
 
@@ -100,7 +100,7 @@ Adds a hook right before running the compiler.
 
 - Callback Parameters: `compiler`
 
-### `run`
+### run
 
 `AsyncSeriesHook`
 
@@ -108,7 +108,7 @@ Hook into the compiler before it begins reading [`records`](/configuration/other
 
 - Callback Parameters: `compiler`
 
-### `watchRun`
+### watchRun
 
 `AsyncSeriesHook`
 
@@ -116,7 +116,7 @@ Executes a plugin during watch mode after a new compilation is triggered but bef
 
 - Callback Parameters: `compiler`
 
-### `normalModuleFactory`
+### normalModuleFactory
 
 `SyncHook`
 
@@ -124,7 +124,7 @@ Called after a [NormalModuleFactory](/api/normalmodulefactory-hooks) is created.
 
 - Callback Parameters: `normalModuleFactory`
 
-### `contextModuleFactory`
+### contextModuleFactory
 
 `SyncHook`
 
@@ -132,7 +132,7 @@ Runs a plugin after a [ContextModuleFactory](/api/contextmodulefactory-hooks) is
 
 - Callback Parameters: `contextModuleFactory`
 
-### `beforeCompile`
+### beforeCompile
 
 `AsyncSeriesHook`
 
@@ -158,7 +158,7 @@ compiler.hooks.beforeCompile.tapAsync('MyPlugin', (params, callback) => {
 });
 ```
 
-### `compile`
+### compile
 
 `SyncHook`
 
@@ -166,7 +166,7 @@ Called right after `beforeCompile`, before a new compilation is created.
 
 - Callback Parameters: `compilationParams`
 
-### `thisCompilation`
+### thisCompilation
 
 `SyncHook`
 
@@ -174,7 +174,7 @@ Executed while initializing the compilation, right before emitting the `compilat
 
 - Callback Parameters: `compilation`, `compilationParams`
 
-### `compilation`
+### compilation
 
 `SyncHook`
 
@@ -182,7 +182,7 @@ Runs a plugin after a compilation has been created.
 
 - Callback Parameters: `compilation`, `compilationParams`
 
-### `make`
+### make
 
 `AsyncParallelHook`
 
@@ -190,7 +190,7 @@ Executed before finishing the compilation.
 
 - Callback Parameters: `compilation`
 
-### `afterCompile`
+### afterCompile
 
 `AsyncSeriesHook`
 
@@ -198,7 +198,7 @@ Called after finishing and sealing the compilation.
 
 - Callback Parameters: `compilation`
 
-### `shouldEmit`
+### shouldEmit
 
 `SyncBailHook`
 
@@ -213,7 +213,7 @@ compiler.hooks.shouldEmit.tap('MyPlugin', (compilation) => {
 });
 ```
 
-### `emit`
+### emit
 
 `AsyncSeriesHook`
 
@@ -221,7 +221,7 @@ Executed right before emitting assets to output dir.
 
 - Callback Parameters: `compilation`
 
-### `afterEmit`
+### afterEmit
 
 `AsyncSeriesHook`
 
@@ -229,7 +229,7 @@ Called after emitting assets to output directory.
 
 - Callback Parameters: `compilation`
 
-### `assetEmitted`
+### assetEmitted
 
 `AsyncSeriesHook`
 
@@ -248,7 +248,7 @@ compiler.hooks.assetEmitted.tap(
 );
 ```
 
-### `done`
+### done
 
 `AsyncSeriesHook`
 
@@ -256,13 +256,13 @@ Executed when the compilation has completed.
 
 - Callback Parameters: `stats`
 
-### `additionalPass`
+### additionalPass
 
 `AsyncSeriesHook`
 
 This hook allows you to do a one more additional pass of the build.
 
-### `failed`
+### failed
 
 `SyncHook`
 
@@ -270,7 +270,7 @@ Called if the compilation fails.
 
 - Callback Parameters: `error`
 
-### `invalid`
+### invalid
 
 `SyncHook`
 
@@ -278,13 +278,13 @@ Executed when a watching compilation has been invalidated.
 
 - Callback Parameters: `fileName`, `changeTime`
 
-### `watchClose`
+### watchClose
 
 `SyncHook`
 
 Called when a watching compilation has stopped.
 
-### `infrastructureLog`
+### infrastructureLog
 
 `SyncBailHook`
 
@@ -292,7 +292,7 @@ Allows to use infrastructure logging when enabled in the configuration via [`inf
 
 - Callback Parameters: `name`, `type`, `args`
 
-### `log`
+### log
 
 `SyncBailHook`
 

--- a/src/content/api/hot-module-replacement.mdx
+++ b/src/content/api/hot-module-replacement.mdx
@@ -38,7 +38,7 @@ The following methods are supported...
 
 ## Module API
 
-### `accept`
+### accept
 
 Accept updates for the given `dependencies` and fire a `callback` to react to those updates, in addition, you can attach an optional error handler:
 
@@ -69,7 +69,7 @@ When using CommonJS you need to update dependencies manually by using `require()
 - `moduleId`: the current module id.
 - `dependencyId`: the module id of the (first) changed dependency.
 
-### `accept` (self)
+### accept (self)
 
 Accept updates for itself.
 
@@ -98,7 +98,7 @@ The `errorHandler` is fired when the evaluation of this module (or dependencies)
   - `module.hot`: allow to use the HMR API of the errored module instance. A common scenario is to self accept it again. It also makes sense to add a dispose handler to pass data along. Note that the errored module might be already partially executed, so make sure to not get into a inconsistent state. You can use `module.hot.data` to store partial state.
   - `module.exports`: can be overridden, but be careful since property names might be mangled in production mode.
 
-### `decline`
+### decline
 
 Reject updates for the given `dependencies` forcing the update to fail with a `'decline'` code.
 
@@ -115,7 +115,7 @@ import.meta.webpackHot.decline(
 
 Flag a dependency as not-update-able. This makes sense when changing exports of this dependency can't be handled or handling is not implemented yet. Depending on your HMR management code, an update to these dependencies (or unaccepted dependencies of it) usually causes a full-reload of the page.
 
-### `decline` (self)
+### decline (self)
 
 Reject updates for itself.
 
@@ -128,7 +128,7 @@ import.meta.webpackHot.decline();
 
 Flag this module as not-update-able. This makes sense when this module has irreversible side-effects, or HMR handling is not implemented for this module yet. Depending on your HMR management code, an update to this module (or unaccepted dependencies) usually causes a full-reload of the page.
 
-### `dispose` (or `addDisposeHandler`)
+### dispose (or addDisposeHandler)
 
 Add a handler which is executed when the current module code is replaced. This should be used to remove any persistent resource you have claimed or created. If you want to transfer state to the updated module, add it to the given `data` parameter. This object will be available at `module.hot.data` after the update.
 
@@ -143,7 +143,7 @@ import.meta.webpackHot.dispose((data) => {
 });
 ```
 
-### `invalidate`
+### invalidate
 
 Calling this method will invalidate the current module, which disposes and recreates it when the HMR update is applied. This bubbles like a normal update of this module. `invalidate` can't be self-accepted by this module.
 
@@ -220,7 +220,7 @@ T> When `invalidate` is called, the [`dispose`](#dispose-or-adddisposehandler) h
 
 W> Do not get caught in an `invalidate` loop, by calling `invalidate` again and again. This will result in stack overflow and HMR entering the `fail` state.
 
-### `removeDisposeHandler`
+### removeDisposeHandler
 
 Remove the handler added via `dispose` or `addDisposeHandler`.
 
@@ -233,7 +233,7 @@ import.meta.webpackHot.removeDisposeHandler(callback);
 
 ## Management API
 
-### `status`
+### status
 
 Retrieve the current status of the hot module replacement process.
 
@@ -255,7 +255,7 @@ import.meta.webpackHot.status();
 | abort   | An update was aborted, but the system is still in its previous state                |
 | fail    | An update has thrown an exception and the system's state has been compromised       |
 
-### `check`
+### check
 
 Test all loaded modules for updates and, if updates exist, `apply` them.
 
@@ -282,7 +282,7 @@ import.meta.webpackHot
 
 The `autoApply` parameter can either be a boolean or `options` to pass to the `apply` method when called.
 
-### `apply`
+### apply
 
 Continue the update process (as long as `module.hot.status() === 'ready'`).
 
@@ -340,7 +340,7 @@ The `info` parameter will be an object containing some of the following values:
 }
 ```
 
-### `addStatusHandler`
+### addStatusHandler
 
 Register a function to listen for changes in `status`.
 
@@ -357,7 +357,7 @@ import.meta.webpackHot.addStatusHandler((status) => {
 
 Bear in mind that when the status handler returns a `Promise`, the HMR system will wait for the `Promise` to resolve before continuing.
 
-### `removeStatusHandler`
+### removeStatusHandler
 
 Remove a registered status handler.
 

--- a/src/content/api/loaders.mdx
+++ b/src/content/api/loaders.mdx
@@ -195,7 +195,7 @@ In `/abc/file.js`:
 require('./loader1?xyz!loader2!./resource?rrr');
 ```
 
-### `this.addContextDependency`
+### this.addContextDependency
 
 ```typescript
 addContextDependency(directory: string)
@@ -203,7 +203,7 @@ addContextDependency(directory: string)
 
 Add a directory as dependency of the loader result.
 
-### `this.addDependency`
+### this.addDependency
 
 ```typescript
 addDependency(file: string)
@@ -212,11 +212,11 @@ dependency(file: string) // shortcut
 
 Add a file as dependency of the loader result in order to make them watchable. For example, [`sass-loader`](https://github.com/webpack-contrib/sass-loader), [`less-loader`](https://github.com/webpack-contrib/less-loader) uses this to recompile whenever any imported `css` file changes.
 
-### `this.async`
+### this.async
 
 Tells the [loader-runner](https://github.com/webpack/loader-runner) that the loader intends to call back asynchronously. Returns `this.callback`.
 
-### `this.cacheable`
+### this.cacheable
 
 A function that sets the cacheable flag:
 
@@ -228,7 +228,7 @@ By default, loader results are flagged as cacheable. Call this method passing `f
 
 A cacheable loader must have a deterministic result when inputs and dependencies haven't changed. This means the loader shouldn't have dependencies other than those specified with `this.addDependency`.
 
-### `this.callback`
+### this.callback
 
 A function that can be called synchronously or asynchronously in order to return multiple results. The expected arguments are:
 
@@ -250,7 +250,7 @@ T> It can be useful to pass an abstract syntax tree (AST), like [`ESTree`](https
 
 In case this function is called, you should return undefined to avoid ambiguous loader results.
 
-### `this.clearDependencies`
+### this.clearDependencies
 
 ```typescript
 clearDependencies();
@@ -258,17 +258,17 @@ clearDependencies();
 
 Remove all dependencies of the loader result, even initial dependencies and those of other loaders. Consider using `pitch`.
 
-### `this.context`
+### this.context
 
 **The directory of the module.** Can be used as a context for resolving other stuff.
 
 In [the example](#example-for-the-loader-context): `/abc` because `resource.js` is in this directory
 
-### `this.data`
+### this.data
 
 A data object shared between the pitch and the normal phase.
 
-### `this.emitError`
+### this.emitError
 
 ```typescript
 emitError(error: Error)
@@ -285,7 +285,7 @@ Here is an Error!
 
 T> Unlike throwing an Error directly, it will NOT interrupt the compilation process of the current module.
 
-### `this.emitFile`
+### this.emitFile
 
 ```typescript
 emitFile(name: string, content: Buffer|string, sourceMap: {...})
@@ -293,7 +293,7 @@ emitFile(name: string, content: Buffer|string, sourceMap: {...})
 
 Emit a file. This is webpack-specific.
 
-### `this.emitWarning`
+### this.emitWarning
 
 ```typescript
 emitWarning(warning: Error)
@@ -310,17 +310,17 @@ Here is a Warning!
 
 T> Note that the warnings will not be displayed if `stats.warnings` is set to `false`, or some other omit setting is used to `stats` such as `none` or `errors-only`. See the [stats presets configuration](/configuration/stats/#stats-presets).
 
-### `this.fs`
+### this.fs
 
 Access to the `compilation`'s `inputFileSystem` property.
 
-### `this.getOptions(schema)`
+### this.getOptions(schema)
 
 Extracts given loader options. Optionally, accepts JSON schema as an argument.
 
 T> Since webpack 5, `this.getOptions` is available in loader context. It substitutes `getOptions` method from [loader-utils](https://github.com/webpack/loader-utils#getoptions).
 
-### `this.getResolve`
+### this.getResolve
 
 ```typescript
 getResolve(options: ResolveOptions): resolve
@@ -337,7 +337,7 @@ Any options under webpack [`resolve` options](/configuration/resolve/#resolve) a
 
 All dependencies of the resolving operation are automatically added as dependencies to the current module.
 
-### `this.hot`
+### this.hot
 
 Information about HMR for loaders.
 
@@ -419,13 +419,13 @@ You might notice something in the above example:
 
 Note that the above example is a simplified one, you can check [the full example on webpack repository](https://github.com/webpack/webpack/tree/master/test/configCases/loader-import-module/css).
 
-### `this.loaderIndex`
+### this.loaderIndex
 
 The index in the loaders array of the current loader.
 
 In [the example](#example-for-the-loader-context): in loader1: `0`, in loader2: `1`
 
-### `this.loadModule`
+### this.loadModule
 
 ```typescript
 loadModule(request: string, callback: function(err, source, sourceMap, module))
@@ -435,7 +435,7 @@ Resolves the given request to a module, applies all configured loaders and calls
 
 `this.loadModule` in a loader context uses CommonJS resolve rules by default. Use `this.getResolve` with an appropriate `dependencyType`, e.g. `'esm'`, `'commonjs'` or a custom one before using a different semantic.
 
-### `this.loaders`
+### this.loaders
 
 An array of all the loaders. It is writable in the pitch phase.
 
@@ -462,24 +462,24 @@ In [the example](#example-for-the-loader-context):
 ];
 ```
 
-### `this.mode`
+### this.mode
 
 Read in which [`mode`](/configuration/mode/) webpack is running.
 
 Possible values: `'production'`, `'development'`, `'none'`
 
-### `this.query`
+### this.query
 
 1. If the loader was configured with an [`options`](/configuration/module/#useentry) object, this will point to that object.
 2. If the loader has no `options`, but was invoked with a query string, this will be a string starting with `?`.
 
-### `this.request`
+### this.request
 
 The resolved request string.
 
 In [the example](#example-for-the-loader-context): `'/abc/loader1.js?xyz!/abc/node_modules/loader2/index.js!/abc/resource.js?rrr'`
 
-### `this.resolve`
+### this.resolve
 
 ```typescript
 resolve(context: string, request: string, callback: function(err, result: string))
@@ -493,33 +493,33 @@ Resolve a request like a require expression.
 
 All dependencies of the resolving operation are automatically added as dependencies to the current module.
 
-### `this.resource`
+### this.resource
 
 The resource part of the request, including query.
 
 In [the example](#example-for-the-loader-context): `'/abc/resource.js?rrr'`
 
-### `this.resourcePath`
+### this.resourcePath
 
 The resource file.
 
 In [the example](#example-for-the-loader-context): `'/abc/resource.js'`
 
-### `this.resourceQuery`
+### this.resourceQuery
 
 The query of the resource.
 
 In [the example](#example-for-the-loader-context): `'?rrr'`
 
-### `this.rootContext`
+### this.rootContext
 
 Since webpack 4, the formerly `this.options.context` is provided as `this.rootContext`.
 
-### `this.sourceMap`
+### this.sourceMap
 
 Tells if source map should be generated. Since generating source maps can be an expensive task, you should check if source maps are actually requested.
 
-### `this.target`
+### this.target
 
 Target of compilation. Passed from configuration options.
 
@@ -548,11 +548,11 @@ module.exports = function (content) {
 };
 ```
 
-### `this.version`
+### this.version
 
 **Loader API version.** Currently `2`. This is useful for providing backwards compatibility. Using the version you can specify custom logic or fallbacks for breaking changes.
 
-### `this.webpack`
+### this.webpack
 
 This boolean is set to true when this is compiled by webpack.
 
@@ -566,11 +566,11 @@ W> Please note that using these webpack specific properties will have a negative
 
 Therefore you should only use them as a last resort. Using them will reduce the portability of your loader.
 
-### `this._compilation`
+### this.\_compilation
 
 Access to the current Compilation object of webpack.
 
-### `this._compiler`
+### this.\_compiler
 
 Access to the current Compiler object of webpack.
 
@@ -578,23 +578,23 @@ Access to the current Compiler object of webpack.
 
 W> The usage of these properties is highly discouraged since we are planning to remove them from the context. They are still listed here for documentation purposes.
 
-### `this.debug`
+### this.debug
 
 A boolean flag. It is set when in debug mode.
 
-### `this.inputValue`
+### this.inputValue
 
 Passed from the last loader. If you would execute the input argument as a module, consider reading this variable for a shortcut (for performance).
 
-### `this.minimize`
+### this.minimize
 
 Tells if result should be minimized.
 
-### `this.value`
+### this.value
 
 Pass values to the next loader. If you know what your result exports if executed as a module, set this value here (as an only element array).
 
-### `this._module`
+### this.\_module
 
 Hacky access to the Module object being loaded.
 

--- a/src/content/api/module-methods.mdx
+++ b/src/content/api/module-methods.mdx
@@ -36,7 +36,7 @@ While webpack supports multiple module syntaxes, we recommend following a single
 
 Version 2 of webpack supports ES6 module syntax natively, meaning you can use `import` and `export` without a tool like babel to handle this for you. Keep in mind that you will still probably need babel for other ES6+ features. The following methods are supported by webpack:
 
-### `import`
+### import
 
 Statically `import` the `export`s of another module.
 
@@ -57,7 +57,7 @@ import {
 } from 'data:text/javascript;charset=utf-8;base64,ZXhwb3J0IGNvbnN0IG51bWJlciA9IDQyOwpleHBvcnQgY29uc3QgZm4gPSAoKSA9PiAiSGVsbG8gd29ybGQiOw==';
 ```
 
-### `export`
+### export
 
 Export anything as a `default` or named export.
 
@@ -74,7 +74,7 @@ export default {
 };
 ```
 
-### `import()`
+### import()
 
 `function(string path):Promise`
 
@@ -185,7 +185,7 @@ It's possible to enable magic comments for `require` as well, see [`module.parse
 
 W> Using it asynchronously may not have the expected effect.
 
-### `require.resolve`
+### require.resolve
 
 ```typescript
 require.resolve(dependency: String);
@@ -197,7 +197,7 @@ W> Module ID's type can be a `number` or a `string` depending on the [`optimizat
 
 See [`module.id`](/api/module-variables/#moduleid-commonjs) for more information.
 
-### `require.cache`
+### require.cache
 
 Multiple requires of the same module result in only one module execution and only one export. Therefore a cache in the runtime exists. Removing values from this cache causes new module execution and a new export.
 
@@ -220,7 +220,7 @@ require('./file.js') !== module.exports; // in theory; in praxis this causes a s
 require.cache[module.id] !== module;
 ```
 
-### `require.ensure`
+### require.ensure
 
 W> `require.ensure()` is specific to webpack and superseded by `import()`.
 
@@ -262,7 +262,7 @@ W> Although the implementation of `require` is passed as an argument to the `cal
 
 Asynchronous Module Definition (AMD) is a JavaScript specification that defines an interface for writing and loading modules. The following AMD methods are supported by webpack:
 
-### `define` (with factory)
+### define (with factory)
 
 ```ts
 define([name: String], [dependencies: String[]], factoryMethod: function(...))
@@ -285,7 +285,7 @@ define(['jquery', 'my-module'], function ($, myModule) {
 
 W> This CANNOT be used in an asynchronous function.
 
-### `define` (with value)
+### define (with value)
 
 ```ts
 define(value: !Function)
@@ -301,7 +301,7 @@ define({
 
 W> This CANNOT be used in an async function.
 
-### `require` (amd-version)
+### require (amd-version)
 
 ```ts
 require(dependencies: String[], [callback: function(...)])
@@ -323,7 +323,7 @@ W> There is no option to provide a chunk name.
 
 The internal `LabeledModulesPlugin` enables you to use the following methods for exporting and requiring within your modules:
 
-### `export` label
+### export label
 
 Export the given `value`. The label can occur before a function declaration or a variable declaration. The function name or variable name is the identifier under which the value is exported.
 
@@ -336,7 +336,7 @@ export: function method(value) {
 
 W> Using it in an async function may not have the expected effect.
 
-### `require` label
+### require label
 
 Make all exports from the dependency available in the current scope. The `require` label can occur before a string. The dependency must export values with the `export` label. CommonJS or AMD modules cannot be consumed.
 
@@ -359,7 +359,7 @@ method(...);
 
 Aside from the module syntaxes described above, webpack also allows a few custom, webpack-specific methods:
 
-### `require.context`
+### require.context
 
 ```ts
 require.context(
@@ -388,7 +388,7 @@ context('localeA').then((locale) => {
 
 The full list of available modes and their behavior is described in [`import()`](#import-1) documentation.
 
-### `require.include`
+### require.include
 
 ```ts
 require.include((dependency: String));
@@ -414,7 +414,7 @@ This will result in the following output:
 
 Without `require.include('a')` it would be duplicated in both anonymous chunks.
 
-### `require.resolveWeak`
+### require.resolveWeak
 
 Similar to `require.resolve`, but this won't pull the `module` into the bundle. It's what is considered a "weak" dependency.
 

--- a/src/content/api/module-variables.mdx
+++ b/src/content/api/module-variables.mdx
@@ -22,15 +22,15 @@ related:
 
 This section covers all **variables** available in code compiled with webpack. Modules will have access to certain data from the compilation process through `module` and other variables.
 
-## `module.loaded` (NodeJS)
+## module.loaded (NodeJS)
 
 This is `false` if the module is currently executing, and `true` if the sync execution has finished.
 
-## `module.hot` (webpack-specific)
+## module.hot (webpack-specific)
 
 Indicates whether or not [Hot Module Replacement](/concepts/hot-module-replacement) is enabled and provides an interface to the process. See the [HMR API page](/api/hot-module-replacement) for details.
 
-## `module.id` (CommonJS)
+## module.id (CommonJS)
 
 The ID of the current module.
 
@@ -38,7 +38,7 @@ The ID of the current module.
 module.id === require.resolve('./file.js');
 ```
 
-## `module.exports` (CommonJS)
+## module.exports (CommonJS)
 
 Defines the value that will be returned when a consumer makes a `require` call to the module (defaults to a new object).
 
@@ -50,7 +50,7 @@ module.exports = function doSomething() {
 
 W> This CANNOT be used in an asynchronous function.
 
-## `exports` (CommonJS)
+## exports (CommonJS)
 
 This variable is equal to the default value of `module.exports` (i.e. an object). If `module.exports` gets overwritten, `exports` will no longer be exported.
 
@@ -64,13 +64,13 @@ exports.aFunction = function doSomething() {
 };
 ```
 
-## `global` (NodeJS)
+## global (NodeJS)
 
 See [node.js global](https://nodejs.org/api/globals.html#globals_global).
 
 For compatibility reasons webpack polyfills the `global` variable by default.
 
-## `__dirname` (NodeJS)
+## \_\_dirname (NodeJS)
 
 Depending on the configuration option `node.__dirname`:
 
@@ -80,7 +80,7 @@ Depending on the configuration option `node.__dirname`:
 
 If used inside an expression that is parsed by the Parser, the configuration option is treated as `true`.
 
-## `import.meta.url`
+## import.meta.url
 
 Returns the absolute `file:` URL of the module.
 
@@ -90,7 +90,7 @@ Returns the absolute `file:` URL of the module.
 console.log(import.meta.url); // output something like `file:///path/to/your/project/src/index.js`
 ```
 
-## `import.meta.webpack`
+## import.meta.webpack
 
 Returns the webpack version.
 
@@ -104,7 +104,7 @@ console.log(import.meta.webpack); // output `5` for webpack 5
 
 Webpack specific. An alias for [`module.hot`](#modulehot-webpack-specific), however `import.meta.webpackHot` can be used in [strict ESM](/guides/ecma-script-modules/#flagging-modules-as-esm) while `module.hot` can't.
 
-## `__filename` (NodeJS)
+## \_\_filename (NodeJS)
 
 Depending on the configuration option `node.__filename`:
 
@@ -114,7 +114,7 @@ Depending on the configuration option `node.__filename`:
 
 If used inside an expression that is parsed by the Parser, the configuration option is treated as `true`.
 
-## `__resourceQuery` (webpack-specific)
+## \_\_resourceQuery (webpack-specific)
 
 The resource query of the current module. If the following `require` call was made, then the query string would be available in `file.js`.
 
@@ -128,11 +128,11 @@ require('file.js?test');
 __resourceQuery === '?test';
 ```
 
-## `__webpack_public_path__` (webpack-specific)
+## \_\_webpack_public_path\_\_ (webpack-specific)
 
 Equals the configuration option's `output.publicPath`.
 
-## `__webpack_require__` (webpack-specific)
+## \_\_webpack_require\_\_ (webpack-specific)
 
 The raw require function. This expression isn't parsed by the Parser for dependencies.
 
@@ -164,19 +164,19 @@ import('./module-a').then((moduleA) => {
 });
 ```
 
-## `__webpack_modules__` (webpack-specific)
+## \_\_webpack_modules\_\_ (webpack-specific)
 
 Access to the internal object of all modules.
 
-## `__webpack_hash__` (webpack-specific)
+## \_\_webpack_hash\_\_ (webpack-specific)
 
 It provides access to the hash of the compilation.
 
-## `__non_webpack_require__` (webpack-specific)
+## \_\_non_webpack_require\_\_ (webpack-specific)
 
 Generates a `require` function that is not parsed by webpack. Can be used to do cool stuff with a global require function if available.
 
-## `__webpack_exports_info__` (webpack-specific)
+## \_\_webpack_exports_info\_\_ (webpack-specific)
 
 In modules, `__webpack_exports_info__` is available to allow exports introspection:
 
@@ -200,7 +200,7 @@ In modules, `__webpack_exports_info__` is available to allow exports introspecti
 
 - Accessing the info from nested exports is possible: i. e. `__webpack_exports_info__.<exportName>.<exportName>.<exportName>.used`
 
-## `__webpack_is_included__` (webpack-specific)
+## \_\_webpack_is_included\_\_ (webpack-specific)
 
 <Badge text="5.16.0+" />
 
@@ -235,6 +235,6 @@ This is a webpack specific feature and it's available since webpack 5.25.0.
 console.log(__webpack_runtime_id__ === 'main');
 ```
 
-## `DEBUG` (webpack-specific)
+## DEBUG (webpack-specific)
 
 Equals the configuration option `debug`.

--- a/src/content/api/node.mdx
+++ b/src/content/api/node.mdx
@@ -38,7 +38,7 @@ Or if you prefer ES2015:
 import webpack from 'webpack';
 ```
 
-## `webpack()`
+## webpack()
 
 The imported `webpack` function is fed a webpack [Configuration Object](/configuration/) and runs the webpack compiler if a callback function is provided:
 
@@ -191,17 +191,17 @@ i.e. the methods described below.
 
 This `stats` object exposes the following methods:
 
-### `stats.hasErrors()`
+### stats.hasErrors()
 
 Can be used to check if there were errors while compiling. Returns `true` or
 `false`.
 
-### `stats.hasWarnings()`
+### stats.hasWarnings()
 
 Can be used to check if there were warnings while compiling. Returns `true` or
 `false`.
 
-### `stats.toJson(options)`
+### stats.toJson(options)
 
 Returns compilation information as a JSON object. `options` can be either a
 string (a preset) or an object for more granular control:
@@ -222,7 +222,7 @@ All available options and presets are described in the stats [documentation](/co
 > Here’s an [example](https://raw.githubusercontent.com/webpack/analyse/master/app/pages/upload/example2.json)
 > of this function’s output.
 
-### `stats.toString(options)`
+### stats.toString(options)
 
 Returns a formatted string of the compilation information (similar to
 [CLI](/api/cli) output).

--- a/src/content/concepts/module-federation.mdx
+++ b/src/content/concepts/module-federation.mdx
@@ -57,15 +57,15 @@ The `packageName` option allows setting a package name to look for a `requiredVe
 
 ## Building blocks
 
-### `ContainerPlugin` (low level)
+### ContainerPlugin (low level)
 
 This plugin creates an additional container entry with the specified exposed modules.
 
-### `ContainerReferencePlugin` (low level)
+### ContainerReferencePlugin (low level)
 
 This plugin adds specific references to containers as externals and allows to import remote modules from these containers. It also calls the `override` API of these containers to provide overrides to them. Local overrides (via `__webpack_override__` or `override` API when build is also a container) and specified overrides are provided to all referenced containers.
 
-### `ModuleFederationPlugin` (high level)
+### ModuleFederationPlugin (high level)
 
 [`ModuleFederationPlugin`](/plugins/module-federation-plugin) combines `ContainerPlugin` and `ContainerReferencePlugin`.
 

--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -28,7 +28,7 @@ This page describes the options that affect the behavior of webpack-dev-server (
 
 W> `webpack-dev-server v4.0.0+` requires `node >= v12.13.0`, `webpack >= v4.37.0` (but we recommend using `webpack >= v5.0.0`), and `webpack-cli >= v4.7.0`.
 
-## `devServer`
+## devServer
 
 `object`
 
@@ -85,7 +85,7 @@ npx webpack serve
 
 A list of CLI options for `serve` is available [here](https://github.com/webpack/webpack-cli/blob/master/SERVE-OPTIONS-v4.md)
 
-## `devServer.allowedHosts`
+## devServer.allowedHosts
 
 `'auto' | 'all'` `[string]`
 
@@ -167,7 +167,7 @@ Usage via the CLI:
 npx webpack serve --allowed-hosts auto
 ```
 
-## `devServer.bonjour`
+## devServer.bonjour
 
 `boolean` `object`
 
@@ -212,9 +212,9 @@ module.exports = {
 };
 ```
 
-## `devServer.client`
+## devServer.client
 
-### `logging`
+### logging
 
 `'log' | 'info' | 'warn' | 'error' | 'none' | 'verbose'`
 
@@ -239,7 +239,7 @@ Usage via the CLI:
 npx webpack serve --client-logging info
 ```
 
-### `overlay`
+### overlay
 
 `boolean = true` `object: { errors boolean = true, warnings boolean = true }`
 
@@ -294,7 +294,7 @@ Usage via the CLI:
 npx webpack serve --client-overlay-errors --no-client-overlay-warnings
 ```
 
-### `progress`
+### progress
 
 Prints compilation progress in percentage in the browser.
 
@@ -443,7 +443,7 @@ module.exports = {
 
 T> To get `protocol`/`hostname`/`port` from browser use `webSocketURL: 'auto://0.0.0.0:0/ws'`.
 
-## `devServer.compress`
+## devServer.compress
 
 `boolean = true`
 
@@ -490,7 +490,7 @@ module.exports = {
 };
 ```
 
-## `devServer.http2`
+## devServer.http2
 
 `boolean`
 
@@ -545,7 +545,7 @@ To pass your own certificate via CLI, use the following options:
 npx webpack serve --http2 --https-key ./path/to/server.key --https-cert ./path/to/server.crt --https-cacert ./path/to/ca.pem
 ```
 
-## `devServer.https`
+## devServer.https
 
 `boolean` `object`
 
@@ -601,7 +601,7 @@ To pass your own certificate via the CLI use the following options:
 npx webpack serve --https-key ./path/to/server.key --https--cert ./path/to/server.crt --https-cacert ./path/to/ca.pem
 ```
 
-## `devServer.headers`
+## devServer.headers
 
 `function` `object`
 
@@ -738,7 +738,7 @@ Specifying local-ipv6 as host will try to resolve the host option as your local 
 npx webpack serve --host local-ipv6
 ```
 
-## `devServer.hot`
+## devServer.hot
 
 `'only'` `boolean`
 

--- a/src/content/configuration/devtool.mdx
+++ b/src/content/configuration/devtool.mdx
@@ -21,7 +21,7 @@ This option controls if and how source maps are generated.
 
 Use the [`SourceMapDevToolPlugin`](/plugins/source-map-dev-tool-plugin) for a more fine grained configuration. See the [`source-map-loader`](/loaders/source-map-loader) to deal with existing source maps.
 
-## `devtool`
+## devtool
 
 `string = 'eval'` `false`
 

--- a/src/content/configuration/entry-context.mdx
+++ b/src/content/configuration/entry-context.mdx
@@ -15,7 +15,7 @@ contributors:
 
 The entry object is where webpack looks to start building the bundle. The context is an absolute string to the directory that contains the entry files.
 
-## `context`
+## context
 
 `string`
 
@@ -34,7 +34,7 @@ By default the current directory is used, but it's recommended to pass a value i
 
 ---
 
-## `entry`
+## entry
 
 `string` `[string]` `object = { <key> string | [string] | object = { import string | [string], dependOn string | [string], filename string, layer string }}` `(function() => string | [string] | object = { <key> string | [string] } | object = { import string | [string], dependOn string | [string], filename string })`
 

--- a/src/content/configuration/externals.mdx
+++ b/src/content/configuration/externals.mdx
@@ -22,7 +22,7 @@ contributors:
 
 The `externals` configuration option provides a way of excluding dependencies from the output bundles. Instead, the created bundle relies on that dependency to be present in the consumer's (any end-user application) environment. This feature is typically most useful to **library developers**, however there are a variety of applications for it.
 
-## `externals`
+## externals
 
 `string` `[string]` `object` `function` `RegExp`
 
@@ -97,7 +97,7 @@ will compile to something like:
 const fs = require('fs-extra');
 ```
 
-### `[string]`
+### [string]
 
 ```javascript
 module.exports = {
@@ -299,7 +299,7 @@ W> [Default type](/configuration/externals/#externalstype) will be used if you s
 
 For more information on how to use this configuration, please refer to the article on [how to author a library](/guides/author-libraries).
 
-### `byLayer`
+### byLayer
 
 `function` `object`
 
@@ -319,7 +319,7 @@ module.exports = {
 };
 ```
 
-## `externalsType`
+## externalsType
 
 `string = 'var'`
 
@@ -470,7 +470,7 @@ T> When loading code with HTML `<script>` tags, the webpack runtime will try to 
 
 T> Options like `output.chunkLoadTimeout`, `output.crossOriginLoading` and `output.scriptType` will also have effect on the external scripts loaded this way.
 
-## `externalsPresets`
+## externalsPresets
 
 `object`
 

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -24,7 +24,7 @@ contributors:
 
 These options determine how the [different types of modules](/concepts/modules) within a project will be treated.
 
-## `module.generator`
+## module.generator
 
 <Badge text="5.12.0+" />
 
@@ -188,7 +188,7 @@ The `'relative'` value for `module.parser.javascript.url` is available since web
 1. This is useful for SSR (Server side rendering) when base URL is not known by server (and it saves a few bytes). To be identical it must also be used for the client build.
 2. Also for static site generators, mini-css-plugin and html-plugin, etc. where server side rendering is commonly needed.
 
-## `module.noParse`
+## module.noParse
 
 `RegExp` `[RegExp]` `function(resource)` `string` `[string]`
 
@@ -214,7 +214,7 @@ module.exports = {
 };
 ```
 
-## `module.unsafeCache`
+## module.unsafeCache
 
 `boolean` `function (module)`
 
@@ -236,7 +236,7 @@ module.exports = {
 
 W> The default value is `true` in webpack 4.
 
-## `module.rules`
+## module.rules
 
 `[Rule]`
 
@@ -293,7 +293,7 @@ The order of evaluation is as follows:
 2. [`rules`](#rulerules)
 3. [`oneOf`](#ruleoneof)
 
-## `Rule.enforce`
+## Rule.enforce
 
 `string`
 
@@ -327,15 +327,15 @@ import { c } from '!!./file3.js';
 
 Inline loaders and `!` prefixes should not be used as they are non-standard. They may be used by loader generated code.
 
-## `Rule.exclude`
+## Rule.exclude
 
 Exclude all modules matching any of these conditions. If you supply a `Rule.exclude` option, you cannot also supply a `Rule.resource`. See [`Rule.resource`](#ruleresource) and [`Condition.exclude`](#condition) for details.
 
-## `Rule.include`
+## Rule.include
 
 Include all modules matching any of these conditions. If you supply a `Rule.include` option, you cannot also supply a `Rule.resource`. See [`Rule.resource`](#ruleresource) and [`Condition.include`](#condition) for details.
 
-## `Rule.issuer`
+## Rule.issuer
 
 A [`Condition`](#condition) to match against the module that issued the request. In the following example, the `issuer` for the `a.js` request would be the path to the `index.js` file.
 
@@ -347,7 +347,7 @@ import A from './a.js';
 
 This option can be used to apply loaders to the dependencies of a specific module or set of modules.
 
-## `Rule.issuerLayer`
+## Rule.issuerLayer
 
 Allows to filter/match by layer of the issuer.
 
@@ -366,7 +366,7 @@ module.exports = {
 };
 ```
 
-## `Rule.layer`
+## Rule.layer
 
 `string`
 
@@ -388,17 +388,17 @@ module.exports = {
 };
 ```
 
-## `Rule.loader`
+## Rule.loader
 
 `Rule.loader` is a shortcut to `Rule.use: [ { loader } ]`. See [`Rule.use`](#ruleuse) and [`UseEntry.loader`](#useentry) for details.
 
-## `Rule.loaders`
+## Rule.loaders
 
 W> This option is **deprecated** in favor of `Rule.use`.
 
 `Rule.loaders` is an alias to `Rule.use`. See [`Rule.use`](#ruleuse) for details.
 
-## `Rule.mimetype`
+## Rule.mimetype
 
 You can match config rules to data uri with `mimetype`.
 
@@ -420,7 +420,7 @@ module.exports = {
 
 `application/json`, `text/javascript`, `application/javascript`, `application/node` and `application/wasm` are already included by default as mimetype.
 
-## `Rule.oneOf`
+## Rule.oneOf
 
 An array of [`Rules`](#rule) from which only the first matching Rule is used when the Rule matches.
 
@@ -451,13 +451,13 @@ module.exports = {
 
 T> See [`Nested rules`](#nested-rules) for more information.
 
-## `Rule.options` / `Rule.query`
+## Rule.options / Rule.query
 
 `Rule.options` and `Rule.query` are shortcuts to `Rule.use: [ { options } ]`. See [`Rule.use`](#ruleuse) and [`UseEntry.options`](#useentry) for details.
 
 W> `Rule.query` is deprecated in favor of `Rule.options` and `UseEntry.options`.
 
-## `Rule.parser`
+## Rule.parser
 
 An object with parser options. All applied parser options are merged.
 
@@ -504,7 +504,7 @@ If `Rule.type` is an `asset` or `asset/inline` then `Rule.generator` option may 
 
 See [Asset Modules guide](/guides/asset-modules/) for additional information and use cases.
 
-## `Rule.parser.dataUrlCondition`
+## Rule.parser.dataUrlCondition
 
 `object = { maxSize number = 8096 }` `function (source, { filename, module }) => boolean`
 
@@ -691,11 +691,11 @@ module.exports = {
 };
 ```
 
-## `Rule.resource`
+## Rule.resource
 
 A [`Condition`](#condition) matched with the resource. See details in [`Rule` conditions](#rule-conditions).
 
-## `Rule.resourceQuery`
+## Rule.resourceQuery
 
 A [`Condition`](#condition) matched with the resource query. This option is used to test against the query section of a request string (i.e. from the question mark onwards). If you were to `import Foo from './foo.css?inline'`, the following condition would match:
 
@@ -716,7 +716,7 @@ module.exports = {
 };
 ```
 
-## `Rule.parser.parse`
+## Rule.parser.parse
 
 `function(input) => string | object`
 
@@ -743,7 +743,7 @@ module.exports = {
 };
 ```
 
-## `Rule.rules`
+## Rule.rules
 
 An array of [`Rules`](#rule) that is also used when the Rule matches.
 
@@ -771,17 +771,17 @@ module.exports = {
 };
 ```
 
-## `Rule.sideEffects`
+## Rule.sideEffects
 
 `bool`
 
 Indicate what parts of the module contain side effects. See [Tree Shaking](/guides/tree-shaking/#mark-the-file-as-side-effect-free) for details.
 
-## `Rule.test`
+## Rule.test
 
 Include all modules that pass test assertion. If you supply a `Rule.test` option, you cannot also supply a `Rule.resource`. See [`Rule.resource`](#ruleresource) and [`Condition.test`](#condition) for details.
 
-## `Rule.type`
+## Rule.type
 
 `string`
 
@@ -809,7 +809,7 @@ module.exports = {
 
 > See [Asset Modules guide](/guides/asset-modules/) for more about `asset*` type.
 
-## `Rule.use`
+## Rule.use
 
 `[UseEntry]` `function(info)`
 
@@ -897,7 +897,7 @@ module.exports = {
 
 See [UseEntry](#useentry) for details.
 
-## `Rule.resolve`
+## Rule.resolve
 
 W> `Rule.resolve` is Available since webpack 4.36.1
 
@@ -964,7 +964,7 @@ module.exports = {
 
 When creating a bundle with updated configuration, `console.log(footer)` will output 'overridden footer'.
 
-### `resolve.fullySpecified`
+### resolve.fullySpecified
 
 `boolean = true`
 
@@ -990,7 +990,7 @@ module.exports = {
 
 W> `resolve.fullySpecified` doesn't affect requests from [mainFields](/configuration/resolve/#resolvemainfields), [aliasFields](/configuration/resolve/#resolvealiasfields) or [aliases](/configuration/resolve/#resolvealias).
 
-## `Condition`
+## Condition
 
 Conditions can be one of these:
 
@@ -1030,7 +1030,7 @@ module.exports = {
 };
 ```
 
-## `UseEntry`
+## UseEntry
 
 `object` `function(info)`
 

--- a/src/content/configuration/node.mdx
+++ b/src/content/configuration/node.mdx
@@ -18,7 +18,7 @@ This feature is provided by webpack's internal [`NodeStuffPlugin`](https://githu
 
 W> As of webpack 5, You can configure only `global`, `__filename` or `__dirname` under `node` option. If you're looking for how to polyfill `fs` alike in Node.js under webpack 5, please check [resolve.fallback](/configuration/resolve/#resolvefallback) for help.
 
-## `node`
+## node
 
 `boolean: false` `object`
 
@@ -37,7 +37,7 @@ module.exports = {
 
 Since webpack 3.0.0, the `node` option may be set to `false` to completely turn off the `NodeStuffPlugin` plugin.
 
-## `node.global`
+## node.global
 
 `boolean`
 
@@ -50,7 +50,7 @@ Options:
 - `true`: Provide a polyfill.
 - `false`: Provide nothing. Code that expects this object may crash with a `ReferenceError`.
 
-## `node.__filename`
+## node.\_\_filename
 
 `boolean` `string: 'mock' | 'eval-only'`
 
@@ -61,7 +61,7 @@ Options:
 - `'mock'`: The fixed value `'/index.js'`.
 - `'eval-only'`
 
-## `node.__dirname`
+## node.\_\_dirname
 
 `boolean` `string: 'mock' | 'eval-only'`
 

--- a/src/content/configuration/optimization.mdx
+++ b/src/content/configuration/optimization.mdx
@@ -21,7 +21,7 @@ related:
 
 Since version 4 webpack runs optimizations for you depending on the chosen [`mode`](/configuration/mode/), still all optimizations are available for manual configuration and overrides.
 
-## `optimization.minimize`
+## optimization.minimize
 
 `boolean = true`
 
@@ -40,7 +40,7 @@ module.exports = {
 
 T> Learn how [mode](/configuration/mode/) works.
 
-## `optimization.minimizer`
+## optimization.minimizer
 
 `[TerserPlugin]` and or `[function (compiler)]`
 
@@ -92,13 +92,13 @@ module.exports = {
 };
 ```
 
-## `optimization.splitChunks`
+## optimization.splitChunks
 
 `object`
 
 By default webpack v4+ provides new common chunks strategies out of the box for dynamically imported modules. See available options for configuring this behavior in the [SplitChunksPlugin](/plugins/split-chunks-plugin/) page.
 
-## `optimization.runtimeChunk`
+## optimization.runtimeChunk
 
 `object` `string` `boolean`
 
@@ -151,7 +151,7 @@ module.exports = {
 };
 ```
 
-## `optimization.emitOnErrors`
+## optimization.emitOnErrors
 
 `boolean = false`
 
@@ -170,7 +170,7 @@ module.exports = {
 
 W> If you are using webpack [CLI](/api/cli/), the webpack process will not exit with an error code while this plugin is enabled. If you want webpack to "fail" when using the CLI, please check out the [`bail` option](/api/cli/#advanced-options).
 
-## `optimization.moduleIds`
+## optimization.moduleIds
 
 `boolean: false` `string: 'natural' | 'named' | 'deterministic' | 'size'`
 
@@ -218,7 +218,7 @@ W> `moduleIds: 'deterministic'` was added in webpack 5 and `moduleIds: 'hashed'`
 
 W> `moduleIds: total-size` has been removed in webpack 5.
 
-## `optimization.chunkIds`
+## optimization.chunkIds
 
 `boolean = false` `string: 'natural' | 'named' | 'size' | 'total-size' | 'deterministic'`
 
@@ -266,7 +266,7 @@ module.exports = {
 };
 ```
 
-## `optimization.nodeEnv`
+## optimization.nodeEnv
 
 `boolean = false` `string`
 
@@ -290,7 +290,7 @@ module.exports = {
 
 T> When [mode](/configuration/mode/) is set to `'none'`, `optimization.nodeEnv` defaults to `false`.
 
-## `optimization.mangleWasmImports`
+## optimization.mangleWasmImports
 
 `boolean = false`
 
@@ -307,7 +307,7 @@ module.exports = {
 };
 ```
 
-## `optimization.removeAvailableModules`
+## optimization.removeAvailableModules
 
 `boolean = false`
 
@@ -326,7 +326,7 @@ module.exports = {
 
 W> `optimization.removeAvailableModules` reduces the performance of webpack, and will be disabled in `production` mode by default in next major release. Disable it in `production` mode if you want extra build performance.
 
-## `optimization.removeEmptyChunks`
+## optimization.removeEmptyChunks
 
 `boolean = true`
 
@@ -343,7 +343,7 @@ module.exports = {
 };
 ```
 
-## `optimization.mergeDuplicateChunks`
+## optimization.mergeDuplicateChunks
 
 `boolean = true`
 
@@ -360,7 +360,7 @@ module.exports = {
 };
 ```
 
-## `optimization.flagIncludedChunks`
+## optimization.flagIncludedChunks
 
 `boolean`
 
@@ -377,7 +377,7 @@ module.exports = {
 };
 ```
 
-## `optimization.providedExports`
+## optimization.providedExports
 
 `boolean`
 
@@ -394,7 +394,7 @@ module.exports = {
 };
 ```
 
-## `optimization.usedExports`
+## optimization.usedExports
 
 `boolean = true` `string: 'global'`
 
@@ -423,7 +423,7 @@ module.exports = {
 };
 ```
 
-## `optimization.concatenateModules`
+## optimization.concatenateModules
 
 `boolean`
 
@@ -441,7 +441,7 @@ module.exports = {
 };
 ```
 
-## `optimization.sideEffects`
+## optimization.sideEffects
 
 `boolean = true` `string: 'flag'`
 
@@ -487,7 +487,7 @@ The `'flag'` value is used by default in non-production builds.
 
 T> `optimization.sideEffects` will also flag modules as side effect free when they contain only side effect free statements.
 
-## `optimization.portableRecords`
+## optimization.portableRecords
 
 `boolean`
 
@@ -506,7 +506,7 @@ module.exports = {
 };
 ```
 
-## `optimization.mangleExports`
+## optimization.mangleExports
 
 `boolean` `string: 'deterministic' | 'size'`
 
@@ -534,7 +534,7 @@ module.exports = {
 };
 ```
 
-## `optimization.innerGraph`
+## optimization.innerGraph
 
 `boolean = true`
 
@@ -551,7 +551,7 @@ module.exports = {
 };
 ```
 
-## `optimization.realContentHash`
+## optimization.realContentHash
 
 `boolean = true`
 

--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -100,7 +100,7 @@ module.exports = {
 };
 ```
 
-## `output.charset`
+## output.charset
 
 `boolean = true`
 
@@ -108,7 +108,7 @@ Tells webpack to add `charset="utf-8"` to the HTML `<script>` tag.
 
 T> Although `charset` attribute for `<script>` tag was [deprecated](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#Deprecated_attributes), webpack still adds it by default for compatibility with non-modern browsers.
 
-## `output.chunkFilename`
+## output.chunkFilename
 
 `string = '[id].js'` `function (pathData, assetInfo) => string`
 
@@ -163,7 +163,7 @@ module.exports = {
 };
 ```
 
-## `output.chunkLoadTimeout`
+## output.chunkLoadTimeout
 
 `number = 120000`
 
@@ -181,7 +181,7 @@ module.exports = {
 };
 ```
 
-## `output.chunkLoadingGlobal`
+## output.chunkLoadingGlobal
 
 `string = 'webpackChunkwebpack'`
 
@@ -304,7 +304,7 @@ Tells webpack to enable [cross-origin](https://developer.mozilla.org/en/docs/Web
 - `'anonymous'` - Enable cross-origin loading **without credentials**
 - `'use-credentials'` - Enable cross-origin loading **with credentials**
 
-## `output.devtoolFallbackModuleFilenameTemplate`
+## output.devtoolFallbackModuleFilenameTemplate
 
 `string` `function (info)`
 
@@ -312,7 +312,7 @@ A fallback used when the template string or function above yields duplicates.
 
 See [`output.devtoolModuleFilenameTemplate`](#outputdevtoolmodulefilenametemplate).
 
-## `output.devtoolModuleFilenameTemplate`
+## output.devtoolModuleFilenameTemplate
 
 `string = 'webpack://[namespace]/[resource-path]?[loaders]'` `function (info) => string`
 
@@ -360,7 +360,7 @@ module.exports = {
 
 If multiple modules would result in the same name, [`output.devtoolFallbackModuleFilenameTemplate`](#outputdevtoolfallbackmodulefilenametemplate) is used instead for these modules.
 
-## `output.devtoolNamespace`
+## output.devtoolNamespace
 
 `string`
 
@@ -646,7 +646,7 @@ module.exports = {
 };
 ```
 
-## `output.globalObject`
+## output.globalObject
 
 `string = 'window'`
 
@@ -668,19 +668,19 @@ module.exports = {
 };
 ```
 
-## `output.hashDigest`
+## output.hashDigest
 
 `string = 'hex'`
 
 The encoding to use when generating the hash. All encodings from Node.JS' [`hash.digest`](https://nodejs.org/api/crypto.html#crypto_hash_digest_encoding) are supported. Using `'base64'` for filenames might be problematic since it has the character `/` in its alphabet. Likewise `'latin1'` could contain any character.
 
-## `output.hashDigestLength`
+## output.hashDigestLength
 
 `number = 20`
 
 The prefix length of the hash digest to use.
 
-## `output.hashFunction`
+## output.hashFunction
 
 `string = 'md4'` `function`
 
@@ -697,11 +697,11 @@ module.exports = {
 
 Make sure that the hashing function will have `update` and `digest` methods available.
 
-## `output.hashSalt`
+## output.hashSalt
 
 An optional salt to update the hash via Node.JS' [`hash.update`](https://nodejs.org/api/crypto.html#crypto_hash_update_data_inputencoding).
 
-## `output.hotUpdateChunkFilename`
+## output.hotUpdateChunkFilename
 
 `string = '[id].[fullhash].hot-update.js'`
 
@@ -722,7 +722,7 @@ module.exports = {
 
 T> Typically you don't need to change `output.hotUpdateChunkFilename`.
 
-## `output.hotUpdateGlobal`
+## output.hotUpdateGlobal
 
 `string`
 
@@ -732,7 +732,7 @@ A JSONP function used to asynchronously load hot-update chunks.
 
 For details see [`output.chunkLoadingGlobal`](#outputchunkloadingglobal).
 
-## `output.hotUpdateMainFilename`
+## output.hotUpdateMainFilename
 
 `string = '[runtime].[fullhash].hot-update.json'` `function`
 
@@ -912,7 +912,7 @@ For the following examples, we'll use `__entry_return_` to indicate the values r
 
 These options assign the return value of the entry point (e.g. whatever the entry point exported) to the name provided by [`output.library.name`](#outputlibraryname) at whatever scope the bundle was included at.
 
-##### `type: 'var'`
+##### type: 'var'
 
 ```js
 module.exports = {
@@ -935,7 +935,7 @@ var MyLibrary = _entry_return_;
 MyLibrary.doSomething();
 ```
 
-##### `type: 'assign'`
+##### type: 'assign'
 
 ```js
 module.exports = {
@@ -957,7 +957,7 @@ MyLibrary = _entry_return_;
 
 Be aware that if `MyLibrary` isn't defined earlier your library will be set in global scope.
 
-##### `type: 'assign-properties'` <Badge text='5.16.0+' />
+##### type: 'assign-properties' <Badge text='5.16.0+' />
 
 ```js
 module.exports = {
@@ -993,7 +993,7 @@ MyLibrary.hello('World');
 
 These options assign the return value of the entry point (e.g. whatever the entry point exported) to a specific object under the name defined by [`output.library.name`](#outputlibraryname).
 
-##### `type: 'this'`
+##### type: 'this'
 
 ```js
 module.exports = {
@@ -1017,7 +1017,7 @@ this.MyLibrary.doSomething();
 MyLibrary.doSomething(); // if `this` is window
 ```
 
-##### `type: 'window'`
+##### type: 'window'
 
 ```js
 module.exports = {
@@ -1039,7 +1039,7 @@ window['MyLibrary'] = _entry_return_;
 window.MyLibrary.doSomething();
 ```
 
-##### `type: 'global'`
+##### type: 'global'
 
 ```js
 module.exports = {
@@ -1061,7 +1061,7 @@ global['MyLibrary'] = _entry_return_;
 global.MyLibrary.doSomething();
 ```
 
-##### `type: 'commonjs'`
+##### type: 'commonjs'
 
 ```js
 module.exports = {
@@ -1089,7 +1089,7 @@ W> Note that not setting a `output.library.name` will cause all properties retur
 
 These options will result in a bundle that comes with a complete header to ensure compatibility with various module systems. The `output.library.name` option will take on a different meaning under the following `output.library.type` options.
 
-##### `type: 'module'`
+##### type: 'module'
 
 ```js
 module.exports = {
@@ -1110,7 +1110,7 @@ Output ES Module.
 
 However this feature is still experimental and not fully supported yet, so make sure to enable [experiments.outputModule](/configuration/experiments/) beforehand. In addition, you can track the development progress in [this thread](https://github.com/webpack/webpack/issues/2933#issuecomment-774253975).
 
-##### `type: 'commonjs2'`
+##### type: 'commonjs2'
 
 ```js
 module.exports = {
@@ -1136,7 +1136,7 @@ If we specify `output.library.name` with `type: commmonjs2`, the return value of
 
 T> Wondering the difference between CommonJS and CommonJS2 is? While they are similar, there are some subtle differences between them that are not usually relevant in the context of webpack. (For further details, please [read this issue](https://github.com/webpack/webpack/issues/1114).)
 
-##### `type: 'amd'`
+##### type: 'amd'
 
 This will expose your library as an AMD module.
 
@@ -1182,7 +1182,7 @@ define(function () {
 
 This bundle will not work as expected, or not work at all (in the case of the almond loader) if loaded directly with a `<script>` tag. It will only work through a RequireJS compatible asynchronous module loader through the actual path to that file, so in this case, the `output.path` and `output.filename` may become important for this particular setup if these are exposed directly on the server.
 
-##### `type: 'amd-require'`
+##### type: 'amd-require'
 
 ```javascript
 module.exports = {
@@ -1202,7 +1202,7 @@ The `'amd-require'` type allows for the use of AMD dependencies without needing 
 
 With this type, the library name can't be used.
 
-##### `type: 'umd'`
+##### type: 'umd'
 
 This exposes your library under all the module definitions, allowing it to work with CommonJS, AMD and as global variable. Take a look at the [UMD Repository](https://github.com/umdjs/umd) to learn more.
 
@@ -1279,7 +1279,7 @@ module.exports = {
 };
 ```
 
-##### `type: 'system'`
+##### type: 'system'
 
 This will expose your library as a [`System.register`](https://github.com/systemjs/systemjs/blob/master/docs/system-register.md) module. This feature was first released in [webpack 4.30.0](https://github.com/webpack/webpack/releases/tag/v4.30.0).
 
@@ -1326,7 +1326,7 @@ System.register(
 
 #### Other Types
 
-##### `type: 'jsonp'`
+##### type: 'jsonp'
 
 ```js
 module.exports = {
@@ -1483,7 +1483,7 @@ The AMD module will be:
 define('MyLibrary', [], factory);
 ```
 
-## `output.libraryExport`
+## output.libraryExport
 
 W> We might drop support for this, so prefer to use [output.library.export](#outputlibraryexport) which works the same as `libraryExport`.
 
@@ -1534,7 +1534,7 @@ T> Note that `_entry_return_` in the example code below is the value returned by
 
 These options assign the return value of the entry point (e.g. whatever the entry point exported) to the name provided by [`output.library`](#outputlibrary) at whatever scope the bundle was included at.
 
-#### `libraryTarget: 'var'`
+#### libraryTarget: 'var'
 
 W> Prefer to use [`output.library.type: 'var'`](#type-var).
 
@@ -1547,7 +1547,7 @@ var MyLibrary = _entry_return_;
 MyLibrary.doSomething();
 ```
 
-#### `libraryTarget: 'assign'`
+#### libraryTarget: 'assign'
 
 W> Prefer to use [`output.library.type: 'assign'`](#type-assign).
 
@@ -1559,7 +1559,7 @@ MyLibrary = _entry_return_;
 
 Be aware that if `MyLibrary` isn't defined earlier your library will be set in global scope.
 
-#### `libraryTarget: 'assign-properties'` <Badge text='5.16.0+' />
+#### libraryTarget: 'assign-properties' <Badge text='5.16.0+' />
 
 W> Prefer to use [output.library.type: 'assign-properties'`](#type-assign-properties).
 
@@ -1599,7 +1599,7 @@ If `output.library` is not assigned a non-empty string, the default behavior is 
 
 W> Note that not setting a `output.library` will cause all properties returned by the entry point to be assigned to the given object; there are no checks against existing property names.
 
-#### `libraryTarget: 'this'`
+#### libraryTarget: 'this'
 
 W> Prefer to use [`output.library.type: 'this'`](#type-this).
 
@@ -1613,7 +1613,7 @@ this.MyLibrary.doSomething();
 MyLibrary.doSomething(); // if this is window
 ```
 
-#### `libraryTarget: 'window'`
+#### libraryTarget: 'window'
 
 W> Prefer to use [`output.library.type: 'window'`](#type-window).
 
@@ -1625,7 +1625,7 @@ window['MyLibrary'] = _entry_return_;
 window.MyLibrary.doSomething();
 ```
 
-#### `libraryTarget: 'global'`
+#### libraryTarget: 'global'
 
 W> Prefer to use [`output.library.type: 'global'`](#type-global).
 
@@ -1637,7 +1637,7 @@ global['MyLibrary'] = _entry_return_;
 global.MyLibrary.doSomething();
 ```
 
-#### `libraryTarget: 'commonjs'`
+#### libraryTarget: 'commonjs'
 
 W> Prefer to use [`output.library.type: 'commonjs'`](#type-commonjs).
 
@@ -1653,7 +1653,7 @@ require('MyLibrary').doSomething();
 
 These options will result in a bundle that comes with a complete header to ensure compatibility with various module systems. The `output.library` option will take on a different meaning under the following `output.libraryTarget` options.
 
-#### `libraryTarget: 'module'`
+#### libraryTarget: 'module'
 
 W> Prefer to use [`output.library.type: 'module'`](#type-module).
 
@@ -1661,7 +1661,7 @@ Output ES Module. Make sure to enable [experiments.outputModule](/configuration/
 
 Note that this feature is not fully supported yet, please track the progress in [this thread](https://github.com/webpack/webpack/issues/2933#issuecomment-774253975).
 
-#### `libraryTarget: 'commonjs2'`
+#### libraryTarget: 'commonjs2'
 
 W> Prefer to use [`output.library.type: 'commonjs2'`](#type-commonjs2).
 
@@ -1677,7 +1677,7 @@ Note that `output.library` can't be used with this particular `output.libraryTar
 
 T> Wondering the difference between CommonJS and CommonJS2 is? While they are similar, there are some subtle differences between them that are not usually relevant in the context of webpack. (For further details, please [read this issue](https://github.com/webpack/webpack/issues/1114).)
 
-#### `libraryTarget: 'amd'`
+#### libraryTarget: 'amd'
 
 W> Prefer to use [`output.library.type: 'amd'`](#type-amd).
 
@@ -1723,7 +1723,7 @@ define([], function () {
 
 This bundle will not work as expected, or not work at all (in the case of the almond loader) if loaded directly with a `<script>` tag. It will only work through a RequireJS compatible asynchronous module loader through the actual path to that file, so in this case, the `output.path` and `output.filename` may become important for this particular setup if these are exposed directly on the server.
 
-#### `libraryTarget: 'amd-require'`
+#### libraryTarget: 'amd-require'
 
 W> Prefer to use [`output.library.type: 'amd-require'`](#type-amd-require).
 
@@ -1733,7 +1733,7 @@ The `'amd-require'` target allows for the use of AMD dependencies without needin
 
 With this target, the library name is ignored.
 
-#### `libraryTarget: 'umd'`
+#### libraryTarget: 'umd'
 
 W> Prefer to use [`output.library.type: 'umd'`](#type-umd).
 
@@ -1808,7 +1808,7 @@ module.exports = {
 };
 ```
 
-#### `libraryTarget: 'system'`
+#### libraryTarget: 'system'
 
 W> Prefer to use [`output.library.type: 'system'`](#type-system).
 
@@ -1865,7 +1865,7 @@ __system_context__.import('./other-file.js').then((m) => {
 
 ### Other Targets
 
-#### `libraryTarget: 'jsonp'`
+#### libraryTarget: 'jsonp'
 
 W> Prefer to use [`output.library.type: 'jsonp'`](#type-jsonp).
 
@@ -1901,7 +1901,7 @@ module.exports = {
 
 W> `output.module` is an experimental feature and can only be enabled by setting [`experiments.outputModule`](/configuration/experiments/#experiments) to `true`.
 
-## `output.path`
+## output.path
 
 `string = path.join(process.cwd(), 'dist')`
 
@@ -1922,7 +1922,7 @@ module.exports = {
 
 Note that `[fullhash]` in this parameter will be replaced with a hash of the compilation. See the [Caching guide](/guides/caching/) for details.
 
-## `output.pathinfo`
+## output.pathinfo
 
 `boolean=true` `string: 'verbose'`
 
@@ -1943,7 +1943,7 @@ module.exports = {
 
 T> It also adds some info about tree shaking to the generated bundle.
 
-## `output.publicPath`
+## output.publicPath
 
 - Type:
 
@@ -2051,7 +2051,7 @@ module.exports = {
 };
 ```
 
-## `output.sourceMapFilename`
+## output.sourceMapFilename
 
 `string = '[file].map[query]'`
 
@@ -2059,7 +2059,7 @@ Configure how source maps are named. Only takes effect when [`devtool`](/configu
 
 The `[name]`, `[id]`, `[fullhash]` and `[chunkhash]` substitutions from [`output.filename`](#outputfilename) can be used. In addition to those, you can use substitutions listed under Filename-level in [Template strings](/configuration/output/#template-strings).
 
-## `output.sourcePrefix`
+## output.sourcePrefix
 
 `string = ''`
 
@@ -2131,7 +2131,7 @@ require('module'); // <- throws
 require('module'); // <- also throws
 ```
 
-## `output.trustedTypes`
+## output.trustedTypes
 
 `boolean = false` `string` `object`
 
@@ -2159,7 +2159,7 @@ module.exports = {
 };
 ```
 
-## `output.umdNamedDefine`
+## output.umdNamedDefine
 
 W> Prefer to use [`output.library.umdNamedDefine`](#outputlibraryumdnameddefine) instead.
 

--- a/src/content/configuration/plugins.mdx
+++ b/src/content/configuration/plugins.mdx
@@ -14,7 +14,7 @@ The `plugins` option is used to customize the webpack build process in a variety
 
 T> Note: This page only discusses using plugins, however if you are interested in writing your own please visit [Writing a Plugin](/contribute/writing-a-plugin/).
 
-## `plugins`
+## plugins
 
 [`[Plugin]`](/plugins/)
 

--- a/src/content/configuration/resolve.mdx
+++ b/src/content/configuration/resolve.mdx
@@ -17,11 +17,12 @@ contributors:
   - anikethsaha
   - chenxsan
   - jamesgeorge007
+  - snitin315
 ---
 
 These options change how modules are resolved. webpack provides reasonable defaults, but it is possible to change the resolving in detail. Have a look at [Module Resolution](/concepts/module-resolution) for more explanation of how the resolver works.
 
-## `resolve`
+## resolve
 
 `object`
 
@@ -38,7 +39,7 @@ module.exports = {
 };
 ```
 
-### `resolve.alias`
+### resolve.alias
 
 `object`
 
@@ -152,7 +153,7 @@ module.exports = {
 };
 ```
 
-### `resolve.aliasFields`
+### resolve.aliasFields
 
 `[string]: ['browser']`
 
@@ -169,7 +170,7 @@ module.exports = {
 };
 ```
 
-### `resolve.cacheWithContext`
+### resolve.cacheWithContext
 
 `boolean` (since webpack 3.1.0)
 
@@ -192,7 +193,7 @@ module.exports = {
 };
 ```
 
-### `resolve.descriptionFiles`
+### resolve.descriptionFiles
 
 `[string] = ['package.json']`
 
@@ -209,7 +210,7 @@ module.exports = {
 };
 ```
 
-### `resolve.enforceExtension`
+### resolve.enforceExtension
 
 `boolean = false`
 
@@ -313,7 +314,7 @@ module.exports = {
 };
 ```
 
-### `resolve.mainFields`
+### resolve.mainFields
 
 `[string]`
 
@@ -356,7 +357,7 @@ For example, consider an arbitrary library called `upstream` with a `package.jso
 
 When we `import * as Upstream from 'upstream'` this will actually resolve to the file in the `browser` property. The `browser` property takes precedence because it's the first item in `mainFields`. Meanwhile, a Node.js application bundled by webpack will first try to resolve using the file in the `module` field.
 
-### `resolve.mainFiles`
+### resolve.mainFiles
 
 `[string] = ['index']`
 
@@ -373,7 +374,7 @@ module.exports = {
 };
 ```
 
-### `resolve.exportsFields`
+### resolve.exportsFields
 
 `[string] = ['exports']`
 
@@ -390,7 +391,7 @@ module.exports = {
 };
 ```
 
-### `resolve.modules`
+### resolve.modules
 
 `[string] = ['node_modules']`
 
@@ -428,7 +429,7 @@ module.exports = {
 };
 ```
 
-### `resolve.unsafeCache`
+### resolve.unsafeCache
 
 `RegExp` `[RegExp]` `boolean: true`
 
@@ -460,7 +461,7 @@ module.exports = {
 
 W> Changes to cached paths may cause failure in rare cases.
 
-### `resolve.plugins`
+### resolve.plugins
 
 [`[Plugin]`](/plugins/)
 
@@ -477,7 +478,7 @@ module.exports = {
 };
 ```
 
-### `resolve.preferRelative`
+### resolve.preferRelative
 
 `boolean`
 
@@ -506,7 +507,7 @@ const b = new URL('module/path', import.meta.url);
 const a = new URL('./module/path', import.meta.url);
 ```
 
-### `resolve.preferAbsolute`
+### resolve.preferAbsolute
 
 `boolean`
 
@@ -525,7 +526,7 @@ module.exports = {
 };
 ```
 
-### `resolve.symlinks`
+### resolve.symlinks
 
 `boolean = true`
 
@@ -544,7 +545,7 @@ module.exports = {
 };
 ```
 
-### `resolve.cachePredicate`
+### resolve.cachePredicate
 
 `function(module) => boolean`
 
@@ -564,7 +565,7 @@ module.exports = {
 };
 ```
 
-### `resolve.restrictions`
+### resolve.restrictions
 
 `[string, RegExp]`
 
@@ -581,7 +582,7 @@ module.exports = {
 };
 ```
 
-### `resolve.roots`
+### resolve.roots
 
 `[string]`
 
@@ -599,7 +600,7 @@ module.exports = {
 };
 ```
 
-### `resolve.importsFields`
+### resolve.importsFields
 
 `[string]`
 
@@ -642,7 +643,7 @@ Configure resolve options by the type of module request.
   };
   ```
 
-## `resolveLoader`
+## resolveLoader
 
 `object { modules [string] = ['node_modules'], extensions [string] = ['.js', '.json'], mainFields [string] = ['loader', 'main']}`
 

--- a/src/content/configuration/target.mdx
+++ b/src/content/configuration/target.mdx
@@ -15,13 +15,13 @@ contributors:
 
 webpack can compile for multiple environments or _targets_. To understand what a `target` is in detail, read through [the targets concept page](/concepts/targets/).
 
-## `target`
+## target
 
 `string` `[string]` `false`
 
 Instructs webpack to target a specific environment. Defaults to `'browserslist'` or to `'web'` when no browserslist configuration was found.
 
-### `string`
+### string
 
 The following string values are supported via [`WebpackOptionsApply`](https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsApply.js):
 
@@ -54,7 +54,7 @@ module.exports = {
 
 It helps determinate ES-features that may be used to generate a runtime-code (all the chunks and modules are wrapped by runtime code).
 
-#### `browserslist`
+#### browserslist
 
 If a project has a browserslist config, then webpack will use it for:
 
@@ -69,7 +69,7 @@ Supported browserslist values:
 - `browserslist:/path/to/config` - explicitly specify browserslist config
 - `browserslist:/path/to/config:modern` - explicitly specify browserslist config and an environment
 
-### `[string]`
+### [string]
 
 When multiple targets are passed, then common subset of features will be used:
 
@@ -97,7 +97,7 @@ module.exports = {
 
 Will cause an error. webpack does not support universal target for now.
 
-### `false`
+### false
 
 Set `target` to `false` if none of the predefined targets from the list above meet your needs, no plugins will be applied.
 

--- a/src/content/configuration/watch.mdx
+++ b/src/content/configuration/watch.mdx
@@ -14,7 +14,7 @@ contributors:
 
 webpack can watch files and recompile whenever they change. This page explains how to enable this and a couple of tweaks you can make if watching does not work properly for you.
 
-## `watch`
+## watch
 
 `boolean = false`
 

--- a/src/content/guides/code-splitting.mdx
+++ b/src/content/guides/code-splitting.mdx
@@ -206,7 +206,7 @@ As you can see there's another `runtime.bundle.js` file generated besides `share
 
 Although using multiple entry points per page is allowed in webpack, it should be avoided when possible in favor of an entry point with multiple imports: `entry: { page: ['./analytics', './app'] }`. This results in a better optimization and consistent execution order when using `async` script tags.
 
-### `SplitChunksPlugin`
+### SplitChunksPlugin
 
 The [`SplitChunksPlugin`](/plugins/split-chunks-plugin/) allows us to extract common dependencies into an existing entry chunk or an entirely new chunk. Let's use this to de-duplicate the `lodash` dependency from the previous example:
 

--- a/src/content/guides/dependency-management.mdx
+++ b/src/content/guides/dependency-management.mdx
@@ -63,7 +63,7 @@ The context module also contains some runtime logic to access the map.
 
 This means dynamic requires are supported but will cause all matching modules to be included in the bundle.
 
-## `require.context`
+## require.context
 
 You can create your own context with the `require.context()` function.
 

--- a/src/content/guides/package-exports.mdx
+++ b/src/content/guides/package-exports.mdx
@@ -201,7 +201,7 @@ These conditions might also be set additionally:
 
 (1) `import` and `require` are both set independent of referencing syntax. `require` has always lower priority.
 
-#### `import`
+#### import
 
 The following syntax will set the `import` condition:
 
@@ -215,7 +215,7 @@ The following syntax will set the `import` condition:
 - JS `Worklet.addModule`
 - Using javascript as entrypoint
 
-#### `require`
+#### require
 
 The following syntax will set the `require` condition:
 
@@ -228,14 +228,14 @@ The following syntax will set the `require` condition:
 - CommonJs HMR (webpack) `module.hot.accept/decline([...])`
 - HTML `<script src="...">`
 
-#### `style`
+#### style
 
 The following syntax will set the `style` condition:
 
 - CSS `@import`
 - HTML `<link rel="stylesheet">`
 
-#### `asset`
+#### asset
 
 The following syntax will set the `asset` condition:
 
@@ -243,7 +243,7 @@ The following syntax will set the `asset` condition:
 - ESM `new URL(..., import.meta.url)`
 - HTML `<img src="...">`
 
-#### `script`
+#### script
 
 The following syntax will set the `script` condition:
 

--- a/src/content/migrate/3.mdx
+++ b/src/content/migrate/3.mdx
@@ -291,7 +291,7 @@ module: {
 }
 ```
 
-### new ExtractTextPlugin({options})
+### `new ExtractTextPlugin({options})`
 
 ```diff
 plugins: [

--- a/src/content/migrate/3.mdx
+++ b/src/content/migrate/3.mdx
@@ -22,7 +22,7 @@ The following sections describe the major changes from webpack 1 to 2.
 
 T> Note that there were far fewer changes between 2 and 3, so that migration shouldn't be too bad. If you are running into issues, please see [the changelog](https://github.com/webpack/webpack/releases) for details.
 
-## `resolve.root`, `resolve.fallback`, `resolve.modulesDirectories`
+## resolve.root, resolve.fallback, resolve.modulesDirectories
 
 These options were replaced by a single option `resolve.modules`. See [resolving](/configuration/resolve) for more usage.
 
@@ -36,15 +36,15 @@ These options were replaced by a single option `resolve.modules`. See [resolving
   }
 ```
 
-## `resolve.extensions`
+## resolve.extensions
 
 This option no longer requires passing an empty string. This behavior was moved to `resolve.enforceExtension`. See [resolving](/configuration/resolve) for more usage.
 
-## `resolve.*`
+## resolve.\*
 
 Several APIs were changed here. Not listed in detail as it's not commonly used. See [resolving](/configuration/resolve) for details.
 
-## `module.loaders` is now `module.rules`
+## module.loaders is now module.rules
 
 The old loader configuration was superseded by a more powerful rules system, which allows configuration of loaders and more.
 For compatibility reasons, the old `module.loaders` syntax is still valid and the old names are parsed.
@@ -134,7 +134,7 @@ You can still opt-in to the old behavior with the `resolveLoader.moduleExtension
 
 See [#2986](https://github.com/webpack/webpack/issues/2986) for the reason behind this change.
 
-## `json-loader` is not required anymore
+## json-loader is not required anymore
 
 When no loader has been configured for a JSON file, webpack will automatically try to load the JSON
 file with the [`json-loader`](https://github.com/webpack-contrib/json-loader).
@@ -176,7 +176,7 @@ You may remove some hacks to work around this:
   }
 ```
 
-## `module.preLoaders` and `module.postLoaders` were removed:
+## module.preLoaders and module.postLoaders were removed:
 
 ```diff
   module: {
@@ -191,7 +191,7 @@ You may remove some hacks to work around this:
   }
 ```
 
-## `UglifyJsPlugin` sourceMap
+## UglifyJsPlugin sourceMap
 
 The `sourceMap` option of the `UglifyJsPlugin` now defaults to `false` instead of `true`. This means that if you are using source maps for minimized code or want correct line numbers for uglifyjs warnings, you need to set `sourceMap: true` for `UglifyJsPlugin`.
 
@@ -204,7 +204,7 @@ The `sourceMap` option of the `UglifyJsPlugin` now defaults to `false` instead o
   ]
 ```
 
-## `UglifyJsPlugin` warnings
+## UglifyJsPlugin warnings
 
 The `compress.warnings` option of the `UglifyJsPlugin` now defaults to `false` instead of `true`.
 This means that if you want to see uglifyjs warnings, you need to set `compress.warnings` to `true`.
@@ -220,7 +220,7 @@ This means that if you want to see uglifyjs warnings, you need to set `compress.
   ]
 ```
 
-## `UglifyJsPlugin` minimize loaders
+## UglifyJsPlugin minimize loaders
 
 `UglifyJsPlugin` no longer switches loaders into minimize mode. The `minimize: true` setting needs to be passed via loader options in the long-term. See loader documentation for relevant options.
 
@@ -236,11 +236,11 @@ To keep compatibility with old loaders, loaders can be switched to minimize mode
   ]
 ```
 
-## `DedupePlugin` has been removed
+## DedupePlugin has been removed
 
 `webpack.optimize.DedupePlugin` isn't needed anymore. Remove it from your configuration.
 
-## `BannerPlugin` - breaking change
+## BannerPlugin - breaking change
 
 `BannerPlugin` no longer accepts two parameters, but a single options object.
 
@@ -251,7 +251,7 @@ To keep compatibility with old loaders, loaders can be switched to minimize mode
   ]
 ```
 
-## `OccurrenceOrderPlugin` is now on by default
+## OccurrenceOrderPlugin is now on by default
 
 The `OccurrenceOrderPlugin` is now enabled by default and has been renamed (`OccurenceOrderPlugin` in webpack 1).
 Thus make sure to remove the plugin from your configuration:
@@ -265,7 +265,7 @@ Thus make sure to remove the plugin from your configuration:
   ]
 ```
 
-## `ExtractTextWebpackPlugin` - breaking change
+## ExtractTextWebpackPlugin - breaking change
 
 [ExtractTextPlugin](https://github.com/webpack-contrib/extract-text-webpack-plugin) requires version 2 to work with webpack 2.
 
@@ -273,7 +273,7 @@ Thus make sure to remove the plugin from your configuration:
 
 The configuration changes for this plugin are mainly syntactical.
 
-### `ExtractTextPlugin.extract`
+### ExtractTextPlugin.extract
 
 ```diff
 module: {
@@ -291,7 +291,7 @@ module: {
 }
 ```
 
-### `new ExtractTextPlugin({options})`
+### new ExtractTextPlugin({options})
 
 ```diff
 plugins: [
@@ -341,7 +341,7 @@ module.exports = function (env) {
 
 See [CLI](/api/cli).
 
-## `require.ensure` and AMD `require` are asynchronous
+## require.ensure and AMD require are asynchronous
 
 These functions are now always asynchronous instead of calling their callback synchronously if the chunk is already loaded.
 
@@ -402,7 +402,7 @@ module.exports = {
 };
 ```
 
-## `LoaderOptionsPlugin` context
+## LoaderOptionsPlugin context
 
 Some loaders need context information and read them from the configuration. This needs to be passed via loader options in the long-term. See loader documentation for relevant options.
 
@@ -418,7 +418,7 @@ To keep compatibility with old loaders, this information can be passed via plugi
   ]
 ```
 
-## `debug`
+## debug
 
 The `debug` option switched loaders to debug mode in webpack 1. This needs to be passed via loader options in long-term. See loader documentation for relevant options.
 

--- a/src/content/plugins/dll-plugin.mdx
+++ b/src/content/plugins/dll-plugin.mdx
@@ -17,7 +17,7 @@ related:
 
 The `DllPlugin` and `DllReferencePlugin` provide means to split bundles in a way that can drastically improve build time performance. The term "DLL" stands for Dynamic-link library which was originally introduced by Microsoft.
 
-## `DllPlugin`
+## DllPlugin
 
 This plugin is used in a separate webpack configuration exclusively to create a dll-only-bundle. It creates a `manifest.json` file, which is used by the [`DllReferencePlugin`](#dllreferenceplugin) to map dependencies.
 
@@ -38,7 +38,7 @@ Creates a `manifest.json` which is written to the given `path`. It contains mapp
 
 Combine this plugin with [`output.library`](/configuration/output/#outputlibrary) option to expose (aka, put into the global scope) the dll function.
 
-## `DllReferencePlugin`
+## DllReferencePlugin
 
 This plugin is used in the primary webpack config, it references the dll-only-bundle(s) to require pre-built dependencies.
 

--- a/src/content/plugins/environment-plugin.mdx
+++ b/src/content/plugins/environment-plugin.mdx
@@ -103,7 +103,7 @@ new webpack.EnvironmentPlugin({
 });
 ```
 
-## `DotenvPlugin`
+## DotenvPlugin
 
 The third-party [`DotenvPlugin`](https://github.com/mrsteele/dotenv-webpack) (`dotenv-webpack`) allows you to expose (a subset of) [dotenv variables](https://www.npmjs.com/package/dotenv):
 

--- a/src/content/plugins/limit-chunk-count-plugin.mdx
+++ b/src/content/plugins/limit-chunk-count-plugin.mdx
@@ -22,7 +22,7 @@ new webpack.optimize.LimitChunkCountPlugin({
 
 The following options are supported:
 
-### `maxChunks`
+### maxChunks
 
 `number`
 
@@ -42,7 +42,7 @@ module.exports = {
 };
 ```
 
-### `minChunkSize`
+### minChunkSize
 
 Keeping chunk size above the specified limit is no longer a feature of this plugin. Use [MinChunkSizePlugin](/plugins/min-chunk-size-plugin) instead.
 

--- a/src/content/plugins/split-chunks-plugin.mdx
+++ b/src/content/plugins/split-chunks-plugin.mdx
@@ -171,7 +171,7 @@ Minimum size, in bytes, for a chunk to be generated.
 
 ### splitChunks.enforceSizeThreshold
 
-#### splitChunks.cacheGroups.{cacheGroup}.enforceSizeThreshold
+#### `splitChunks.cacheGroups.{cacheGroup}.enforceSizeThreshold`
 
 `number = 50000`
 
@@ -179,7 +179,7 @@ Size threshold at which splitting is enforced and other restrictions (minRemaini
 
 ### splitChunks.minRemainingSize
 
-#### splitChunks.cacheGroups.{cacheGroup}.minRemainingSize
+#### `splitChunks.cacheGroups.{cacheGroup}.minRemainingSize`
 
 `number = 0`
 
@@ -189,7 +189,7 @@ W> `splitChunks.minRemainingSize` only takes effect when a single chunk is remai
 
 ### splitChunks.layer
 
-#### splitChunks.cacheGroups.{cacheGroup}.layer
+#### `splitChunks.cacheGroups.{cacheGroup}.layer`
 
 `RegExp` `string` `function`
 
@@ -281,7 +281,7 @@ W> When assigning equal names to different split chunks, all vendor modules are 
 
 ### splitChunks.usedExports
 
-#### splitChunks.cacheGroups{cacheGroup}.usedExports
+#### `splitChunks.cacheGroups{cacheGroup}.usedExports`
 
 `boolean = true`
 
@@ -307,13 +307,13 @@ module.exports = {
 };
 ```
 
-#### splitChunks.cacheGroups.{cacheGroup}.priority
+#### `splitChunks.cacheGroups.{cacheGroup}.priority`
 
 `number = -20`
 
 A module can belong to multiple cache groups. The optimization will prefer the cache group with a higher `priority`. The default groups have a negative priority to allow custom groups to take higher priority (default value is `0` for custom groups).
 
-#### splitChunks.cacheGroups.{cacheGroup}.reuseExistingChunk
+#### `splitChunks.cacheGroups.{cacheGroup}.reuseExistingChunk`
 
 `boolean = true`
 
@@ -336,7 +336,7 @@ module.exports = {
 };
 ```
 
-#### splitChunks.cacheGroups.{cacheGroup}.type
+#### `splitChunks.cacheGroups.{cacheGroup}.type`
 
 `function` `RegExp` `string`
 
@@ -361,7 +361,7 @@ module.exports = {
 
 #### splitChunks.cacheGroups.test
 
-#### splitChunks.cacheGroups.{cacheGroup}.test
+#### `splitChunks.cacheGroups.{cacheGroup}.test`
 
 `function (module, { chunkGraph, moduleGraph }) => boolean` `RegExp` `string`
 
@@ -422,7 +422,7 @@ module.exports = {
 };
 ```
 
-#### splitChunks.cacheGroups.{cacheGroup}.filename
+#### `splitChunks.cacheGroups.{cacheGroup}.filename`
 
 `string` `function (pathData, assetInfo) => string`
 
@@ -489,7 +489,7 @@ module.exports = {
 };
 ```
 
-#### splitChunks.cacheGroups.{cacheGroup}.enforce
+#### `splitChunks.cacheGroups.{cacheGroup}.enforce`
 
 `boolean = false`
 
@@ -512,7 +512,7 @@ module.exports = {
 };
 ```
 
-#### splitChunks.cacheGroups.{cacheGroup}.idHint
+#### `splitChunks.cacheGroups.{cacheGroup}.idHint`
 
 `string`
 

--- a/src/content/plugins/split-chunks-plugin.mdx
+++ b/src/content/plugins/split-chunks-plugin.mdx
@@ -50,7 +50,7 @@ webpack provides a set of options for developers that want more control over thi
 
 W> The default configuration was chosen to fit web performance best practices, but the optimal strategy for your project might differ. If you're changing the configuration, you should measure the effect of your changes to ensure there's a real benefit.
 
-## `optimization.splitChunks`
+## optimization.splitChunks
 
 This configuration object represents the default behavior of the `SplitChunksPlugin`.
 
@@ -89,13 +89,13 @@ W> When files paths are processed by webpack, they always contain `/` on Unix sy
 
 W> Since webpack 5, passing an entry name to `{cacheGroup}.test` and using a name of an existing chunk for `{cacheGroup}.name` is no longer allowed.
 
-### `splitChunks.automaticNameDelimiter`
+### splitChunks.automaticNameDelimiter
 
 `string = '~'`
 
 By default webpack will generate names using origin and name of the chunk (e.g. `vendors~main.js`). This option lets you specify the delimiter to use for the generated names.
 
-### `splitChunks.chunks`
+### splitChunks.chunks
 
 `string = 'async'` `function (chunk)`
 
@@ -133,53 +133,53 @@ module.exports = {
 
 T> You can combine this configuration with the [HtmlWebpackPlugin](/plugins/html-webpack-plugin/). It will inject all the generated vendor chunks for you.
 
-### `splitChunks.maxAsyncRequests`
+### splitChunks.maxAsyncRequests
 
 `number = 30`
 
 Maximum number of parallel requests when on-demand loading.
 
-### `splitChunks.maxInitialRequests`
+### splitChunks.maxInitialRequests
 
 `number = 30`
 
 Maximum number of parallel requests at an entry point.
 
-### `splitChunks.defaultSizeTypes`
+### splitChunks.defaultSizeTypes
 
 `[string] = ['javascript', 'unknown']`
 
 Sets the size types which are used when a number is used for sizes.
 
-### `splitChunks.minChunks`
+### splitChunks.minChunks
 
 `number = 1`
 
 The minimum times must a module be shared among chunks before splitting.
 
-### `splitChunks.hidePathInfo`
+### splitChunks.hidePathInfo
 
 `boolean`
 
 Prevents exposing path info when creating names for parts splitted by maxSize.
 
-### `splitChunks.minSize`
+### splitChunks.minSize
 
 `number = 20000`
 
 Minimum size, in bytes, for a chunk to be generated.
 
-### `splitChunks.enforceSizeThreshold`
+### splitChunks.enforceSizeThreshold
 
-#### `splitChunks.cacheGroups.{cacheGroup}.enforceSizeThreshold`
+#### splitChunks.cacheGroups.{cacheGroup}.enforceSizeThreshold
 
 `number = 50000`
 
 Size threshold at which splitting is enforced and other restrictions (minRemainingSize, maxAsyncRequests, maxInitialRequests) are ignored.
 
-### `splitChunks.minRemainingSize`
+### splitChunks.minRemainingSize
 
-#### `splitChunks.cacheGroups.{cacheGroup}.minRemainingSize`
+#### splitChunks.cacheGroups.{cacheGroup}.minRemainingSize
 
 `number = 0`
 
@@ -187,15 +187,15 @@ Size threshold at which splitting is enforced and other restrictions (minRemaini
 
 W> `splitChunks.minRemainingSize` only takes effect when a single chunk is remaining.
 
-### `splitChunks.layer`
+### splitChunks.layer
 
-#### `splitChunks.cacheGroups.{cacheGroup}.layer`
+#### splitChunks.cacheGroups.{cacheGroup}.layer
 
 `RegExp` `string` `function`
 
 Assign modules to a cache group by module layer.
 
-### `splitChunks.maxSize`
+### splitChunks.maxSize
 
 `number = 0`
 
@@ -210,7 +210,7 @@ T> `maxSize` takes higher priority than `maxInitialRequest/maxAsyncRequests`. Ac
 
 T> Setting the value for `maxSize` sets the value for both `maxAsyncSize` and `maxInitialSize`.
 
-### `splitChunks.maxAsyncSize`
+### splitChunks.maxAsyncSize
 
 `number`
 
@@ -218,7 +218,7 @@ Like `maxSize`, `maxAsyncSize` can be applied globally (`splitChunks.maxAsyncSiz
 
 The difference between `maxAsyncSize` and `maxSize` is that `maxAsyncSize` will only affect on-demand loading chunks.
 
-### `splitChunks.maxInitialSize`
+### splitChunks.maxInitialSize
 
 `number`
 
@@ -226,7 +226,7 @@ Like `maxSize`, `maxInitialSize` can be applied globally (`splitChunks.maxInitia
 
 The difference between `maxInitialSize` and `maxSize` is that `maxInitialSize` will only affect initial load chunks.
 
-### `splitChunks.name`
+### splitChunks.name
 
 `boolean = false` `function (module, chunks, cacheGroupKey) => string` `string`
 
@@ -279,16 +279,16 @@ Running webpack with following `splitChunks` configuration would also output a c
 
 W> When assigning equal names to different split chunks, all vendor modules are placed into a single shared chunk, though it's not recommend since it can result in more code downloaded.
 
-### `splitChunks.usedExports`
+### splitChunks.usedExports
 
-#### `splitChunks.cacheGroups{cacheGroup}.usedExports`
+#### splitChunks.cacheGroups{cacheGroup}.usedExports
 
 `boolean = true`
 
 Figure out which exports are used by modules to mangle export names, omit unused exports and generate more efficient code.
 When it is `true`: analyse used exports for each runtime, when it is `"global"`: analyse exports globally for all runtimes combined).
 
-### `splitChunks.cacheGroups`
+### splitChunks.cacheGroups
 
 Cache groups can inherit and/or override any options from `splitChunks.*`; but `test`, `priority` and `reuseExistingChunk` can only be configured on cache group level. To disable any of the default cache groups, set them to `false`.
 
@@ -307,13 +307,13 @@ module.exports = {
 };
 ```
 
-#### `splitChunks.cacheGroups.{cacheGroup}.priority`
+#### splitChunks.cacheGroups.{cacheGroup}.priority
 
 `number = -20`
 
 A module can belong to multiple cache groups. The optimization will prefer the cache group with a higher `priority`. The default groups have a negative priority to allow custom groups to take higher priority (default value is `0` for custom groups).
 
-#### `splitChunks.cacheGroups.{cacheGroup}.reuseExistingChunk`
+#### splitChunks.cacheGroups.{cacheGroup}.reuseExistingChunk
 
 `boolean = true`
 
@@ -336,7 +336,7 @@ module.exports = {
 };
 ```
 
-#### `splitChunks.cacheGroups.{cacheGroup}.type`
+#### splitChunks.cacheGroups.{cacheGroup}.type
 
 `function` `RegExp` `string`
 
@@ -359,9 +359,9 @@ module.exports = {
 };
 ```
 
-#### `splitChunks.cacheGroups.test`
+#### splitChunks.cacheGroups.test
 
-#### `splitChunks.cacheGroups.{cacheGroup}.test`
+#### splitChunks.cacheGroups.{cacheGroup}.test
 
 `function (module, { chunkGraph, moduleGraph }) => boolean` `RegExp` `string`
 
@@ -422,7 +422,7 @@ module.exports = {
 };
 ```
 
-#### `splitChunks.cacheGroups.{cacheGroup}.filename`
+#### splitChunks.cacheGroups.{cacheGroup}.filename
 
 `string` `function (pathData, assetInfo) => string`
 
@@ -489,7 +489,7 @@ module.exports = {
 };
 ```
 
-#### `splitChunks.cacheGroups.{cacheGroup}.enforce`
+#### splitChunks.cacheGroups.{cacheGroup}.enforce
 
 `boolean = false`
 
@@ -512,7 +512,7 @@ module.exports = {
 };
 ```
 
-#### `splitChunks.cacheGroups.{cacheGroup}.idHint`
+#### splitChunks.cacheGroups.{cacheGroup}.idHint
 
 `string`
 


### PR DESCRIPTION
Avoid `code(``)` in heading as it has different font family and also for consistency throughout the docs