### PR TITLE
perf: change webpack hash function to improve speed of hash calculation

### DIFF
--- a/webpack.prod.mjs
+++ b/webpack.prod.mjs
@@ -23,6 +23,7 @@ export default (env) =>
     },
     output: {
       filename: '[name].[contenthash].js',
+      hashFunction: 'xxhash64'
     },
     optimization: {
       splitChunks: {


### PR DESCRIPTION
_describe your changes..._
webpack.js.org/webpack.prod.mjs
change webpack hash function to improve speed of hash calculation
set output.hashFunction to 'xxhash64'


