### PR TITLE
ci: use `ubuntu-22.04` for `errata-ai/vale-action`

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -51,7 +51,8 @@ jobs:
     name: Proselint
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        # TODO remove after https://github.com/errata-ai/vale-action/issues/128
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
`errata-ai/vale-action` is failing on ubuntu-laltest. Related issue - https://github.com/errata-ai/vale-action/issues/128

Pin version as workaround.

[Reference CI failure](https://github.com/webpack/webpack.js.org/actions/runs/11304327686/job/31442570735?pr=7426)
<img width="1067" alt="Screenshot 2024-10-12 at 2 22 46 PM" src="https://github.com/user-attachments/assets/f4605c00-da7b-4a91-a8c3-a97c18c89bbc">
