### PR TITLE
docs(configuration): update `devServer.http2`

### DIFF
--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -515,6 +515,18 @@ module.exports = {
 };
 ```
 
+Usage via CLI
+
+```bash
+npx webpack serve --http2
+```
+
+To disable:
+
+```bash
+npx webpack serve --no-http2
+```
+
 Provide your own certificate using the [https](#devserverhttps) option:
 
 **webpack.config.js**
@@ -531,18 +543,6 @@ module.exports = {
     },
   },
 };
-```
-
-Usage via CLI
-
-```bash
-npx webpack serve --http2
-```
-
-To disable:
-
-```bash
-npx webpack serve --no-http2
 ```
 
 To pass your own certificate via CLI, use the following options:


### PR DESCRIPTION
Move CLI usage close to the related configuration, like the rest of the options.