### PR TITLE
docs(plugins): update outdated content

### DIFF
--- a/src/content/plugins/internal-plugins.mdx
+++ b/src/content/plugins/internal-plugins.mdx
@@ -60,9 +60,9 @@ Plugins, which add entry chunks to the compilation.
 
 ### EntryPlugin
 
-`EntryPlugin(context, request, chunkName)`
+`EntryPlugin(context, entry, options)`
 
-Adds an entry chunk on compilation. The chunk is named `chunkName` and contains only one module (plus dependencies). The module is resolved from `request` in `context` (absolute path).
+Adds an entry chunk on compilation. The chunk is named `options.name` and contains only one module (plus dependencies). The module is resolved from `entry` in `context` (absolute path).
 
 ### PrefetchPlugin
 


### PR DESCRIPTION
See https://github.com/webpack/webpack/blob/main/lib/EntryPlugin.js#L20:

> passing a string is deprecated