### PR TITLE
fix(utillities/fetch-pacakge-readmes): add second parameters (encoding) of `fs.readFile`

### DIFF
--- a/src/utilities/fetch-package-readmes.mjs
+++ b/src/utilities/fetch-package-readmes.mjs
@@ -39,7 +39,7 @@ async function main() {
     await mkdirp(outputDir);
 
     const repos = JSON.parse(
-      await readFile(path.resolve(__dirname, `../../repositories/${type}.json`))
+      await readFile(path.resolve(__dirname, `../../repositories/${type}.json`), 'utf-8')
     );
 
     for (const repo of repos) {


### PR DESCRIPTION
As the title and code says.

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].
- **Remove these instructions from your PR as they are for your eyes only.**

[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
