### PR TITLE
docs(output): remove `fetch-streaming` value for `wasmLoading` option

### DIFF
--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -2432,7 +2432,7 @@ module.exports = {
 
 ## output.wasmLoading
 
-`false` `'fetch-streaming' | 'fetch' | 'async-node'` `string`
+`false` `'fetch' | 'async-node'` `string`
 
 Option to set the method of loading WebAssembly Modules. Methods included by default are `'fetch'` (web/WebWorker), `'async-node'` (Node.js), but others might be added by plugins.
 


### PR DESCRIPTION
Fix https://github.com/webpack/webpack.js.org/issues/7469