### PR TITLE
docs(configuration): fix link for `init` command

### DIFF
--- a/src/content/configuration/index.mdx
+++ b/src/content/configuration/index.mdx
@@ -1137,7 +1137,7 @@ module.exports = {
 
 W> webpack applies configuration defaults after [plugins defaults](/contribute/writing-a-plugin/#configuration-defaults) are applied.
 
-Use [webpack-cli's `init` command](https://github.com/webpack/webpack-cli/tree/master/packages/init#cli-via-webpack-cli) to rapidly generate webpack configuration files for your project requirements, it will ask you a couple of questions before creating a configuration file.
+Use [webpack-cli's `init` command](/api/cli/#init) to rapidly generate webpack configuration files for your project requirements, it will ask you a couple of questions before creating a configuration file.
 
 ```bash
 npx webpack-cli init


### PR DESCRIPTION
Fix link. Old link is 404 - https://github.com/webpack/webpack-cli/tree/master/packages/init#cli-via-webpack-cli