### PR TITLE
docs(config): update typescript setup in configuration-languages.mdx

### DIFF
--- a/src/content/configuration/configuration-languages.mdx
+++ b/src/content/configuration/configuration-languages.mdx
@@ -2,6 +2,7 @@
 title: Configuration Languages
 sort: 2
 contributors:
+  - piouson
   - sokra
   - skipjack
   - tarang9211
@@ -33,8 +34,8 @@ and then proceed to write your configuration:
 **webpack.config.ts**
 
 ```typescript
-import * as path from 'path';
-import * as webpack from 'webpack';
+import path from 'path';
+import webpack from 'webpack';
 // in case you run into any typescript error when configuring `devServer`
 import 'webpack-dev-server';
 
@@ -48,6 +49,15 @@ const config: webpack.Configuration = {
 };
 
 export default config;
+```
+
+**tsconfig.json**
+
+```json
+{
+  "allowSyntheticDefaultImports": true,
+  "esModuleInterop": true
+}
 ```
 
 The above sample assumes version >= 2.7 or newer of TypeScript is used with the new `esModuleInterop` and `allowSyntheticDefaultImports` compiler options in your `tsconfig.json` file.

--- a/src/content/configuration/configuration-languages.mdx
+++ b/src/content/configuration/configuration-languages.mdx
@@ -55,8 +55,10 @@ export default config;
 
 ```json
 {
-  "allowSyntheticDefaultImports": true,
-  "esModuleInterop": true
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true
+  }
 }
 ```
 


### PR DESCRIPTION
`import *` not required when `esModuleInterop: true` in `tsconfig.json`.

```json
{
  "devDependencies": {
    "@types/node": "^20.3.1",
    "@types/webpack": "^5.28.1",
    "@types/webpack-dev-server": "^4.7.2",
    "ts-loader": "^9.2.6",
    "ts-node": "^10.9.1",
    "typescript": "^5.1.3",
    "webpack": "^5.88.0",
    "webpack-cli": "^5.1.4",
    "webpack-dev-server": "^4.7.4"
  }
}
```
