### PR TITLE
Redirect vote to v4

### DIFF
--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -249,7 +249,7 @@ function Site(props) {
                 ),
               },
               { content: 'Contribute', url: '/contribute/' },
-              { content: 'Vote', url: '/vote/' },
+              { content: 'Vote', url: 'https://v4.webpack.js.org/vote/' },
               { content: 'Blog', url: '/blog/' },
             ]}
           />


### PR DESCRIPTION
Unfortunately the `/vote` page is not working anymore after https://github.com/webpack/webpack.js.org/pull/5764 according to https://github.com/webpack/webpack.js.org/pull/3019#issuecomment-1013668828. I'm not quite sure what's going on there. Since that Vote App is built with webpack 4, it might be a good idea to redirect v5 vote to v4 because the later is built with webpack 4 as well.