### PR TITLE
docs(guides): remove outdated tip regarding `package-lock.json`

### DIFF
--- a/src/content/guides/asset-management.mdx
+++ b/src/content/guides/asset-management.mdx
@@ -11,6 +11,7 @@ contributors:
   - AnayaDesign
   - wizardofhogwarts
   - astonizer
+  - snitin315
 ---
 
 If you've been following the guides from the start, you will now have a small project that shows "Hello webpack". Now let's try to incorporate some other assets, like images, to see how they can be handled.
@@ -100,6 +101,7 @@ Let's try it out by adding a new `style.css` file to our project and import it i
 ```diff
   webpack-demo
   |- package.json
+  |- package-lock.json
   |- webpack.config.js
   |- /dist
     |- bundle.js
@@ -201,6 +203,7 @@ Let's add an image to our project and see how this works, you can use any image 
 ```diff
   webpack-demo
   |- package.json
+  |- package-lock.json
   |- webpack.config.js
   |- /dist
     |- bundle.js
@@ -315,6 +318,7 @@ Add some font files to your project:
 ```diff
   webpack-demo
   |- package.json
+  |- package-lock.json
   |- webpack.config.js
   |- /dist
     |- bundle.js
@@ -433,6 +437,7 @@ Add some data files to your project:
 ```diff
   webpack-demo
   |- package.json
+  |- package-lock.json
   |- webpack.config.js
   |- /dist
     |- bundle.js
@@ -705,6 +710,7 @@ For the next guides we won't be using all the different assets we've used in thi
 ```diff
   webpack-demo
   |- package.json
+  |- package-lock.json
   |- webpack.config.js
   |- /dist
     |- bundle.js

--- a/src/content/guides/caching.mdx
+++ b/src/content/guides/caching.mdx
@@ -13,6 +13,7 @@ contributors:
   - EugeneHlushko
   - AnayaDesign
   - aholzner
+  - snitin315
 related:
   - title: Issue 652
     url: https://github.com/webpack/webpack.js.org/issues/652
@@ -35,6 +36,7 @@ Let's get our project set up using the example from [getting started](/guides/ge
 ```diff
 webpack-demo
 |- package.json
+|- package-lock.json
 |- webpack.config.js
 |- /dist
 |- /src
@@ -192,6 +194,7 @@ Let's add another module, `print.js`, to our project:
 ```diff
 webpack-demo
 |- package.json
+|- package-lock.json
 |- webpack.config.js
 |- /dist
 |- /src

--- a/src/content/guides/code-splitting.mdx
+++ b/src/content/guides/code-splitting.mdx
@@ -33,6 +33,7 @@ contributors:
   - chenxsan
   - Adarah
   - atesgoral
+  - snitin315
 related:
   - title: <link rel="prefetch/preload" /> in webpack
     url: https://medium.com/webpack/link-rel-prefetch-preload-in-webpack-51a52358f84c
@@ -61,6 +62,7 @@ This is by far the easiest and most intuitive way to split code. However, it is 
 ```diff
 webpack-demo
 |- package.json
+|- package-lock.json
 |- webpack.config.js
 |- /dist
 |- /src
@@ -293,6 +295,7 @@ We'll also update our project to remove the now unused files:
 ```diff
 webpack-demo
 |- package.json
+|- package-lock.json
 |- webpack.config.js
 |- /dist
 |- /src

--- a/src/content/guides/development.mdx
+++ b/src/content/guides/development.mdx
@@ -15,6 +15,7 @@ contributors:
   - aholzner
   - chenxsan
   - maxloh
+  - snitin315
 ---
 
 T> This guide extends on code examples found in the [Output Management](/guides/output-management) guide.
@@ -319,6 +320,7 @@ The `publicPath` will be used within our server script as well in order to make 
 ```diff
   webpack-demo
   |- package.json
+  |- package-lock.json
   |- webpack.config.js
 + |- server.js
   |- /dist

--- a/src/content/guides/getting-started.mdx
+++ b/src/content/guides/getting-started.mdx
@@ -25,6 +25,7 @@ contributors:
   - myshov
   - anshumanv
   - d3lm
+  - snitin315
 ---
 
 Webpack is used to compile JavaScript modules. Once [installed](/guides/installation), you can interact with webpack either from its [CLI](/api/cli) or [API](/api/node). If you're still new to webpack, please read through the [core concepts](/concepts) and [this comparison](/comparison) to learn why you might use it over the other tools that are out in the community.
@@ -59,6 +60,7 @@ Now we'll create the following directory structure, files and their contents:
 ```diff
   webpack-demo
   |- package.json
+  |- package-lock.json
 + |- index.html
 + |- /src
 +   |- index.js
@@ -140,6 +142,7 @@ First we'll tweak our directory structure slightly, separating the "source" code
 ```diff
   webpack-demo
   |- package.json
