### PR TITLE
docs(guides): remove trailing comma in package.json

### DIFF
--- a/src/content/guides/getting-started.mdx
+++ b/src/content/guides/getting-started.mdx
@@ -26,6 +26,7 @@ contributors:
   - anshumanv
   - d3lm
   - snitin315
+  - Etheryen
 ---
 
 Webpack is used to compile JavaScript modules. Once [installed](/guides/installation), you can interact with webpack either from its [CLI](/api/cli) or [API](/api/node). If you're still new to webpack, please read through the [core concepts](/concepts) and [this comparison](/comparison) to learn why you might use it over the other tools that are out in the community.
@@ -118,7 +119,7 @@ T> If you want to learn more about the inner workings of `package.json`, then we
    "license": "MIT",
    "devDependencies": {
      "webpack": "^5.38.1",
-     "webpack-cli": "^4.7.2",
+     "webpack-cli": "^4.7.2"
    }
  }
 ```


### PR DESCRIPTION
Remove a trailing comma in `package.json` in the "Basic Setup" section as they are not allowed in JSON.
