### PR TITLE
docs(api): remove outdated webpack 4 warning

### DIFF
--- a/src/content/api/compilation-object.mdx
+++ b/src/content/api/compilation-object.mdx
@@ -292,8 +292,6 @@ Parameters:
 
 `function (file, source, assetInfo = {})`
 
-W> Available since webpack 4.40.0
-
 Parameters:
 
 - `file` - file name of the asset
@@ -303,8 +301,6 @@ Parameters:
 ### updateAsset
 
 `function (file, newSourceOrFunction, assetInfoUpdateOrFunction)`
-
-W> Available since webpack 4.40.0
 
 Parameters:
 
@@ -324,15 +320,11 @@ Parameters:
 
 `function`
 
-W> Available since webpack 4.40.0
-
 Returns array of all assets under the current compilation.
 
 ### getAsset
 
 `function (name)`
-
-W> Available since webpack 4.40.0
 
 Parameters:
 


### PR DESCRIPTION
current docs aim for `webpack >= v5.0.0`