### PR TITLE
docs(blog): add `resolve.moduleExtensions` as removed option

### DIFF
--- a/src/content/blog/2020-10-10-webpack-5-release.mdx
+++ b/src/content/blog/2020-10-10-webpack-5-release.mdx
@@ -658,6 +658,7 @@ The minimum supported Node.js version has increased from 6 to 10.13.0(LTS).
 - `snapshot.immutablePaths` added
 - `resolve.cache` added: Allows to disable/enable the safe resolve cache
 - `resolve.concord` removed
+- `resolve.moduleExtensions` removed
 - `resolve.alias` values can be arrays or `false` now
 - `resolve.restrictions` added: Allows to restrict potential resolve results
 - `resolve.fallback` added: Allow to alias requests that failed to resolve


### PR DESCRIPTION
Fix https://github.com/webpack/webpack.js.org/issues/5572