### PR TITLE
Replace `whitelist` with `allowlist` where possible

### DIFF
--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -96,7 +96,7 @@ See the related [API documentation for `webpack-dev-server`](/api/webpack-dev-se
 
 `'auto' | 'all'` `[string]`
 
-This option allows you to whitelist services that are allowed to access the dev server.
+This option allows you to allowlist services that are allowed to access the dev server.
 
 **webpack.config.js**
 

--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -21,6 +21,7 @@ contributors:
   - anikethsaha
   - snitin315
   - Biki-das
+  - SaulSilver
 ---
 
 [webpack-dev-server](https://github.com/webpack/webpack-dev-server) can be used to quickly develop an application. See the [development guide](/guides/development/) to get started.

--- a/src/content/configuration/externals.mdx
+++ b/src/content/configuration/externals.mdx
@@ -18,6 +18,7 @@ contributors:
   - pranshuchittora
   - kinetifex
   - anshumanv
+  - SaulSilver
 ---
 
 The `externals` configuration option provides a way of excluding dependencies from the output bundles. Instead, the created bundle relies on that dependency to be present in the consumer's (any end-user application) environment. This feature is typically most useful to **library developers**, however there are a variety of applications for it.

--- a/src/content/configuration/externals.mdx
+++ b/src/content/configuration/externals.mdx
@@ -164,7 +164,7 @@ This syntax is used to describe all the possible ways that an external library c
 - `function ({ context, request, contextInfo, getResolve }, callback)`
 - `function ({ context, request, contextInfo, getResolve }) => promise` <Badge text='5.15.0+' />
 
-It might be useful to define your own function to control the behavior of what you want to externalize from webpack. [webpack-node-externals](https://www.npmjs.com/package/webpack-node-externals), for example, excludes all modules from the `node_modules` directory and provides options to whitelist packages.
+It might be useful to define your own function to control the behavior of what you want to externalize from webpack. [webpack-node-externals](https://www.npmjs.com/package/webpack-node-externals), for example, excludes all modules from the `node_modules` directory and provides options to allowlist packages.
 
 Here're arguments the function can receive:
 


### PR DESCRIPTION
## Description of changes
Partially fixes #6485 

Replacing "whitelist" with "allowlist" where possible. There are still 2 places with the word "Whitelist" but they are external article title so I should not change these words.

## Context and motivation
Contributing to Webpack's efforts of being more inclusive and follow the guidelines from [NIST](https://www.nist.gov/news-events/news/2021/04/nists-inclusive-language-guidance-aims-clarity-standards-publications).