### PR TITLE
docs(configuration): fix typo in `devServer.onListening` usage

### DIFF
--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -842,7 +842,7 @@ module.exports = {
   //...
   devServer: {
     onListening: function (server) {
-      const port = server.address().port;
+      const port = server.server.address().port;
       console.log('Listening on port:', port);
     },
   },

--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -841,8 +841,8 @@ Provides the ability to execute a custom function when webpack-dev-server starts
 module.exports = {
   //...
   devServer: {
-    onListening: function (server) {
-      const port = server.server.address().port;
+    onListening: function (devServer) {
+      const port = devServer.server.address().port;
       console.log('Listening on port:', port);
     },
   },

--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -842,6 +842,10 @@ module.exports = {
   //...
   devServer: {
     onListening: function (devServer) {
+      if (!devServer) {
+        throw new Error('webpack-dev-server is not defined');
+      }
+
       const port = devServer.server.address().port;
       console.log('Listening on port:', port);
     },


### PR DESCRIPTION
It should be `server.server.address()`