### PR TITLE
fix: example webpack config in `externalsType.module-import` doc is incorrect

### DIFF
--- a/src/content/configuration/externals.mdx
+++ b/src/content/configuration/externals.mdx
@@ -547,9 +547,10 @@ async function foo() {
 
 ```js
 module.exports = {
-  externalsType: 'import',
+  externalsType: 'module-import',
   externals: {
     jquery: 'jquery',
+    lodash: 'lodash',
   },
 };
 ```


### PR DESCRIPTION
The example `webpack.config.js` in `externalsType.module-import` section is incorrect