### PR TITLE
docs(contribute): update to loader-utils@3.0.0

### DIFF
--- a/src/content/contribute/writing-a-loader.mdx
+++ b/src/content/contribute/writing-a-loader.mdx
@@ -2,13 +2,13 @@
 title: Writing a Loader
 sort: 2
 contributors:
-- asulaiman
-- michael-ciniawsky
-- byzyk
-- anikethsaha
-- jamesgeorge007
-- chenxsan
-- dev-itsheng
+  - asulaiman
+  - michael-ciniawsky
+  - byzyk
+  - anikethsaha
+  - jamesgeorge007
+  - chenxsan
+  - dev-itsheng
 ---
 
 A loader is a node module that exports a function. This function is called when a resource should be transformed by this loader. The given function will have access to the [Loader API](/api/loaders/) using the `this` context provided to it.
@@ -138,9 +138,7 @@ Make sure the loader does not retain state between module transformations. Each 
 
 ### Loader Utilities
 
-Take advantage of the [`loader-utils`](https://github.com/webpack/loader-utils) package. It provides a variety of useful tools. Along with `loader-utils`, the [`schema-utils`](https://github.com/webpack-contrib/schema-utils) package should be used for consistent JSON Schema based validation of loader options. Here's a brief example that utilizes both:
-
-T> In webpack5, the loader can use `this.getOptions` to retrieve the options passed to the loader, so `loader-utils` removed `getOptions` method since 3.0.0.
+Take advantage of the [`loader-utils`](https://github.com/webpack/loader-utils) package which provides a variety of useful tools. Along with `loader-utils`, the [`schema-utils`](https://github.com/webpack-contrib/schema-utils) package should be used for consistent JSON Schema based validation of loader options. Here's a brief example that utilizes both:
 
 **loader.js**
 


### PR DESCRIPTION
_describe your changes..._

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].
- **Remove these instructions from your PR as they are for your eyes only.**

[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests

When I read the document of Webpack 5, I try to run the code example. But I realized that it can't execute successfully, so I found the reason of the question and change the document.

The reason is that [when loader-utils update to 3.0.0, it removed some methods](https://github.com/webpack/loader-utils/releases/tag/v3.0.0), I think that the document should be updated.