### PR TITLE
Remove @types/webpack-dev-server from docs

### DIFF
--- a/src/content/configuration/configuration-languages.mdx
+++ b/src/content/configuration/configuration-languages.mdx
@@ -13,6 +13,7 @@ contributors:
   - liyiming22
   - daimalou
   - ChocolateLoverRaj
+  - snitin315
 ---
 
 Webpack accepts configuration files written in multiple programming and data languages. The list of supported file extensions can be found in the [node-interpret](https://github.com/gulpjs/interpret) package. Using [node-interpret](https://github.com/gulpjs/interpret), webpack can handle many different types of configuration files.
@@ -23,6 +24,8 @@ To write the webpack configuration in [TypeScript](http://www.typescriptlang.org
 
 ```bash
 npm install --save-dev typescript ts-node @types/node @types/webpack
+# and, if using webpack-dev-server < v4.7.0
+npm install --save-dev @types/webpack-dev-server
 ```
 
 and then proceed to write your configuration:

--- a/src/content/configuration/configuration-languages.mdx
+++ b/src/content/configuration/configuration-languages.mdx
@@ -12,6 +12,7 @@ contributors:
   - Nek-
   - liyiming22
   - daimalou
+  - ChocolateLoverRaj
 ---
 
 Webpack accepts configuration files written in multiple programming and data languages. The list of supported file extensions can be found in the [node-interpret](https://github.com/gulpjs/interpret) package. Using [node-interpret](https://github.com/gulpjs/interpret), webpack can handle many different types of configuration files.
@@ -22,8 +23,6 @@ To write the webpack configuration in [TypeScript](http://www.typescriptlang.org
 
 ```bash
 npm install --save-dev typescript ts-node @types/node @types/webpack
-# and, if using webpack-dev-server
-npm install --save-dev @types/webpack-dev-server
 ```
 
 and then proceed to write your configuration:


### PR DESCRIPTION
I read the article about writing webpack config file in TypeScript. I installed `@types/webpack-dev-server` but it's deprecated:
![deprecated screenshot](https://user-images.githubusercontent.com/52586855/148659278-3351b5b0-9ef4-46e0-97b0-c9099b83c394.png)
Since anyone who installs `webpack-dev-server` will get the types, the docs don't need to say "install `@types/webpack-dev-server`"