### PR TITLE
docs(#7717): clarify Webpack 5 minimum Node.js version wording

### DIFF
--- a/src/content/concepts/index.mdx
+++ b/src/content/concepts/index.mdx
@@ -167,4 +167,4 @@ Webpack supports all browsers that are [ES5-compliant](https://compat-table.gith
 
 ## Environment
 
-Webpack 5 runs on Node.js version 10.13.0+.
+Webpack 5 requires Node.js version 10.13.0 or later.


### PR DESCRIPTION
Summary
This PR updates the Webpack 5 documentation to clarify the minimum required Node.js version. 
The previous wording "Webpack 5 runs on Node.js version 10.13.0+" could be confusing for new users. 
This change makes it explicit that Node.js version 10.13.0 or later is required.

What kind of change does this PR introduce?
Documentation clarification

Did you add tests for your changes?
No, this PR only affects documentation.

Does this PR introduce a breaking change?
No, this change does not affect functionality or break existing code.

If relevant, what needs to be documented once your changes are merged or what have you already documented?
The clarification is already included in the documentation; no further changes are needed.