### PR TITLE
docs(api): add `internalIP` and `internalIPSync` for webpack-dev-server

### DIFF
--- a/src/content/api/webpack-dev-server.mdx
+++ b/src/content/api/webpack-dev-server.mdx
@@ -150,6 +150,8 @@ node server.js
 
 Returns the internal IP address asynchronously.
 
+**server.js**
+
 ```js
 const WebpackDevServer = require('webpack-dev-server');
 
@@ -167,6 +169,8 @@ logInternalIPs();
 ## internalIPSync(family: "v4" | "v6")
 
 Returns the internal IP address synchronously.
+
+**server.js**
 
 ```js
 const WebpackDevServer = require('webpack-dev-server');

--- a/src/content/api/webpack-dev-server.mdx
+++ b/src/content/api/webpack-dev-server.mdx
@@ -148,7 +148,7 @@ node server.js
 
 ## internalIP(family: "v4" | "v6")
 
-Returns the internal IP address asynchronously.
+Returns the internal `IPv4`/`IPv6` address asynchronously.
 
 **server.js**
 
@@ -168,7 +168,7 @@ logInternalIPs();
 
 ## internalIPSync(family: "v4" | "v6")
 
-Returns the internal IP address synchronously.
+Returns the internal `IPv4`/`IPv6` address synchronously.
 
 **server.js**
 

--- a/src/content/api/webpack-dev-server.mdx
+++ b/src/content/api/webpack-dev-server.mdx
@@ -145,3 +145,35 @@ And then run the server with the following command:
 ```bash
 node server.js
 ```
+
+## internalIP(family: "v4" | "v6")
+
+Returns the internal IP address asynchronously.
+
+```js
+const WebpackDevServer = require('webpack-dev-server');
+
+const logInternalIPs = async () => {
+  const localIPv4 = await WebpackDevServer.internalIP('v4');
+  const localIPv6 = await WebpackDevServer.internalIP('v6');
+
+  console.log('Local IPv4 address:', localIPv4);
+  console.log('Local IPv6 address:', localIPv6);
+};
+
+logInternalIPs();
+```
+
+## internalIPSync(family: "v4" | "v6")
+
+Returns the internal IP address synchronously.
+
+```js
+const WebpackDevServer = require('webpack-dev-server');
+
+const localIPv4 = WebpackDevServer.internalIPSync('v4');
+const localIPv6 = WebpackDevServer.internalIPSync('v6');
+
+console.log('Local IPv4 address:', localIPv4);
+console.log('Local IPv6 address:', localIPv6);
+```


### PR DESCRIPTION
Documents `internalIP` and `internalIPSync` for webpack-dev-server API with example.