### PR TITLE
fix missing classNames for pre

### DIFF
--- a/src/components/Configuration/Configuration.jsx
+++ b/src/components/Configuration/Configuration.jsx
@@ -1,5 +1,6 @@
 import { Children, isValidElement } from 'react';
 import { Details } from './components';
+import PropTypes from 'prop-types';
 
 const detailComponentsList = [
   'link',
@@ -77,9 +78,11 @@ export const Pre = (props) => {
   };
 
   return (
-    <pre>
+    <pre className={props?.children?.props?.className ?? ''}>
       <code {...newProps} />
     </pre>
   );
 };
-Pre.propTypes = {};
+Pre.propTypes = {
+  children: PropTypes.node,
+};


### PR DESCRIPTION
`className` for `pre` is missing now:

![](https://user-images.githubusercontent.com/1091472/132123173-944bea9c-c889-4a71-b015-aae092254014.png)

Should be something like `language-diff` etc. I believe it's a bug introduced when migrating to mdx.

## After

![](https://user-images.githubusercontent.com/1091472/132123438-9d902cc9-036b-44f6-a89a-efcc1acef7d1.png)
