### PR TITLE
fix splash width under Safari

### DIFF
--- a/src/components/SplashViz/SplashViz.scss
+++ b/src/components/SplashViz/SplashViz.scss
@@ -37,7 +37,7 @@
     display: none;
 
     @include break {
-      display: table; // Get height of its child svg
+      display: block; // Get height of its child svg
     }
 
     img {


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/1091472/210978113-e755dbfb-9cb1-4853-9aa0-ba4045e99dd7.png)

Seems when `display` set to `table`, Safari won't respect the `max-width` here.

Test under safari 16.2.