### PR TITLE
docs(configuration): move `name` option to correct place

### DIFF
--- a/src/content/configuration/index.mdx
+++ b/src/content/configuration/index.mdx
@@ -57,7 +57,7 @@ W> Notice that many array configurations allow to reference the default value vi
 const path = require('path');
 
 module.exports = {
- name: "my-config", // name of the configuration, shown in output
+  name: "my-config", // name of the configuration, shown in output
   <mode "/configuration/mode">
     <default>
       mode: "production", // "production" | "development" | "none"

--- a/src/content/configuration/index.mdx
+++ b/src/content/configuration/index.mdx
@@ -18,6 +18,7 @@ contributors:
   - bigdawggi
   - anshumanv
   - textbook
+  - coly010
 ---
 
 Out of the box, webpack won't require you to use a configuration file. However, it will assume the entry point of your project is `src/index.js` and will output the result in `dist/main.js` minified and optimized for production.
@@ -64,6 +65,7 @@ module.exports = {
     mode: "development", // enabled useful tools for development
     mode: "none", // no defaults
   </mode>
+  name: "my-config", // name of the configuration, shown in output
   // Chosen mode tells webpack to use its built-in optimizations accordingly.
   <entry "/configuration/entry-context/#entry">
     <default>
@@ -178,8 +180,6 @@ module.exports = {
     },
     uniqueName: "my-application", // (defaults to package.json "name")
     // unique name for this build to avoid conflicts with other builds in the same HTML
-    name: "my-config",
-    // name of the configuration, shown in output
     <advancedOutput "#">
       <default>
         /* Advanced output configuration (click to show) */

--- a/src/content/configuration/index.mdx
+++ b/src/content/configuration/index.mdx
@@ -57,6 +57,7 @@ W> Notice that many array configurations allow to reference the default value vi
 const path = require('path');
 
 module.exports = {
+   name: "my-config", // name of the configuration, shown in output
   <mode "/configuration/mode">
     <default>
       mode: "production", // "production" | "development" | "none"
@@ -65,7 +66,6 @@ module.exports = {
     mode: "development", // enabled useful tools for development
     mode: "none", // no defaults
   </mode>
-  name: "my-config", // name of the configuration, shown in output
   // Chosen mode tells webpack to use its built-in optimizations accordingly.
   <entry "/configuration/entry-context/#entry">
     <default>

--- a/src/content/configuration/index.mdx
+++ b/src/content/configuration/index.mdx
@@ -57,7 +57,7 @@ W> Notice that many array configurations allow to reference the default value vi
 const path = require('path');
 
 module.exports = {
-   name: "my-config", // name of the configuration, shown in output
+ name: "my-config", // name of the configuration, shown in output
   <mode "/configuration/mode">
     <default>
       mode: "production", // "production" | "development" | "none"


### PR DESCRIPTION
The `name` option was listed under the `output` object which is incorrect.

Move it to top-level configuration object.
