### PR TITLE
Update output-management.mdx

### DIFF
--- a/src/content/guides/output-management.mdx
+++ b/src/content/guides/output-management.mdx
@@ -46,6 +46,7 @@ export default function printMe() {
 
 And use that function in our `src/index.js` file:
 
+
 **src/index.js**
 
 ```diff


### PR DESCRIPTION
In Preparation section we see creating two modules:

1) src/index.js
2) src/print.js

Inside webpack config we made two enrty points:

```
entry: {
    index: './src/index.js',
    print: './src/print.js',
},
```

We, also, made changes inside html:

```
<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8" />
    <title>Output Management</title>
    <script src="./print.bundle.js"></script>
   </head>
   <body>
    <script src="./index.bundle.js"></script>
   </body>
 </html>
```

We expose print.bundle.js and index.bundle.js module, bucause after building we will have two separated modules


But, there is anoter odd code. We import print.js module inside index.js module. I not understand for what.

We will have separated modules, connected on index.html, but index.js already include print module inside itself. It's weird, or i am stupit.

Please explain me, why we should include print module indide index module?

_describe your changes..._

- [ ] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [ ] Make sure your PR complies with the [writer's guide][2].
- [ ] Review the diff carefully as sometimes this can reveal issues.
- [ ] Do not abandon your Pull Request: [Stale Pull Requests][3].
- **Remove these instructions from your PR as they are for your eyes only.**

[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
