### PR TITLE
Fix `resolveData` casing in `beforeResolve` hook docs.

### DIFF
--- a/src/content/api/normalmodulefactory-hooks.mdx
+++ b/src/content/api/normalmodulefactory-hooks.mdx
@@ -30,7 +30,7 @@ depending on the type of hook.
 
 Called when a new dependency request is encountered. A dependency can be ignored by returning `false`. Otherwise, it should return `undefined` to proceed.
 
-- Callback Parameters: `ResolveData`
+- Callback Parameters: `resolveData`
 
 ### factorize
 


### PR DESCRIPTION
I noticed the callback parameter for other hooks lowercase `resolveData` so I updated this for consistency. Thanks.
