### PR TITLE
Fix type description for ctx.contextInfo for externals callback

### DIFF
--- a/src/content/configuration/externals.mdx
+++ b/src/content/configuration/externals.mdx
@@ -171,7 +171,7 @@ Here're arguments the function can receive:
 - `ctx` (`object`): Object containing details of the file.
   - `ctx.context` (`string`): The directory of the file which contains the import.
   - `ctx.request` (`string`): The import path being requested.
-  - `ctx.contextInfo` (`string`): Contains information about the issuer (e.g. the layer).
+  - `ctx.contextInfo` (`object`): Contains information about the issuer (e.g. the layer and compiler)
   - `ctx.getResolve` <Badge text='5.15.0+' />: Get a resolve function with the current resolver options.
 - `callback` (`function (err, result, type)`): Callback function used to indicate how the module should be externalized.
 


### PR DESCRIPTION
Fix the type declaration for `ctx.contextinfo`  in externals handling callback

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].
- **Remove these instructions from your PR as they are for your eyes only.**

[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
