### PR TITLE
docs: added working Discord link in contribute page

### DIFF
--- a/src/content/contribute/index.mdx
+++ b/src/content/contribute/index.mdx
@@ -80,9 +80,9 @@ To anyone else who is interested in helping our mission – e.g. venture capital
 
 ## Community
 
-Need help, want to ask questions, or just hang out with other webpack contributors?
+Looking for help, have questions, or want to connect with fellow webpack contributors?
 
-👉 Join our [Discord](https://discord.com/invite/5sxFZPdx2k) for real-time support and collaboration!
+Join our [Discord server](https://discord.com/invite/5sxFZPdx2k) for real-time support, discussions, and collaboration.
 
 ## Pull requests
 

--- a/src/content/contribute/index.mdx
+++ b/src/content/contribute/index.mdx
@@ -78,6 +78,12 @@ You can also encourage your developers to contribute to the ecosystem by open-so
 
 To anyone else who is interested in helping our mission – e.g. venture capitalists, government entities, digital agencies, etc. – we would love for you to work with us, one of the top npm packages, to improve your product! Please don't hesitate to reach out with questions.
 
+## Community
+
+Need help, want to ask questions, or just hang out with other webpack contributors?
+
+👉 Join our [Discord](https://discord.com/invite/5sxFZPdx2k) for real-time support and collaboration!
+
 ## Pull requests
 
 Documentation of webpack features and changes is now being updated as webpack evolves. An automated issue creation integration was established and proven to be effective in the recent years.


### PR DESCRIPTION
### Describe your changes

Added a working Discord invite link under the "How to Contribute" section to help new contributors easily join the community for discussions and support.

📍 **Updated file**: `/src/content/contribute/index.mdx`  
🔗 **New Discord link**: [https://discord.com/invite/5sxFZPdx2k](https://discord.com/invite/5sxFZPdx2k)

---

- [x] Read and signed the [CLA][1]  
- [x] PR complies with the [writer's guide][2]  
- [x] Carefully reviewed the diff  
- [x] Will stay active and responsive  

Closes #7598

[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
