### PR TITLE
Update docs for entry-context

### DIFF
--- a/src/content/configuration/entry-context.mdx
+++ b/src/content/configuration/entry-context.mdx
@@ -30,7 +30,8 @@ module.exports = {
 };
 ```
 
-By default, the current directory is used, but it's recommended to pass a value in your configuration. This makes your configuration independent from CWD (current working directory).
+By default, use the directory where the script that started webpack is loacted. It's recommended to pass a value in your configuration. This makes your configuration 
+independent from CWD (current working directory).
 
 ---
 

--- a/src/content/configuration/entry-context.mdx
+++ b/src/content/configuration/entry-context.mdx
@@ -30,7 +30,7 @@ module.exports = {
 };
 ```
 
-By default, the current working directory of the Node.js is used, but it's recommended to pass a value in your configuration. This makes your configuration independent from CWD (current working directory).
+By default, the current working directory of Node.js is used, but it's recommended to pass a value in your configuration. This makes your configuration independent from CWD (current working directory).
 
 ---
 

--- a/src/content/configuration/entry-context.mdx
+++ b/src/content/configuration/entry-context.mdx
@@ -30,8 +30,7 @@ module.exports = {
 };
 ```
 
-By default, the current working directory of the Node.js process is used, but it's recommended to pass a value in your configuration. This makes your configuration 
-independent from CWD (current working directory).
+By default, the current working directory of the Node.js process is used, but it's recommended to pass a value in your configuration. This makes your configuration independent from CWD (current working directory).
 
 ---
 

--- a/src/content/configuration/entry-context.mdx
+++ b/src/content/configuration/entry-context.mdx
@@ -30,7 +30,7 @@ module.exports = {
 };
 ```
 
-By default, use the directory where the script that started webpack is loacted. It's recommended to pass a value in your configuration. This makes your configuration 
+By default, the current working directory of the Node.js process is used. It's recommended to pass a value in your configuration. This makes your configuration 
 independent from CWD (current working directory).
 
 ---

--- a/src/content/configuration/entry-context.mdx
+++ b/src/content/configuration/entry-context.mdx
@@ -30,7 +30,7 @@ module.exports = {
 };
 ```
 
-By default, the current working directory of the Node.js process is used, but it's recommended to pass a value in your configuration. This makes your configuration independent from CWD (current working directory).
+By default, the current working directory of the Node.js is used, but it's recommended to pass a value in your configuration. This makes your configuration independent from CWD (current working directory).
 
 ---
 

--- a/src/content/configuration/entry-context.mdx
+++ b/src/content/configuration/entry-context.mdx
@@ -30,7 +30,7 @@ module.exports = {
 };
 ```
 
-By default, the current working directory of the Node.js process is used. It's recommended to pass a value in your configuration. This makes your configuration 
+By default, the current working directory of the Node.js process is used, but it's recommended to pass a value in your configuration. This makes your configuration 
 independent from CWD (current working directory).
 
 ---


### PR DESCRIPTION
I think this current directory has a ambiguity. Does the current directory refer to the root directory of the project? Or is it the directory where webpack.config.js is located?

After I tested it, I found neither of them, the default should be the directory of the script that starts webpack. For example, I ran the script `webpack --config relativebase` in a non-project root directory. Then, the value of the context at this time is the directory where the script is located.

In order to better illustrate my ideas, I wrote a demo code, but I don’t know how to give the sample code, so I created a warehouse to store the sample code. https://github.com/spicylemonhaha/webpack-demo
