### PR TITLE
fix: show `API` instead of `Api` in sub navigation

### DIFF
--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -217,7 +217,9 @@ function Navigation({ links, pathname, hash = '', toggleSidebar }) {
                       className="text-blue-400 py-5 text-sm capitalize hover:text-black dark:hover:text-white"
                       activeClassName="active-submenu"
                     >
-                      {child.content}
+                      {child.content === 'api'
+                        ? child.content.toUpperCase()
+                        : child.content}
                     </NavLink>
                   ))}
                 </div>


### PR DESCRIPTION
Because API is an acronym.

### after

<img width="472" alt="Screenshot 2021-10-26 at 4 23 19 AM" src="https://user-images.githubusercontent.com/46647141/138868573-557d7469-413b-4cf5-a7af-e49168abf1be.png">

### before
<img width="471" alt="Screenshot 2021-10-26 at 4 23 31 AM" src="https://user-images.githubusercontent.com/46647141/138868580-3d7902aa-b273-4006-996b-2436fbf15fc4.png">
