### PR TITLE
document for specifying the `buildHttp.proxy` for `HttpUrlPlugin`

### DIFF
--- a/src/content/configuration/experiments.mdx
+++ b/src/content/configuration/experiments.mdx
@@ -164,6 +164,14 @@ Define the location to store the lockfile.
 
 By default webpack would generate a `<compiler-name.>webpack.lock` file>. Make sure to commit it into a version control system. During the `production` build, webpack will build those modules beginning with `http(s):` protocol from the lockfile and caches under [`experiments.buildHttp.cacheLocation`](#experimentsbuildhttpcachelocation).
 
+#### experiments.buildHttp.proxy
+
+Specify the proxy server to use for fetching remote resources.
+
+- Type: `string`
+
+By default, Webpack would imply the proxy server to use for fetching remote resources from the `http_proxy` (case insensitive) environment variable. However, you can also specify one through the `proxy` option.
+
 #### experiments.buildHttp.upgrade
 
 Detect changes to remote resources and upgrade them automatically.


### PR DESCRIPTION
For https://github.com/webpack/webpack/pull/15354

closes https://github.com/webpack/webpack.js.org/issues/5994

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].
- **Remove these instructions from your PR as they are for your eyes only.**

[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
