### PR TITLE
docs(configuration): correct Condition reference

### DIFF
--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -1028,7 +1028,7 @@ Indicate what parts of the module contain side effects. See [Tree Shaking](/guid
 
 ## Rule.test
 
-Include all modules that pass test assertion. If you supply a `Rule.test` option, you cannot also supply a `Rule.resource`. See [`Rule.resource`](#ruleresource) and [`Condition.test`](#condition) for details.
+Include all modules that pass test assertion. If you supply a `Rule.test` option, you cannot also supply a `Rule.resource`. See [`Rule.resource`](#ruleresource) and [`Condition`](#condition) for details.
 
 ## Rule.type
 


### PR DESCRIPTION
Based on the name in the sidebar, I believe this should be called “Condition”, not “Condition.test”.