### PR TITLE
fix: experiment options, executeModule option removed

### DIFF
--- a/src/content/configuration/experiments.mdx
+++ b/src/content/configuration/experiments.mdx
@@ -37,7 +37,6 @@ module.exports = {
   experiments: {
     asyncWebAssembly: true,
     buildHttp: true,
-    executeModule: true,
     layers: true,
     lazyCompilation: true,
     outputModule: true,


### PR DESCRIPTION
executeModule has been removed from options and is now enabled by default

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [ ] Review the diff carefully as sometimes this can reveal issues.
- [ ] Do not abandon your Pull Request: [Stale Pull Requests][3].
- **Remove these instructions from your PR as they are for your eyes only.**

[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
