### PR TITLE
Remove deprecation warning for Module Context opts

### DIFF
--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -1105,8 +1105,6 @@ module.exports = {
 
 ## Module Contexts
 
-> Avoid using these options as they are **deprecated** and will soon be removed.
-
 These options describe the default settings for the context created when a dynamic dependency is encountered.
 
 Example for an `unknown` dynamic dependency: `require`.


### PR DESCRIPTION
According to @sokra in [this comment](https://github.com/webpack/webpack/issues/3158#issuecomment-686617158), these are not deprecated.
