### PR TITLE
docs(configuration): add note for resource name when filename is data URI

### DIFF
--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -38,6 +38,8 @@ The top-level `output` key contains a set of options instructing webpack on how 
 
 The same as [`output.filename`](#outputfilename) but for [Asset Modules](/guides/asset-modules/).
 
+`[name]`, `[file]`, `[query]`, `[fragment]`, `[base]`, and `[path]` are set to an empty string for the assets built from data URI replacements.
+
 ## output.asyncChunks
 
 `boolean = true`


### PR DESCRIPTION
Fix https://github.com/webpack/webpack.js.org/issues/5941

To be merged after the new webpack release.