### PR TITLE
docs(module-federation): Fix typo

### DIFF
--- a/src/content/concepts/module-federation.mdx
+++ b/src/content/concepts/module-federation.mdx
@@ -10,6 +10,7 @@ contributors:
   - snitin315
   - XiaofengXie16
   - KyleBastien
+  - Alevale
 related:
   - title: 'Webpack 5 Module Federation: A game-changer in JavaScript architecture'
     url: https://medium.com/swlh/webpack-5-module-federation-a-game-changer-to-javascript-architecture-bcdd30e02669
@@ -219,7 +220,7 @@ This approach is particularly helpful when you mount independently deployed chil
 Scenario:
 
 You have a host app hosted on `https://my-host.com/app/*` and a child app hosted on `https://foo-app.com`. The child app is also mounted on the host domain, hence,
-`https://foo-app.com` is expected to be accessible via `https://my-host.com/app/foo-app` and `https://my-host.com/app/foo/*` requests are redirected to `https://foo-app.com/*` via a proxy.
+`https://foo-app.com` is expected to be accessible via `https://my-host.com/app/foo-app` and `https://my-host.com/app/foo-app/*` requests are redirected to `https://foo-app.com/*` via a proxy.
 
 Example:
 


### PR DESCRIPTION
_Small fix to correct a typo on the URL for the module federation "public-path" explanation_
