### PR TITLE
Deprecate doc refs to parallel-webpack and cache-loader

### DIFF
--- a/src/content/api/node.mdx
+++ b/src/content/api/node.mdx
@@ -276,8 +276,7 @@ webpack([
 
 W> Multiple configurations will **not be run in parallel**. Each
 configuration is only processed after the previous one has finished
-processing. To process them in parallel, you can use a third-party solution
-like [parallel-webpack](https://www.npmjs.com/package/parallel-webpack).
+processing.
 
 ## Error Handling
 

--- a/src/content/guides/build-performance.mdx
+++ b/src/content/guides/build-performance.mdx
@@ -231,13 +231,6 @@ The following steps are especially useful in _production_.
 
 W> **Don't sacrifice the quality of your application for small performance gains!** Keep in mind that optimization quality is, in most cases, more important than build performance.
 
-### Multiple Compilations
-
-When using multiple compilations, the following tools can help:
-
-- [`parallel-webpack`](https://github.com/trivago/parallel-webpack): It allows for compilation in a worker pool.
-- `cache-loader`: The cache can be shared between multiple compilations.
-
 ### Source Maps
 
 Source maps are really expensive. Do you really need them?


### PR DESCRIPTION
parallel-webpack appears to be no longer actively developed

cache-loader has been archived

Resolves https://github.com/webpack/webpack/issues/14386
