### PR TITLE
Make .deleted changes non-selectable.

### DIFF
--- a/src/components/Markdown/prism-theme.scss
+++ b/src/components/Markdown/prism-theme.scss
@@ -75,6 +75,7 @@ pre[class*='lang-'] {
 
 .token.deleted {
   color: #f79494;
+  user-select: none;
 }
 
 .token.operator,


### PR DESCRIPTION
Simple change, but would make guides easier to follow. This would make people easily copy the entire file's content instead of manually making line changes, especially if there are many changes to make in multiple files.