### PR TITLE
docs(configuration) module rule.compiler ident fix

### DIFF
--- a/src/content/configuration/experiments.mdx
+++ b/src/content/configuration/experiments.mdx
@@ -235,37 +235,36 @@ Compile entrypoints and dynamic `import`s only when they are in use. It can be u
 
     ```ts
     {
-    // define a custom backend
-    backend?: ((
-      compiler: Compiler,
-      callback: (err?: Error, api?: BackendApi) => void
+      // define a custom backend
+      backend?: ((
+        compiler: Compiler,
+        callback: (err?: Error, api?: BackendApi) => void
       ) => void)
-      | ((compiler: Compiler) => Promise<BackendApi>)
-      | {
-        /**
-         * A custom client.
-        */
-        client?: string;
+        | ((compiler: Compiler) => Promise<BackendApi>)
+        | {
+          /**
+           * A custom client.
+           */
+          client?: string;
 
-        /**
-         * Specify where to listen to from the server.
-         */
-        listen?: number | ListenOptions | ((server: Server) => void);
+          /**
+           * Specify where to listen to from the server.
+           */
+          listen?: number | ListenOptions | ((server: Server) => void);
 
-        /**
-         * Specify the protocol the client should use to connect to the server.
-         */
-        protocol?: "http" | "https";
+          /**
+           * Specify the protocol the client should use to connect to the server.
+           */
+          protocol?: "http" | "https";
 
-        /**
-         * Specify how to create the server handling the EventSource requests.
-         */
-        server?: ServerOptionsImport | ServerOptionsHttps | (() => Server);
-
-    },
-    entries?: boolean,
-    imports?: boolean,
-    test?: string | RegExp | ((module: Module) => boolean)
+          /**
+           * Specify how to create the server handling the EventSource requests.
+           */
+          server?: ServerOptionsImport | ServerOptionsHttps | (() => Server);
+        },
+      entries?: boolean,
+      imports?: boolean,
+      test?: string | RegExp | ((module: Module) => boolean)
     }
     ```
 

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -760,20 +760,20 @@ A [`Condition`](#condition) that allows you to match the child compiler name.
 ```javascript
 module.exports = {
   // ...
-  name: "compiler"
+  name: 'compiler',
   module: {
     rules: [
-			{
-				test: /a\.js$/,
-				compiler: "compiler", // Matches the "compiler" name, loader will be applied
-				use: "./loader"
-			},
-			{
-				test: /b\.js$/,
-				compiler: "other-compiler", // Does not match the "compiler" name, loader will NOT be applied
-				use: "./loader"
-			}
-		]
+      {
+        test: /a\.js$/,
+        compiler: 'compiler', // Matches the "compiler" name, loader will be applied
+        use: './loader',
+      },
+      {
+        test: /b\.js$/,
+        compiler: 'other-compiler', // Does not match the "compiler" name, loader will NOT be applied
+        use: './loader',
+      },
+    ],
   },
 };
 ```


### PR DESCRIPTION
## Refs:
- #7392
- https://webpack.js.org/configuration/module/#rulecompiler

module rule.compiler ident fix

## Demonstration of the problem ↓

<img width="1043" alt="image" src="https://github.com/user-attachments/assets/be425be4-ca00-462e-9119-e9b4c8109ea2">


[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
