### PR TITLE
docs(api): remove outdated tip for webpack 4

### DIFF
--- a/src/content/api/logging.mdx
+++ b/src/content/api/logging.mdx
@@ -5,9 +5,8 @@ contributors:
   - EugeneHlushko
   - wizardofhogwarts
   - chenxsan
+  - snitin315
 ---
-
-T> Available since webpack 4.39.0
 
 Logging output is an additional way to display messages to the end users.
 


### PR DESCRIPTION
Redundant tip, as the current docs targets webpack 5
