### PR TITLE
Update source-map-dev-tool-plugin.mdx

### DIFF
--- a/src/content/plugins/source-map-dev-tool-plugin.mdx
+++ b/src/content/plugins/source-map-dev-tool-plugin.mdx
@@ -102,7 +102,7 @@ project
     |- bundle-[hash].js.map
 ```
 
-With next config:
+With the following config:
 
 ```js
 new webpack.SourceMapDevToolPlugin({


### PR DESCRIPTION
Hello,

I think the word 'next' used here is confusing. If the intent of the author was 'the content directly after this sentence' then using 'the following' would be way better and understandable. 

Please advise/review.


