### PR TITLE
updating method signature for compilation.addModule()

### DIFF
--- a/src/content/api/compilation-object.mdx
+++ b/src/content/api/compilation-object.mdx
@@ -21,14 +21,14 @@ Returns Stats object for the current compilation.
 
 ### addModule
 
-`function (module, cacheGroup)`
+`function (module, callback)`
 
 Adds a module to the current compilation.
 
 Parameters:
 
 - `module` - module to be added
-- `cacheGroup` - `cacheGroup` of the module
+- `callback` - a callback after the module has been added
 
 ### getModule
 


### PR DESCRIPTION
The `addModule()` method takes a `module` and a `callback`, not a `cacheGroup`:

https://github.com/webpack/webpack/blob/8241da7f1e75c5581ba535d127fa66aeb9eb2ac8/lib/Compilation.js#L1253-L1261