### PR TITLE
fix(docs): correct typo in the setupMiddlewares example

### DIFF
--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -1581,7 +1581,7 @@ module.exports = {
       // Use the `unshift` method if you want to run a middleware before all other middlewares
       // or when you are migrating from the `onBeforeSetupMiddleware` option
       middlewares.unshift({
-        name: 'fist-in-array',
+        name: 'first-in-array',
         // `path` is optional
         path: '/foo/path',
         middleware: (req, res) => {


### PR DESCRIPTION
The injected middleware is the first in the array, it makes more sense to call it like that. Also, I'm not sure we should condone violence through fists against JS arrays.