### PR TITLE
docs(Configuration): fix lang for code block

### DIFF
--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -1654,7 +1654,7 @@ module.exports = {
 
 Usage via CLI:
 
-```console
+```bash
 npx webpack serve --static assets
 ```
 
@@ -1673,7 +1673,7 @@ module.exports = {
 
 Usage via CLI:
 
-```console
+```bash
 npx webpack serve --static assets --static css
 ```
 


### PR DESCRIPTION
There's no `console` language for code block https://github.com/wooorm/refractor#data