### PR TITLE
Update 2020-10-10-webpack-5-release.mdx

### DIFF
--- a/src/content/blog/2020-10-10-webpack-5-release.mdx
+++ b/src/content/blog/2020-10-10-webpack-5-release.mdx
@@ -361,7 +361,7 @@ The inner graph algorithm will figure out that `something` is only used when the
 
 When `"sideEffects": false` is set, this allows to omit even more modules. In this example `./something` will be omitted when the `test` export is unused.
 
-To get the information about unused exports `optimization.unusedExports` is required. To remove side-effect-free modules `optimization.sideEffects` is required.
+To get the information about unused exports `optimization.usedExports` is required. To remove side-effect-free modules `optimization.sideEffects` is required.
 
 The following symbols can be analysed:
 


### PR DESCRIPTION
`optimization.unusedExports` -> `optimization.usedExports`

There is no `unusedExports` property in [`optimization` option](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/config/defaults.js#L1149).

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].
- **Remove these instructions from your PR as they are for your eyes only.**

[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
