### PR TITLE
docs: update docs for top level await

### DIFF
--- a/src/content/configuration/experiments.mdx
+++ b/src/content/configuration/experiments.mdx
@@ -307,9 +307,9 @@ module.exports = {
 
 ### experiments.topLevelAwait
 
-`boolean`
+`boolean = true`
 
-The `topLevelAwait` experiment transforms a module into an async module when an `await` is used at the top level. Starting from version `5.83.0`, this feature is enabled by default. However, in versions prior to that, you can enable it by setting `experiments.topLevelAwait` to `true`.
+The `topLevelAwait` option transforms a module into an `async` module when an `await` is used at the top level. Starting from webpack version `5.83.0`, this feature is enabled by default. However, in versions prior to that, you can enable it by setting `experiments.topLevelAwait` to `true`.
 
 ```js
 module.exports = {

--- a/src/content/configuration/experiments.mdx
+++ b/src/content/configuration/experiments.mdx
@@ -29,7 +29,7 @@ Available options:
 - [`lazyCompilation`](#experimentslazycompilation)
 - [`outputModule`](#experimentsoutputmodule)
 - `syncWebAssembly`: Support the old WebAssembly like in webpack 4.
-- `topLevelAwait`: Support the [Top Level Await Stage 3 proposal](https://github.com/tc39/proposal-top-level-await), it makes the module an async module when `await` is used on the top-level. And it is enabled by default when [`experiments.futureDefaults`](#experimentsfuturedefaults) is set to `true`.
+- [`topLevelAwait`](#experimentstoplevelawait)
 
 **webpack.config.js**
 
@@ -301,6 +301,20 @@ Once enabled, webpack will output ECMAScript module syntax whenever possible. Fo
 module.exports = {
   experiments: {
     outputModule: true,
+  },
+};
+```
+
+### experiments.topLevelAwait
+
+`boolean`
+
+The `topLevelAwait` experiment transforms a module into an async module when an `await` is used at the top level. Starting from version `5.83.0`, this feature is enabled by default. However, in versions prior to that, you can enable it by setting `experiments.topLevelAwait` to `true`.
+
+```js
+module.exports = {
+  experiments: {
+    topLevelAwait: true,
   },
 };
 ```


### PR DESCRIPTION


https://github.com/webpack/webpack/pull/17192 Made Top Level Await enabled by default. Updating the docs for the experiment to add this information
