### PR TITLE
docs: update grunt-webpack repository links

### DIFF
--- a/src/components/NotificationBar/MessageBar.jsx
+++ b/src/components/NotificationBar/MessageBar.jsx
@@ -33,7 +33,7 @@ export default function MessageBar(props) {
           <Content />
           {localStorageIsEnabled ? (
             <div
-              type="button"
+              role="button"
               className="px-20 self-stretch inline-flex items-center cursor-pointer"
               onClick={close}
             >


### PR DESCRIPTION
Problem: The grunt-webpack repository links in the documentation were pointing to an external or outdated repository location.

Solution: Updated the repository link in src/content/guides/integrations.mdx to the official location: https://github.com/webpack/grunt-webpack.

fixes https://github.com/webpack/webpack.js.org/issues/7742