### PR TITLE
minor - remove typo extra underscore

### DIFF
--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -924,7 +924,7 @@ Configure how the library will be exposed.
 
   Types included by default are `'var'`, `'module'`, `'assign'`, `'assign-properties'`, `'this'`, `'window'`, `'self'`, `'global'`, `'commonjs'`, `'commonjs2'`, `'commonjs-module'`, `'commonjs-static'`, `'amd'`, `'amd-require'`, `'umd'`, `'umd2'`, `'jsonp'` and `'system'`, but others might be added by plugins.
 
-For the following examples, we'll use `__entry_return_` to indicate the values returned by the entry point.
+For the following examples, we'll use `_entry_return_` to indicate the values returned by the entry point.
 
 #### Expose a Variable
 

--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -1501,7 +1501,7 @@ which will yield the following:
   //Test Comment
   else root['MyLibrary'] = factory();
 })(self, function () {
-  return __entry_return_;
+  return _entry_return_;
 });
 ```
 


### PR DESCRIPTION
Remove an extra underscore in the documentation.
