### PR TITLE
ci: use composite action for webpack persistent caching

### DIFF
--- a/.github/actions/webpack-persistent-cache/action.yml
+++ b/.github/actions/webpack-persistent-cache/action.yml
@@ -1,0 +1,19 @@
+name: Webpack persistent cache
+description: Cache webpack's persistent cache between builds.
+
+outputs:
+  cache-hit:
+    description: Whether the cache was restored from the cache key.
+    value: ${{ steps.build-webpack-persistent-cache.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@v4
+      id: build-webpack-persistent-cache
+      with:
+        path: node_modules/.cache
+        key: build-${{ hashFiles('**/webpack.*.mjs') }}-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |-
+          build-${{ hashFiles('**/webpack.*.mjs') }}-${{ hashFiles('**/yarn.lock') }}
+          build-${{ hashFiles('**/webpack.*.mjs') }}-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,14 +24,7 @@ jobs:
           cache: yarn
 
       - name: Enable webpack persistent caching
-        uses: actions/cache@v4
-        id: build-webpack-persistent-cache
-        with:
-          path: node_modules/.cache
-          key: build-${{ hashFiles('**/webpack.*.mjs') }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |-
-            build-${{ hashFiles('**/webpack.*.mjs') }}-${{ hashFiles('**/yarn.lock') }}
-            build-${{ hashFiles('**/webpack.*.mjs') }}-
+        uses: ./.github/actions/webpack-persistent-cache
 
       - run: yarn --frozen-lockfile
       - name: Build site

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -82,14 +82,7 @@ jobs:
       - run: yarn
 
       - name: Enable webpack persistent caching
-        uses: actions/cache@v4
-        id: build-webpack-persistent-cache
-        with:
-          path: node_modules/.cache
-          key: build-${{ hashFiles('**/webpack.*.mjs') }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |-
-            build-${{ hashFiles('**/webpack.*.mjs') }}-${{ hashFiles('**/yarn.lock') }}
-            build-${{ hashFiles('**/webpack.*.mjs') }}-
+        uses: ./.github/actions/webpack-persistent-cache
 
       - name: Cypress run
         uses: cypress-io/github-action@v6


### PR DESCRIPTION
#### What this PR does / why we need it?

Closes #7076 

For each workflow, the webpack persistent caching step is written in the same code:

```yaml
- name: Enable webpack persistent caching
  uses: actions/cache@v4
  id: build-webpack-persistent-cache
  with:
    path: node_modules/.cache
    key: build-${{ hashFiles('**/webpack.*.mjs') }}-${{ hashFiles('**/yarn.lock') }}
    restore-keys: |-
      build-${{ hashFiles('**/webpack.*.mjs') }}-${{ hashFiles('**/yarn.lock') }}
      build-${{ hashFiles('**/webpack.*.mjs') }}-
```

If requirements change, we'll need to edit it for each workflow. This makes maintenance difficult and can lead to mistakes.

Duplicate workflow steps can be abstracted into [composite action](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action).

```yaml
- name: Enable webpack persistent caching
  uses: ./.github/actions/webpack-persistent-cache
```

See also https://docs.github.com/en/actions/creating-actions/creating-a-composite-action