### PR TITLE
fix(example/html): make HTML tags into the correct format

### DIFF
--- a/examples/module-federation/app1/public/index.html
+++ b/examples/module-federation/app1/public/index.html
@@ -5,6 +5,6 @@
         <title>App 1</title>
     </head>
     <body>
-        <div id="root"/>
+        <div id="root"></div>
     </body>
 </html>

--- a/examples/module-federation/app2/public/index.html
+++ b/examples/module-federation/app2/public/index.html
@@ -5,6 +5,6 @@
         <title>App 2</title>
     </head>
     <body>
-        <div id="root"/>
+        <div id="root"></div>
     </body>
 </html>


### PR DESCRIPTION
When I jump to [StackBlitz](https://stackblitz.com/github/webpack/webpack.js.org/tree/master/examples/module-federation?file=app2%2Fpublic%2Findex.html&terminal=start&terminal=) in the [Module Federation chapter](https://webpack.js.org/concepts/module-federation/) of the Webpack documentation , I realized that its HTML template file had some problems:

<img width="329" alt="image" src="https://user-images.githubusercontent.com/10683193/169649947-0acdd3aa-56ad-4b61-bb0c-1865cf0a6c33.png">

According to the HTML specification, `div` tags should not be self-closing.

Although on modern browsers it correctly identifies the offending HTML tag (since it happens to be the only tag in the HTML body) and thus happens to render the correct result. But I think it should keep the correct format anyway, so I made a change.

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].
- **Remove these instructions from your PR as they are for your eyes only.**

[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
