### PR TITLE
fix formatting in split-chunks-plugin.mdx

### DIFF
--- a/src/content/plugins/split-chunks-plugin.mdx
+++ b/src/content/plugins/split-chunks-plugin.mdx
@@ -210,7 +210,12 @@ Assign modules to a cache group by module layer.
 
 `number = 0`
 
-Using `maxSize` (either globally `optimization.splitChunks.maxSize` per cache group `optimization.splitChunks.cacheGroups[x].maxSize` or for the fallback cache group `optimization.splitChunks.fallbackCacheGroup.maxSize`) tells webpack to try to split chunks bigger than `maxSize` bytes into smaller parts. Parts will be at least `minSize` (next to `maxSize`) in size.
+Using `maxSize`
+- either globally - `optimization.splitChunks.maxSize` 
+- per cache group - `optimization.splitChunks.cacheGroups[x].maxSize` 
+- or for the fallback cache group - `optimization.splitChunks.fallbackCacheGroup.maxSize`
+
+tells webpack to try to split chunks bigger than `maxSize` bytes into smaller parts. Parts will be at least `minSize` (next to `maxSize`) in size.
 The algorithm is deterministic and changes to the modules will only have local effects. So that it is usable when using long term caching and doesn't require records. `maxSize` is only a hint and could be violated when modules are bigger than `maxSize` or splitting would violate `minSize`.
 
 When the chunk has a name already, each part will get a new name derived from that name. Depending on the value of `optimization.splitChunks.hidePathInfo` it will add a key derived from the first module name or a hash of it.


### PR DESCRIPTION
Fixed formatting for list of options in the maxSize section

