### PR TITLE
fix cache.compression default

### DIFF
--- a/src/content/configuration/cache.mdx
+++ b/src/content/configuration/cache.mdx
@@ -135,7 +135,7 @@ module.exports = {
 
 <Badge text="5.42.0+" />
 
-Compression type used for the cache files. By default it is `false` for `development` mode and `'gzip'` for `production` mode.
+Compression type used for the cache files. By default it is `false`.
 
 `cache.compression` option is only available when [`cache.type`](#cachetype) is set to `'filesystem'`.
 


### PR DESCRIPTION
see https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/config/defaults.js#L414

It's always off by default