### PR TITLE
docs(configuration): fix `stats.context` info & example

### DIFF
--- a/src/content/configuration/stats.mdx
+++ b/src/content/configuration/stats.mdx
@@ -539,18 +539,22 @@ module.exports = {
 
 ### stats.context
 
-`string = '../src/'`
+`string`
 
-Sets the context directory for shortening the request information.
+The stats base directory, an **absolute path** for shortening the request information.
 
 ```javascript
+const path = require('path');
+
 module.exports = {
   //...
   stats: {
-    context: '../src/components/',
+    context: path.resolve(__dirname, 'src/components'),
   },
 };
 ```
+
+By default, the value of [`context`](/configuration/entry-context/#context) or the Node.js current working directory is used.
 
 ### stats.colors
 


### PR DESCRIPTION
When using a relative path for `stats.context`, the build fails:

```shell
[webpack-cli] Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 - configuration.stats.context: The provided value "./src" is not an absolute path!
   -> Context directory for request shortening.
error Command failed with exit code 2.
```

Example repo: https://github.com/vio/webpack-stats-context