### PR TITLE
docs(api): add `shutdown` compiler hook

### DIFF
--- a/src/content/api/compiler-hooks.mdx
+++ b/src/content/api/compiler-hooks.mdx
@@ -284,6 +284,12 @@ Executed when a watching compilation has been invalidated. This hook is _not_ co
 
 Called when a watching compilation has stopped.
 
+### shutdown
+
+`AsyncSeriesHook`
+
+Called when the compiler is closing.
+
 ### infrastructureLog
 
 `SyncBailHook`


### PR DESCRIPTION
Fix https://github.com/webpack/webpack.js.org/issues/6187
