### PR TITLE
Update hot-module-replacement.mdx

### DIFF
--- a/src/content/guides/hot-module-replacement.mdx
+++ b/src/content/guides/hot-module-replacement.mdx
@@ -397,7 +397,7 @@ There are many other loaders and examples out in the community to make HMR inter
 - [React Hot Loader](https://github.com/gaearon/react-hot-loader): Tweak react components in real time.
 - [Vue Loader](https://github.com/vuejs/vue-loader): This loader supports HMR for vue components out of the box.
 - [Elm Hot webpack Loader](https://github.com/klazuka/elm-hot-webpack-loader): Supports HMR for the Elm programming language.
-- [Angular HMR](https://github.com/gdi2290/angular-hmr): No loader necessary! A small change to your main NgModule file is all that's required to have full control over the HMR APIs.
+- [Angular HMR](https://angular.io/cli/serve): No loader necessary! HMR support is built in the Angular CLI, simply add the `--hmr` flag to you `ng serve` command.
 - [Svelte Loader](https://github.com/sveltejs/svelte-loader): This loader supports HMR for Svelte components out of the box.
 
 T> If you know of any other loaders or plugins that help with or enhance HMR, please submit a pull request to add them to this list!


### PR DESCRIPTION
Updates the documentation regarding HMR support in Angular. 

HMR support is now built-in the Angular CLI, and does not require an external package anymore, and does not require any changes in the codebase.