### PR TITLE
set limit for dependabot to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    open-pull-requests-limit: 10
     schedule:
       interval: "daily"
     labels:


### PR DESCRIPTION
The default limit is 5, currently we have [5 of them](https://github.com/webpack/webpack.js.org/pulls?q=is%3Apr+is%3Aopen+label%3Adependencies) which can't be merged because of the ESM compatibility problem.