### PR TITLE
docs(development): Mention `runtimeChunk: single` for multi-endpoint dev server

### DIFF
--- a/src/content/guides/development.mdx
+++ b/src/content/guides/development.mdx
@@ -225,10 +225,15 @@ Change your configuration file to tell the dev server where to look for files:
      path: path.resolve(__dirname, 'dist'),
      clean: true,
    },
++  optimization: {
++    runtimeChunk: 'single',
++  },
  };
 ```
 
 This tells `webpack-dev-server` to serve the files from the `dist` directory on `localhost:8080`.
+
+The `optimization.runtimeChunk: 'single'` was added because in this example we have more than one entrypoint on a single HTML page. Without this, we could get into trouble described [here](https://bundlers.tooling.report/code-splitting/multi-entry/). Read the [Code Splitting](/guides/code-splitting/) section of the guide for more details.
 
 T> `webpack-dev-server` serves bundled files from the directory defined in [`output.path`](/configuration/output/#outputpath), i.e., files will be available under `http://[devServer.host]:[devServer.port]/[output.publicPath]/[output.filename]`.
 

--- a/src/content/guides/development.mdx
+++ b/src/content/guides/development.mdx
@@ -16,6 +16,7 @@ contributors:
   - chenxsan
   - maxloh
   - snitin315
+  - f3ndot
 ---
 
 T> This guide extends on code examples found in the [Output Management](/guides/output-management) guide.

--- a/src/content/guides/development.mdx
+++ b/src/content/guides/development.mdx
@@ -233,7 +233,7 @@ Change your configuration file to tell the dev server where to look for files:
 
 This tells `webpack-dev-server` to serve the files from the `dist` directory on `localhost:8080`.
 
-The `optimization.runtimeChunk: 'single'` was added because in this example we have more than one entrypoint on a single HTML page. Without this, we could get into trouble described [here](https://bundlers.tooling.report/code-splitting/multi-entry/). Read the [Code Splitting](/guides/code-splitting/) section of the guide for more details.
+T> The `optimization.runtimeChunk: 'single'` was added because in this example we have more than one entrypoint on a single HTML page. Without this, we could get into trouble described [here](https://bundlers.tooling.report/code-splitting/multi-entry/). Read the [Code Splitting](/guides/code-splitting/) chapter for more details.
 
 T> `webpack-dev-server` serves bundled files from the directory defined in [`output.path`](/configuration/output/#outputpath), i.e., files will be available under `http://[devServer.host]:[devServer.port]/[output.publicPath]/[output.filename]`.
 


### PR DESCRIPTION
This section of the guide introduces the concept of a dev server for the first time, but has not introduced the concept that multiple endpoints on a single html file served by the webserver is problematic without `optimization.runtimeChunk: 'single'`.

This commit attempts to give new developers a softer landing, and references the Code Splitting section to more deeply understand as well as link to the same pitfall external resource as the Code Splitting section does.

See https://github.com/webpack/webpack/discussions/14873#discussioncomment-2449779 for rationale
