### PR TITLE
docs(awesome): add pwa-manifest-loader

### DIFF
--- a/src/content/awesome-webpack.mdx
+++ b/src/content/awesome-webpack.mdx
@@ -66,6 +66,7 @@ _People passionate about Webpack (In no particular order)_
 - [Auto ngTemplate Loader](https://github.com/YashdalfTheGray/auto-ngtemplate-loader): Autodetect Angular 1 templates and load them. -- _Maintainer_: `Yash Kulshrestha` [![Github][githubicon]](https://github.com/YashdalfTheGray)
 - [Pug Loader](https://github.com/pugjs/pug-loader) - Pug template loader (formerly Jade). -- _Maintainer_: `Pug Team` [![Github][githubicon]](https://github.com/pugjs)
 - [Simple Nunjucks Loader](https://github.com/ogonkov/nunjucks-loader) - Nunjucks template loader. -- _Maintainer_: `ogonkov` [![Github][githubicon]](https://github.com/ogonkov)
+- [PWA Manifest Loader](https://github.com/autopulated/webpack-pwa-manifest-loader) - PWA manifest loader. -- _Maintainer_: `autopulated` [![Github][githubicon]](https://github.com/autopulated)
 
 #### Styles
 


### PR DESCRIPTION
Add [pwa-manifest-loader](https://github.com/autopulated/webpack-pwa-manifest-loader) to the community list, hopefully this is useful for other people?

The PWA manifest references other assets, so it's nice to have a loader automatically handle them.
