### PR TITLE
chore: run lint-staged on `*.mjs` files

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,13 +59,13 @@
     "prepare": "husky && rimraf ./node_modules/.cache/webpack && yarn-deduplicate --strategy fewer"
   },
   "lint-staged": {
-    "*.{js,jsx,md,mdx}": [
+    "*.{js,mjs,jsx,md,mdx}": [
       "npm run lint-js"
     ],
     "*.{md,mdx}": [
       "npm run lint-markdown"
     ],
-    "*.{js,jsx,css,scss,md,mdx,json}": [
+    "*.{js,mjs,jsx,css,scss,md,mdx,json}": [
       "prettier --write"
     ]
   },


### PR DESCRIPTION
We have a lot of `.mjs` files present in the codebase.