### PR TITLE
docs(configuration): update `proxy` example configuration

### DIFF
--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -1275,7 +1275,7 @@ module.exports = {
 };
 ```
 
-Note that requests to root won't be proxied by default. To enable root proxying, the `devServer.index` option should be specified as a falsy value:
+Note that requests to root won't be proxied by default. To enable root proxying, the [`devMiddleware.index`](#devserverdevmiddleware) option should be specified as a falsy value:
 
 **webpack.config.js**
 
@@ -1283,9 +1283,9 @@ Note that requests to root won't be proxied by default. To enable root proxying,
 module.exports = {
   //...
   devServer: {
-    index: '', // specify to enable root proxying
-    host: '...',
-    static: '...',
+    devMiddleware: {
+      index: false, // specify to enable root proxying
+    },
     proxy: {
       context: () => true,
       target: 'http://localhost:1234',


### PR DESCRIPTION
Fix https://github.com/webpack/webpack.js.org/issues/5532

Update outdated content.