### PR TITLE
Fix `webpackExports` section header

### DIFF
--- a/src/content/api/module-methods.mdx
+++ b/src/content/api/module-methods.mdx
@@ -190,7 +190,9 @@ A regular expression that will be matched against during import resolution. Any 
 
 T> Note that `webpackInclude` and `webpackExclude` options do not interfere with the prefix. eg: `./locale`.
 
-`webpackExports`: tells webpack to only bundle the specified exports of a dynamically `import()`ed module. It can decrease the output size of a chunk. Available since [webpack 5.0.0-beta.18](https://github.com/webpack/webpack/releases/tag/v5.0.0-beta.18).
+##### `webpackExports`
+
+Tells webpack to only bundle the specified exports of a dynamically `import()`ed module. It can decrease the output size of a chunk. Available since [webpack 5.0.0-beta.18](https://github.com/webpack/webpack/releases/tag/v5.0.0-beta.18).
 
 ## CommonJS
 


### PR DESCRIPTION
On the https://webpack.js.org/api/module-methods/ page, the `webpackExports` section was not the right format. It wasn't an actual heading, and as a consequence it didn't have an anchor link.