### PR TITLE
docs: fix spelling error 'accomodate' to 'accommodate'

### DIFF
--- a/src/content/plugins/normal-module-replacement-plugin.mdx
+++ b/src/content/plugins/normal-module-replacement-plugin.mdx
@@ -19,7 +19,7 @@ new webpack.NormalModuleReplacementPlugin(resourceRegExp, newResource);
 
 Note that the `resourceRegExp` is tested against the request you write in your code, not the resolved resource. For instance, `'./sum'` will be used to test instead of `'./sum.js'` when you have code `import sum from './sum'`.
 
-Also please note that when using Windows, you have to accomodate for the different folder separator symbol. E.g. `/src\/environments\/environment\.ts/` won't work on Windows, you have to use `/src[\\/]environments[\\/]environment\.ts/,` instead.
+Also please note that when using Windows, you have to accommodate for the different folder separator symbol. E.g. `/src\/environments\/environment\.ts/` won't work on Windows, you have to use `/src[\\/]environments[\\/]environment\.ts/,` instead.
 
 ## Basic Example
 


### PR DESCRIPTION

Summary

This PR fixes a spelling error in the NormalModuleReplacementPlugin documentation. During a comprehensive documentation analysis, I discovered that "accomodate" was misspelled on line 22 of the plugin documentation. The correct spelling is "accommodate" (with double 'm').

Motivation:

Improves documentation professionalism and credibility
Ensures correct spelling for non-native English speakers
Maintains high-quality documentation standards
File changed:

[normal-module-replacement-plugin.mdx](vscode-file://vscode-app/c:/Users/ASUS/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (Line 22)
Change:

What kind of change does this PR introduce?

Documentation fix - spelling/typo correction. This is a non-functional change that only corrects a misspelled word in the documentation text.

Did you add tests for your changes?

No tests were added as this is a text-only documentation fix. The change does not modify any code functionality, does not change any examples or code snippets, and only corrects a spelling error in descriptive text.

Does this PR introduce a breaking change?

No. This PR does not introduce any breaking changes. It's a simple spelling correction that does not affect any APIs, does not modify any code examples, does not change functionality, and maintains backward compatibility.

If relevant, what needs to be documented once your changes are merged or what have you already documented?

No additional documentation is needed. This PR itself is a documentation improvement. The change is self-contained and only affects the spelling of a single word in the documentation text.
