### PR TITLE
fix bug in readme processing

### DIFF
--- a/src/utilities/process-readme.mjs
+++ b/src/utilities/process-readme.mjs
@@ -76,7 +76,7 @@ function linkFixerFactory(sourceUrl) {
       console.log('REWRITE URL:', oldHref, '-->', href);
     }
 
-    return markdownLink.replace(oldHref, href);
+    return markdownLink.replaceAll(oldHref, href);
   };
 }
 
@@ -105,6 +105,7 @@ export default function processREADME(body, options = {}) {
     // EXAMPLE: [Contributing](./.github/CONTRIBUTING.md)
     // EXAMPLE: [Contributing](CONTRIBUTING.md)
     // EXAMPLE: [line-identifier]: https://webpack.js.org/loaders/
+    // EXAMPLE: [`./src/config.d.ts`](./src/config.d.ts)
     .replace(inlineLinkRegex, linkFixerFactory(options.source))
     // Replace any <h2> with `##`
     .replace(/<h2[^>]*>/g, '## ')

--- a/src/utilities/process-readme.test.mjs
+++ b/src/utilities/process-readme.test.mjs
@@ -28,4 +28,15 @@ describe('processReadme', () => {
       '- [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin)'
     );
   });
+  it('rewrite relative url', () => {
+    const options = {
+      source:
+        'https://raw.githubusercontent.com/webpack-contrib/postcss-loader/master/README.md',
+    };
+    const loaderMDData =
+      'See the file [`./src/config.d.ts`](./src/config.d.ts).';
+    expect(processReadme(loaderMDData, options)).toEqual(
+      'See the file [`https://github.com/webpack-contrib/postcss-loader/blob/master/src/config.d.ts`](https://github.com/webpack-contrib/postcss-loader/blob/master/src/config.d.ts).'
+    );
+  });
 });


### PR DESCRIPTION
Noticed a bug in https://github.com/webpack/webpack.js.org/actions/runs/4600783997/jobs/8127825773?pr=6734#step:7:9 caused by the readme of https://github.com/webpack-contrib/postcss-loader:

```md
### `postcssOptions`

See the file [`./src/config.d.ts`](./src/config.d.ts).

Type:
```

Both matched relative links should be replaced with new one.