### PR TITLE
docs(configuration): clarify `devtool` disabling

### DIFF
--- a/src/content/configuration/devtool.mdx
+++ b/src/content/configuration/devtool.mdx
@@ -125,7 +125,7 @@ The following options are not ideal for development nor production. They are nee
 
 These options are typically used in production:
 
-`(none)` (Omit the `devtool` option) - No SourceMap is emitted. This is a good option to start with.
+`(none)` (Omit the `devtool` option or set `devtool: false`) - No SourceMap is emitted. This is a good option to start with.
 
 `source-map` - A full SourceMap is emitted as a separate file. It adds a reference comment to the bundle so development tools know where to find it.
 


### PR DESCRIPTION
I was trying to avoid `eval` being generated by `devtool` in my local development workflow, but the docs weren't clear on how to disable the `devtool`. The solution was to explicitly set `devtool: false` so that both the development and production modes use `(none)`.
