### PR TITLE
Update entry-context.mdx

### DIFF
--- a/src/content/configuration/entry-context.mdx
+++ b/src/content/configuration/entry-context.mdx
@@ -175,6 +175,19 @@ module.exports = {
 
 For example: you can use dynamic entries to get the actual entries from an external source (remote server, file system content or database):
 
+### Multiple Entry Points in Different Folders
+In some scenarios, you might want to organize your entry points into different folders for better structure and maintainability. Here's how you can define multiple entry points located in different folders:
+```
+module.exports = {
+  //...
+  entry: {
+    './js/one': './js/one.js/,
+    './js/two': './js/two.js/
+  },
+};
+```
+
+
 **webpack.config.js**
 
 ```js


### PR DESCRIPTION
multiple js config entry added

the technical document in which you wanted to determine the input and output names of different files was not included. That's why I added this.


[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
