### PR TITLE
docs(configuration): add the default value for the `bonjour` option

### DIFF
--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -169,7 +169,7 @@ npx webpack serve --allowed-hosts auto
 
 ## devServer.bonjour
 
-`boolean` `object`
+`boolean = false` `object`
 
 This option broadcasts the server via [ZeroConf](http://www.zeroconf.org/) networking on start.
 


### PR DESCRIPTION
add the default value for the `bonjour` option.

https://github.com/webpack/webpack-dev-server/blob/d4282dc2f6858b2768658fbc091660bdd704cb05/lib/Server.js#L434