### PR TITLE
Update stats.mdx to better describe the entry point objects

### DIFF
--- a/src/content/api/stats.mdx
+++ b/src/content/api/stats.mdx
@@ -165,6 +165,14 @@ What good would these statistics be without some description of the compiled app
     "building": 73, // Loading and parsing
     "dependencies": 242, // Building dependencies
     "factory": 11 // Resolving dependencies
+
+    "total": 0,
+    "resolving": 0,
+    "restoring": 0,
+    "integration": 0,
+    "storing": 0,
+    "additionalResolving": 0,
+    "additionalIntegration": 0
   },
   "reasons": [
     // See the description below...

--- a/src/content/api/stats.mdx
+++ b/src/content/api/stats.mdx
@@ -10,6 +10,7 @@ contributors:
   - chenxsan
   - rahul3v
   - snitin315
+  - rudolfolah
 ---
 
 When compiling source code with webpack, users can generate a JSON file containing statistics about modules. These statistics can be used to analyze an application's dependency graph as well as to optimize compilation speed. The file is typically generated with the following CLI command:
@@ -54,7 +55,8 @@ The top-level structure of the output JSON file is fairly straightforward but th
     // A list of [module objects](#module-objects)
   ],
   'entryPoints': {
-    // A list of [entry objects](#entry-objects)
+    // A map of [entry objects](#entry-objects), where the key is the entry point name
+    "main": {},
   },
   'errors': [
     // A list of [error objects](#errors-and-warnings)
@@ -190,12 +192,12 @@ Every module also contains a list of `reasons` objects describing why that modul
 ### Entry Objects
 
 ```json
-"main": {
+{
   "name": "main",
-  "chunks": [
+  "chunks": [ // list of chunk ids
     179
   ],
-  "assets": [
+  "assets": [ // list of asset objects
     {
       "name": "main.js",
       "size": 22
@@ -203,11 +205,11 @@ Every module also contains a list of `reasons` objects describing why that modul
   ],
   "filteredAssets": 0,
   "assetsSize": 22,
-  "auxiliaryAssets": [],
+  "auxiliaryAssets": [], // list of asset objects
   "filteredAuxiliaryAssets": 0,
   "auxiliaryAssetsSize": 0,
-  "children": {},
-  "childAssets": {},
+  "children": {}, // map of entry objects where the key is the entry object name
+  "childAssets": {}, // map of assets, where the key is the id of the asset
   "isOverSizeLimit": false
 }
 ```


### PR DESCRIPTION
Updating the description of the schema in the Profiling Stats section of the documentation.

- Fixed the "a list of entry objects" to "a **map** of entry objects" to show that each entry object is a value for a key
- Added small descriptions in comments to other fields on the Entry Object: `chunks`, `assets`, `auxiliaryAssets`, `children`, `childAssets`
- Added more of the fields that can appear in the module `profile`. The additional fields are: `total`, `resolving`, `restoring`, `integration`, `storing`, `additionalResolving`, `additionalIntegration`

---

I hereby agree to the terms set out in the CLA: https://github.com/openjs-foundation/EasyCLA/blob/main/openjs_foundation_icla-PREVIEW.pdf
