### PR TITLE
add library config changes to migration guide

### DIFF
--- a/src/content/migrate/5.mdx
+++ b/src/content/migrate/5.mdx
@@ -126,6 +126,28 @@ If you were not able to upgrade some plugins/loaders to the latest in Upgrade we
   }
   ```
 
+- If you have output.library or output.libraryTarget defined, change the property names: (output.libraryTarget -> output.library.type, output.library -> output.library.name). Example
+
+  ```json
+  // for webpack 4
+  {
+      output: {
+        library: 'MyLibrary',
+        libraryTarget: 'commonjs2'
+      }
+  }
+
+  // for webpack 5
+  {
+      output: {
+        library: {
+          name: 'MyLibrary',
+          type: 'commonjs2'
+        }
+      }
+  }
+  ```
+
 If you were using WebAssembly via import, you should follow this two step process:
 
 - Enable the deprecated spec by setting `experiments.syncWebAssembly: true`, to get the same behavior as in webpack 4.


### PR DESCRIPTION
As far as I can tell this is so far only mentioned in this issue comment - it seems to have changed after the blog post listing all the changes in config: https://github.com/webpack/webpack/issues/13584#issuecomment-863272803

(I also needed this question and answer to figure it out: https://stackoverflow.com/questions/77951581/webpack-5-builds-for-aws-lambda-with-typescript-runtime-handlernotfound)