### PR TITLE
docs(vote): redirect voting page in sidebar to v4 instead

### DIFF
--- a/src/components/SidebarItem/SidebarItem.jsx
+++ b/src/components/SidebarItem/SidebarItem.jsx
@@ -5,6 +5,7 @@ import ChevronRightIcon from '../../styles/icons/chevron-right.svg';
 import BarIcon from '../../styles/icons/vertical-bar.svg';
 import PropTypes from 'prop-types';
 import { NavLink } from 'react-router-dom';
+import Link from '../Link/Link';
 
 const block = 'sidebar-item';
 
@@ -79,15 +80,22 @@ export default class SidebarItem extends Component {
           />
         )}
 
-        <NavLink
-          end
-          key={this.props.url}
-          className={`${block}__title`}
-          to={this.props.url}
-          onClick={this.scrollTop}
-        >
-          {title}
-        </NavLink>
+        {this.props.url.startsWith('http') ||
+        this.props.url.startsWith('//') ? (
+          <Link url={this.props.url} className={`${block}__title`}>
+            {title}
+          </Link>
+        ) : (
+          <NavLink
+            end
+            key={this.props.url}
+            className={`${block}__title`}
+            to={this.props.url}
+            onClick={this.scrollTop}
+          >
+            {title}
+          </NavLink>
+        )}
 
         {anchors.length > 0 ? this.renderAnchors(tree) : null}
       </div>

--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -142,6 +142,18 @@ function Site(props) {
   let sections = extractSections(Content);
   let section = sections.find(({ url }) => location.pathname.startsWith(url));
   let pages = extractPages(Content);
+
+  const overrideUrls = {
+    '/vote/': 'https://v4.webpack.js.org/vote/',
+  };
+
+  pages = pages.map((p) => {
+    if (p.url && overrideUrls[p.url]) {
+      p.url = overrideUrls[p.url];
+    }
+    return p;
+  });
+
   const sidebarPages = _strip(
     section
       ? section.children


### PR DESCRIPTION
Changes:

Redirecting the sidebar link for the Vote page to open the v4 version instead of a blank page.