### PR TITLE
docs(contribute): remove broken link to the documentation team

### DIFF
--- a/src/content/contribute/index.mdx
+++ b/src/content/contribute/index.mdx
@@ -8,6 +8,7 @@ contributors:
   - dhedgecock
   - tbroadley
   - EugeneHlushko
+  - dkdk225
 ---
 
 The people who contribute to webpack do so for the love of open source, our users and ecosystem, and most importantly, pushing the web forward together. Because of our [Open Collective](https://opencollective.com/webpack) model for funding and transparency, we are able to funnel support and funds through contributors, dependent projects, and the contributor and core teams. To make a donation, click the button below...
@@ -80,4 +81,4 @@ To anyone else who is interested in helping our mission – e.g. venture capital
 
 Documentation of webpack features and changes is now being updated as webpack evolves. An automated issue creation integration was established and proven to be effective in the recent years.
 When a feature gets merged, an issue with a documentation request is created in our repository and we expect to resolve it in a timely manner. This means that there are features, changes and breaking changes awaiting to be documented, reviewed and released. That said, if Pull Request's author is abandoning it for more than 30 days, we may mark such Pull Request as stale. We may take over the work that is needed to finish it.
-If Pull Request author grants write access to their fork to the [webpack Documentation team](https://github.com/orgs/webpack/teams/documentation-team/members) we will commit directly to your branch and finish the work. In other cases, we may have to start over by ourselves or by delegating it to willing community members. This may render your Pull Request redundant and it might get closed as a part of the cleanup process.
+If Pull Request author grants write access to their fork to the webpack Documentation team we will commit directly to your branch and finish the work. In other cases, we may have to start over by ourselves or by delegating it to willing community members. This may render your Pull Request redundant and it might get closed as a part of the cleanup process.


### PR DESCRIPTION
I was unable to find a new documentation team link. As a solution i suggest removing it completely



