### PR TITLE
docs(configuration): update `devServer` option types

### DIFF
--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -1117,7 +1117,7 @@ module.exports = {
 
 ## devServer.open
 
-`boolean` `string` `[string]` `object` `[object]`
+`boolean` `string` `object` `[string, object]`
 
 Tells dev-server to open the browser after server had been started. Set it to `true` to open your default browser.
 
@@ -1612,7 +1612,7 @@ module.exports = {
 
 ## devServer.static
 
-`boolean` `string` `[string]` `object` `[object]`
+`boolean` `string` `object` `[string, object]`
 
 This option allows configuring options for serving static files from the directory (by default 'public' directory). To disable set it to `false`:
 
@@ -1882,7 +1882,7 @@ module.exports = {
 
 ## devServer.watchFiles
 
-`string` `[string]` `object` `[object]`
+`string` `object` `[string, object]`
 
 This option allows you to configure a list of globs/directories/files to watch for file changes. For example:
 


### PR DESCRIPTION
use consistent format as per the writer's guide - https://webpack.js.org/contribute/writers-guide/#configuration-defaults-and-types