### PR TITLE
docs(footer): fix invalid Discord link

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -39,7 +39,10 @@ const Footer = () => (
         <Link className="footer__link" to="/branding/">
           Branding
         </Link>
-        <Link className="footer__link" to="https://discord.com/invite/8WWf6F7p">
+        <Link
+          className="footer__link"
+          to="https://discord.com/invite/5sxFZPdx2k"
+        >
           Discord
         </Link>
         <Link


### PR DESCRIPTION
Fix the invalid Discord link in the footer. I replaced the old broken link with the correct one, which is present in the contribution docs and can be found [here](http://localhost:3000/contribute/#community)