### PR TITLE
Fix related link format

### DIFF
--- a/src/content/guides/code-splitting.mdx
+++ b/src/content/guides/code-splitting.mdx
@@ -38,7 +38,7 @@ related:
     url: https://medium.com/webpack/link-rel-prefetch-preload-in-webpack-51a52358f84c
   - title: Preload, Prefetch And Priorities in Chrome
     url: https://medium.com/reloading/preload-prefetch-and-priorities-in-chrome-776165961bbf
-  - title: Preloading content with rel="preload"
+  - title: Preloading content with <link rel="preload" />
     url: https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content
 ---
 

--- a/src/content/guides/code-splitting.mdx
+++ b/src/content/guides/code-splitting.mdx
@@ -32,8 +32,9 @@ contributors:
   - smelukov
   - chenxsan
   - Adarah
+  - atesgoral
 related:
-  - title: &lt;link rel="prefetch/preload"&gt; in webpack
+  - title: <link rel="prefetch/preload"> in webpack
     url: https://medium.com/webpack/link-rel-prefetch-preload-in-webpack-51a52358f84c
   - title: Preload, Prefetch And Priorities in Chrome
     url: https://medium.com/reloading/preload-prefetch-and-priorities-in-chrome-776165961bbf

--- a/src/content/guides/code-splitting.mdx
+++ b/src/content/guides/code-splitting.mdx
@@ -34,7 +34,7 @@ contributors:
   - Adarah
   - atesgoral
 related:
-  - title: <link rel="prefetch/preload"> in webpack
+  - title: <link rel="prefetch/preload" /> in webpack
     url: https://medium.com/webpack/link-rel-prefetch-preload-in-webpack-51a52358f84c
   - title: Preload, Prefetch And Priorities in Chrome
     url: https://medium.com/reloading/preload-prefetch-and-priorities-in-chrome-776165961bbf


### PR DESCRIPTION
The **Further Reading** section on https://webpack.js.org/guides/code-splitting/ has a dangling `&gt;`:

![image](https://user-images.githubusercontent.com/50832/130184840-6bc2fa57-3e10-42a0-812a-335455c116a0.png)

Fixing this by converting the HTML entities to the actual angle brackets:

![image](https://user-images.githubusercontent.com/50832/130184963-907f3e1d-c3b6-48e7-92cb-492449ea3e3e.png)

**Note:** The last item in this list completely omits the `<link>` and just mentions `rel="preload"`, so it could also be a good idea to standardize either using a `<link>` or not.