### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/src/components/Support/Support.jsx
+++ b/src/components/Support/Support.jsx
@@ -85,7 +85,7 @@ function formatMoney(number) {
   let str = Math.round(number) + '';
 
   if (str.length > 3) {
-    str = str.substr(0, str.length - 3) + ',' + str.substr(-3);
+    str = str.slice(0, -3) + ',' + str.slice(-3);
   }
   return str;
 }

--- a/src/remark-plugins/remark-custom-asides/index.mjs
+++ b/src/remark-plugins/remark-custom-asides/index.mjs
@@ -20,7 +20,7 @@ export default function customAsides(
       if (!textNode) return;
 
       // looking for mapping in the beginning
-      const className = mapping[textNode.substr(0, 2)];
+      const className = mapping[textNode.slice(0, 2)];
       // >This is a joke <- ignore this
       // >T hi there
       const hasPostfixWhitespace = textNode.indexOf(' ') === 2;


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Breaking Changes

None

### Additional Info
