### PR TITLE
replace outdated references to libraryTarget with library.type

### DIFF
--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -29,6 +29,7 @@ contributors:
   - mrzalyaul
   - JakobJingleheimer
   - long76
+  - tanyabouman
 ---
 
 The top-level `output` key contains a set of options instructing webpack on how and where it should output your bundles, assets, and anything else you bundle or load with webpack.
@@ -685,9 +686,9 @@ T> In some contexts properties will use JavaScript code expressions instead of r
 
 `string = 'self'`
 
-When targeting a library, especially when `libraryTarget` is `'umd'`, this option indicates what global object will be used to mount the library. To make UMD build available on both browsers and Node.js, set `output.globalObject` option to `'this'`. Defaults to `self` for Web-like targets.
+When targeting a library, especially when `library.type` is `'umd'`, this option indicates what global object will be used to mount the library. To make UMD build available on both browsers and Node.js, set `output.globalObject` option to `'this'`. Defaults to `self` for Web-like targets.
 
-The return value of your entry point will be assigned to the global object using the value of `output.library.name`. Depending on the value of the `target` option, the global object could change respectively, e.g., `self`, `global`, or `globalThis`.
+The return value of your entry point will be assigned to the global object using the value of `output.library.name`. Depending on the value of the `type` option, the global object could change respectively, e.g., `self`, `global`, or `globalThis`.
 
 For example:
 
@@ -697,8 +698,10 @@ For example:
 module.exports = {
   // ...
   output: {
-    library: 'myLib',
-    libraryTarget: 'umd',
+    library: {
+      name: 'myLib',
+      type: 'umd',
+    },
     filename: 'myLib.js',
     globalObject: 'this',
   },
@@ -1394,7 +1397,7 @@ Note that omitting `library.name` will result in the assignment of all propertie
 module.exports = {
   //...
   output: {
-    libraryTarget: 'umd',
+    type: 'umd',
   },
 };
 ```


### PR DESCRIPTION
The `libraryTarget` option has a warning that support might be dropped and it's better to use `library.type`.  I left `libraryTarget` in other sections that are marked as maybe dropping support later because that seems consistent for those options.