### PR TITLE
docs(configuration): update link for `serve` options

### DIFF
--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -81,7 +81,7 @@ You can invoke webpack-dev-server via CLI by:
 npx webpack serve
 ```
 
-A list of CLI options for `serve` is available [here](https://github.com/webpack/webpack-cli/blob/master/SERVE-OPTIONS-v3.md)
+A list of CLI options for `serve` is available [here](https://github.com/webpack/webpack-cli/blob/master/SERVE-OPTIONS-v4.md)
 
 ## `devServer.allowedHosts`
 


### PR DESCRIPTION
update the link to v4 options.