### PR TITLE
docs: add use Rspack to build performance guide

### DIFF
--- a/src/content/guides/build-performance.mdx
+++ b/src/content/guides/build-performance.mdx
@@ -26,6 +26,14 @@ Use the latest webpack version. We are always making performance improvements. T
 
 Staying up-to-date with **Node.js** can also help with performance. On top of this, keeping your package manager (e.g. `npm` or `yarn`) up-to-date can also help. Newer versions create more efficient module trees and increase resolving speed.
 
+### Use Rspack
+
+Rspack is a high performance Rust-based bundler that offers strong interoperability with the webpack ecosystem.
+
+It provides configuration options and APIs that are essentially the same as webpack, and can typically improve the build performance of webpack applications by 5 to 10 times.
+
+See [Rspack documentation](https://www.rspack.dev/) for more details.
+
 ### Loaders
 
 Apply loaders to the minimal number of modules necessary. Instead of:


### PR DESCRIPTION
This PR adds the "use Rspack" guide to the build performance document.

Using Rspack can be a pragmatic option for Webpack users.  If the user has already tried to optimize the build performance of the webpack application and has not achieved the expected results, then using Rspack would be a good choice.

Feel free to close this if this is inappropriate for webpack documentation ❤️

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].
- **Remove these instructions from your PR as they are for your eyes only.**

[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
