### PR TITLE
docs(configuration/output): Warn about module output being not usable in webpack4

### DIFF
--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -1970,7 +1970,7 @@ module.exports = {
 };
 ```
 
-W> `output.module` is an experimental feature and can only be enabled by setting [`experiments.outputModule`](/configuration/experiments/#experiments) to `true`.
+W> `output.module` is an experimental feature and can only be enabled by setting [`experiments.outputModule`](/configuration/experiments/#experiments) to `true`. [One of the known problems](https://github.com/webpack/webpack/issues/11277#issuecomment-992565287) is that such a library can't be consumed by webpack4-based (and possibly other too) applications.
 
 ## output.path
 


### PR DESCRIPTION
As explained in https://github.com/webpack/webpack/issues/11277#issuecomment-1277258335, when outputting as a module, one would expect it'll simply work as any other npm module. Currently it doesn't, e.g. it won't work in webpack4-based applications.