### PR TITLE
fix: excluded zero donation backers

### DIFF
--- a/src/components/Support/Support.jsx
+++ b/src/components/Support/Support.jsx
@@ -32,6 +32,7 @@ SUPPORTERS.sort((a, b) => b.totalDonations - a.totalDonations);
 // Define ranks
 const totalRanks = {
   backer: {
+    minimum: 1,
     maximum: 200,
     random: 100,
   },
@@ -57,6 +58,7 @@ const totalRanks = {
 };
 const monthlyRanks = {
   backer: {
+    minimum: 1,
     maximum: 10,
     random: 100,
   },


### PR DESCRIPTION
Fixes: https://github.com/webpack/webpack.js.org/issues/7584

Filtered out individuals who have made no financial contribution to the project from the backers list by ensuring that only users with a positive contribution are shown in the list.

Before: 
<img width="1098" alt="Screenshot 2025-03-15 at 5 22 08 PM" src="https://github.com/user-attachments/assets/fea262e6-a7b5-49be-8bc8-7cfd6d4223e9" />

After:
<img width="1042" alt="Screenshot 2025-03-15 at 5 21 46 PM" src="https://github.com/user-attachments/assets/65c05e5f-ed9f-4dbe-88e8-6668f7870c6f" />
