### PR TITLE
docs: fixed grammar issue

### DIFF
--- a/src/content/configuration/target.mdx
+++ b/src/content/configuration/target.mdx
@@ -12,6 +12,7 @@ contributors:
   - EugeneHlushko
   - smelukov
   - chenxsan
+  - JamesHoran
 ---
 
 Webpack can compile for multiple environments or _targets_. To understand what a `target` is in detail, read through [the targets concept page](/concepts/targets/).
@@ -20,7 +21,7 @@ Webpack can compile for multiple environments or _targets_. To understand what a
 
 `string` `[string]` `false`
 
-Instructs webpack to generate runtime code for a specific environment. Note that webpack runtime code is not the same as the user code you write, you should transpile those code with transpilers like Babel if you want to target specific environments, e.g, you have arrow functions in source code and want to run the bundled code in ES5 environments. Webpack won't transpile them automatically with a `target` configured.
+Instructs webpack to generate runtime code for a specific environment. Note that webpack runtime code is not the same as the user code you write, you should transpile that code with transpilers like Babel if you want to target specific environments, e.g, you have arrow functions in source code and want to run the bundled code in ES5 environments. Webpack won't transpile them automatically with a `target` configured.
 
 Defaults to `'browserslist'` or to `'web'` when no browserslist configuration was found.
 


### PR DESCRIPTION
Fixed a grammar issue on the target page of configuration

Changed "you should transpile those code with transpilers" to be the grammatically correct and more professionally sounding "you should transpile that code with transpilers"