### PR TITLE
docs(guides): Fix capitalization in getting-started.mdx

### DIFF
--- a/src/content/guides/getting-started.mdx
+++ b/src/content/guides/getting-started.mdx
@@ -347,6 +347,6 @@ webpack-demo
 |- /node_modules
 ```
 
-W> Do not compile untrusted code with webpack. It could lead to execution of malicious code on your computer, remote servers, or in the Web browsers of the end users of your application.
+W> Do not compile untrusted code with webpack. It could lead to execution of malicious code on your computer, remote servers, or in the web browsers of the end users of your application.
 
 If you want to learn more about webpack's design, you can check out the [basic concepts](/concepts) and [configuration](/configuration) pages. Furthermore, the [API](/api) section digs into the various interfaces webpack offers.


### PR DESCRIPTION
Hi, this is my first contribution. I found a small capitalization error in the getting-started.mdx guide ("Web browsers" -> "web browsers").

I'm a 2nd year student and I'm looking forward to contributing more as I prepare for GSoC 2026!