### PR TITLE
docs(guides): add link to the docs of webpack-dev-server API

### DIFF
--- a/src/content/guides/hot-module-replacement.mdx
+++ b/src/content/guides/hot-module-replacement.mdx
@@ -223,6 +223,8 @@ const server = new webpackDevServer({ hot: false, client: false }, compiler);
 })();
 ```
 
+See the [full documentation of `webpack-dev-server` Node.js API](/api/webpack-dev-server/).
+
 T> If you're [using `webpack-dev-middleware`](/guides/development/#using-webpack-dev-middleware), check out the [`webpack-hot-middleware`](https://github.com/webpack-contrib/webpack-hot-middleware) package to enable HMR on your custom dev server.
 
 ## Gotchas


### PR DESCRIPTION
Add link for the full documentation of webpack-dev-server Nodejs API.