### PR TITLE
Fix typo in __dirname and __filename options

### DIFF
--- a/src/content/configuration/node.mdx
+++ b/src/content/configuration/node.mdx
@@ -54,7 +54,7 @@ Options:
 
 ## node.\_\_filename
 
-`boolean` `'mock' | 'warn-mock' | 'node_module' | 'eval-only'`
+`boolean` `'mock' | 'warn-mock' | 'node-module' | 'eval-only'`
 
 Options:
 
@@ -62,12 +62,12 @@ Options:
 - `false`: Webpack won't touch your `__filename` code, which means you have the regular Node.js `__filename` behavior. The filename of the **output** file when run in a Node.js environment.
 - `'mock'`: The fixed value `'/index.js'`.
 - `'warn-mock'`: Use the fixed value of `'/index.js'` but show a warning.
-- `node_module`: Replace `__filename` in CommonJS modules to `fileURLToPath(import.meta.url)` when `output.module` is enabled.
+- `'node-module'`: Replace `__filename` in CommonJS modules to `fileURLToPath(import.meta.url)` when `output.module` is enabled.
 - `'eval-only'`
 
 ## node.\_\_dirname
 
-`boolean` `'mock' | 'warn-mock' | 'node_module' | 'eval-only'`
+`boolean` `'mock' | 'warn-mock' | 'node-module' | 'eval-only'`
 
 Options:
 
@@ -75,5 +75,5 @@ Options:
 - `false`: Webpack won't touch your `__dirname` code, which means you have the regular Node.js `__dirname` behavior. The dirname of the **output** file when run in a Node.js environment.
 - `'mock'`: The fixed value `'/'`.
 - `'warn-mock'`: Use the fixed value of `'/'` but show a warning.
-- `node_module`: Replace `__dirname` in CommonJS modules to `fileURLToPath(import.meta.url + "/..")` when `output.module` is enabled.
+- `'node-module'`: Replace `__dirname` in CommonJS modules to `fileURLToPath(import.meta.url + "/..")` when `output.module` is enabled.
 - `'eval-only'`


### PR DESCRIPTION
node.__filename and node.__dirname accept 'node-module' as an option, not 'node_module'

Using 'node-module' works, whereas using 'node_module' gives the following error:
```
[webpack-cli] Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 - configuration.node.__filename should be one of these:
   false | true | "warn-mock" | "mock" | "node-module" | "eval-only"
   -> Include a polyfill for the '__filename' variable.
```
