### PR TITLE
fix: update WebStorm "safe write" to "Back up files before saving"

### DIFF
--- a/src/content/configuration/watch.mdx
+++ b/src/content/configuration/watch.mdx
@@ -213,4 +213,4 @@ On some machines Vim is preconfigured with the [backupcopy option](http://vimdoc
 
 ### Saving in WebStorm
 
-When using the JetBrains WebStorm IDE, you may find that saving changed files does not trigger the watcher as you might expect. Try disabling the `safe write` option in the settings, which determines whether files are saved to a temporary location first before the originals are overwritten: uncheck `File > {Settings|Preferences} > Appearance & Behavior > System Settings > Use "safe write" (save changes to a temporary file first)`.
+When using the JetBrains WebStorm IDE, you may find that saving changed files does not trigger the watcher as you might expect. Try disabling the `Back up files before saving` option in the settings, which determines whether files are saved to a temporary location first before the originals are overwritten: uncheck `File > {Settings|Preferences} > Appearance & Behavior > System Settings > Back up files before saving`. On some versions of Webstorm, this option may be called `Use "safe write" (save changes to a temporary file first)`.


### PR DESCRIPTION
See https://www.jetbrains.com/help/webstorm/system-settings.html

> **Back up files before saving**: Before saving the file, create a backup. If the save operation is successful, WebStorm deletes the backup. If not, it restores the contents of the original file from backup. This behavior is known as "safe write", and it prevents losing your file in case of a faulty save operation.
