### PR TITLE
Update output-management.mdx

### DIFF
--- a/src/content/guides/output-management.mdx
+++ b/src/content/guides/output-management.mdx
@@ -175,6 +175,21 @@ cacheable modules 530 KiB
   ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
 webpack 5.4.0 compiled successfully in 2189 ms
 ```
+If an error show up saying npm ERR! Missing script: "build". In other to fix this problem, open the package.json in script properties, add "build": "webpack". After that, run the `npm run build`.
+
+**package.json**
+```diff
+{
+  "name": "webpack-setup",
+  "version": "1.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+   + "build": "webpack"
+  }
+
+```
 
 If you open `index.html` in your code editor, you'll see that the `HtmlWebpackPlugin` has created an entirely new file for you and that all the bundles are automatically added.
 


### PR DESCRIPTION
I run the npm run build and had some errors that missing the script build. I included it in my package.json and it works correctly.

_describe your changes..._

- [ ] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [ ] Make sure your PR complies with the [writer's guide][2].
- [ ] Review the diff carefully as sometimes this can reveal issues.
- [ ] Do not abandon your Pull Request: [Stale Pull Requests][3].
- **Remove these instructions from your PR as they are for your eyes only.**

[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
