### PR TITLE
Fix --open-aoo-name typo

### DIFF
--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -930,7 +930,7 @@ module.exports = {
 Usage via the CLI:
 
 ```bash
-npx webpack serve --open-aoo-name 'google-chrome'
+npx webpack serve --open-app-name 'google-chrome'
 ```
 
 The object accepts all [open](https://www.npmjs.com/package/open) options:


### PR DESCRIPTION
Fix typo `--open-aoo-name` to `--open-app-name`