### PR TITLE
[Docs]: Changes to diff blocks in Code Splitting Section

### DIFF
--- a/src/content/guides/code-splitting.mdx
+++ b/src/content/guides/code-splitting.mdx
@@ -218,18 +218,28 @@ The [`SplitChunksPlugin`](/plugins/split-chunks-plugin/) allows us to extract co
   module.exports = {
     mode: 'development',
     entry: {
-      index: './src/index.js',
-      another: './src/another-module.js',
+-    index: {
+-      import: './src/index.js',
+-      dependOn: 'shared',
+-    },
++    index: './src/index.js',
+-    another: {
+-      import: './src/another-module.js',
+-      dependOn: 'shared',
+-    },
++    another: './src/another-module.js',
+-    shared: 'lodash',
     },
     output: {
       filename: '[name].bundle.js',
       path: path.resolve(__dirname, 'dist'),
     },
-+   optimization: {
+    optimization: {
+-     runtimeChunk: 'single',
 +     splitChunks: {
 +       chunks: 'all',
 +     },
-+   },
+    },
   };
 ```
 


### PR DESCRIPTION
Signed-off-by: Gurkiran Singh <gurkiransinghk@gmail.com>

Added the diff blocks code changes between entry dependency and SplitChunksPlugin. Previously, the code changes weren't matching, so I couldn't figure which line to remove or add while I am following the documentation guide.
