### PR TITLE
docs(configuration): add example for `devServer.headers` as function

### DIFF
--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -626,6 +626,19 @@ module.exports = {
 };
 ```
 
+You can also pass a function:
+
+```javascript
+module.exports = {
+  //...
+  devServer: {
+    headers: () => {
+      return { 'X-Bar': ['key1=value1', 'key2=value2'] };
+    },
+  },
+};
+```
+
 ## devServer.historyApiFallback
 
 `boolean = false` `object`


### PR DESCRIPTION
add an example configuration for `devServer.headers` as function.