### PR TITLE
Mention end of  support for subpath mapping exports by Node > 17

### DIFF
--- a/src/content/guides/package-exports.mdx
+++ b/src/content/guides/package-exports.mdx
@@ -149,7 +149,7 @@ Example: `{ "./a/": "./x/", "./a/b/": "./y/", "./a/b/c": "./z" }` == `{ "./a/b/c
 | -------------------------------------- | ---------------------------------------------------------------------------------- |
 | `"."` property                         | Node.js, webpack, rollup, esinstall, wmr                                           |
 | normal property                        | Node.js, webpack, rollup, esinstall, wmr                                           |
-| property ending with `/`               | Node.js<sup>(1)</sup>, webpack, rollup, esinstall<sup>(2)</sup>, wmr<sup>(3)</sup> |
+| property ending with `/`<sup>(1)</sup> | webpack, rollup, esinstall<sup>(2)</sup>, wmr<sup>(3)</sup>                        |
 | property ending with `*`               | Node.js, webpack, rollup, esinstall                                                |
 | Alternatives                           | Node.js, webpack, rollup, <strike>esinstall</strike><sup>(4)</sup>                 |
 | Abbreviation only path                 | Node.js, webpack, rollup, esinstall, wmr                                           |
@@ -162,7 +162,7 @@ Example: `{ "./a/": "./x/", "./a/b/": "./y/", "./a/b/c": "./z" }` == `{ "./a/b/c
 | Error when not mapped                  | Node.js, webpack, rollup, esinstall, wmr<sup>(7)</sup>                             |
 | Error when mixing conditions and paths | Node.js, webpack, rollup                                                           |
 
-(1) deprecated in Node.js, `*` should be preferred.
+(1) Removed in Node.js 17. Use `*` instead.
 
 (2) `"./"` is intentionally ignored as key.
 


### PR DESCRIPTION
Subpath mapping exports are no longer handled by Node.js. I removed it from the list of supported platforms.

See : https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V17.md#2021-10-19-version-1700-current-bethgriggs
