### PR TITLE
improve require docs

### DIFF
--- a/src/content/api/module-methods.mdx
+++ b/src/content/api/module-methods.mdx
@@ -433,3 +433,15 @@ __webpack_modules__[require.resolveWeak(`./page/${page}`)];
 ```
 
 T> `require.resolveWeak` is the foundation of _universal rendering_ (SSR + Code Splitting), as used in packages such as [react-universal-component](https://github.com/faceyspacey/react-universal-component). It allows code to render synchronously on both the server and initial page-loads on the client. It requires that chunks are manually served or somehow available. It's able to require modules without indicating they should be bundled into a chunk. It's used in conjunction with `import()` which takes over when user navigation triggers additional imports.
+
+### warning
+
+If the module source contains a require that cannot be statically analyzed, critical dependencies warning is emitted.
+
+Example code:
+
+```javascript
+someFn(require);
+require.bind(null);
+require(variable);
+```


### PR DESCRIPTION
- describe critical dependency warning

there was a section about critical dependency [in archived docs](https://github.com/webpack/docs/wiki/context#critical-dependencies) about warning like:
```
Critical dependencies:
158:18-25 require function is used in a way in which dependencies cannot be statically extracted
```

will be great to add this in current docs too. not sure where place this better... 
<!-- Name of the feature(s) and a link to related pull request of the feature implementat

- [ ] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [ ] Make sure your PR complies with the [writer's guide][2].
- [ ] Review the diff carefully as sometimes this can reveal issues.
- [ ] Do not abandon your Pull Request: [Stale Pull Requests][3].
- **Remove these instructions from your PR as they are for your eyes only.**

[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
