### PR TITLE
build(deps): upgrade markdownlint

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -13,7 +13,6 @@
   "MD034": false,
   "MD036": false,
   "MD041": false,
-  "MD053": false,
   "no-hard-tabs": false,
   "whitespace": false
 }

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "lightningcss": "^1.17.1",
     "lint-staged": "^13.1.0",
     "lodash": "^4.17.21",
-    "markdownlint": "^0.26.2",
     "markdownlint-cli": "^0.32.2",
     "mdast-util-to-string": "^3.1.0",
     "mini-css-extract-plugin": "^2.7.2",
@@ -163,6 +162,7 @@
   "resolutions": {
     "sitemap-static/minimist": "1.2.5",
     "ini": "1.3.7",
-    "eval": "^0.1.5"
+    "eval": "^0.1.5",
+    "markdownlint-cli/markdownlint": "^0.27.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -148,12 +148,7 @@
   dependencies:
     "@babel/highlight" "^7.18.6"
 
-"@babel/compat-data@^7.17.7", "@babel/compat-data@^7.20.1":
-  version "7.20.1"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.20.1.tgz#f2e6ef7790d8c8dbf03d379502dcc246dcce0b30"
-  integrity sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==
-
-"@babel/compat-data@^7.20.5":
+"@babel/compat-data@^7.17.7", "@babel/compat-data@^7.20.1", "@babel/compat-data@^7.20.5":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.20.5.tgz#86f172690b093373a933223b4745deeb6049e733"
   integrity sha512-KZXo2t10+/jxmkhNXc7pZTqRvSOIvVv/+lJwHS+B2rErwOyjuVRh60yVpb7liQ1U5t7lLJ1bz+t8tSypUZdm0g==
@@ -7793,10 +7788,10 @@ markdownlint-rule-helpers@~0.17.2:
   resolved "https://registry.yarnpkg.com/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.17.2.tgz#64d6e8c66e497e631b0e40cf1cef7ca622a0b654"
   integrity sha512-XaeoW2NYSlWxMCZM2B3H7YTG6nlaLfkEZWMBhr4hSPlq9MuY2sy83+Xr89jXOqZMZYjvi5nBCGoFh7hHoPKZmA==
 
-markdownlint@^0.26.2, markdownlint@~0.26.2:
-  version "0.26.2"
-  resolved "https://registry.yarnpkg.com/markdownlint/-/markdownlint-0.26.2.tgz#11d3d03e7f0dd3c2e239753ee8fd064a861d9237"
-  integrity sha512-2Am42YX2Ex5SQhRq35HxYWDfz1NLEOZWWN25nqd2h3AHRKsGRE+Qg1gt1++exW792eXTrR4jCNHfShfWk9Nz8w==
+markdownlint@^0.27.0, markdownlint@~0.26.2:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/markdownlint/-/markdownlint-0.27.0.tgz#9dabf7710a4999e2835e3c68317f1acd0bc89049"
+  integrity sha512-HtfVr/hzJJmE0C198F99JLaeada+646B5SaG2pVoEakLFI6iRGsvMqrnnrflq8hm1zQgwskEgqSnhDW11JBp0w==
   dependencies:
     markdown-it "13.0.1"
 


### PR DESCRIPTION
A follow-up of https://github.com/webpack/webpack.js.org/pull/6446#discussion_r992198793.