### PR TITLE
docs: append `webpack-stats-viewer` in code-splitting

### DIFF
--- a/src/content/guides/code-splitting.mdx
+++ b/src/content/guides/code-splitting.mdx
@@ -459,6 +459,7 @@ Once you start splitting your code, it can be useful to analyze the output to ch
 - [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer): A plugin and CLI utility that represents bundle content as a convenient interactive zoomable treemap.
 - [webpack bundle optimize helper](https://webpack.jakoblind.no/optimize): This tool will analyze your bundle and give you actionable suggestions on what to improve to reduce your bundle size.
 - [bundle-stats](https://github.com/bundle-stats/bundle-stats): Generate a bundle report(bundle size, assets, modules) and compare the results between different builds.
+- [webpack-stats-viewer](https://github.com/moonrailgun/webpack-stats-viewer): A plugin with build for webpack stats. Show more information about webpack bundle detail.
 
 ## Next Steps
 


### PR DESCRIPTION
I make a tools for show more detail which existed in webpack. At my work for improve my project performance, I found i need more and more detail content which can help me. so i build it. And i wanna make more people like me known it.

Its copy from my repo:

> Many same webpack analyzer tools can show summary, but as a developer, when i try go deep into, and think why those file bundled into those chunk, those tools make me powerless, because of i cannot get more detail. So i develop this tool, no magic, just plain data. I think i need it.
> This is for in-depth study of webpack chunks composition and for deep website performance optimization



---------

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].

