### PR TITLE
chore(scripts): updated npm scripts that use rimraf and glob patterns to use `--glob` option to fix `Illegal characters in path` error

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   },
   "scripts": {
     "clean-dist": "rimraf ./dist",
-    "clean-printable": "rimraf src/content/**/printable.mdx",
+    "clean-printable": "rimraf --glob src/content/**/printable.mdx",
     "preclean": "run-s clean-dist clean-printable",
-    "clean": "rimraf src/content/**/_*.mdx src/**/_*.json repositories/*.json",
+    "clean": "rimraf --glob src/content/**/_*.mdx src/**/_*.json repositories/*.json",
     "start": "npm run clean-dist && webpack serve --config webpack.dev.mjs --env dev --progress --define-process-env-node-env development",
     "content": "node src/scripts/build-content-tree.mjs ./src/content ./src/_content.json",
     "bundle-analyze": "run-s clean fetch content && webpack --config webpack.prod.mjs --define-process-env-node-env production && run-s printable content && webpack --config webpack.ssg.mjs --define-process-env-node-env production --env ssg --profile --json > stats.json && webpack-bundle-analyzer stats.json",

--- a/src/content/guides/getting-started.mdx
+++ b/src/content/guides/getting-started.mdx
@@ -27,6 +27,7 @@ contributors:
   - d3lm
   - snitin315
   - Etheryen
+  - RajeevPullat
 ---
 
 Webpack is used to compile JavaScript modules. Once [installed](/guides/installation), you can interact with webpack either from its [CLI](/api/cli) or [API](/api/node). If you're still new to webpack, please read through the [core concepts](/concepts) and [this comparison](/comparison) to learn why you might use it over the other tools that are out in the community.


### PR DESCRIPTION
updated npm scripts that use rimraf and glob patterns to use `--glob` option to fix `Illegal characters in path` error

If we are using rimraf from the command line and using glob patterns, we have to use `--glob` command line option. Otherwise, we will get a `Error: Illegal characters in path.` error. So, this is fixed with adding `--glob` option to npm scripts that use rimraf and glob patterns.


