### PR TITLE
docs(configuration): fix typo in resolve documentation

### DIFF
--- a/src/content/configuration/resolve.mdx
+++ b/src/content/configuration/resolve.mdx
@@ -534,7 +534,7 @@ const a = new URL('./module/path', import.meta.url);
 
 Prefer absolute paths to [`resolve.roots`](#resolveroots) when resolving.
 
-**wepack.config.js**
+**webpack.config.js**
 
 ```js
 module.exports = {


### PR DESCRIPTION
Very minor typoe fix in src/content/configuration/resolve.mdx