### PR TITLE
docs(Migration): `loaders` → `use`

### DIFF
--- a/src/content/migrate/5.mdx
+++ b/src/content/migrate/5.mdx
@@ -68,7 +68,7 @@ Update the following options to their new version (if used):
 - `Compilation.entries` → `Compilation.entryDependencies`
 - `serve` → `serve` is removed in favor of [`DevServer`](/configuration/dev-server/)
 - [`Rule.query`](/configuration/module/#ruleoptions--rulequery) (deprecated since v3) → `Rule.options`/`UseEntry.options`
-- `loaders` → `use` 
+- `Rule.loaders` → [`Rule.use`](/configuration/module/#ruleuse)
 
 ### Test webpack 5 compatibility
 

--- a/src/content/migrate/5.mdx
+++ b/src/content/migrate/5.mdx
@@ -68,6 +68,7 @@ Update the following options to their new version (if used):
 - `Compilation.entries` → `Compilation.entryDependencies`
 - `serve` → `serve` is removed in favor of [`DevServer`](/configuration/dev-server/)
 - [`Rule.query`](/configuration/module/#ruleoptions--rulequery) (deprecated since v3) → `Rule.options`/`UseEntry.options`
+- `loaders` → `use` 
 
 ### Test webpack 5 compatibility
 


### PR DESCRIPTION
My understanding is that the deprecated `loaders` was removed in https://github.com/webpack/webpack/pull/9138 which was in https://github.com/webpack/webpack/releases/tag/v5.74.0 (should that have been a major version upgrade?)

_describe your changes..._

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [ ] Do not abandon your Pull Request: [Stale Pull Requests][3].

[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
