### PR TITLE
docs(tree-shaking): remove imprecise language

### DIFF
--- a/src/content/guides/tree-shaking.mdx
+++ b/src/content/guides/tree-shaking.mdx
@@ -132,7 +132,7 @@ Note the `unused harmony export square` comment above. If you look at the code b
 
 ## Mark the file as side-effect-free
 
-In a 100% ESM module world, identifying side effects is straightforward. However, we aren't there quite yet, so in the mean time it's necessary to provide hints to webpack's compiler on the "pureness" of your code.
+It's necessary to provide hints to webpack's compiler on the "pureness" of your code.
 
 The way this is accomplished is the `"sideEffects"` package.json property.
 


### PR DESCRIPTION
The prior language suggested that ESM helps identify side effects. This is not the case.

The following case demonstrates an effect during ESM load.

```js
export const foo = (() => { window.bar = true; return 0; })();
```

Module evaluation of the above ES module induces a side effect during evaluation, and usage of ESM did not help identify it.

ESM did help compiler tooling evaluate `usedExports`, because the exported symbols are fixed.

The use of PURE and sideEffects are a bit contradictory in the webpack definitions. It's probably worth defining explicit definitions for webpack's interpreation of `pure` and `side effect` in the glossary page.

_describe your changes..._

- [ ] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [ ] Make sure your PR complies with the [writer's guide][2].
- [ ] Review the diff carefully as sometimes this can reveal issues.
- [ ] Do not abandon your Pull Request: [Stale Pull Requests][3].
- **Remove these instructions from your PR as they are for your eyes only.**

[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
