### PR TITLE
Fix typo at `module-federation.mdx`

### DIFF
--- a/src/content/concepts/module-federation.mdx
+++ b/src/content/concepts/module-federation.mdx
@@ -255,7 +255,7 @@ export function set(value) {
 const publicPath = await import('remote/public-path');
 publicPath.set('/your-public-path');
 
-//boostrap app  e.g. import('./boostrap.js')
+//bootstrap app  e.g. import('./bootstrap.js')
 ```
 
 ### Infer publicPath from script


### PR DESCRIPTION
Fix typo: `boostrap` => `bootstrap`
