### PR TITLE
docs: Update index.mdx to move from webpack-cli init in favor of create-web…

### DIFF
--- a/src/content/configuration/index.mdx
+++ b/src/content/configuration/index.mdx
@@ -46,44 +46,33 @@ If for some reason you want to use a different configuration file depending on c
 
 W> webpack applies configuration defaults after [plugins defaults](/contribute/writing-a-plugin/#configuration-defaults) are applied.
 
-Webpack has a huge set of options which might be overwhelming to you, please take advantage of [webpack-cli's `init` command](/api/cli/#init) which could rapidly generate webpack configuration files for your project requirements, it will ask you a couple of questions before creating a configuration file.
+Webpack has a huge set of options which might be overwhelming to you, please take advantage of `webpack-cli` starting from version v6.0.0 new tool [create-new-webpack-app](https://github.com/webpack/webpack-cli/) which could rapidly generate webpack application with specific configuration files for your project requirements, it will ask you a couple of questions before creating a configuration file.
 
 ```bash
-npx webpack init
+npx create-new-webpack-app [command] [options]
 ```
 
-npx might prompt you to install `@webpack-cli/generators` if it is not yet installed in the project or globally. You might also get additional packages installed to your project depending on the choices you've made during the configuration generation.
+npx might prompt you to install `create-new-webpack-app` if it is not yet installed in the project or globally. You might also get additional packages installed to your project depending on the choices you've made during the new webpack application generation.
 
 ```bash
-$ npx webpack init
+$ npx create-new-webpack-app init
 
-[webpack-cli] For using this command you need to install: '@webpack-cli/generators' package.
-[webpack-cli] Would you like to install '@webpack-cli/generators' package? (That will run 'npm install -D @webpack-cli/generators') (Y/n)
-devDependencies:
-+ @webpack-cli/generators 2.5.0
-? Which of the following JS solutions do you want to use? ES6
+Need to install the following packages:
+create-new-webpack-app@1.1.1
+Ok to proceed? (y)
+
+? Which of the following JS solutions do you want to use? Typescript
 ? Do you want to use webpack-dev-server? Yes
 ? Do you want to simplify the creation of HTML files for your bundle? Yes
 ? Do you want to add PWA support? No
 ? Which of the following CSS solutions do you want to use? CSS only
 ? Will you be using PostCSS in your project? Yes
 ? Do you want to extract CSS for every file? Only for Production
-? Do you like to install prettier to format generated configuration? Yes
-? Pick a package manager: pnpm
-[webpack-cli] ℹ INFO  Initialising project...
-
-devDependencies:
-+ @babel/core 7.19.3
-+ @babel/preset-env 7.19.4
-+ autoprefixer 10.4.12
-+ babel-loader 8.2.5
-+ css-loader 6.7.1
-+ html-webpack-plugin 5.5.0
-+ mini-css-extract-plugin 2.6.1
-+ postcss 8.4.17
-+ postcss-loader 7.0.1
-+ prettier 2.7.1
-+ style-loader 3.3.1
-+ webpack-dev-server 4.11.1
-[webpack-cli] Project has been initialised with webpack!
+? Which package manager do you want to use? npm
+[create-webpack] ℹ️ Initializing a new Webpack project
+...
+...
+...
+[create-webpack] ✅ Project dependencies installed successfully!
+[create-webpack] ✅ Project has been initialised with webpack!
 ```


### PR DESCRIPTION
Update index.mdx to move from `webpack-cli` init in favor of `create-webpack-app`

Fixes https://github.com/webpack/webpack-cli/issues/3768

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].
- **Remove these instructions from your PR as they are for your eyes only.**

[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
