### PR TITLE
docs(configuration): fix `https` CLI usage

### DIFF
--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -604,7 +604,7 @@ This object is passed straight to Node.js HTTPS module, so see the [HTTPS docume
 To pass your own certificate via the CLI use the following options:
 
 ```bash
-npx webpack serve --https-key ./path/to/server.key --https--cert ./path/to/server.crt --https-cacert ./path/to/ca.pem
+npx webpack serve --https-key ./path/to/server.key --https-cert ./path/to/server.crt --https-cacert ./path/to/ca.pem
 ```
 
 ## devServer.headers


### PR DESCRIPTION
fix typo in CLI usage, `--https--cert` -> `--https-cert`