### PR TITLE
docs(plugins): add `footer` parameter for `BannerPlugin`

### DIFF
--- a/src/content/plugins/banner-plugin.mdx
+++ b/src/content/plugins/banner-plugin.mdx
@@ -30,6 +30,7 @@ new webpack.BannerPlugin(options);
   test: string | RegExp | [string, RegExp], // Include all modules that pass test assertion.
   include: string | RegExp | [string, RegExp], // Include all modules matching any of these conditions.
   exclude: string | RegExp | [string, RegExp], // Exclude all modules matching any of these conditions.
+  footer?: boolean, // if true, the banner will be placed at the end of the compilation
 }
 ```
 


### PR DESCRIPTION
Fixes #6077 

There is a plugin we are using for version 4 that does the same thing as BannerPlugin, but it could place the text at the bottom of the file instead of the top. This allows the BannerPlugin to place the banner either as a header or footer. No other changes.

BannerPlugin was updated by https://github.com/webpack/webpack/pull/15617