### PR TITLE
docs(loaders): add link to esbuild-loader

### DIFF
--- a/src/content/loaders/index.mdx
+++ b/src/content/loaders/index.mdx
@@ -29,6 +29,7 @@ Loaders are activated by using `loadername!` prefixes in `require()` statements,
 ## Transpiling
 
 - [`babel-loader`](/loaders/babel-loader) Loads ES2015+ code and transpiles to ES5 using [Babel](https://babeljs.io/)
+- [`esbuild-loader`](https://github.com/privatenumber/esbuild-loader) Loads ES2015+ code and transpiles to ES6+ using [esbuild](https://esbuild.github.io/)
 - [`buble-loader`](https://github.com/sairion/buble-loader) Loads ES2015+ code and transpiles to ES5 using [Bublé](https://buble.surge.sh/guide/)
 - [`traceur-loader`](https://github.com/jupl/traceur-loader) Loads ES2015+ code and transpiles to ES5 using [Traceur](https://github.com/google/traceur-compiler#readme)
 - [`ts-loader`](https://github.com/TypeStrong/ts-loader) Loads [TypeScript](https://www.typescriptlang.org/) 2.0+ like JavaScript


### PR DESCRIPTION
PR adds `esbuild-loader` as a possible option for a transpiling loader as it's gaining a lot of popularity vs using babel-loader.