### PR TITLE
docs(plugins): update append option usage

### DIFF
--- a/src/content/plugins/eval-source-map-dev-tool-plugin.mdx
+++ b/src/content/plugins/eval-source-map-dev-tool-plugin.mdx
@@ -29,7 +29,7 @@ The following options are supported:
 - `test` (`string|RegExp|array`): Include source maps for modules based on their extension (defaults to `.js` and `.css`).
 - `include` (`string|RegExp|array`): Include source maps for module paths that match the given value.
 - `exclude` (`string|RegExp|array`): Exclude modules that match the given value from source map generation.
-- `append` (`string|function`): Appends the given value to the original asset. Usually the `#sourceMappingURL` comment. `[url]` is replaced with a URL to the source map file. `false` disables the appending.
+- `append` (`string|function`): Appends the given value to the original asset. Usually the `#sourceMappingURL` comment. `[url]` is replaced with a URL to the source map file.
 
   Starting from version 5.84.0, webpack allows the `append` option to be a function that accepts path data and an asset info object as arguments, and returns a string.
 

--- a/src/content/plugins/source-map-dev-tool-plugin.mdx
+++ b/src/content/plugins/source-map-dev-tool-plugin.mdx
@@ -27,7 +27,7 @@ The following options are supported:
 - `include` (`string` `RegExp` `[string, RegExp]`): Include source maps for module paths that match the given value.
 - `exclude` (`string` `RegExp` `[string, RegExp]`): Exclude modules that match the given value from source map generation.
 - `filename` (`string`): Defines the output filename of the SourceMap (will be inlined if no value is provided).
-- `append` (`string` `function`): Appends the given value to the original asset. Usually the `#sourceMappingURL` comment. `[url]` is replaced with a URL to the source map file. Since webpack v4.36.0, path parameters are supported: `[chunk]`, `[filename]` and `[contenthash]`. Setting `append` to `false` disables the appending.
+- `append` (`string` `function` `false`): Appends the given value to the original asset. Usually the `#sourceMappingURL` comment. `[url]` is replaced with a URL to the source map file. Since webpack v4.36.0, path parameters are supported: `[chunk]`, `[filename]` and `[contenthash]`. Setting `append` to `false` disables the appending.
 
   Starting from version 5.84.0, webpack allows the `append` option to be a function that accepts path data and an asset info object as arguments, and returns a string.
 


### PR DESCRIPTION
Fix https://github.com/webpack/webpack/issues/17663

Only `SourceMapDevtoolPlugin` supports `false`.