### PR TITLE
docs(configuration): add warning about `[ext]` and `output.filename`

### DIFF
--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -580,6 +580,8 @@ Substitutions available on File-level:
 | [name]     | Only filename without extension or path            |
 | [ext]      | Extension with leading `.`                         |
 
+W> `[ext]` is not supported for [output.filename](#outputfilename).
+
 Substitutions available on URL-level:
 
 | Template | Description |

--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -569,18 +569,16 @@ Substitutions available on Module-level:
 
 Substitutions available on File-level:
 
-| Template   | Description                                        |
-| ---------- | -------------------------------------------------- |
-| [file]     | Filename and path, without query or fragment       |
-| [query]    | Query with leading `?`                             |
-| [fragment] | Fragment with leading `#`                          |
-| [base]     | Only filename (including extensions), without path |
-| [filebase] | Same, but deprecated                               |
-| [path]     | Only path, without filename                        |
-| [name]     | Only filename without extension or path            |
-| [ext]      | Extension with leading `.`                         |
-
-W> `[ext]` is not supported for [output.filename](#outputfilename).
+| Template   | Description                                                                       |
+| ---------- | --------------------------------------------------------------------------------- |
+| [file]     | Filename and path, without query or fragment                                      |
+| [query]    | Query with leading `?`                                                            |
+| [fragment] | Fragment with leading `#`                                                         |
+| [base]     | Only filename (including extensions), without path                                |
+| [filebase] | Same, but deprecated                                                              |
+| [path]     | Only path, without filename                                                       |
+| [name]     | Only filename without extension or path                                           |
+| [ext]      | Extension with leading `.` (not available for [output.filename](#outputfilename)) |
 
 Substitutions available on URL-level:
 


### PR DESCRIPTION
Fix https://github.com/webpack/webpack.js.org/issues/5538