### PR TITLE
docs: replace contentBase by static

### DIFF
--- a/examples/module-federation/app1/package.json
+++ b/examples/module-federation/app1/package.json
@@ -19,6 +19,6 @@
     "html-webpack-plugin": "^5.3.1",
     "webpack": "^5.38.1",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.0.0"
   }
 }

--- a/examples/module-federation/app1/webpack.config.js
+++ b/examples/module-federation/app1/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: path.join(__dirname, "dist"),
     port: 3001,
   },
   output: {

--- a/examples/module-federation/app2/package.json
+++ b/examples/module-federation/app2/package.json
@@ -18,6 +18,6 @@
     "html-webpack-plugin": "^5.3.1",
     "webpack": "^5.38.1",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.0.0"
   }
 }

--- a/examples/module-federation/app2/webpack.config.js
+++ b/examples/module-federation/app2/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
   entry: './src/index',
   mode: 'development',
   devServer: {
-    contentBase: path.join(__dirname, 'dist'),
+    static: path.join(__dirname, 'dist'),
     port: 3002,
   },
   output: {

--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -1110,7 +1110,7 @@ module.exports = {
   devServer: {
     index: '', // specify to enable root proxying
     host: '...',
-    contentBase: '...',
+    static: '...',
     proxy: {
       context: () => true,
       target: 'http://localhost:1234',

--- a/src/content/configuration/index.mdx
+++ b/src/content/configuration/index.mdx
@@ -874,7 +874,7 @@ module.exports = {
     proxy: { // proxy URLs to backend development server
       '/api': 'http://localhost:3000'
     },
-    contentBase: path.join(__dirname, 'public'), // boolean | string | array, static file location
+    static: path.join(__dirname, 'public'), // boolean | string | array, static file location
     compress: true, // enable gzip compression
     historyApiFallback: true, // true for index.html upon 404, object for multiple paths
     hot: true, // hot module replacement. Depends on HotModuleReplacementPlugin

--- a/src/content/contribute/writers-guide.mdx
+++ b/src/content/contribute/writers-guide.mdx
@@ -112,8 +112,8 @@ Tables should also be ordered alphabetically.
 The [configuration](/configuration) properties should be ordered alphabetically as well:
 
 - `devServer.compress`
-- `devServer.contentBase`
 - `devServer.hot`
+- `devServer.static`
 
 ### Quotes
 

--- a/src/content/guides/development.mdx
+++ b/src/content/guides/development.mdx
@@ -212,7 +212,7 @@ Change your configuration file to tell the dev server where to look for files:
    },
    devtool: 'inline-source-map',
 +  devServer: {
-+    contentBase: './dist',
++    static: './dist',
 +  },
    plugins: [
      new HtmlWebpackPlugin({
@@ -296,7 +296,7 @@ Now we need to make some adjustments to our webpack configuration file in order 
    },
    devtool: 'inline-source-map',
    devServer: {
-     contentBase: './dist',
+     static: './dist',
    },
    plugins: [
      new HtmlWebpackPlugin({

--- a/src/content/guides/hot-module-replacement.mdx
+++ b/src/content/guides/hot-module-replacement.mdx
@@ -53,7 +53,7 @@ T> If you took the route of using `webpack-dev-middleware` instead of `webpack-d
     },
     devtool: 'inline-source-map',
     devServer: {
-      contentBase: './dist',
+      static: './dist',
 +     hot: true,
     },
     plugins: [
@@ -144,7 +144,7 @@ const webpack = require('webpack');
 
 const config = require('./webpack.config.js');
 const options = {
-  contentBase: './dist',
+  static: './dist',
   hot: true,
   host: 'localhost',
 };
@@ -229,7 +229,7 @@ Now let's update the configuration file to make use of the loader.
     },
     devtool: 'inline-source-map',
     devServer: {
-      contentBase: './dist',
+      static: './dist',
       hot: true,
     },
 +   module: {

--- a/src/content/guides/production.mdx
+++ b/src/content/guides/production.mdx
@@ -90,7 +90,7 @@ npm install --save-dev webpack-merge
 +   mode: 'development',
 +   devtool: 'inline-source-map',
 +   devServer: {
-+     contentBase: './dist',
++     static: './dist',
 +   },
 + });
 ```


### PR DESCRIPTION
`contentBase` has been deprecated by `static`. This changes the docs accordingly so people will be able to read up-to-date docs.
