### PR TITLE
feat: Added codemods for migrating webpack from v4 to v5

### DIFF
--- a/src/content/migrate/5.mdx
+++ b/src/content/migrate/5.mdx
@@ -12,6 +12,7 @@ contributors:
   - jamesgeorge007
   - getsnoopy
   - yevhen-logosha
+  - akash-kumar-dev
 ---
 
 This guide aims to help you migrating to webpack 5 when using webpack directly. If you are using a higher level tool to run webpack, please refer to the tool for migration instructions.

--- a/src/content/migrate/5.mdx
+++ b/src/content/migrate/5.mdx
@@ -35,6 +35,24 @@ Webpack 5 requires at least Node.js 10.13.0 (LTS), so make sure you upgrade your
    Some Plugins and Loaders might have a beta version that has to be used in order to be compatible with webpack 5.
    Make sure to read release notes of each individual plugin/loader when upgrading it, since latest version might only support webpack 5 and will fail in v4. In such case, it's recommended to update to the latest version that supports webpack 4.
 
+
+## Codemods
+
+To assist with the upgrade webpack from v4 to v5, we have added features that utilize codemods to automatically update your code to many of the new APIs and patterns. Run the following command to automatically update your code for webpack v5 migration:
+
+```bash
+npx codemod webpack/v5/migration-recipe
+```
+
+This will run the following codemods from the webpack Codemod repository:
+
+- **webpack/v5/set-target-to-false-and-update-plugins**
+- **webpack/v5/migrate-library-target-to-library-object**
+- **webpack/v5/json-imports-to-default-imports**
+
+Each of these codemods automates the changes listed in the v5 migration guide. For a complete list of available webpack codemods and further details, see the [codemod registry](https://codemod.com/registry?q=webpack).
+
+
 ### Make sure your build has no errors or warnings
 
 There might be new errors or warnings because of the upgraded versions of `webpack`, `webpack-cli`, Plugins and Loaders. Keep an eye for deprecation warnings during the build.
@@ -126,6 +144,14 @@ If you were not able to upgrade some plugins/loaders to the latest in Upgrade we
   }
   ```
 
+  > **Note**: Codemod for this Chnages:
+  >
+  > ```bash
+  > npx codemod set-target-to-false-and-update-plugins
+  > ```
+  >
+  > (See the [registry here](https://codemod.com/registry/webpack-v5-set-target-to-false-and-update-plugins).)
+
 - If you have output.library or output.libraryTarget defined, change the property names: (output.libraryTarget -> output.library.type, output.library -> output.library.name). Example
 
   ```json
@@ -147,6 +173,14 @@ If you were not able to upgrade some plugins/loaders to the latest in Upgrade we
       }
   }
   ```
+
+  > **Note**: Codemod for this Chnages:
+  >
+  > ```bash
+  > npx codemod webpack/v5/migrate-library-target-to-library-object
+  > ```
+  >
+  > (See the [registry here](https://codemod.com/registry/webpack-v5-migrate-library-target-to-library-object).)
 
 If you were using WebAssembly via import, you should follow this two step process:
 
@@ -203,6 +237,14 @@ use:
 import pkg from './package.json';
 console.log(pkg.version);
 ```
+
+  > **Note**: Codemod for this Chnages:
+  >
+  > ```bash
+  > npx codemod codemod webpack/v5/json-imports-to-default-imports
+  > ```
+  >
+  > (See the [registry here](https://codemod.com/registry/webpack-v5-json-imports-to-default-imports).)
 
 #### Cleanup the build code
 

--- a/src/content/migrate/5.mdx
+++ b/src/content/migrate/5.mdx
@@ -39,7 +39,7 @@ Webpack 5 requires at least Node.js 10.13.0 (LTS), so make sure you upgrade your
 
 ## Codemods
 
-To assist with the upgrade webpack from v4 to v5, we have added features that utilize codemods to automatically update your code to many of the new APIs and patterns. Run the following command to automatically update your code for webpack v5 migration:
+To assist with the upgrade from Webpack v4 to v5, we have provided a community codemod that can help automate parts of the migration process. Please note that this codemod is not an official Webpack tool, and while it aims to streamline the migration, it may not cover all cases. You may still need to perform additional manual steps to fully complete the upgrade. Run the following command to use the codemod for Webpack v5 migration:
 
 ```bash
 npx codemod webpack/v5/migration-recipe


### PR DESCRIPTION
This PR enhances the webpack v5 from v4 migration guide by incorporating codemod integration to streamline the upgrade process for developers. The motivation behind this change is to provide a more efficient and time-saving approach for migrating from v4 to v5, helping the community upgrade with ease.

Key changes include:

1. **Introducing Codemods**: Added a section in the migration guide to highlight the availability of codemods for automating common migration tasks.
2. **Codemod Recipe**: Provided a codemod recipe that runs the following codemods from the Sentry.js Codemod repository:
   ```
   npx codemod webpack/v5/migration-recipe
   ```
- **webpack/v5/set-target-to-false-and-update-plugins** [Registry Link](https://codemod.com/registry/webpack-v5-set-target-to-false-and-update-plugins)
- **webpack/v5/migrate-library-target-to-library-object** [Registry Link](https://codemod.com/registry/webpack-v5-migrate-library-target-to-library-object)
- **webpack/v5/json-imports-to-default-imports** [Registry Link](https://codemod.com/registry/webpack-v5-json-imports-to-default-imports)

By incorporating these changes, the migration guide now provides a more comprehensive and efficient solution for upgrading to webpack v5, helping developers save time and effort during the migration process.