### PR TITLE
Add missing directory in getting-started.mdx

### DIFF
--- a/src/content/guides/getting-started.mdx
+++ b/src/content/guides/getting-started.mdx
@@ -242,6 +242,7 @@ As of version 4, webpack doesn't require any configuration, but most projects wi
     |- index.html
   |- /src
     |- index.js
+  |- /node_modules
 ```
 
 **webpack.config.js**


### PR DESCRIPTION
_describe your changes..._
At that juncture, the /node_modules directory was present, causing confusion, which could potentially confuse other users as well. I ensured it was appropriately included in the correct location.

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].

[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
