### PR TITLE
docs(plugins): add `debugIds` option for `SourceMapDevToolPlugin`

### DIFF
--- a/src/content/plugins/source-map-dev-tool-plugin.mdx
+++ b/src/content/plugins/source-map-dev-tool-plugin.mdx
@@ -8,6 +8,7 @@ contributors:
   - byzyk
   - EugeneHlushko
   - chenxsan
+  - snitin315
 related:
   - title: Building Source Maps
     url: https://survivejs.com/webpack/building/source-maps/#-sourcemapdevtoolplugin-and-evalsourcemapdevtoolplugin-
@@ -44,6 +45,7 @@ The following options are supported:
 - `publicPath` (`string`): Emits absolute URLs with public path prefix, e.g. `https://example.com/project/`.
 - `fileContext` (`string`): Makes the `[file]` argument relative to this directory.
 - `sourceRoot` (`string`): Provide a custom value for the `sourceRoot` property in the SourceMap.
+- `debugIds` (`boolean`): If `true`, unique ids will be emitted in source and sourcemaps which streamlines identifying sourcemaps across different builds. See the [TC39 sourcemap debug ID proposal(https://github.com/tc39/ecma426/blob/main/proposals/debug-id.md) for more details.
 
 The `fileContext` option is useful when you want to store source maps in an upper level directory to avoid `../../` appearing in the absolute `[url]`.
 

--- a/src/content/plugins/source-map-dev-tool-plugin.mdx
+++ b/src/content/plugins/source-map-dev-tool-plugin.mdx
@@ -45,7 +45,7 @@ The following options are supported:
 - `publicPath` (`string`): Emits absolute URLs with public path prefix, e.g. `https://example.com/project/`.
 - `fileContext` (`string`): Makes the `[file]` argument relative to this directory.
 - `sourceRoot` (`string`): Provide a custom value for the `sourceRoot` property in the SourceMap.
-- `debugIds` (`boolean`): If `true`, unique ids will be emitted in source and sourcemaps which streamlines identifying sourcemaps across different builds. See the [TC39 sourcemap debug ID proposal(https://github.com/tc39/ecma426/blob/main/proposals/debug-id.md) for more details.
+- `debugIds` (`boolean`): If `true`, unique ids will be emitted in source and sourcemaps which streamlines identifying sourcemaps across different builds. See the [TC39 sourcemap debug ID proposal](https://github.com/tc39/ecma426/blob/main/proposals/debug-id.md) for more details.
 
 The `fileContext` option is useful when you want to store source maps in an upper level directory to avoid `../../` appearing in the absolute `[url]`.
 


### PR DESCRIPTION
Fix https://github.com/webpack/webpack.js.org/issues/7476