### PR TITLE
docs(configuration): add default value for `hot` option

### DIFF
--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -740,7 +740,7 @@ npx webpack serve --host local-ipv6
 
 ## devServer.hot
 
-`'only'` `boolean`
+`'only'` `boolean = true`
 
 Enable webpack's [Hot Module Replacement](/concepts/hot-module-replacement/) feature:
 


### PR DESCRIPTION
add default value for `devServer.hot`.

https://github.com/webpack/webpack-dev-server/blob/79e4bd73655dd20f7ee117091a6762c7f645dac3/lib/Server.js#L509