### PR TITLE
docs(configuration): add default value for `historyApiFallback`

### DIFF
--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -622,7 +622,7 @@ module.exports = {
 
 ## devServer.historyApiFallback
 
-`boolean` `object`
+`boolean = false` `object`
 
 When using the [HTML5 History API](https://developer.mozilla.org/en-US/docs/Web/API/History), the `index.html` page will likely have to be served in place of any `404` responses. Enable `devServer.historyApiFallback` by setting it to `true`:
 


### PR DESCRIPTION
Add default for `devServer.historyApiFallback`.

https://github.com/webpack/webpack-dev-server/blob/0ba652a9d8bac9544c85f79dd8aceeb2b74c27c4/lib/Server.js#L499