### PR TITLE
fix(docs): syntax fix in "Inline matchResource"

### DIFF
--- a/src/content/api/loaders.mdx
+++ b/src/content/api/loaders.mdx
@@ -716,7 +716,7 @@ The loader could look like this:
 **extract-style-loader/index.js**
 
 ```javascript
-const getStylesLoader = require.resolve('./getStyle');
+const getStylesLoader = require.resolve('./getStyles');
 
 module.exports = function (source) {
   if (STYLES_REGEXP.test(source)) {
@@ -733,7 +733,7 @@ module.exports = function (source) {
 
 ```javascript
 module.exports = function (source) {
-  const match = STYLES_REGEXP.match(source);
+  const match = source.match(STYLES_REGEXP);
   return match[0];
 };
 ```


### PR DESCRIPTION
syntax fix in Inline matchResource example:
"const match = STYLES_REGEXP.match(source);"  is in the wrong order -> "const match = source.match(STYLES_REGEXP);"
"require.resolve('./getStyle');" is missing the "s" to match with the file getStyles.js
