### PR TITLE
Adds note about passing variables to Webworker

### DIFF
--- a/src/content/guides/web-workers.mdx
+++ b/src/content/guides/web-workers.mdx
@@ -15,6 +15,8 @@ new Worker(new URL('./worker.js', import.meta.url));
 
 The syntax was chosen to allow running code without bundler, it is also available in native ECMAScript modules in the browser.
 
+**Note:** Assigning `URL` to a variable and passing the variable to the worker is not analyzable thus the Worker will not be properly compiled.
+
 ## Example
 
 **src/index.js**


### PR DESCRIPTION
Updates documentation to note that a URL needs to be passed directly to the Worker constructor, and not as a variable.
