### PR TITLE
docs: fix webpack repo links that use legacy branch name

### DIFF
--- a/src/content/api/loaders.mdx
+++ b/src/content/api/loaders.mdx
@@ -471,7 +471,7 @@ In [the example](#example-for-the-loader-context): in loader1: `0`, in loader2: 
 loadModule(request: string, callback: function(err, source, sourceMap, module))
 ```
 
-Resolves the given request to a module, applies all configured loaders and calls back with the generated source, the sourceMap and the module instance (usually an instance of [`NormalModule`](https://github.com/webpack/webpack/blob/master/lib/NormalModule.js)). Use this function if you need to know the source code of another module to generate the result.
+Resolves the given request to a module, applies all configured loaders and calls back with the generated source, the sourceMap and the module instance (usually an instance of [`NormalModule`](https://github.com/webpack/webpack/blob/main/lib/NormalModule.js)). Use this function if you need to know the source code of another module to generate the result.
 
 `this.loadModule` in a loader context uses CommonJS resolve rules by default. Use `this.getResolve` with an appropriate `dependencyType`, e.g. `'esm'`, `'commonjs'` or a custom one before using a different semantic.
 

--- a/src/content/api/node.mdx
+++ b/src/content/api/node.mdx
@@ -76,8 +76,8 @@ registered plugins.
 
 The `hooks` property on a `Compiler` instance is used to register a plugin to
 any hook event in the `Compiler`'s lifecycle. The
-[`WebpackOptionsDefaulter`](https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsDefaulter.js)
-and [`WebpackOptionsApply`](https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsApply.js)
+[`WebpackOptionsDefaulter`](https://github.com/webpack/webpack/blob/main/lib/WebpackOptionsDefaulter.js)
+and [`WebpackOptionsApply`](https://github.com/webpack/webpack/blob/main/lib/WebpackOptionsApply.js)
 utilities are used by webpack to configure its `Compiler` instance with all the
 built-in plugins.
 

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -1387,7 +1387,7 @@ Example for an `expr` dynamic dependency: `require(expr)`.
 
 Example for an `wrapped` dynamic dependency: `require('./templates/' + expr)`.
 
-Here are the available options with their [defaults](https://github.com/webpack/webpack/blob/master/lib/config/defaults.js):
+Here are the available options with their [defaults](https://github.com/webpack/webpack/blob/main/lib/config/defaults.js):
 
 **webpack.config.js**
 

--- a/src/content/configuration/node.mdx
+++ b/src/content/configuration/node.mdx
@@ -14,7 +14,7 @@ contributors:
 
 The following Node.js options configure whether to polyfill or mock certain [Node.js globals](https://nodejs.org/docs/latest/api/globals.html).
 
-This feature is provided by webpack's internal [`NodeStuffPlugin`](https://github.com/webpack/webpack/blob/master/lib/NodeStuffPlugin.js) plugin.
+This feature is provided by webpack's internal [`NodeStuffPlugin`](https://github.com/webpack/webpack/blob/main/lib/NodeStuffPlugin.js) plugin.
 
 W> As of webpack 5, You can configure only `global`, `__filename` or `__dirname` under `node` option. If you're looking for how to polyfill `fs` alike in Node.js under webpack 5, please check [resolve.fallback](/configuration/resolve/#resolvefallback) for help.
 

--- a/src/content/configuration/optimization.mdx
+++ b/src/content/configuration/optimization.mdx
@@ -513,7 +513,7 @@ module.exports = {
 
 `boolean = true` `string: 'flag'`
 
-Tells webpack to recognise the [`sideEffects`](https://github.com/webpack/webpack/blob/master/examples/side-effects/README.md) flag in `package.json` or rules to skip over modules which are flagged to contain no side effects when exports are not used.
+Tells webpack to recognise the [`sideEffects`](https://github.com/webpack/webpack/blob/main/examples/side-effects/README.md) flag in `package.json` or rules to skip over modules which are flagged to contain no side effects when exports are not used.
 
 **package.json**
 

--- a/src/content/configuration/stats.mdx
+++ b/src/content/configuration/stats.mdx
@@ -741,7 +741,7 @@ module.exports = {
 
 `array = []: string | RegExp | function (assetName) => boolean` `string` `RegExp` `function (assetName) => boolean` `boolean: false`
 
-Tells `stats` to exclude the matching modules information. This can be done with a `string`, a `RegExp`, a `function` that is getting the module's source as an argument and returns a `boolean`. `stats.excludeModules` can be an `array` of any of the above. `stats.excludeModules`'s configuration [is merged](https://github.com/webpack/webpack/blob/master/lib/Stats.js#L215) with the `stats.exclude`'s configuration value.
+Tells `stats` to exclude the matching modules information. This can be done with a `string`, a `RegExp`, a `function` that is getting the module's source as an argument and returns a `boolean`. `stats.excludeModules` can be an `array` of any of the above. `stats.excludeModules`'s configuration [is merged](https://github.com/webpack/webpack/blob/main/lib/Stats.js#L215) with the `stats.exclude`'s configuration value.
 
 ```javascript
 module.exports = {

--- a/src/content/configuration/target.mdx
+++ b/src/content/configuration/target.mdx
@@ -26,7 +26,7 @@ Defaults to `'browserslist'` or to `'web'` when no browserslist configuration wa
 
 ### string
 
-The following string values are supported via [`WebpackOptionsApply`](https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsApply.js):
+The following string values are supported via [`WebpackOptionsApply`](https://github.com/webpack/webpack/blob/main/lib/WebpackOptionsApply.js):
 
 | Option                     | Description                                                                                                                                                                                                                                                                                          |
 | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/content/license.mdx
+++ b/src/content/license.mdx
@@ -8,7 +8,7 @@ contributors:
 
 ## webpack
 
-Webpack is [MIT licensed](https://github.com/webpack/webpack/blob/master/LICENSE).
+Webpack is [MIT licensed](https://github.com/webpack/webpack/blob/main/LICENSE).
 
 ## webpack logo and icon
 

--- a/src/content/plugins/banner-plugin.mdx
+++ b/src/content/plugins/banner-plugin.mdx
@@ -7,7 +7,7 @@ contributors:
   - chenxsan
 related:
   - title: banner-plugin-hashing test
-    url: https://github.com/webpack/webpack/blob/master/test/configCases/plugins/banner-plugin-hashing/webpack.config.js
+    url: https://github.com/webpack/webpack/blob/main/test/configCases/plugins/banner-plugin-hashing/webpack.config.js
 ---
 
 Adds a banner to the top of each generated chunk.

--- a/src/content/plugins/commons-chunk-plugin.mdx
+++ b/src/content/plugins/commons-chunk-plugin.mdx
@@ -174,7 +174,7 @@ new webpack.optimize.CommonsChunkPlugin({
 You also have the ability to pass the `minChunks` property a function. This function is called by the `CommonsChunkPlugin` and calls the function with `module` and `count` arguments.
 
 The `module` argument represents each module in the chunks you have provided via the `name`/`names` property.
-`module` has the shape of a [NormalModule](https://github.com/webpack/webpack/blob/master/lib/NormalModule.js), which has two particularly useful properties for this use case:
+`module` has the shape of a [NormalModule](https://github.com/webpack/webpack/blob/main/lib/NormalModule.js), which has two particularly useful properties for this use case:
 
 - `module.context`: The directory that stores the file. For example: `'/my_project/node_modules/example-dependency'`
 - `module.resource`: The name of the file being processed. For example: `'/my_project/node_modules/example-dependency/index.js'`

--- a/src/content/plugins/dll-plugin.mdx
+++ b/src/content/plugins/dll-plugin.mdx
@@ -13,7 +13,7 @@ contributors:
   - snitin315
 related:
   - title: Code Splitting Example
-    url: https://github.com/webpack/webpack/blob/master/examples/explicit-vendor-chunk/README.md
+    url: https://github.com/webpack/webpack/blob/main/examples/explicit-vendor-chunk/README.md
 ---
 
 The `DllPlugin` and `DllReferencePlugin` provide means to split bundles in a way that can drastically improve build time performance. The term "DLL" stands for Dynamic-link library which was originally introduced by Microsoft.
@@ -24,7 +24,7 @@ This plugin is used in a separate webpack configuration exclusively to create a 
 
 - `context` (optional): context of requests in the manifest file (defaults to the webpack context.)
 - `format` (boolean = false): If `true`, manifest json file (output) will be formatted.
-- `name`: name of the exposed dll function ([TemplatePaths](https://github.com/webpack/webpack/blob/master/lib/TemplatedPathPlugin.js): `[fullhash]`, `[chunkhash]`, `[contenthash]`, & `[name]` )
+- `name`: name of the exposed dll function ([TemplatePaths](https://github.com/webpack/webpack/blob/main/lib/TemplatedPathPlugin.js): `[fullhash]`, `[chunkhash]`, `[contenthash]`, & `[name]` )
 - `path`: **absolute path** to the manifest json file (output)
 - `entryOnly` (boolean = true): if `true`, only entry points will be exposed
 - `type`: type of the dll bundle
@@ -114,14 +114,14 @@ T> Multiple `DllPlugins` and multiple `DllReferencePlugins`.
 
 ### Source
 
-- [DllPlugin source](https://github.com/webpack/webpack/blob/master/lib/DllPlugin.js)
-- [DllReferencePlugin source](https://github.com/webpack/webpack/blob/master/lib/DllReferencePlugin.js)
-- [DllEntryPlugin source](https://github.com/webpack/webpack/blob/master/lib/DllEntryPlugin.js)
-- [DllModuleFactory source](https://github.com/webpack/webpack/blob/master/lib/DllModuleFactory.js)
-- [ManifestPlugin source](https://github.com/webpack/webpack/blob/master/lib/LibManifestPlugin.js)
+- [DllPlugin source](https://github.com/webpack/webpack/blob/main/lib/DllPlugin.js)
+- [DllReferencePlugin source](https://github.com/webpack/webpack/blob/main/lib/DllReferencePlugin.js)
+- [DllEntryPlugin source](https://github.com/webpack/webpack/blob/main/lib/DllEntryPlugin.js)
+- [DllModuleFactory source](https://github.com/webpack/webpack/blob/main/lib/DllModuleFactory.js)
+- [ManifestPlugin source](https://github.com/webpack/webpack/blob/main/lib/LibManifestPlugin.js)
 
 ### Tests
 
-- [DllPlugin creation test](https://github.com/webpack/webpack/blob/master/test/configCases/dll-plugin/0-create-dll/webpack.config.js)
-- [DllPlugin without scope test](https://github.com/webpack/webpack/blob/master/test/configCases/dll-plugin/2-use-dll-without-scope/webpack.config.js)
+- [DllPlugin creation test](https://github.com/webpack/webpack/blob/main/test/configCases/dll-plugin/0-create-dll/webpack.config.js)
+- [DllPlugin without scope test](https://github.com/webpack/webpack/blob/main/test/configCases/dll-plugin/2-use-dll-without-scope/webpack.config.js)
 - [DllReferencePlugin use Dll test](https://github.com/webpack/webpack/tree/master/test/configCases/dll-plugin)

--- a/src/content/plugins/progress-plugin.mdx
+++ b/src/content/plugins/progress-plugin.mdx
@@ -152,4 +152,4 @@ T> _Hooks marked with \* allow plugins to report progress information using `rep
 
 ## Source
 
-- [`ProgressPlugin` source](https://github.com/webpack/webpack/blob/master/lib/ProgressPlugin.js)
+- [`ProgressPlugin` source](https://github.com/webpack/webpack/blob/main/lib/ProgressPlugin.js)

--- a/src/content/plugins/split-chunks-plugin.mdx
+++ b/src/content/plugins/split-chunks-plugin.mdx
@@ -21,7 +21,7 @@ contributors:
   - snitin315
 related:
   - title: webpack's automatic deduplication algorithm example
-    url: https://github.com/webpack/webpack/blob/master/examples/many-pages/README.md
+    url: https://github.com/webpack/webpack/blob/main/examples/many-pages/README.md
   - title: 'webpack 4: Code Splitting, chunk graph and the splitChunks optimization'
     url: https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
 ---


### PR DESCRIPTION
The new default branch name of webpack repository is `main`, and the links in the docs still use the legacy branch name `master`.