### PR TITLE
Clarify how .test and .include options work when they are a string.

### DIFF
--- a/src/content/plugins/source-map-dev-tool-plugin.mdx
+++ b/src/content/plugins/source-map-dev-tool-plugin.mdx
@@ -24,8 +24,8 @@ new webpack.SourceMapDevToolPlugin(options);
 
 The following options are supported:
 
-- `test` (`string` `RegExp` `[string, RegExp]`): Include source maps for modules based on their extension (defaults to `.js`, `.mjs`, and `.css`).
-- `include` (`string` `RegExp` `[string, RegExp]`): Include source maps for module paths that match the given value.
+- `test` (`string` `RegExp` `[string, RegExp]`): Include source maps for modules paths that match the given value (defaults to modules with the extensions `.js`, `.cjs`, `.mjs`, and `.css`). Note that when this option is a string, it matches from the start of the path.
+- `include` (`string` `RegExp` `[string, RegExp]`): Include source maps for module paths that match the given value. Note that when this option is a string, it matches from the start of the path.
 - `exclude` (`string` `RegExp` `[string, RegExp]`): Exclude modules that match the given value from source map generation.
 - `filename` (`string`): Defines the output filename of the SourceMap (will be inlined if no value is provided).
 - `append` (`string` `function` `false`): Appends the given value to the original asset. Usually the `#sourceMappingURL` comment. `[url]` is replaced with a URL to the source map file. Since webpack v4.36.0, path parameters are supported: `[chunk]`, `[filename]` and `[contenthash]`. Setting `append` to `false` disables the appending.


### PR DESCRIPTION
The `test` option on the SourceMapDevToolPlugin includes a note about the default being a [set of extensions](https://github.com/webpack/webpack/blob/79c5575cfc85f5edd76a5b07c52311d87d1d77a5/lib/SourceMapDevToolPlugin.js#L57). This documentation, along with the behaviour to match from the [start of the module path](https://github.com/webpack/webpack/blob/97d4961cd1de9c69dba0f050a63f3b56bb64fab2/lib/ModuleFilenameHelpers.js#L321C2-L323C3) when the option is a string is confusing and difficult to debug. 

This PR attempts to clarify the setting.

Related to: https://github.com/webpack/webpack/issues/19360
