### PR TITLE
docs(plugins): clarify `SourceMapDevToolPlugin` usage

### DIFF
--- a/src/content/plugins/source-map-dev-tool-plugin.mdx
+++ b/src/content/plugins/source-map-dev-tool-plugin.mdx
@@ -80,7 +80,7 @@ Set a URL for source maps. Useful for hosting them on a host that requires autho
 ```js
 new webpack.SourceMapDevToolPlugin({
   append: '\n//# sourceMappingURL=https://example.com/sourcemap/[url]',
-  filename: '[name].map',
+  filename: '[file].map[query]',
 });
 ```
 


### PR DESCRIPTION
While implementing the `SourceMapDevToolPlugin` in my project I was following the documentation and noticed it caused an error in the build. I copied this from the documentation:

```javascript
new webpack.SourceMapDevToolPlugin({
  append: '\n//# sourceMappingURL=https://example.com/sourcemap/[url]',
  filename: '[name].map',
});
```

Ultimately I encountered this error: `Multiple assets emit different content to the same filename`

After some research I noticed it should be set to `[file].map[query]` as specified in this issue https://github.com/webpack/webpack/issues/9732#issuecomment-555461786

I figured this was worth fixing so others don't encounter the same issue I did.
