### PR TITLE
fix background color for inline code under dark mode

### DIFF
--- a/src/styles/dark.scss
+++ b/src/styles/dark.scss
@@ -17,6 +17,7 @@ body {
   code,
   tt {
     text-shadow: none;
+    background-color: transparentize(getColor(fiord), 0.55);
   }
   blockquote {
     border-left-color: #343434;
@@ -53,6 +54,9 @@ body {
   }
   pre {
     background-color: #131b1f;
+    code {
+      background: transparent;
+    }
   }
   a code {
     color: #69a8ee;


### PR DESCRIPTION
The background color for `<code />` under dark mode is so lighter at the moment.

## Before

<img width="764" alt="CleanShot 2022-10-09 at 21 07 46@2x" src="https://user-images.githubusercontent.com/1091472/194758512-d7ee3993-c2d7-4213-9e3d-af46b4ac2fbe.png">

## After

<img width="729" alt="CleanShot 2022-10-09 at 21 08 03@2x" src="https://user-images.githubusercontent.com/1091472/194758523-db30dd7e-7d13-4b64-a351-2286ac4571e9.png">
