### PR TITLE
handle api limit automatically

### DIFF
--- a/src/utilities/fetch-supporters.mjs
+++ b/src/utilities/fetch-supporters.mjs
@@ -34,6 +34,10 @@ if (process.env.OPENCOLLECTIVE_API_KEY) {
   // by default a personal access token of @chenxsan was used as I don't have access to the webpack one
   // @doc https://graphql-docs-v2.opencollective.com/access#with-a-personal-token
   graphqlEndpoint = `https://api.opencollective.com/graphql/v2?personalToken=${process.env.OPENCOLLECTIVE_API_KEY}`;
+} else {
+  console.log(
+    'No personal access token found, using public API to fetch supporters from OpenCollective'
+  );
 }
 
 // https://github.com/opencollective/opencollective-api/blob/master/server/graphql/v2/query/TransactionsQuery.ts#L81

--- a/src/utilities/fetch-supporters.mjs
+++ b/src/utilities/fetch-supporters.mjs
@@ -129,7 +129,7 @@ const getAllNodes = async (graphqlQuery, getNodes) => {
         'Content-Type': 'application/json',
       },
     }).then(async (response) => {
-      try {
+      if (response.headers.get('content-type').includes('json')) {
         const json = await response.json();
         const headers = response.headers.raw();
         console.log('json', json);
@@ -148,9 +148,9 @@ const getAllNodes = async (graphqlQuery, getNodes) => {
           );
         }
         return json;
-      } catch (err) {
+      } else {
         // utilities/fetch-supporters: SyntaxError: Unexpected token < in JSON at position 0
-        console.log('err', err, await response.text());
+        console.log('something wrong when fetching', await response.text());
       }
     });
     // when rate limit exceeded, api will return {error: {message: ''}}

--- a/src/utilities/fetch-supporters.mjs
+++ b/src/utilities/fetch-supporters.mjs
@@ -131,7 +131,7 @@ const getAllNodes = async (graphqlQuery, getNodes) => {
     }).then((response) => {
       const json = response.json();
       const headers = response.headers.raw();
-
+      console.log('json', json);
       if (json.error) {
         // when rate limit exceeded, api won't return headers data like x-ratelimit-limit, etc.
         remaining = 0;

--- a/src/utilities/fetch-supporters.mjs
+++ b/src/utilities/fetch-supporters.mjs
@@ -129,24 +129,29 @@ const getAllNodes = async (graphqlQuery, getNodes) => {
         'Content-Type': 'application/json',
       },
     }).then(async (response) => {
-      const json = await response.json();
-      const headers = response.headers.raw();
-      console.log('json', json);
-      if (json.error) {
-        // when rate limit exceeded, api won't return headers data like x-ratelimit-limit, etc.
-        remaining = 0;
-        reset = Date.now() + 1000 * 60; // 1 minute
-      } else {
-        limit = headers['x-ratelimit-limit'] * 1;
-        remaining = headers['x-ratelimit-remaining'] * 1;
-        reset = headers['x-ratelimit-reset'] * 1000;
-        console.log(
-          `Rate limit: ${remaining}/${limit} remaining. Reset in ${new Date(
-            reset
-          )}`
-        );
+      try {
+        const json = await response.json();
+        const headers = response.headers.raw();
+        console.log('json', json);
+        if (json.error) {
+          // when rate limit exceeded, api won't return headers data like x-ratelimit-limit, etc.
+          remaining = 0;
+          reset = Date.now() + 1000 * 60; // 1 minute
+        } else {
+          limit = headers['x-ratelimit-limit'] * 1;
+          remaining = headers['x-ratelimit-remaining'] * 1;
+          reset = headers['x-ratelimit-reset'] * 1000;
+          console.log(
+            `Rate limit: ${remaining}/${limit} remaining. Reset in ${new Date(
+              reset
+            )}`
+          );
+        }
+        return json;
+      } catch (err) {
+        // utilities/fetch-supporters: SyntaxError: Unexpected token < in JSON at position 0
+        console.log('err', err, await response.text());
       }
-      return json;
     });
     // when rate limit exceeded, api will return {error: {message: ''}}
     // but we could hopefully avoid rate limit by sleeping in the beginning of the loop

--- a/src/utilities/fetch-supporters.mjs
+++ b/src/utilities/fetch-supporters.mjs
@@ -150,7 +150,12 @@ const getAllNodes = async (graphqlQuery, getNodes) => {
         return json;
       } else {
         // utilities/fetch-supporters: SyntaxError: Unexpected token < in JSON at position 0
-        console.log('something wrong when fetching', await response.text());
+        console.log('something wrong when fetching supporters');
+        return {
+          error: {
+            message: await response.text(),
+          },
+        };
       }
     });
     // when rate limit exceeded, api will return {error: {message: ''}}

--- a/src/utilities/fetch-supporters.mjs
+++ b/src/utilities/fetch-supporters.mjs
@@ -128,8 +128,8 @@ const getAllNodes = async (graphqlQuery, getNodes) => {
       headers: {
         'Content-Type': 'application/json',
       },
-    }).then((response) => {
-      const json = response.json();
+    }).then(async (response) => {
+      const json = await response.json();
       const headers = response.headers.raw();
       console.log('json', json);
       if (json.error) {


### PR DESCRIPTION
This is a much better version to handle the opencollective api limit.

The code will automatically wait until api limit is lifted then continue, and it supports running fetch simultaneously in different tasks, no more manually restart the failed tasks!