### PR TITLE
docs(configuration): add CLI usage for `devServer.port`

### DIFF
--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -1120,7 +1120,7 @@ Usage via the CLI:
 npx webpack serve --port 8080
 ```
 
-`port` option can't be `null` or empty string, to automatically use a free port please use `port: 'auto'`:
+`port` option can't be `null` or an empty string, to automatically use a free port please use `port: 'auto'`:
 
 **webpack.config.js**
 
@@ -1131,6 +1131,12 @@ module.exports = {
     port: 'auto',
   },
 };
+```
+
+Usage via the CLI:
+
+```bash
+npx webpack serve --port auto
 ```
 
 ## devServer.proxy


### PR DESCRIPTION
add CLI usage for `devServer.port`