### PR TITLE
docs(api): add troubleshooting with typescript ECMA modules

### DIFF
--- a/src/content/api/cli.mdx
+++ b/src/content/api/cli.mdx
@@ -613,6 +613,8 @@ WEBPACK_PACKAGE=webpack-5 npx webpack
 
 ### TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for ./webpack.config.ts
 
+You might encounter this error in acnse of typescript ECMA modules (i.e. `type: "module"` in `package.json`).
+
 `webpack-cli` supports `commonjs` and `ES` format, at first it tries to load a configuration using `require()`, if it fails with an error code of `'ERR_REQUIRE_ESM'` (special code for this case) it tries to load the configuration using `import()`.
 But here are some problems, without `--loader=ts-node/esm` `import()` will not work with `ts-node` - need runtime hooks (described here [`TypeStrong/ts-node#1007`](https://github.com/TypeStrong/ts-node/issues/1007)).
 

--- a/src/content/api/cli.mdx
+++ b/src/content/api/cli.mdx
@@ -613,13 +613,13 @@ WEBPACK_PACKAGE=webpack-5 npx webpack
 
 ### TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for ./webpack.config.ts
 
-You might encounter this error in the case of typescript ECMA modules (i.e. `type: "module"` in `package.json`).
+You might encounter this error in the case of using native ESM in TypeScript (i.e. `type: "module"` in `package.json`).
 
-`webpack-cli` supports `commonjs` and `ES` format, at first it tries to load a configuration using `require()`, if it fails with an error code of `'ERR_REQUIRE_ESM'` (special code for this case) it tries to load the configuration using `import()`.
-But here are some problems, without `--loader=ts-node/esm` `import()` will not work with `ts-node` - need runtime hooks (described here [`TypeStrong/ts-node#1007`](https://github.com/TypeStrong/ts-node/issues/1007)).
+`webpack-cli` supports configuration in both `CommonJS` and `ESM` format, at first it tries to load a configuration using `require()`, once it fails with an error code of `'ERR_REQUIRE_ESM'` (a special code for this case) it would try to load the configuration using `import()`.
+However, the `import()` method won't work with `ts-node` without [loader hooks](https://nodejs.org/api/esm.html#esm_experimental_loaders) enabled (described at [`TypeStrong/ts-node#1007`](https://github.com/TypeStrong/ts-node/issues/1007)).
 
 To fix the error above use the following command:
 
 ```bash
-NODE_OPTIONS="--loader ts-node/esm" npx webpack --entry ./index.js --mode production
+NODE_OPTIONS="--loader ts-node/esm" npx webpack --entry ./src/index.js --mode production
 ```

--- a/src/content/api/cli.mdx
+++ b/src/content/api/cli.mdx
@@ -613,7 +613,7 @@ WEBPACK_PACKAGE=webpack-5 npx webpack
 
 ### TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for ./webpack.config.ts
 
-You might encounter this error in acnse of typescript ECMA modules (i.e. `type: "module"` in `package.json`).
+You might encounter this error in the case of typescript ECMA modules (i.e. `type: "module"` in `package.json`).
 
 `webpack-cli` supports `commonjs` and `ES` format, at first it tries to load a configuration using `require()`, if it fails with an error code of `'ERR_REQUIRE_ESM'` (special code for this case) it tries to load the configuration using `import()`.
 But here are some problems, without `--loader=ts-node/esm` `import()` will not work with `ts-node` - need runtime hooks (described here [`TypeStrong/ts-node#1007`](https://github.com/TypeStrong/ts-node/issues/1007)).

--- a/src/content/api/cli.mdx
+++ b/src/content/api/cli.mdx
@@ -608,3 +608,16 @@ To use `webpack v5.32.0`:
 ```bash
 WEBPACK_PACKAGE=webpack-5 npx webpack
 ```
+
+## Troubleshooting
+
+### TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for ./webpack.config.ts
+
+`webpack-cli` supports `commonjs` and `ES` format, at first it tries to load a configuration using `require()`, if it fails with an error code of `'ERR_REQUIRE_ESM'` (special code for this case) it tries to load the configuration using `import()`.
+But here are some problems, without `--loader=ts-node/esm` `import()` will not work with `ts-node` - need runtime hooks (described here [`TypeStrong/ts-node#1007`](https://github.com/TypeStrong/ts-node/issues/1007)).
+
+To fix the error above use the following command:
+
+```bash
+NODE_OPTIONS="--loader ts-node/esm" npx webpack --entry ./index.js --mode production
+```


### PR DESCRIPTION
add troubleshooting with typescript ECMA modules.

Resolve https://github.com/webpack/webpack-cli/issues/2916