### PR TITLE
fix: don't replace comments inside codeblocks while processing README

### DIFF
--- a/src/utilities/__snapshots__/process-readme.test.mjs.snap
+++ b/src/utilities/__snapshots__/process-readme.test.mjs.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`processReadme should preserve comments inside code blocks 1`] = `
+"
+    
+    ### Disable url resolving using the \`<!-- webpackIgnore: true -->\` comment
+
+    \`\`\`html
+    <!-- Disabled url handling for the src attribute -->
+    <!-- webpackIgnore: true -->
+    <img src="image.png" />
+
+    <!-- Disabled url handling for the src and srcset attributes -->
+    <!-- webpackIgnore: true -->
+    <img
+      srcset="image.png 480w, image.png 768w"
+      src="image.png"
+      alt="Elva dressed as a fairy"
+    />
+
+    <!-- Disabled url handling for the content attribute -->
+    <!-- webpackIgnore: true -->
+    <meta itemprop="image" content="./image.png" />
+
+    <!-- Disabled url handling for the href attribute -->
+    <!-- webpackIgnore: true -->
+    <link rel="icon" type="image/png" sizes="192x192" href="./image.png" />
+    \`\`\`
+    "
+`;

--- a/src/utilities/process-readme.mjs
+++ b/src/utilities/process-readme.mjs
@@ -109,9 +109,9 @@ export default function processREADME(body, options = {}) {
     .replace(inlineLinkRegex, linkFixerFactory(options.source))
     // Replace any <h2> with `##`
     .replace(/<h2[^>]*>/g, '## ')
-    .replace(/<\/h2>/g, '')
+    .replace(/<\/h2>/g, '');
     // Drop any comments
-    .replace(/<!--[\s\S]*?-->/g, '');
+    // .replace(/<!--[\s\S]*?-->/g, '');
 
   // find the laoders links
   const loaderMatches = getMatches(

--- a/src/utilities/process-readme.mjs
+++ b/src/utilities/process-readme.mjs
@@ -109,11 +109,36 @@ export default function processREADME(body, options = {}) {
     .replace(inlineLinkRegex, linkFixerFactory(options.source))
     // Replace any <h2> with `##`
     .replace(/<h2[^>]*>/g, '## ')
-    .replace(/<\/h2>/g, '')
-    // Drop any comments
-    .replace(/^<!--[\s\S]*?-->/g, '');
+    .replace(/<\/h2>/g, '');
 
-  // find the laoders links
+  // Drop any comments that are not in code blocks
+  // EXAMPLE: <!-- some comment --> should be dropped
+  // EXAMPLE: `<!-- webpackIgnore: true -->` should  not be dropped
+  // EXAMPLE: ```html <!-- webpackIgnore: true -->  <!-- some comment -->``` should not be dropped
+  processingString = processingString.replace(/<!--[\s\S]*?-->/g, (match) => {
+    const codeBlockPattern = /```([\s\S]*?)```|`([\s\S]*?)`/g;
+    const contents = [];
+    let matches;
+    while ((matches = codeBlockPattern.exec(processingString)) !== null) {
+      // Content inside triple backticks
+      if (matches[1] !== undefined) {
+        contents.push(matches[1]);
+      }
+      // Content inside single backticks
+      else if (matches[2] !== undefined) {
+        contents.push(matches[2]);
+      }
+    }
+
+    // If the comment is inside a code block, return the match
+    if (contents.join('').includes(match)) {
+      return match;
+    }
+
+    return '';
+  });
+
+  // find the loaders links
   const loaderMatches = getMatches(
     processingString,
     /https?:\/\/github.com\/(webpack|webpack-contrib)\/([-A-za-z0-9]+-loader\/?)([)"])/g

--- a/src/utilities/process-readme.mjs
+++ b/src/utilities/process-readme.mjs
@@ -109,9 +109,9 @@ export default function processREADME(body, options = {}) {
     .replace(inlineLinkRegex, linkFixerFactory(options.source))
     // Replace any <h2> with `##`
     .replace(/<h2[^>]*>/g, '## ')
-    .replace(/<\/h2>/g, '');
+    .replace(/<\/h2>/g, '')
     // Drop any comments
-    // .replace(/<!--[\s\S]*?-->/g, '');
+    .replace(/^<!--[\s\S]*?-->/g, '');
 
   // find the laoders links
   const loaderMatches = getMatches(

--- a/src/utilities/process-readme.test.mjs
+++ b/src/utilities/process-readme.test.mjs
@@ -39,4 +39,38 @@ describe('processReadme', () => {
       'See the file [`https://github.com/webpack-contrib/postcss-loader/blob/master/src/config.d.ts`](https://github.com/webpack-contrib/postcss-loader/blob/master/src/config.d.ts).'
     );
   });
+
+  it('should preserve comments inside code blocks', () => {
+    const options = {
+      source:
+        'https://raw.githubusercontent.com/webpack-contrib/postcss-loader/master/README.md',
+    };
+    const loaderMDData = `
+    <!-- some comment that should be dropped -->
+    ### Disable url resolving using the \`<!-- webpackIgnore: true -->\` comment
+
+    \`\`\`html
+    <!-- Disabled url handling for the src attribute -->
+    <!-- webpackIgnore: true -->
+    <img src="image.png" />
+
+    <!-- Disabled url handling for the src and srcset attributes -->
+    <!-- webpackIgnore: true -->
+    <img
+      srcset="image.png 480w, image.png 768w"
+      src="image.png"
+      alt="Elva dressed as a fairy"
+    />
+
+    <!-- Disabled url handling for the content attribute -->
+    <!-- webpackIgnore: true -->
+    <meta itemprop="image" content="./image.png" />
+
+    <!-- Disabled url handling for the href attribute -->
+    <!-- webpackIgnore: true -->
+    <link rel="icon" type="image/png" sizes="192x192" href="./image.png" />
+    \`\`\`
+    `;
+    expect(processReadme(loaderMDData, options)).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/webpack-contrib/html-loader/issues/502


## [Before](https://webpack.js.org/loaders/html-loader/#disable-url-resolving-using-the--comment)
<img width="863" alt="Screenshot 2024-01-13 at 9 07 36 AM" src="https://github.com/webpack/webpack.js.org/assets/46647141/1ea402ef-3ee5-4a61-adb3-db62951ee68e">


## [After](https://webpack-js-org-git-fix-escape-md-comments-webpack-docs.vercel.app/loaders/html-loader/#disable-url-resolving-using-the----webpackignore-true----comment)

<img width="852" alt="Screenshot 2024-01-13 at 9 07 15 AM" src="https://github.com/webpack/webpack.js.org/assets/46647141/b63db83b-addb-4a01-baf8-01616ae8615b">
