### PR TITLE
fix: use "contributed" instead of "pledged" for sponsors

### DIFF
--- a/src/components/Support/Support.jsx
+++ b/src/components/Support/Support.jsx
@@ -217,7 +217,7 @@ export default class Support extends Component {
                     </span>
                   ) : (
                     <span>
-                      are those who have pledged{' '}
+                      are those who have contributed{' '}
                       {minimum ? `$${formatMoney(minimum)}` : 'up'}{' '}
                       {maximum ? `to $${formatMoney(maximum)}` : 'or more'} to
                       webpack.


### PR DESCRIPTION
- **Pledged $1000:** The company has _promised_ to give $1000, but has not necessarily given it yet. It's a commitment for the future.
- **Contributed $1000:** The company has _actually given_ $1000 already. The money has been transferred or donated.


In short:
- Pledge = promise (future)
- Contribute = action done (completed)