### PR TITLE
docs(guides): fix link to CLI environment variables

### DIFF
--- a/src/content/guides/environment-variables.mdx
+++ b/src/content/guides/environment-variables.mdx
@@ -8,6 +8,7 @@ contributors:
   - legalcodes
   - byzyk
   - jceipek
+  - snitin315
 ---
 
 To disambiguate in your `webpack.config.js` between [development](/guides/development) and [production builds](/guides/production) you may use environment variables.
@@ -44,4 +45,4 @@ module.exports = (env) => {
 };
 ```
 
-T> Webpack CLI offers some [built-in environment variables](/api/cli/#environment-variables) which you can access inside a webpack configuration.
+T> Webpack CLI offers some [built-in environment variables](/api/cli/#cli-environment-variables) which you can access inside a webpack configuration.


### PR DESCRIPTION
Fix https://github.com/webpack/webpack.js.org/pull/5862/
