### PR TITLE
docs(configuration): use `https.ca` instead of `https.cacert`

### DIFF
--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -540,7 +540,7 @@ module.exports = {
     https: {
       key: fs.readFileSync('/path/to/server.key'),
       cert: fs.readFileSync('/path/to/server.crt'),
-      cacert: fs.readFileSync('/path/to/ca.pem'),
+      ca: fs.readFileSync('/path/to/ca.pem'),
     },
   },
 };
@@ -549,7 +549,7 @@ module.exports = {
 To pass your certificate via CLI, use the following options:
 
 ```bash
-npx webpack serve --http2 --https-key ./path/to/server.key --https-cert ./path/to/server.crt --https-cacert ./path/to/ca.pem
+npx webpack serve --http2 --https-key ./path/to/server.key --https-cert ./path/to/server.crt --https-ca ./path/to/ca.pem
 ```
 
 ## devServer.https
@@ -589,7 +589,7 @@ With the above setting, a self-signed certificate is used, but you can provide y
 module.exports = {
   devServer: {
     https: {
-      cacert: './server.pem',
+      ca: './server.pem',
       pfx: './server.pfx',
       key: './server.key',
       cert: './server.crt',
@@ -605,7 +605,7 @@ This object is passed straight to the Node.js HTTPS module, so see the [HTTPS do
 To pass your own certificate via the CLI use the following options:
 
 ```bash
-npx webpack serve --https-key ./path/to/server.key --https-cert ./path/to/server.crt --https-cacert ./path/to/ca.pem
+npx webpack serve --https-key ./path/to/server.key --https-cert ./path/to/server.crt --https-ca ./path/to/ca.pem
 ```
 
 `webpack-dev-server >= v4.2.0` allows you to set additional [TLS options](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options) like `minVersion`. Also, you can directly pass the contents of respective files:


### PR DESCRIPTION
`https.cacert` is deprecated and will be removed in the next major release.