### PR TITLE
docs(configuration): add `output.environment.nodePrefixForCoreModules`

### DIFF
--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -496,6 +496,9 @@ module.exports = {
       globalThis: true,
       // The environment supports ECMAScript Module syntax to import ECMAScript modules (import ... from '...').
       module: false,
+      // Determines if the node: prefix is generated for core module imports in environments that support it.
+      // This is only applicable to Webpack runtime code.
+      nodePrefixForCoreModules: false,
       // The environment supports optional chaining ('obj?.a' or 'obj?.()').
       optionalChaining: true,
       // The environment supports template literals.


### PR DESCRIPTION
Fix https://github.com/webpack/webpack.js.org/issues/7230