### PR TITLE
docs(plugins): replace a typo with a convenient word

### DIFF
--- a/src/content/concepts/plugins.mdx
+++ b/src/content/concepts/plugins.mdx
@@ -37,7 +37,7 @@ class ConsoleLogOnBuildWebpackPlugin {
 module.exports = ConsoleLogOnBuildWebpackPlugin;
 ```
 
-It is recommended that the first parameter of the tap method of the compiler hook should be a caramelized version of the plugin name. It is advisable to use a constant for this so it can be reused in all hooks.
+It is recommended that the first parameter of the tap method of the compiler hook should be a camelized version of the plugin name. It is advisable to use a constant for this so it can be reused in all hooks.
 
 ## Usage
 


### PR DESCRIPTION
I believe that `caramelized` was just a typo
