### PR TITLE
Clarify use of paths in Condition

### DIFF
--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -1022,7 +1022,7 @@ module.exports = {
           // e.g. `app/styles.css`, `app/styles/styles.css`, `app/stylesheet.css`
           path.resolve(__dirname, 'app/styles'),
           // add an extra slash to only include the content of the directory `vendor/styles/`
-          path.resolve(__dirname, 'vendor/styles') + '/', 
+          path.join(__dirname, 'vendor/styles/'), 
         ],
       },
     ],

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -1018,8 +1018,8 @@ module.exports = {
       {
         test: /\\.css$/,
         include: [
-          path.resolve(__dirname, 'app/styles'),
-          path.resolve(__dirname, 'vendor/styles'),
+          path.resolve(__dirname, 'app/styles'), // will include any paths relative to the current directory starting with `app/styles`, e.g. `app/styles.css`, `app/styles/styles.css`, `app/stylesheet.css`
+          path.resolve(__dirname, 'vendor/styles') + '/', // add an extra slash to only include the content of the directory `vendor/styles/`
         ],
       },
     ],

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -1018,8 +1018,11 @@ module.exports = {
       {
         test: /\\.css$/,
         include: [
-          path.resolve(__dirname, 'app/styles'), // will include any paths relative to the current directory starting with `app/styles`, e.g. `app/styles.css`, `app/styles/styles.css`, `app/stylesheet.css`
-          path.resolve(__dirname, 'vendor/styles') + '/', // add an extra slash to only include the content of the directory `vendor/styles/`
+          // will include any paths relative to the current directory starting with `app/styles`
+          // e.g. `app/styles.css`, `app/styles/styles.css`, `app/stylesheet.css`
+          path.resolve(__dirname, 'app/styles'),
+          // add an extra slash to only include the content of the directory `vendor/styles/`
+          path.resolve(__dirname, 'vendor/styles') + '/', 
         ],
       },
     ],


### PR DESCRIPTION
Due to path.resolve not adding a trailing slash automatically, building a Condition using it might apply to more than the user expects. Modified the example slightly and added some comments to it.