### PR TITLE
Add Deprecation message for WatchIgnorePlugin

### DIFF
--- a/src/content/plugins/watch-ignore-plugin.mdx
+++ b/src/content/plugins/watch-ignore-plugin.mdx
@@ -16,3 +16,5 @@ new webpack.WatchIgnorePlugin({ paths });
 ## Options
 
 - `paths` (`Array<string | RegExp>`): A list of RegExps or absolute paths to directories or files that should be ignored.
+
+W> This plugin is deprecated in favor of [watchOptions.ignored](/configuration/watch/#watchoptionsignored) option.


### PR DESCRIPTION
Documentation update following https://github.com/webpack/webpack.js.org/issues/6673 which will be then closed
CC: @TheLarkInn 

Before:
![image](https://user-images.githubusercontent.com/171174/227133984-75e918fb-82af-4a07-be97-1f71fab641bb.png)


After:
![image](https://user-images.githubusercontent.com/171174/227133775-a367ed31-e77f-4ba2-a1e2-406d633c55e4.png)

Closes https://github.com/webpack/webpack.js.org/pull/6709

[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
