### PR TITLE
docs: update fetchPriority link

### DIFF
--- a/src/content/api/module-methods.mdx
+++ b/src/content/api/module-methods.mdx
@@ -187,7 +187,7 @@ A name for the new chunk. Since webpack 2.6.0, the placeholders `[index]` and `[
 
 <Badge text="5.87.0+" />
 
-Set [`fetchPriority`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority) for specific dynamic imports. It's also possible to set a global default value for all dynamic imports by using the [`module.parser.javascript.dynamicImportFetchPriority`](/configuration/module/#moduleparserjavascriptdynamicimportfetchpriority) option.
+Set [`fetchPriority`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement/fetchPriority) for specific dynamic imports. It's also possible to set a global default value for all dynamic imports by using the [`module.parser.javascript.dynamicImportFetchPriority`](/configuration/module/#moduleparserjavascriptdynamicimportfetchpriority) option.
 
 ```js
 import(

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -481,7 +481,7 @@ const x = require(/* webpackIgnore: true */ 'x');
 
 #### module.parser.javascript.dynamicImportFetchPriority
 
-Specify the global [fetchPriority](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority) for dynamic import.
+Specify the global [fetchPriority](https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement/fetchPriority) for dynamic import.
 
 - Type: `'low' | 'high' | 'auto' | false`
 - Available: 5.87.0+


### PR DESCRIPTION
This PR update the `fetchPriority` link to point to the `HTMLScriptElement` mdn docs instead of `HTMLImageElement`, which seems more appropriate for codesplitting. Thanks!


