### PR TITLE
EIUNAB-3645/Impact : Work with Teams to get the YAML into Backstage.io for all projects

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1beta1
+kind: Component
+metadata:
+  name: webpack-js-org
+  namespace: economist-impact
+  annotations:
+    github.com/project-slug: signal-noise/webpack.js.org
+    backstage.io/techdocs-ref: dir:.
+spec:
+  type: website
+  lifecycle: production
+  owner: group:economist-impact/signal-noise

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,6 +5,14 @@ metadata:
   namespace: economist-impact
   annotations:
     github.com/project-slug: signal-noise/webpack.js.org
+      # the circleCI project, mirrors github repo in this case: 
+    circleci.com/project-slug: github/signal-noise/webpack.js.org
+      # GUID - see https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard/
+    newrelic.com/dashboard-guid: MzY1MjgxOXxWSVp8REFTSEJPQVJEfGRhOjE3MDkwOA
+    newrelic.com/dashboard-guid: MzY1MjgxOXxWSVp8REFTSEJPQVJEfGRhOjE5NTIyNw
+    description: covid-relative-risk for SignalNoise Economist Impact Project
+    opsgenie:
+      domain: https://economist.app.opsgenie.com/teams/dashboard/49177ca8-5e59-4364-af23-c22cc60c026f/main
     backstage.io/techdocs-ref: dir:.
 spec:
   type: website

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,66 @@
+<div align="center">
+  <a href="https://github.com/webpack/webpack">
+    <img width="200" height="200" src="https://webpack.js.org/assets/icon-square-big.svg">
+  </a>
+  <h1>webpack.js.org</h1>
+
+  [![Build Status][build-status]][build-status-url]
+  [![Standard Version][release]][release-url]
+  [![chat on gitter][chat]][chat-url]  
+  
+  Guides, documentation, and all things webpack.
+</div>
+
+
+## Content Progress
+
+Now that we've covered much of the backlog of _missing documentation_, we are
+starting to heavily review each section of the site's content to sort and
+structure it appropriately. The following issues should provide a pretty good
+idea of where things are, and where they are going:
+
+- [Guides - Review and Simplify][guides-url]
+- [Concepts - Review and Organize][concepts-url]
+
+We haven't created issues for the other sections yet, but they will be coming
+soon. For dev-related work please see [General - Updates & Fixes][general-url].
+
+The alpha version of webpack 5 is out and we are lagging behind with documenting all of the related changes. See [this refined search][webpack5-milestone-url] for the list of relevant documentation requests.
+
+## Translation
+
+To help translate this documentation please jump to the [translation branch][translate-url].
+
+## Contributing
+
+Read through the [writer's guide][writer-guide-url] if you're interested in editing the
+content on this site. See the [contributors page][contributing-url] to learn how to set up and
+start working on the site locally.
+
+## License
+
+The content is available under the [Creative Commons BY 4.0][license-url] license.
+
+## Special Thanks
+
+_BrowserStack_ has graciously allowed us to do cross-browser and cross-os
+testing of the site at no cost...
+
+[![BrowserStackLogo][browserstack]][browserstack-url]
+
+[webpack5-milestone-url]: https://github.com/webpack/webpack.js.org/issues?q=is%3Aopen+is%3Aissue+milestone%3A%22webpack+5%22
+[build-status]: https://secure.travis-ci.org/webpack/webpack.js.org.svg
+[build-status-url]: http://travis-ci.org/webpack/webpack.js.org
+[browserstack]: ./browserstack-logo.png
+[browserstack-url]: http://browserstack.com/
+[chat]: https://badges.gitter.im/webpack/webpack.svg
+[chat-url]: https://gitter.im/webpack/webpack
+[concepts-url]: https://github.com/webpack/webpack.js.org/issues/1386
+[contributing-url]: https://github.com/webpack/webpack.js.org/blob/master/.github/CONTRIBUTING.md
+[general-url]: https://github.com/webpack/webpack.js.org/issues/1525
+[guides-url]: https://github.com/webpack/webpack.js.org/issues/1258
+[license-url]: https://creativecommons.org/licenses/by/4.0/
+[release]: https://img.shields.io/badge/release-standard%20version-brightgreen.svg
+[release-url]: https://github.com/conventional-changelog/standard-version
+[translate-url]: https://github.com/webpack/webpack.js.org/tree/translation
+[writer-guide-url]: https://webpack.js.org/contribute/writers-guide

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,5 @@
+docs_dir: docs
+nav:
+  - Main: index.md
+plugins:
+  - techdocs-core


### PR DESCRIPTION
Description
Add to Backstage - Economist Impact Signal Noise Team

Reason for change
Backstage.io rollout across the Economist Group via platform.economist.com

Breaking changes
None

Remarks
Github added, CircleCI Added (where CICD applicable), New Relic added, Opsgenie added (where applicable), docs file added to be updated in depth by the team upon review.

Testing
Once merged the Enablement team will test integration into backstage. The yaml files are pulled via polling on the main branch for automated incorporation.

Checklist
My commits, pull request name follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
style
I have made corresponding changes to the documentation
I have updated unit tests, integration tests
I have tested in dev environment
I have update swagger, where applicable
I have provided cdk diff result for infrastructure changes, where applicable