### PR TITLE
docs: fix incorrect sentence

### DIFF
--- a/src/content/contribute/writing-a-plugin.mdx
+++ b/src/content/contribute/writing-a-plugin.mdx
@@ -131,7 +131,7 @@ class HelloCompilationPlugin {
 module.exports = HelloCompilationPlugin;
 ```
 
-The list of hooks available on the `compiler`, `compilation`, and other important objects, see the [plugins API](/api/plugins/) docs.
+For the list of hooks available on `compiler`, `compilation`, and other important objects, see the [plugins API](/api/plugins/) docs.
 
 ## Async event hooks
 


### PR DESCRIPTION
Fixes a grammatically incorrect sentence found on the [writing-a-plugin](https://webpack.js.org/contribute/writing-a-plugin/) page.