### PR TITLE
deprecate worker-loader for webpack 5

### DIFF
--- a/src/utilities/constants.js
+++ b/src/utilities/constants.js
@@ -23,6 +23,7 @@ const excludedLoaders = [
   'webpack-contrib/null-loader',
   'webpack-contrib/mocha-loader',
   'webpack-contrib/istanbul-instrumenter-loader',
+  'webpack-contrib/worker-loader',
 ];
 const excludedPlugins = [
   'webpack-contrib/component-webpack-plugin',

--- a/webpack.ssg.js
+++ b/webpack.ssg.js
@@ -100,6 +100,8 @@ module.exports = (env) =>
             'https://v4.webpack.js.org/loaders/mocha-loader/',
           'loaders/istanbul-instrumenter-loader':
             'https://v4.webpack.js.org/loaders/istanbul-instrumenter-loader/',
+          'loaders/worker-loader/':
+            'https://v4.webpack.js.org/loaders/worker-loader/',
         },
       }),
       new CopyWebpackPlugin({


### PR DESCRIPTION
<img width="1127" alt="" src="https://user-images.githubusercontent.com/1091472/132936200-039a0696-d2fc-4ce8-9c58-ff2737cf5827.png">
