### PR TITLE
docs(configuration): remove [ext] for filename

### DIFF
--- a/src/content/configuration/entry-context.mdx
+++ b/src/content/configuration/entry-context.mdx
@@ -98,8 +98,8 @@ module.exports = {
   //...
   entry: {
     app: './app.js',
-    home: { import: './contact.js', filename: 'pages/[name][ext]' },
-    about: { import: './about.js', filename: 'pages/[name][ext]' },
+    home: { import: './contact.js', filename: 'pages/[name].js' },
+    about: { import: './about.js', filename: 'pages/[name].js' },
   },
 };
 ```


### PR DESCRIPTION
it seem there no support [ext] placeholder in entery filename

See https://webpack.js.org/configuration/output/#template-strings

![CleanShot 2023-02-24 at 15 52 18@2x](https://user-images.githubusercontent.com/1091472/221122736-a309b813-0990-4b16-b186-19f7d51967d3.png)
