### PR TITLE
docs(configuration): add `stats.optimizationBailout`

### DIFF
--- a/src/content/configuration/stats.mdx
+++ b/src/content/configuration/stats.mdx
@@ -790,6 +790,8 @@ module.exports = {
 
 ### stats.optimizationBailout
 
+`boolean`
+
 Tells `stats` to show the reasons why optimization bailed out for modules.
 
 ```javascript

--- a/src/content/configuration/stats.mdx
+++ b/src/content/configuration/stats.mdx
@@ -788,6 +788,19 @@ module.exports = {
 };
 ```
 
+### stats.optimizationBailout
+
+Tells `stats` to show the reasons why optimization bailed out for modules.
+
+```javascript
+module.exports = {
+  //...
+  stats: {
+    optimizationBailout: false,
+  },
+};
+```
+
 ### stats.outputPath
 
 `boolean = true`


### PR DESCRIPTION
Add `stats.optimizationBailout` option to the documentation:

https://github.com/webpack/webpack/blob/abd21a27f3ee77f2ad18c051d746690fc9511b56/schemas/WebpackOptions.json#L4332