### PR TITLE
Fixed a mistake in the package.json diff

### DIFF
--- a/src/content/guides/getting-started.mdx
+++ b/src/content/guides/getting-started.mdx
@@ -26,6 +26,7 @@ contributors:
   - anshumanv
   - d3lm
   - snitin315
+  - tomjdv
 ---
 
 Webpack is used to compile JavaScript modules. Once [installed](/guides/installation), you can interact with webpack either from its [CLI](/api/cli) or [API](/api/node). If you're still new to webpack, please read through the [core concepts](/concepts) and [this comparison](/comparison) to learn why you might use it over the other tools that are out in the community.
@@ -287,8 +288,7 @@ Given it's not particularly fun to run a local copy of webpack from the CLI, we 
    "description": "",
    "private": true,
    "scripts": {
--    "test": "echo \"Error: no test specified\" && exit 1"
-+    "test": "echo \"Error: no test specified\" && exit 1",
+     "test": "echo \"Error: no test specified\" && exit 1"
 +    "build": "webpack"
    },
    "keywords": [],


### PR DESCRIPTION
The test script was removed and then added again in the diff, I think it was just meant to be replaced by the build command. As you don't _have_ to remove it in order to add a new script, I just left it in to avoid confusion.