### PR TITLE
docs: add note about how publicPath interacts with asset modules

### DIFF
--- a/src/content/guides/asset-modules.mdx
+++ b/src/content/guides/asset-modules.mdx
@@ -78,6 +78,30 @@ module.exports = {
 }
 ```
 
+### Public Path
+
+By default, the `asset` type does `__webpack_public_path__ + import.meta` under the hood. This means that setting the `output.publicPath` in your config will allow you to override the url that the `asset` loads from.
+
+#### On The Fly Override
+
+If you set the `__webpack_public_path__` in code, the way you need to achive it so as not to break the `asset` loading logic is to make sure you run it as the first code in your app and not use a function to do so. An example of this would be having a file called `publicPath.js` with contents
+
+```javascript
+__webpack_public_path = https://cdn.url.com
+```
+
+And then in your `webpack.config.js` updating your `entry` field to look like
+
+```javascript
+entry: ['./publicPath.js', './App.js']
+```
+
+Alternatively, you can do the following in your `App.js` without modifying your webpack config. The only downside is you have to enforce ordering here and that can collide with some linting tools.
+
+```javascript
+import './publicPath.js'
+```
+
 ## Resource assets
 
 **webpack.config.js**

--- a/src/content/guides/asset-modules.mdx
+++ b/src/content/guides/asset-modules.mdx
@@ -87,19 +87,21 @@ By default, the `asset` type does `__webpack_public_path__ + import.meta` under 
 If you set the `__webpack_public_path__` in code, the way you need to achive it so as not to break the `asset` loading logic is to make sure you run it as the first code in your app and not use a function to do so. An example of this would be having a file called `publicPath.js` with contents
 
 ```javascript
-__webpack_public_path = https://cdn.url.com
+__webpack_public_path__ = 'https://cdn.url.com';
 ```
 
 And then in your `webpack.config.js` updating your `entry` field to look like
 
 ```javascript
-entry: ['./publicPath.js', './App.js']
+module.exports = {
+  entry: ['./publicPath.js', './App.js'],
+};
 ```
 
 Alternatively, you can do the following in your `App.js` without modifying your webpack config. The only downside is you have to enforce ordering here and that can collide with some linting tools.
 
 ```javascript
-import './publicPath.js'
+import './publicPath.js';
 ```
 
 ## Resource assets

--- a/src/content/guides/asset-modules.mdx
+++ b/src/content/guides/asset-modules.mdx
@@ -84,7 +84,7 @@ By default, the `asset` type does `__webpack_public_path__ + import.meta` under 
 
 #### On The Fly Override
 
-If you set the `__webpack_public_path__` in code, the way you need to achive it so as not to break the `asset` loading logic is to make sure you run it as the first code in your app and not use a function to do so. An example of this would be having a file called `publicPath.js` with contents
+If you set the `__webpack_public_path__` in code, the way you need to achieve it so as not to break the `asset` loading logic is to make sure you run it as the first code in your app and not use a function to do so. An example of this would be having a file called `publicPath.js` with contents
 
 ```javascript
 __webpack_public_path__ = 'https://cdn.url.com';

--- a/src/content/guides/asset-modules.mdx
+++ b/src/content/guides/asset-modules.mdx
@@ -80,7 +80,7 @@ module.exports = {
 
 ### Public Path
 
-By default, the `asset` type does `__webpack_public_path__ + import.meta` under the hood. This means that setting the `output.publicPath` in your config will allow you to override the url that the `asset` loads from.
+By default, under the hood, the `asset` type does `__webpack_public_path__ + import.meta`. This means that setting the `output.publicPath` in your config will allow you to override the URL from which the `asset` loads.
 
 #### On The Fly Override
 

--- a/src/content/guides/asset-modules.mdx
+++ b/src/content/guides/asset-modules.mdx
@@ -78,11 +78,11 @@ module.exports = {
 }
 ```
 
-### Public Path
+## Public Path
 
 By default, under the hood, the `asset` type does `__webpack_public_path__ + import.meta`. This means that setting the `output.publicPath` in your config will allow you to override the URL from which the `asset` loads.
 
-#### On The Fly Override
+### On The Fly Override
 
 If you set the `__webpack_public_path__` in code, the way you need to achieve it so as not to break the `asset` loading logic is to make sure you run it as the first code in your app and not use a function to do so. An example of this would be having a file called `publicPath.js` with contents
 


### PR DESCRIPTION
This updates the documentation to better define how `publicPath` interacts with `asset` module types. Specifically, it is poorly documented on how to dynamically set the `publicPath` on the fly for these module types. This is important and useful in an enterprise environment where there may be different upstream CDNs or other locations that the app hosts assets on that aren't the server or a static site.
