### PR TITLE
Replaced correct es5 compat-table link

### DIFF
--- a/src/content/concepts/index.mdx
+++ b/src/content/concepts/index.mdx
@@ -163,7 +163,7 @@ Learn more about the [mode configuration here](/configuration/mode) and what opt
 
 ## Browser Compatibility
 
-Webpack supports all browsers that are [ES5-compliant](https://kangax.github.io/compat-table/es5/) (IE8 and below are not supported). Webpack needs `Promise` for [`import()` and `require.ensure()`](/guides/code-splitting/#dynamic-imports). If you want to support older browsers, you will need to [load a polyfill](/guides/shimming/) before using these expressions.
+Webpack supports all browsers that are [ES5-compliant](https://compat-table.github.io/compat-table/es5/) (IE8 and below are not supported). Webpack needs `Promise` for [`import()` and `require.ensure()`](/guides/code-splitting/#dynamic-imports). If you want to support older browsers, you will need to [load a polyfill](/guides/shimming/) before using these expressions.
 
 ## Environment
 


### PR DESCRIPTION
Updated the link to ES5 compatability table in webpack docs.


- **Old Link**: https://kangax.github.io/compat-table/es5/
- **New Link**: https://compat-table.github.io/compat-table/es5/

[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