+  |- package-lock.json
 + |- /dist
 +   |- index.html
 - |- index.html
@@ -232,6 +235,7 @@ As of version 4, webpack doesn't require any configuration, but most projects wi
 ```diff
   webpack-demo
   |- package.json
+  |- package-lock.json
 + |- webpack.config.js
   |- /dist
     |- index.html
@@ -329,6 +333,7 @@ Now that you have a basic build together you should move on to the next guide [`
 ```diff
 webpack-demo
 |- package.json
+|- package-lock.json
 |- webpack.config.js
 |- /dist
   |- main.js
@@ -337,8 +342,6 @@ webpack-demo
   |- index.js
 |- /node_modules
 ```
-
-T> If you're using npm 5+, you'll probably also see a `package-lock.json` file in your directory.
 
 W> Do not compile untrusted code with webpack. It could lead to execution of malicious code on your computer, remote servers, or in the Web browsers of the end users of your application.
 

--- a/src/content/guides/lazy-loading.mdx
+++ b/src/content/guides/lazy-loading.mdx
@@ -9,6 +9,7 @@ contributors:
   - EugeneHlushko
   - AnayaDesign
   - tapanprakasht
+  - snitin315
 related:
   - title: Lazy Loading ES2015 Modules in the Browser
     url: https://dzone.com/articles/lazy-loading-es2015-modules-in-the-browser
@@ -31,6 +32,7 @@ Let's try something different. We'll add an interaction to log some text to the 
 ```diff
 webpack-demo
 |- package.json
+|- package-lock.json
 |- webpack.config.js
 |- /dist
 |- /src

--- a/src/content/guides/output-management.mdx
+++ b/src/content/guides/output-management.mdx
@@ -9,6 +9,7 @@ contributors:
   - EugeneHlushko
   - AnayaDesign
   - chenxsan
+  - snitin315
 ---
 
 T> This guide extends on code examples found in the [`Asset Management`](/guides/asset-management) guide.
@@ -24,6 +25,7 @@ First, let's adjust our project a little bit:
 ```diff
   webpack-demo
   |- package.json
+  |- package-lock.json
   |- webpack.config.js
   |- /dist
   |- /src

--- a/src/content/guides/production.mdx
+++ b/src/content/guides/production.mdx
@@ -46,6 +46,7 @@ npm install --save-dev webpack-merge
 ```diff
   webpack-demo
   |- package.json
+  |- package-lock.json
 - |- webpack.config.js
 + |- webpack.common.js
 + |- webpack.dev.js

--- a/src/content/guides/shimming.mdx
+++ b/src/content/guides/shimming.mdx
@@ -42,6 +42,7 @@ Let's start with the first use case of shimming global variables. Before we do a
 ```diff
 webpack-demo
 |- package.json
+|- package-lock.json
 |- webpack.config.js
 |- /dist
   |- index.html
@@ -209,6 +210,7 @@ Let's say a library creates a global variable that it expects its consumers to u
 ```diff
   webpack-demo
   |- package.json
+  |- package-lock.json
   |- webpack.config.js
   |- /dist
   |- /src
@@ -336,6 +338,7 @@ npm install --save whatwg-fetch
 ```diff
   webpack-demo
   |- package.json
+  |- package-lock.json
   |- webpack.config.js
   |- /dist
   |- /src

--- a/src/content/guides/tree-shaking.mdx
+++ b/src/content/guides/tree-shaking.mdx
@@ -17,6 +17,7 @@ contributors:
   - AnayaDesign
   - torifat
   - rahul3v
+  - snitin315
 related:
   - title: Debugging Optimization Bailouts
     url: https://webpack.js.org/plugins/module-concatenation-plugin/#debugging-optimization-bailouts
@@ -39,6 +40,7 @@ Let's add a new utility file to our project, `src/math.js`, that exports two fun
 ```diff
 webpack-demo
 |- package.json
+|- package-lock.json
 |- webpack.config.js
 |- /dist
   |- bundle.js

--- a/src/content/guides/typescript.mdx
+++ b/src/content/guides/typescript.mdx
@@ -8,6 +8,7 @@ contributors:
   - byzyk
   - EugeneHlushko
   - chenxsan
+  - snitin315
 ---
 
 T> This guide stems from the [_Getting Started_](/guides/getting-started/) guide.
@@ -29,6 +30,7 @@ Now we'll modify the directory structure & the configuration files:
 ```diff
   webpack-demo
   |- package.json
+  |- package-lock.json
 + |- tsconfig.json
   |- webpack.config.js
   |- /dist


### PR DESCRIPTION
Remove the outdated tip regarding `package-lock.json` and update the directory structure throughout the guides.