### PR TITLE
docs(configuration): add entry[x].runtime

### DIFF
--- a/src/content/configuration/entry-context.mdx
+++ b/src/content/configuration/entry-context.mdx
@@ -11,6 +11,7 @@ contributors:
   - smelukov
   - anshumanv
   - snitin315
+  - hai-x
 ---
 
 The entry object is where webpack looks to start building the bundle. The context is an absolute string to the directory that contains the entry files.
@@ -36,7 +37,7 @@ By default, the current working directory of Node.js is used, but it's recommend
 
 ## entry
 
-`string` `[string]` `object = { <key> string | [string] | object = { import string | [string], dependOn string | [string], filename string, layer string }}` `(function() => string | [string] | object = { <key> string | [string] } | object = { import string | [string], dependOn string | [string], filename string })`
+`string` `[string]` `object = { <key> string | [string] | object = { import string | [string], dependOn string | [string], filename string, layer string, runtime string | false }}` `(function() => string | [string] | object = { <key> string | [string] } | object = { import string | [string], dependOn string | [string], filename string, layer string, runtime string | false })`
 
 The point or points where to start the application bundling process. If an array is passed then all items will be processed.
 
@@ -185,3 +186,25 @@ module.exports = {
 ```
 
 When combining with the [`output.library`](/configuration/output/#outputlibrary) option: If an array is passed only the last item is exported.
+
+### Runtime chunk
+
+It allows to set the runtime chunk for an entrypoint and it can be set to `false` to avoid a new runtime chunk since webpack 5.43.0.
+
+`optimization.runtimeChunk` allows to set it globally for unspecified entrypoints.
+
+```js
+module.exports = {
+  //...
+  entry: {
+    home: {
+      import: './home.js',
+      runtime: 'home-runtime',
+    },
+    about: {
+      import: './about.js',
+      runtime: false,
+    },
+  },
+};
+```

--- a/src/content/configuration/entry-context.mdx
+++ b/src/content/configuration/entry-context.mdx
@@ -189,9 +189,9 @@ When combining with the [`output.library`](/configuration/output/#outputlibrary)
 
 ### Runtime chunk
 
-It allows to set the runtime chunk for an entrypoint and it can be set to `false` to avoid a new runtime chunk since webpack 5.43.0.
+It allows setting the runtime chunk for an entry point and setting it to `false` to avoid a new runtime chunk since webpack `v5.43.0`.
 
-`optimization.runtimeChunk` allows to set it globally for unspecified entrypoints.
+`optimization.runtimeChunk` allows setting it globally for unspecified entry points.
 
 ```js
 module.exports = {


### PR DESCRIPTION
Add `entry[x].runtime` configuration that also align with https://webpack.js.org/concepts/entry-points/#entrydescription-object

Related pr 
https://github.com/webpack/webpack/pull/11235

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [ ] Do not abandon your Pull Request: [Stale Pull Requests][3].
