### PR TITLE
docs(configuration): remove webpack 4 warning for `module.unsafeCache`

### DIFF
--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -234,8 +234,6 @@ module.exports = {
 };
 ```
 
-W> The default value is `true` in webpack 4.
-
 ## module.rules
 
 `[Rule]`
@@ -1022,7 +1020,7 @@ module.exports = {
           // e.g. `app/styles.css`, `app/styles/styles.css`, `app/stylesheet.css`
           path.resolve(__dirname, 'app/styles'),
           // add an extra slash to only include the content of the directory `vendor/styles/`
-          path.join(__dirname, 'vendor/styles/'), 
+          path.join(__dirname, 'vendor/styles/'),
         ],
       },
     ],


### PR DESCRIPTION
warning for webpack 4 is no longer necessary. The docs target webpack 5.