### PR TITLE
Add globalObject when type is umd

### DIFF
--- a/src/content/guides/author-libraries.mdx
+++ b/src/content/guides/author-libraries.mdx
@@ -197,6 +197,7 @@ Let's update the `output.library` option with its `type` set to [`'umd'`](/confi
      path: path.resolve(__dirname, 'dist'),
      filename: 'webpack-numbers.js',
 -    library: 'webpackNumbers',
++    globalObject: 'this',
 +    library: {
 +      name: 'webpackNumbers',
 +      type: 'umd',


### PR DESCRIPTION
https://webpack.js.org/configuration/output/#outputglobalobject

When targeting a library, especially when libraryTarget is 'umd', this option indicates what global object will be used to mount the library. To make UMD build available on both browsers and Node.js, set `output.globalObject` option to 'this'. Defaults to self for Web-like targets.
