### PR TITLE
Clarify interaction between `--node-env` and `mode`

### DIFF
--- a/src/content/api/cli.mdx
+++ b/src/content/api/cli.mdx
@@ -620,7 +620,7 @@ You can use `--node-env` option to set `process.env.NODE_ENV`, which is availabl
 npx webpack --node-env production   # process.env.NODE_ENV = 'production'
 ```
 
-T> The `mode` option would respect the `--node-env` option if you don't set it explicitly, i.e. `--node-env production` would set both `process.env.NODE_ENV` and `mode` to `'production'`
+T> When the `mode` option is not set in the configuration, the `--node-env` option can be used to set `mode`. For example, `--node-env production` would set both `process.env.NODE_ENV` and `mode` to `'production'`. If the configuration [exports a function](/configuration/configuration-types/#exporting-a-function), the `--node-env` value is assigned to `mode` after the function returns, so it will not be set in the function arguments (`env` and `argv`).
 
 ### define-process-env-node-env
 


### PR DESCRIPTION
The interpretation of the current description is ambiguous, as it pertains to how a configuration function can or cannot benefit from the use of `--node-env` as a way to set `mode`. One might interpret it as if that happens before the configuration function is invoked, and therefore should be available to use for logic like switching in the function. That would be wrong. This update makes it clear that the assignment of a default `mode` based on `--node-env` happens after the configuration function is executed.

Related: webpack/webpack-cli#4009 

Fixes webpack/webpack-cli#3992
