### PR TITLE
docs(configuration): update `devServer.static.watch`

### DIFF
--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -1547,6 +1547,7 @@ npx webpack serve --no-static-serve-index
 `boolean` `object`
 
 Tell dev-server to watch the files served by the [`static.directory`](#directory) option. It is enabled by default, and file changes will trigger a full page reload. This can be disabled by setting the `watch` option to `false`.
+
 **webpack.config.js**
 
 ```javascript


### PR DESCRIPTION
According to the [migration guide](https://github.com/webpack/webpack-dev-server/blob/master/migration-v4.md), the `static.watch` option is enabled by default. This PR updates the `dev-server` docs to align with that.

[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
