### PR TITLE
docs: remove extra space after backtick in 'module' configuration

### DIFF
--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -518,7 +518,7 @@ Specifies global mode for dynamic import.
 
 Specifies global prefetch for dynamic import.
 
-- Type: ` number | boolean`
+- Type: `number | boolean`
 - Available: 5.73.0+
 - Example:
 
@@ -538,7 +538,7 @@ Specifies global prefetch for dynamic import.
 
 Specifies global preload for dynamic import.
 
-- Type: ` number | boolean`
+- Type: `number | boolean`
 - Available: 5.73.0+
 - Example:
 


### PR DESCRIPTION
## Problem
There was an unnecessary space after the backtick in the markdown file for the **Module of Content Configuration** challenge, which caused formatting inconsistencies.

## Solution
- Removed the extra space before the backtick to maintain consistent formatting in the challenge description.
- Ensured the file aligns with the other markdown files in the curriculum.

## Test
- Visually reviewed the markdown content.
- Verified that no other formatting issues were present in the file.
- No errors reported when viewing the file in the curriculum.
