### PR TITLE
docs: update output.mdx

### DIFF
--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -208,7 +208,7 @@ module.exports = {
 
 ## output.chunkLoadingGlobal
 
-`string = 'webpackChunkwebpack'`
+`string = 'webpackChunkdata'`
 
 The global variable is used by webpack for loading chunks.
 


### PR DESCRIPTION
I use the output.chunkLoadingGlobal filed in webpack.config.js and want to know how this filed work.

I find the default name is 'webpackChunkdata' string, not 'webpackChunkwebpack' which in this doc.

_describe your changes..._

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].
- **Remove these instructions from your PR as they are for your eyes only.**

[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
