### PR TITLE
Add chrome-extension-archive-webpack-plugin to awesome-webpack plugin list

### DIFF
--- a/src/content/awesome-webpack.mdx
+++ b/src/content/awesome-webpack.mdx
@@ -168,6 +168,7 @@ _People passionate about Webpack (In no particular order)_
 - [Gettext Webpack Plugin](https://github.com/juanluispaz/gettext-webpack-plugin): Embed localization into your bundle using gettext. -- _Maintainer_: `Juan Luis Paz` [![Github][githubicon]](https://github.com/juanluispaz)
 - [Node Polyfill Plugin](https://github.com/Richienb/node-polyfill-webpack-plugin): Polyfill Node.js core modules. -- _Maintainer_: `Richie Bendall` [![Github][githubicon]](https://github.com/Richienb) [![Twitter][twittericon]](https://twitter.com/Richienb2)
 - [Bytenode Plugin](https://github.com/herberttn/bytenode-webpack-plugin): Compile JavaScript into bytecode using bytenode. -- _Maintainer_: `Herbert Treis Neto` [![Github][githubicon]](https://github.com/herberttn)
+- [Chrome Extension Archive Webpack Plugin](https://github.com/KeisukeYamashita/chrome-extension-archive-webpack-plugin) Create archive file to publish Chrome Exentions to Chrome Web Store -- _Maintainer_: `KeisukeYamashita` [![Github][githubicon]](https://github.com/KeisukeYamashita)
 
 ### Webpack Tools
 


### PR DESCRIPTION
I added [KeisukeYamashita/chrome-extension-archive-webpack-plugin](https://github.com/KeisukeYamashita/chrome-extension-archive-webpack-plugin), a webpack plugin to create Chrome Extension archives to publish to the Chrome Web Store.

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].
- **Remove these instructions from your PR as they are for your eyes only.**

[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
