### PR TITLE
docs(configuration): fix stats.entrypoints & stats.errorDetails type

### DIFF
--- a/src/content/configuration/stats.mdx
+++ b/src/content/configuration/stats.mdx
@@ -414,7 +414,7 @@ module.exports = {
 
 ### stats.entrypoints
 
-`boolean = true` `string = 'auto'`
+`boolean = true` `"auto"`
 
 Tells `stats` whether to display the entry points with the corresponding bundles.
 
@@ -446,7 +446,7 @@ module.exports = {
 
 ### stats.errorDetails
 
-`boolean` `string = "auto"`
+`boolean` `"auto"`
 
 Tells `stats` whether to add the details to the errors. It defaults to `'auto'` which will show error details when there're only 2 or less errors.
 


### PR DESCRIPTION
`string = 'auto'` means any string is accepted and it has a default value `'auto'`. While the option only accepts `auto` as the valid value.

https://github.com/webpack/webpack/blob/4fda15571d66bb593a1bad69835a6797b2f911c6/schemas/WebpackOptions.json#L4950