### PR TITLE
docs: Replace overkill regex with a much simpler one

### DIFF
--- a/src/content/plugins/normal-module-replacement-plugin.mdx
+++ b/src/content/plugins/normal-module-replacement-plugin.mdx
@@ -5,6 +5,7 @@ contributors:
   - gonzoyumo
   - byzyk
   - chenxsan
+  - askoufis
 ---
 
 The `NormalModuleReplacementPlugin` allows you to replace resources that match `resourceRegExp` with `newResource`. If `newResource` is relative, it is resolved relative to the previous resource. If `newResource` is a function, it is expected to overwrite the request attribute of the supplied resource.
@@ -46,7 +47,7 @@ module.exports = function (env) {
   return {
     plugins: [
       new webpack.NormalModuleReplacementPlugin(
-        /(.*)-APP_TARGET(\.*)/,
+        /-APP_TARGET$/,
         function (resource) {
           resource.request = resource.request.replace(
             /-APP_TARGET/,


### PR DESCRIPTION
The example given in the docs for `NormalModuleReplacementPlugin` uses quite an expensive regex for what it's trying to achieve. This exact regex was the source of a sizeable performance hit in one of our applications. I've updated it to be simpler and more performant.