### PR TITLE
Update 5.mdx

### DIFF
--- a/src/content/migrate/5.mdx
+++ b/src/content/migrate/5.mdx
@@ -11,6 +11,7 @@ contributors:
   - chenxsan
   - jamesgeorge007
   - getsnoopy
+  - yevhen-logosha
 ---
 
 This guide aims to help you migrating to webpack 5 when using webpack directly. If you are using a higher level tool to run webpack, please refer to the tool for migration instructions.
@@ -32,6 +33,7 @@ Webpack 5 requires at least Node.js 10.13.0 (LTS), so make sure you upgrade your
 3. Upgrade all used Plugins and Loaders to the latest available version
 
    Some Plugins and Loaders might have a beta version that has to be used in order to be compatible with webpack 5.
+   Make sure to read release notes of each individual plugin/loader when upgrading it, since latest version might only support webpack 5 and will fail in v4. In such case, it's recommended to update to the latest version that supports webpack 4.
 
 ### Make sure your build has no errors or warnings
 
@@ -91,6 +93,8 @@ Now let's upgrade webpack to version 5:
 - npm: `npm install webpack@latest`
 
 - Yarn: `yarn add webpack@latest`
+
+If you were not able to upgrade some plugins/loaders to the latest in Upgrade webpack 4 and its plugins/loaders step, don't forget to upgrade them now.
 
 ### Clean up configuration
 


### PR DESCRIPTION
Upgrade webpack 4 and its plugins/loaders section offers to upgrade all plugins/loaders to latest, but some of the common loaders (eg `css-loader`, `sass-loader`) and plugins (eg `@svgr/webpack`, `mini-css-extract-plugin`, `html-webpack-plugin`) latest versions are not supporting webpack v4 any more, resulting in users facing errors, and having to go back and downgrading in order to successfully pass this section. Tweaks in migration guide aim to stress the necessity to pay attention to each individual release note.
