### PR TITLE
docs(configuration): update `https` and `historyApiFallback`

### DIFF
--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -566,6 +566,18 @@ module.exports = {
 };
 ```
 
+Usage via the CLI:
+
+```bash
+npx webpack serve --https
+```
+
+To disable:
+
+```bash
+npx webpack serve --no-https
+```
+
 With the above setting, a self-signed certificate is used, but you can provide your own:
 
 **webpack.config.js**
@@ -586,18 +598,6 @@ module.exports = {
 ```
 
 This object is passed straight to Node.js HTTPS module, so see the [HTTPS documentation](https://nodejs.org/api/https.html) for more information.
-
-Usage via the CLI:
-
-```bash
-npx webpack serve --https
-```
-
-To disable:
-
-```bash
-npx webpack serve --no-https
-```
 
 To pass your own certificate via the CLI use the following options:
 
@@ -641,6 +641,18 @@ module.exports = {
 };
 ```
 
+Usage via the CLI:
+
+```bash
+npx webpack serve --history-api-fallback
+```
+
+To disable:
+
+```bash
+npx webpack serve --no-history-api-fallback
+```
+
 By passing an object this behavior can be controlled further using options like `rewrites`:
 
 **webpack.config.js**
@@ -673,18 +685,6 @@ module.exports = {
     },
   },
 };
-```
-
-Usage via the CLI:
-
-```bash
-npx webpack serve --history-api-fallback
-```
-
-To disable:
-
-```bash
-npx webpack serve --no-history-api-fallback
 ```
 
 For more options and information, see the [connect-history-api-fallback](https://github.com/bripkens/connect-history-api-fallback) documentation.


### PR DESCRIPTION
Move CLI usage close to the related configuration, like the rest of the options. 
