### PR TITLE
fix: show `Contributors`/`Contributor` correctly

### DIFF
--- a/src/components/Page/Page.jsx
+++ b/src/components/Page/Page.jsx
@@ -60,9 +60,10 @@ export default function Page(props) {
     }
   }, [contentLoaded, pathname, hash]);
 
+  const numberOfContributors = contributors.length;
   const loadRelated = contentLoaded && related && related.length !== 0;
   const loadContributors =
-    contentLoaded && contributors && contributors.length !== 0;
+    contentLoaded && contributors && numberOfContributors !== 0;
 
   let contentRender;
 
@@ -116,7 +117,8 @@ export default function Page(props) {
         {loadContributors && (
           <div data-testid="contributors" className="print:hidden">
             <h2 className="!font-sans !font-normal">
-              {contributors.length} Contributors
+              {numberOfContributors}{' '}
+              {numberOfContributors === 1 ? 'Contributor' : 'Contributors'}
             </h2>
             <Contributors contributors={contributors} />
           </div>


### PR DESCRIPTION
## Before

<img width="241" alt="Screenshot 2021-09-26 at 7 00 36 AM" src="https://user-images.githubusercontent.com/46647141/134790105-93995c5b-f364-44f2-8643-7a65f29c088a.png">


## After

<img width="397" alt="Screenshot 2021-09-26 at 6 59 46 AM" src="https://user-images.githubusercontent.com/46647141/134790096-34df9ec7-ca02-4a21-bbf7-7178544ddd6b.png">
