### PR TITLE
docs(configuration): add deprecation warning for devServer options

### DIFF
--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -625,7 +625,7 @@ To pass your certificate via CLI, use the following options:
 npx webpack serve --http2 --https-key ./path/to/server.key --https-cert ./path/to/server.crt --https-ca ./path/to/ca.pem
 ```
 
-W> This option is deprecated in favor of [devServer.server](#devserverserver) option.
+W> This option is deprecated in favor of the [devServer.server](#devserverserver) option.
 
 ## devServer.https
 
@@ -708,7 +708,7 @@ module.exports = {
 
 W> Don't specify `https.ca` and `https.cacert` options together, if specified `https.ca` will be used. `https.cacert` is deprecated and will be removed in the next major release.
 
-W> This option is deprecated in favor of [devServer.server](#devserverserver) option.
+W> This option is deprecated in favor of the [devServer.server](#devserverserver) option.
 
 ## devServer.headers
 
@@ -1060,7 +1060,7 @@ module.exports = {
 };
 ```
 
-W> This option is deprecated in favor of [devServer.setupMiddlewares](#devserversetupmiddlewares) option.
+W> This option is deprecated in favor of the [devServer.setupMiddlewares](#devserversetupmiddlewares) option.
 
 ## devServer.onBeforeSetupMiddleware
 
@@ -1089,7 +1089,7 @@ module.exports = {
 };
 ```
 
-W> This option is deprecated in favor of [devServer.setupMiddlewares](#devserversetupmiddlewares) option.
+W> This option is deprecated in favor of the [devServer.setupMiddlewares](#devserversetupmiddlewares) option.
 
 ## devserver.onListening
 

--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -1060,6 +1060,8 @@ module.exports = {
 };
 ```
 
+W> This option is deprecated in favor of [devServer.setupMiddlewares](#devserversetupmiddlewares) option.
+
 ## devServer.onBeforeSetupMiddleware
 
 `function (devServer)`
@@ -1086,6 +1088,8 @@ module.exports = {
   },
 };
 ```
+
+W> This option is deprecated in favor of [devServer.setupMiddlewares](#devserversetupmiddlewares) option.
 
 ## devserver.onListening
 


### PR DESCRIPTION
Add deprecated option warning for `onBeforeSetupMiddleware` and `onAfterSetupMiddleware`.