### PR TITLE
fix api limit of opencollective

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,7 @@ jobs:
         run: yarn build
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          OPENCOLLECTIVE_API_KEY: ${{secrets.OPENCOLLECTIVE_API_KEY}}
       - run: yarn lint:links
 
       - name: Deploy


### PR DESCRIPTION
We kept hitting the api limit of opencollective recently.

<img width="1248" alt="" src="https://github.com/webpack/webpack.js.org/assets/1091472/f92677c1-6000-4d04-a5c3-002b33a7b8e0">

Let's see if adding a personal token would help a little.

Note that this only targets the `deploy.yml` action at the moment as there're [some limitation of environment secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow) stops us from applying to others:

> With the exception of GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository.