### PR TITLE
fix alignment of navigation icons

### DIFF
--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -31,7 +31,7 @@ const Tooltip = ({
   const bgColor = '#526B78';
   return (
     <div
-      className={`relative ${className}`}
+      className={`relative flex items-center justify-center ${className}`}
       onMouseEnter={showTooltip}
       onMouseLeave={hideTooltip}
       onFocus={showTooltip}


### PR DESCRIPTION
Seems the tooltip introduced have caused a alignment problem:

![Screenshot-ddJ3pZL7@2x](https://github.com/user-attachments/assets/1c1a72a5-4750-4dd4-8303-cf6629c376cf)
