### PR TITLE
chore: open browser on configured port by default on yarn start

### DIFF
--- a/webpack.dev.mjs
+++ b/webpack.dev.mjs
@@ -44,5 +44,6 @@ export default (env) =>
       hot: true,
       compress: true,
       historyApiFallback: true,
+      open: true,
     },
   });


### PR DESCRIPTION
Open default browser on configured port (3000) on running `yarn start`

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].
- **Remove these instructions from your PR as they are for your eyes only.**

[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
