### PR TITLE
chore(docs): Fix broken CommonJS link in webpack.js.org documentation

### DIFF
--- a/src/content/concepts/modules.mdx
+++ b/src/content/concepts/modules.mdx
@@ -27,7 +27,7 @@ Webpack builds on lessons learned from these systems and applies the concept of 
 In contrast to [Node.js modules](https://nodejs.org/api/modules.html), webpack _modules_ can express their _dependencies_ in a variety of ways. A few examples are:
 
 - An [ES2015 `import`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) statement
-- A [CommonJS](http://www.commonjs.org/specs/modules/1.0/) `require()` statement
+- A [CommonJS](https://wiki.commonjs.org/wiki/Modules/1.1) `require()` statement
 - An [AMD](https://github.com/amdjs/amdjs-api/blob/master/AMD.md) `define` and `require` statement
 - An [`@import` statement](https://developer.mozilla.org/en-US/docs/Web/CSS/@import) inside of a css/sass/less file.
 - An image url in a stylesheet `url(...)` or HTML `<img src=...>` file.


### PR DESCRIPTION
This PR addresses a broken link issue in the webpack.js.org documentation. The previous link for the CommonJS specification was leading to a "Not Found" page. I've updated the link to the correct URL (https://wiki.commonjs.org/wiki/Modules/1.1) to ensure users can access the accurate information about CommonJS modules.
Resolves https://github.com/webpack/webpack.js.org/issues/7084