### PR TITLE
docs: add warning for ! usage in `output.path`

### DIFF
--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -2093,6 +2093,8 @@ module.exports = {
 
 Note that `[fullhash]` in this parameter will be replaced with a hash of the compilation. See the [Caching guide](/guides/caching/) for details.
 
+W> The path must not contain an exclamation mark (`!`) as it is reserved by webpack for [loader syntax](/concepts/loaders/#inline).
+
 ## output.pathinfo
 
 `boolean=true` `string: 'verbose'`


### PR DESCRIPTION
Fix #7279 