### PR TITLE
fix: revert Sponsor logo alignment (#7568)

### DIFF
--- a/src/components/Support/Support.jsx
+++ b/src/components/Support/Support.jsx
@@ -240,7 +240,7 @@ export default class Support extends Component {
               >
                 {
                   <img
-                    className={`support__${rank}-avatar support__image`}
+                    className={`support__${rank}-avatar`}
                     src={
                       inView && supporter.avatar ? supporter.avatar : SmallIcon
                     }

--- a/src/components/Support/Support.scss
+++ b/src/components/Support/Support.scss
@@ -1,17 +1,5 @@
 @import 'functions';
 
-.support__image {
-  width: 100px; /* Default width */
-  height: 100px; /* Default height */
-  object-fit: contain; /* Maintain aspect ratio */
-  border-radius: 10px; /* Rounded corners */
-  background-color: white; /* Fallback background */
-  padding: 3px; /* Spacing */
-
-  /* Responsive adjustments */
-  max-width: 100%;
-}
-
 .support {
   display: flex;
   flex-wrap: wrap;
@@ -70,11 +58,6 @@
 
     @media (min-width: 400px) {
       max-width: 384px;
-      .support__image {
-        width: 60px;
-        height: 60px;
-        padding: 2px;
-      }
     }
   }
 


### PR DESCRIPTION
Reverts https://github.com/webpack/webpack.js.org/pull/7568

Reverting because now the Platinum sponsor logo size is same as Gold sponsor logo size () after this change.

This fixes the platinum sponsor size from 100x100 px to 128x128px
I'll fix the alignment in a separate PR.

**Before**

<img width="859" alt="Screenshot 2025-03-14 at 12 16 36 PM" src="https://github.com/user-attachments/assets/feb9ee26-3a04-42b7-91c1-3cbf4781114f" />


**After**
<img width="921" alt="Screenshot 2025-03-14 at 12 15 54 PM" src="https://github.com/user-attachments/assets/015eb361-cb59-459b-8869-4a0d30412bb6" />

