### PR TITLE
upgrade directory-tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "css-loader": "^6.2.0",
     "css-minimizer-webpack-plugin": "^3.0.2",
     "cypress": "^8.4.0",
-    "directory-tree": "^2.3.1",
+    "directory-tree": "^2.4.0",
     "directory-tree-webpack-plugin": "^1.0.2",
     "duplexer": "^0.1.1",
     "eslint": "^7.32.0",

--- a/src/scripts/build-content-tree.js
+++ b/src/scripts/build-content-tree.js
@@ -31,7 +31,10 @@ function buildContentTree(source, output) {
     );
   }
 
-  let content = directoryTree(source, { extensions: /\.(md|mdx)/ });
+  let content = directoryTree(source, {
+    extensions: /\.(md|mdx)/,
+    attributes: ['size', 'type', 'extension'],
+  });
 
   content = restructure(content, {
     dir: source,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4621,10 +4621,15 @@ directory-tree-webpack-plugin@^1.0.2:
   dependencies:
     directory-tree "^2.0.0"
 
-directory-tree@^2.0.0, directory-tree@^2.3.1:
+directory-tree@^2.0.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/directory-tree/-/directory-tree-2.3.1.tgz#78b8aa84878eb84dd29a51dcd664ded4cd0247c7"
   integrity sha512-hxolIHCtQ/a56CUywaLzGD/V78zPwFihI+UK/4ZjOp7GoV4Mptmtv95yavOn/RlnTi7cCMjszvfcNrwCoWLH+Q==
+
+directory-tree@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/directory-tree/-/directory-tree-2.4.0.tgz#66113ef8c2e19f906cf73d2402fc60c2eff0fad5"
+  integrity sha512-AM03Th+ypDAHefyB6SP3uezaWkTbol1P43CS5yFU7wePTuHnR4YoHgY6KbGHLr/a065ocN26l9lXOoFBzzM31w==
 
 dlv@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
Closes https://github.com/webpack/webpack.js.org/pull/5460, seems they introduced a breaking change in a minor version.