### PR TITLE
docs(concepts): add note about deprecated CLI usage for loaders

### DIFF
--- a/src/content/concepts/loaders.mdx
+++ b/src/content/concepts/loaders.mdx
@@ -51,6 +51,8 @@ There are two ways to use loaders in your application:
 - [Configuration](#configuration) (recommended): Specify them in your **webpack.config.js** file.
 - [Inline](#inline): Specify them explicitly in each `import` statement.
 
+Note that loaders can be used from CLI under webpack v4, but the feature was deprecated in webpack v5.
+
 ### Configuration
 
 [`module.rules`](/configuration/module/#modulerules) allows you to specify several loaders within your webpack configuration.


### PR DESCRIPTION
Closes https://github.com/webpack/webpack.js.org/issues/5735