### PR TITLE
issue7085

### DIFF
--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -582,6 +582,7 @@ module.exports = {
   },
 };
 ```
+W> we can't run the funtion before getting the filename because we pass pathData to this function.
 
 Make sure to read the [Caching guide](/guides/caching) for details. There are more steps involved than only setting this option.
 


### PR DESCRIPTION
we can't run the funtion before getting the name because we pass pathData to this function

updated a line in output.filename to tell user you can run funcyion before filename, that described in https://github.com/webpack/webpack.js.org/issues/7085