### PR TITLE
docs(configuration): Added dependencies docs

### DIFF
--- a/src/content/configuration/configuration-types.mdx
+++ b/src/content/configuration/configuration-types.mdx
@@ -90,6 +90,27 @@ module.exports = [
 
 T> If you pass a name to [`--config-name`](/api/cli/#config-name) flag, webpack will only build that specific configuration.
 
+### dependencies
+
+In case you have a configuration that depends on the output of another configuration, you can specify a list of dependencies using the [`dependencies`](/configuration/other-options/#dependencies) array.
+
+**webpack.config.js**
+
+```js
+module.exports = [
+  {
+    name: 'client',
+    target: 'web',
+    // …
+  },
+  {
+    name: 'server',
+    target: 'node',
+    dependencies: ['client'],
+  },
+];
+```
+
 ### parallelism
 
 In case you export multiple configurations, you can use the `parallelism` option on the configuration array to specify the maximum number of compilers that will compile in parallel.


### PR DESCRIPTION
Added some docs from the other-options page directly to the multiple configuration docs where it makes more sense.

I had this use case where I wanted one webpack config rely upon the output of a previous run, but I was told it wasn't possible and I couldn't see it in the multiple configs docs, so I assumed it was true.