### PR TITLE
fix(scripts/build-content-tree): fix `JSON.stringify` method

### DIFF
--- a/src/scripts/build-content-tree.mjs
+++ b/src/scripts/build-content-tree.mjs
@@ -43,7 +43,7 @@ function buildContentTree(source, output) {
 
   fs.writeFileSync(
     path.resolve(output),
-    JSON.stringify(content, 2),
+    JSON.stringify(content, null, 2),
     (error) => {
       if (error) {
         console.log('scripts/build-content-tree', error);


### PR DESCRIPTION
As the title and code says.

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].
- **Remove these instructions from your PR as they are for your eyes only.**

[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
