### PR TITLE
docs: add `'modern-module'` value for `output.library.type`

### DIFF
--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -1025,7 +1025,7 @@ Configure how the library will be exposed.
 
 - Type: `string`
 
-  Types included by default are `'var'`, `'module'`, `'assign'`, `'assign-properties'`, `'this'`, `'window'`, `'self'`, `'global'`, `'commonjs'`, `'commonjs2'`, `'commonjs-module'`, `'commonjs-static'`, `'amd'`, `'amd-require'`, `'umd'`, `'umd2'`, `'jsonp'` and `'system'`, but others might be added by plugins.
+  Types included by default are `'var'`, `'module'`, `'modern-module'`, `'assign'`, `'assign-properties'`, `'this'`, `'window'`, `'self'`, `'global'`, `'commonjs'`, `'commonjs2'`, `'commonjs-module'`, `'commonjs-static'`, `'amd'`, `'amd-require'`, `'umd'`, `'umd2'`, `'jsonp'` and `'system'`, but others might be added by plugins.
 
 For the following examples, we'll use `_entry_return_` to indicate the values returned by the entry point.
 

--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -1235,6 +1235,8 @@ However this feature is still experimental and not fully supported yet, so make 
 
 ##### type: 'modern-module'
 
+<Badge text="v5.93.0+" />
+
 ```js
 module.exports = {
   // …

--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -1233,6 +1233,27 @@ Output ES Module.
 
 However this feature is still experimental and not fully supported yet, so make sure to enable [experiments.outputModule](/configuration/experiments/) beforehand. In addition, you can track the development progress in [this thread](https://github.com/webpack/webpack/issues/2933#issuecomment-774253975).
 
+##### type: 'modern-module'
+
+```js
+module.exports = {
+  // …
+  experiments: {
+    outputModule: true,
+  },
+  output: {
+    library: {
+      // do not specify a `name` here
+      type: 'modern-module',
+    },
+  },
+};
+```
+
+This configuration generates tree-shakable output for ES Modules.
+
+However this feature is still experimental and not fully supported yet, so make sure to enable [experiments.outputModule](/configuration/experiments/) beforehand.
+
 ##### type: 'commonjs2'
 
 ```js


### PR DESCRIPTION
Refers https://github.com/webpack/webpack/pull/18272