### PR TITLE
docs(ProgressPlugin): remove duplicated defaults & types

### DIFF
--- a/src/content/plugins/progress-plugin.mdx
+++ b/src/content/plugins/progress-plugin.mdx
@@ -8,8 +8,6 @@ contributors:
   - smelukov
 ---
 
-`object = { boolean activeModules = false, boolean entries = true, function (number percentage, string message, [string] ...args) handler, boolean modules = true, number modulesCount = 5000, boolean profile = false, boolean dependencies = true, number dependenciesCount = 10000 }`
-
 The `ProgressPlugin` provides a way to customize how progress is reported during a compilation.
 
 ## Usage


### PR DESCRIPTION
This section was added in https://github.com/webpack/webpack.js.org/commit/3ad6ca2f2c34e1423b21a60cb770b6330b5a03b1#diff-f755004f96d7e121ee1a14518b71aae0eaa70811750ac9c92ac90745b0402916R9-R10 and updated in https://github.com/webpack/webpack.js.org/commit/fac7a5046344a293554897cdbf060d7fb2de775b#diff-f755004f96d7e121ee1a14518b71aae0eaa70811750ac9c92ac90745b0402916R9-R12 before being renamed to `.mdx`.

The provided default option is out of date so I updated them according to [current implementation](https://github.com/webpack/webpack/blob/2eecffb2739d13d3095568d118ffc0baacec5cd8/lib/ProgressPlugin.js#L604-L612) in https://github.com/webpack/webpack.js.org/commit/94508eb84f0f9a835c6a564fb986111a064e7c6d .

However, since this section is actually duplicated with [ProgressPlugin - Providing `object`](https://webpack.js.org/plugins/progress-plugin/#providing-object) so I later remove it entirely later in https://github.com/webpack/webpack.js.org/pull/5557/commits/5059e7664d1de38eed917d5ed1d7953b1187015e .