### PR TITLE
fix(build): correct writeFileSync usage; harden is-client env check; cleanup map→forEach

### DIFF
--- a/src/scripts/build-content-tree.mjs
+++ b/src/scripts/build-content-tree.mjs
@@ -41,15 +41,16 @@ function buildContentTree(source, output) {
     dir: source,
   });
 
-  fs.writeFileSync(
-    path.resolve(output),
-    JSON.stringify(content, null, 2),
-    (error) => {
-      if (error) {
-        console.log('scripts/build-content-tree', error);
-      } else {
-        console.log('Successfully built content tree file at ' + output);
-      }
-    }
-  );
+  // fs.writeFileSync does not accept a callback; wrap with try/catch and
+  // log a clear success or error instead.
+  try {
+    fs.writeFileSync(
+      path.resolve(output),
+      JSON.stringify(content, null, 2)
+    );
+    console.log('Successfully built content tree file at ' + output);
+  } catch (error) {
+    console.error('scripts/build-content-tree', error);
+    process.exitCode = 1;
+  }
 }

--- a/src/utilities/flatten-content-tree.mjs
+++ b/src/utilities/flatten-content-tree.mjs
@@ -7,11 +7,13 @@ export default (tree) => {
     }
 
     if ('children' in node) {
-      node.children.map(crawl);
+      node.children.forEach(crawl);
     }
   };
 
-  tree.children.map(crawl);
+  if (Array.isArray(tree.children)) {
+    tree.children.forEach(crawl);
+  }
 
   return paths;
 };

--- a/src/utilities/is-client.js
+++ b/src/utilities/is-client.js
@@ -1,3 +1,6 @@
-const isClient = window !== undefined && window.document !== undefined;
+// Guard against ReferenceError in non-browser/SSR environments
+// and use a consistent ESM default export.
+const isClient =
+  typeof window !== 'undefined' && typeof window.document !== 'undefined';
 
-module.exports = isClient;
+export default isClient;


### PR DESCRIPTION
## PR description
This PR delivers a focused set of safe improvements that keep existing behavior intact while addressing a real bug and two quality issues:

1) Fix build-content-tree script
- Problem: `fs.writeFileSync` was called with a callback, which is invalid for the synchronous API and throws a TypeError. This breaks `npm run content` and any CI job invoking the script.
- Fix: Replace the callback with a try/catch and explicit logging. On success the file is written as before; on error we log and set `process.exitCode = 1`.

2) Harden is-client detection and unify module style
- Problem: Directly referencing `window` at module scope can throw `ReferenceError` in non‑browser environments (SSR/SSG, tests, or tooling). The file also used CJS export while the rest of the codebase predominantly uses ESM imports.
- Fix: Guard with `typeof window !== 'undefined' && typeof window.document !== 'undefined'` and export a default ESM value. All existing imports already use `import isClient from ...`, so this is backward‑compatible.

3) Clarify content tree flattener
- Problem: `Array.map` was used purely for side effects (the returned array was ignored) in `flatten-content-tree.mjs`.
- Fix: Replace `map` with `forEach` and add a small defensive `Array.isArray` check. This improves readability and avoids lint noise without changing behavior.

### Rationale and impact
- Stability: Prevents an immediate runtime error in the content build script.
- Correctness: Ensures safe execution in non‑browser contexts and proper script exit signaling.
- Readability: Clarifies iteration intent.
- Scope: 3 files touched; no new dependencies; no public API or feature changes.

### Testing and verification
- Script correctness: Running `node src/scripts/build-content-tree.mjs ./src/content ./src/_content.json` will now succeed (assuming deps installed) and log success; failures set a non‑zero exit code.
- App behavior: `isClient` remains `true` in browsers and `false` elsewhere. Components importing it (`Site`, `Splash`, `index.jsx`) continue to work unchanged.
- Build: No config changes. Webpack/SSG paths are unaffected.

### Backward compatibility
- No public API changes. Only internal implementation details were updated.
- The ESM default export for `is-client` matches current import sites; there are no `require()` callers in the repository.
