### PR TITLE
doc(plugins): add ChunksWebpackPlugin

### DIFF
--- a/src/content/plugins/index.mdx
+++ b/src/content/plugins/index.mdx
@@ -19,6 +19,7 @@ Webpack has a rich plugin interface. Most of the features within webpack itself 
 | Name                                                                            | Description                                                                            |
 | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
 | [`BannerPlugin`](/plugins/banner-plugin)                                        | Add a banner to the top of each generated chunk                                        |
+| [`ChunksWebpackPlugin`](/plugins/chunks-webpack-plugin/)                        | Create HTML files with entrypoints and chunks relations to serve your bundles          |
 | [`CommonsChunkPlugin`](/plugins/commons-chunk-plugin)                           | Extract common modules shared between chunks                                           |
 | [`CompressionWebpackPlugin`](/plugins/compression-webpack-plugin)               | Prepare compressed versions of assets to serve them with Content-Encoding              |
 | [`ContextReplacementPlugin`](/plugins/context-replacement-plugin)               | Override the inferred context of a `require` expression                                |

--- a/src/content/plugins/split-chunks-plugin.mdx
+++ b/src/content/plugins/split-chunks-plugin.mdx
@@ -147,7 +147,7 @@ module.exports = {
 };
 ```
 
-T> You can combine this configuration with the [HtmlWebpackPlugin](/plugins/html-webpack-plugin/). It will inject all the generated vendor chunks for you.
+T> You can combine this configuration with the [HtmlWebpackPlugin](/plugins/html-webpack-plugin/) for Single Page Application or [ChunksWebpackPlugin](https://github.com/yoriiis/chunks-webpack-plugin?tab=readme-ov-file#chunkswebpackplugin) for Multiple Page Application. It will inject all the generated vendor chunks for you.
 
 ### splitChunks.maxAsyncRequests
 

--- a/src/utilities/fetch-package-readmes.mjs
+++ b/src/utilities/fetch-package-readmes.mjs
@@ -34,6 +34,9 @@ const loaderGroup = {
 const communityPackages = [{
   name: 'svg-chunk-webpack-plugin',
   contributors: ['yoriiis', 'alexander-akait']
+}, {
+  name: 'chunks-webpack-plugin',
+  contributors: ['yoriiis', 'alexander-akait']
 }];
 
 async function main() {

--- a/src/utilities/fetch-package-repos.mjs
+++ b/src/utilities/fetch-package-repos.mjs
@@ -29,6 +29,7 @@ const fetch = {
       hides: excludedPlugins,
     },
     'yoriiis/svg-chunk-webpack-plugin',
+    'yoriiis/chunks-webpack-plugin',
   ],
 };
 


### PR DESCRIPTION
This PR adds the `ChunksWebpackPlugin` to the plugins documentation page on the community group. The README is automatically fetched from the [GitHub repository](https://github.com/yoriiis/chunks-webpack-plugin).

With `splitChunks.chunks: 'all'` webpack generates chunks that are not known before compilation.
- In a Single Page Application, there is `html-webpack-plugin` to generate styles and scripts chunks dependencies.
- In Multiple Page Application with multiple entry point (e.g. Symfony) this is possible with `chunks-webpack-plugin`.

History: The plugin was already proposed on the official documentation in 2020 (#3771) and  but there was not yet the community group to separate the contributions from the webpack core team.

Note: The latest version of the package and therefore of the readme is not yet available on npm in order to be able to synchronize any feedback made on this MR with the project's readme if necessary.