### PR TITLE
docs(configuration): add tip for `output.hashDigestLength` default value

### DIFF
--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -681,7 +681,7 @@ The encoding to use when generating the hash. All encodings from Node.JS' [`hash
 
 The prefix length of the hash digest to use.
 
-T> For `webpack v5.65.0+`, `16` will be used as the default value for the`hashDigestLength` option when [`experiments.futureDefaults`](/configuration/experiments/#experimentsfuturedefaults) is enabled.
+T> For `webpack v5.65.0+`, `16` will be used as the default value for the `hashDigestLength` option when [`experiments.futureDefaults`](/configuration/experiments/#experimentsfuturedefaults) is enabled.
 
 ## output.hashFunction
 

--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -681,7 +681,7 @@ The encoding to use when generating the hash. All encodings from Node.JS' [`hash
 
 The prefix length of the hash digest to use.
 
-T> Since `webpack v5.65.0`, `16` will be used as the default value for `hashDigestLength` when [`experiments.futureDefaults`](/configuration/experiments/#experimentsfuturedefaults) is enabled.
+T> For `webpack v5.65.0+`, `16` will be used as the default value for the`hashDigestLength` option when [`experiments.futureDefaults`](/configuration/experiments/#experimentsfuturedefaults) is enabled.
 
 ## output.hashFunction
 

--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -681,6 +681,8 @@ The encoding to use when generating the hash. All encodings from Node.JS' [`hash
 
 The prefix length of the hash digest to use.
 
+T> Since `webpack v5.65.0`, `16` will be used as default for `hashDigestLength` when [`experiments.futureDefaults`](/configuration/experiments/#experimentsfuturedefaults) is enabled.
+
 ## output.hashFunction
 
 `string = 'md4'` `function`

--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -681,7 +681,7 @@ The encoding to use when generating the hash. All encodings from Node.JS' [`hash
 
 The prefix length of the hash digest to use.
 
-T> Since `webpack v5.65.0`, `16` will be used as default for `hashDigestLength` when [`experiments.futureDefaults`](/configuration/experiments/#experimentsfuturedefaults) is enabled.
+T> Since `webpack v5.65.0`, `16` will be used as the default value for `hashDigestLength` when [`experiments.futureDefaults`](/configuration/experiments/#experimentsfuturedefaults) is enabled.
 
 ## output.hashFunction
 


### PR DESCRIPTION
Resolve https://github.com/webpack/webpack.js.org/issues/5743