### PR TITLE
feat: Take default theme as system theme

### DIFF
--- a/src/components/HelloDarkness.jsx
+++ b/src/components/HelloDarkness.jsx
@@ -10,13 +10,12 @@ HelloDarkness.propTypes = {
   switchTheme: PropTypes.func,
 };
 
-HelloDarkness.defaultProps = {
-  theme: LIGHT,
-};
 export default function HelloDarkness() {
   const [theme, setTheme] = useLocalStorage(
     THEME_LOCAL_STORAGE_KEY,
-    THEME.LIGHT
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? THEME.DARK
+      : THEME.LIGHT
   );
   const applyTheme = (theme) => {
     document.documentElement.setAttribute('data-theme', theme);
@@ -26,6 +25,16 @@ export default function HelloDarkness() {
       document.documentElement.classList.remove(THEME.DARK);
     }
   };
+  useEffect(() => {
+    window
+      .matchMedia('(prefers-color-scheme: dark)')
+      .addEventListener('change', function (e) {
+        let changedTheme = e.matches ? THEME.DARK : THEME.LIGHT;
+        applyTheme(changedTheme);
+        setTheme(changedTheme);
+      });
+  }, [setTheme]);
+
   useEffect(() => {
     applyTheme(theme);
   }, [theme]);

--- a/src/components/HelloDarkness.jsx
+++ b/src/components/HelloDarkness.jsx
@@ -13,23 +13,21 @@ HelloDarkness.propTypes = {
 export default function HelloDarkness() {
   const [theme, setTheme] = useLocalStorage(
     THEME_LOCAL_STORAGE_KEY,
-    window.matchMedia('(prefers-color-scheme: dark)').matches
-      ? THEME.DARK
-      : THEME.LIGHT
+    window.matchMedia('(prefers-color-scheme: dark)').matches ? DARK : LIGHT
   );
   const applyTheme = (theme) => {
     document.documentElement.setAttribute('data-theme', theme);
-    if (theme === THEME.DARK) {
-      document.documentElement.classList.add(THEME.DARK);
+    if (theme === DARK) {
+      document.documentElement.classList.add(DARK);
     } else {
-      document.documentElement.classList.remove(THEME.DARK);
+      document.documentElement.classList.remove(DARK);
     }
   };
   useEffect(() => {
     window
       .matchMedia('(prefers-color-scheme: dark)')
       .addEventListener('change', function (e) {
-        let changedTheme = e.matches ? THEME.DARK : THEME.LIGHT;
+        let changedTheme = e.matches ? DARK : LIGHT;
         applyTheme(changedTheme);
         setTheme(changedTheme);
       });

--- a/webpack.ssg.mjs
+++ b/webpack.ssg.mjs
@@ -51,6 +51,7 @@ export default (env) =>
         globals: {
           window: {
             __ssgrun: true,
+            matchMedia: () => ({matches: true})
           },
         },
         paths,


### PR DESCRIPTION
Why this change?
- When the site loads for the first time we default the theme with light. But there are chances were the users might prefer site to take system's preference.

What have I done? 
- Default theme will be same as user's system theme preference.
- When the user changes the system's preference the site's changes the theme too.
