### PR TITLE
!perf: change webpack hash function to improve speed of hash calculation

### DIFF
--- a/webpack.common.mjs
+++ b/webpack.common.mjs
@@ -148,5 +148,6 @@ export default ({ ssg = false }) => ({
     path: path.resolve(__dirname, './dist'),
     publicPath: '/',
     filename: '[name].bundle.js',
+    hashFunction: 'xxhash64'
   },
 });

--- a/webpack.prod.mjs
+++ b/webpack.prod.mjs
@@ -22,8 +22,7 @@ export default (env) =>
       },
     },
     output: {
-      filename: '[name].[contenthash].js',
-      hashFunction: 'xxhash64'
+      filename: '[name].[contenthash].js'
     },
     optimization: {
       splitChunks: {

--- a/webpack.prod.mjs
+++ b/webpack.prod.mjs
@@ -23,6 +23,7 @@ export default (env) =>
     },
     output: {
       filename: '[name].[contenthash].js',
+      hashFunction: 'xxhash64'
     },
     optimization: {
       splitChunks: {


### PR DESCRIPTION
change: webpack.common.mjs
change webpack hash function to improve speed of hash calculation
set output.hashFunction to 'xxhash64'

