### PR TITLE
docs(guides): improve "Asset modules" grammar

### DIFF
--- a/src/content/guides/asset-modules.mdx
+++ b/src/content/guides/asset-modules.mdx
@@ -28,7 +28,7 @@ Asset Modules types replace all of these loaders by adding 4 new module types:
 - `asset/source` exports the source code of the asset. Previously achievable by using `raw-loader`.
 - `asset` automatically chooses between exporting a data URI and emitting a separate file. Previously achievable by using `url-loader` with asset size limit.
 
-When using the old assets loaders (i.e. `file-loader`/`url-loader`/`raw-loader`) along with Asset Modules in webpack 5, you might want to stop Asset Modules from processing your assets again as that would result in asset duplication. This can be done by setting assets loader's type to `'javascript/auto'`.
+When using the old assets loaders (i.e. `file-loader`/`url-loader`/`raw-loader`) along with Asset Modules in webpack 5, you might want to stop Asset Modules from processing your assets again as that would result in asset duplication. This can be done by setting the asset's module type to `'javascript/auto'`.
 
 **webpack.config.js**
 

--- a/src/content/guides/asset-modules.mdx
+++ b/src/content/guides/asset-modules.mdx
@@ -7,12 +7,13 @@ contributors:
   - chenxsan
   - anshumanv
   - spence-s
+  - dkdk225
 related:
   - title: webpack 5 - Asset Modules
     url: https://dev.to/smelukov/webpack-5-asset-modules-2o3h
 ---
 
-Asset Modules is a type of module that allows one to use asset files (fonts, icons, etc) without configuring additional loaders.
+Asset Module is a type of module that allows one to use asset files (fonts, icons, etc) without configuring additional loaders.
 
 Prior to webpack 5 it was common to use:
 
@@ -20,7 +21,7 @@ Prior to webpack 5 it was common to use:
 - [`url-loader`](https://v4.webpack.js.org/loaders/url-loader/) to inline a file into the bundle as a data URI
 - [`file-loader`](https://v4.webpack.js.org/loaders/file-loader/) to emit a file into the output directory
 
-Asset Modules type replaces all of these loaders by adding 4 new module types:
+Asset Module type replaces all of these loaders by adding 4 new module types:
 
 - `asset/resource` emits a separate file and exports the URL. Previously achievable by using `file-loader`.
 - `asset/inline` exports a data URI of the asset. Previously achievable by using `url-loader`.

--- a/src/content/guides/asset-modules.mdx
+++ b/src/content/guides/asset-modules.mdx
@@ -21,7 +21,7 @@ Prior to webpack 5 it was common to use:
 - [`url-loader`](https://v4.webpack.js.org/loaders/url-loader/) to inline a file into the bundle as a data URI
 - [`file-loader`](https://v4.webpack.js.org/loaders/file-loader/) to emit a file into the output directory
 
-Asset Module type replaces all of these loaders by adding 4 new module types:
+Asset Modules types replace all of these loaders by adding 4 new module types:
 
 - `asset/resource` emits a separate file and exports the URL. Previously achievable by using `file-loader`.
 - `asset/inline` exports a data URI of the asset. Previously achievable by using `url-loader`.

--- a/src/content/guides/asset-modules.mdx
+++ b/src/content/guides/asset-modules.mdx
@@ -28,7 +28,7 @@ Asset Modules types replace all of these loaders by adding 4 new module types:
 - `asset/source` exports the source code of the asset. Previously achievable by using `raw-loader`.
 - `asset` automatically chooses between exporting a data URI and emitting a separate file. Previously achievable by using `url-loader` with asset size limit.
 
-When using the old assets loaders (i.e. `file-loader`/`url-loader`/`raw-loader`) along with Asset Module in webpack 5, you might want to stop Asset Module from processing your assets again as that would result in asset duplication. This can be done by setting asset's module type to `'javascript/auto'`.
+When using the old assets loaders (i.e. `file-loader`/`url-loader`/`raw-loader`) along with Asset Modules in webpack 5, you might want to stop Asset Modules from processing your assets again as that would result in asset duplication. This can be done by setting asset's module type to `'javascript/auto'`.
 
 **webpack.config.js**
 

--- a/src/content/guides/asset-modules.mdx
+++ b/src/content/guides/asset-modules.mdx
@@ -13,7 +13,7 @@ related:
     url: https://dev.to/smelukov/webpack-5-asset-modules-2o3h
 ---
 
-Asset Module is a type of module that allows one to use asset files (fonts, icons, etc) without configuring additional loaders.
+Asset Modules allow one to use asset files (fonts, icons, etc) without configuring additional loaders.
 
 Prior to webpack 5 it was common to use:
 

--- a/src/content/guides/asset-modules.mdx
+++ b/src/content/guides/asset-modules.mdx
@@ -28,7 +28,7 @@ Asset Modules types replace all of these loaders by adding 4 new module types:
 - `asset/source` exports the source code of the asset. Previously achievable by using `raw-loader`.
 - `asset` automatically chooses between exporting a data URI and emitting a separate file. Previously achievable by using `url-loader` with asset size limit.
 
-When using the old assets loaders (i.e. `file-loader`/`url-loader`/`raw-loader`) along with Asset Modules in webpack 5, you might want to stop Asset Modules from processing your assets again as that would result in asset duplication. This can be done by setting asset's module type to `'javascript/auto'`.
+When using the old assets loaders (i.e. `file-loader`/`url-loader`/`raw-loader`) along with Asset Modules in webpack 5, you might want to stop Asset Modules from processing your assets again as that would result in asset duplication. This can be done by setting assets loader's type to `'javascript/auto'`.
 
 **webpack.config.js**
 


### PR DESCRIPTION
Change "Asset modules" that was used as singular into "Asset module" (it's singular form)

