### PR TITLE
docs(configuration): fix typo

### DIFF
--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -474,7 +474,7 @@ To disable:
 npx webpack serve --no-compress
 ```
 
-## devserver.devMiddleware
+## devServer.devMiddleware
 
 `object`
 


### PR DESCRIPTION
`devserver` -> `devServer`