### PR TITLE
Fix path to correct header

### DIFF
--- a/src/content/guides/environment-variables.mdx
+++ b/src/content/guides/environment-variables.mdx
@@ -44,4 +44,4 @@ module.exports = (env) => {
 };
 ```
 
-T> Webpack CLI offers some [built-in environment variables](/api/cli/#environment-variables) which you can access inside a webpack configuration.
+T> Webpack CLI offers some [built-in environment variables](/api/cli/#cli-environment-variables) which you can access inside a webpack configuration.


### PR DESCRIPTION
Hi folks! 👋 

I fix a anchor for `CLI Environment Variables` so used `cli-environment-variables`.