### PR TITLE
docs: clarify multiple entry point examples

### DIFF
--- a/src/content/configuration/entry-context.mdx
+++ b/src/content/configuration/entry-context.mdx
@@ -178,7 +178,7 @@ module.exports = {
 
 In some scenarios, you might want to organize your entry points into different folders for better structure and maintainability. Here's how you can define multiple entry points located in different folders:
 
-```js
+```javascript
 module.exports = {
  entry: {
     '/scriptFolder/one/app': './src/one/app.js',


### PR DESCRIPTION
Simplified multiple entry point examples to avoid confusion around entry keys and file paths.

Follow-up to #7328 and #7397, with updated examples based on @evenstensberg feedback.

This example is different from the original one. Folder paths in the key and value are used intentionally to demonstrate custom `from` and `to` paths.



<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

---

**Summary**

Clarifies multiple entry point examples by simplifying entry keys and file paths to reduce potential confusion.

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

Not applicable. This PR only updates documentation.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

The documentation has already been updated in this PR.

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
