### PR TITLE
docs(configuration): update `output.trustedTypes`

### DIFF
--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -2272,13 +2272,13 @@ require('module'); // <- also throws
 
 ## output.trustedTypes
 
-`boolean = false` `string` `object`
+`true` `string` `object`
 
 <Badge text="5.37.0+" />
 
 Controls [Trusted Types](https://web.dev/trusted-types) compatibility. When enabled, webpack will detect Trusted Types support and, if they are supported, use Trusted Types policies to create script URLs it loads dynamically. Use when the application runs under a [`require-trusted-types-for`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for) Content Security Policy directive.
 
-It defaults to `false` (no compatibility, script URLs are strings).
+It is disabled by default (no compatibility, script URLs are strings).
 
 - When set to `true`, webpack will use [`output.uniqueName`](#outputuniquename) as the Trusted Types policy name.
 - When set to a non-empty string, its value will be used as a policy name.


### PR DESCRIPTION
`trustedTypes: false` is invalid. [Ref Schema](https://github.com/webpack/webpack/blob/611bded369b5a9ea695f2669b25a6f88b67d7826/schemas/WebpackOptions.json#L3392-L3406)

<img width="1108" alt="Screenshot 2024-02-23 at 10 27 44 PM" src="https://github.com/webpack/webpack.js.org/assets/46647141/bfb0a267-e15a-4416-ad78-f176b1fea0d7">
