### PR TITLE
chore: use authenticated GitHub API locally if token is present

### DIFF
--- a/src/utilities/githubAPI.mjs
+++ b/src/utilities/githubAPI.mjs
@@ -23,6 +23,10 @@ if (
   api = new GithubAPI({
     auth: process.env.GITHUB_TOKEN,
   });
-  console.log(typeof process.env.GITHUB_TOKEN === "undefined" ? 'api is not authenticated' : 'api is authenticated locally');
+  console.log(
+    typeof process.env.GITHUB_TOKEN === 'undefined'
+      ? 'api is not authenticated'
+      : 'api is authenticated locally'
+  );
 }
 export default api;

--- a/src/utilities/githubAPI.mjs
+++ b/src/utilities/githubAPI.mjs
@@ -20,7 +20,9 @@ if (
   });
   console.log('api is authenticated on vercel');
 } else {
-  api = new GithubAPI();
-  console.log('api is not authenticated');
+  api = new GithubAPI({
+    auth: process.env.GITHUB_TOKEN,
+  });
+  console.log(typeof process.env.GITHUB_TOKEN === "undefined" ? 'api is not authenticated' : 'api is authenticated locally');
 }
 export default api;


### PR DESCRIPTION
Allow developers to use authenticated  API locally to avoid rate limit errors while trying to build locally:

<img width="1025" alt="Screenshot 2024-11-03 at 4 00 25 PM" src="https://github.com/user-attachments/assets/30a213d7-c36d-4b16-a2af-947c53f32041">
