### PR TITLE
fix naming in sidebar version select

### DIFF
--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -49,7 +49,7 @@ export default function Sidebar({ className = '', pages, currentPage }) {
           >
             {versions.map((version) => (
               <option key={version} value={version}>
-                Webpack {version}
+                webpack {version}
               </option>
             ))}
           </select>


### PR DESCRIPTION
I have spotted that almost everywhere on the docs webpack is referred to as `webpack` (lowercase), when in the sidebar version select the capitalized name has been used, so I have corrected it for the naming consistency.