### PR TITLE
Fix service worker installation failure on Firefox

### DIFF
--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -262,7 +262,6 @@ function Site(props) {
         />
         <meta name="mobile-web-app-capable" content="yes" />
         <link rel="icon" sizes="192x192" href="/icon_192x192.png" />
-        <link rel="icon" sizes="512x512" href="/icon_512x512.png" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black" />
         <meta name="apple-mobile-web-app-title" content="webpack" />

--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -262,6 +262,7 @@ function Site(props) {
         />
         <meta name="mobile-web-app-capable" content="yes" />
         <link rel="icon" sizes="192x192" href="/icon_192x192.png" />
+        <link rel="icon" sizes="512x512" href="/icon_512x512.png" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black" />
         <meta name="apple-mobile-web-app-title" content="webpack" />

--- a/src/sw.js
+++ b/src/sw.js
@@ -58,7 +58,6 @@ self.addEventListener("activate", (event) => {
     ),
   );
 });
-
 registerRoute(
   ({ url }) => manifestURLs.includes(url.href),
   new NetworkFirst({

--- a/src/sw.js
+++ b/src/sw.js
@@ -41,7 +41,6 @@ self.addEventListener("install", (event) => {
     })(),
   );
 });
-
 self.addEventListener("activate", (event) => {
   // - [x] clean up outdated runtime cache
   event.waitUntil(

--- a/src/sw.js
+++ b/src/sw.js
@@ -88,10 +88,7 @@ setDefaultHandler(new NetworkOnly());
 
 // fallback to app-shell for document request
 setCatchHandler(({ event }) => {
-  switch (event.request.destination) {
-    case "document":
-      return caches.match("/app-shell/index.html");
-    default:
-      return fetch(event.request);
+  if (event.request.destination === "document") {
+    return caches.match("/app-shell/index.html");
   }
 });

--- a/src/sw.js
+++ b/src/sw.js
@@ -88,7 +88,10 @@ setDefaultHandler(new NetworkOnly());
 
 // fallback to app-shell for document request
 setCatchHandler(({ event }) => {
-  if (event.request.destination === "document") {
-    return caches.match("/app-shell/index.html");
+  switch (event.request.destination) {
+    case "document":
+      return caches.match("/app-shell/index.html");
+    default:
+      return Response.error();
   }
 });

--- a/src/sw.js
+++ b/src/sw.js
@@ -2,7 +2,6 @@
 import { CacheableResponsePlugin } from "workbox-cacheable-response";
 import { cacheNames } from "workbox-core";
 import { ExpirationPlugin } from "workbox-expiration";
-
 import {
   registerRoute,
   setCatchHandler,

--- a/src/sw.js
+++ b/src/sw.js
@@ -44,7 +44,6 @@ self.addEventListener("install", (event) => {
 self.addEventListener("activate", (event) => {
   // - [x] clean up outdated runtime cache
   event.waitUntil(
-    // clean up those who are not listed in manifestURLs
     caches.open(cacheName).then((cache) =>
       // clean up those who are not listed in manifestURLs
       cache
@@ -93,6 +92,6 @@ setCatchHandler(({ event }) => {
     case "document":
       return caches.match("/app-shell/index.html");
     default:
-      return Response.error();
+      return fetch(event.request);
   }
 });

--- a/src/sw.js
+++ b/src/sw.js
@@ -44,6 +44,7 @@ self.addEventListener("install", (event) => {
 self.addEventListener("activate", (event) => {
   // - [x] clean up outdated runtime cache
   event.waitUntil(
+     // clean up those who are not listed in manifestURLs
     caches.open(cacheName).then((cache) =>
       // clean up those who are not listed in manifestURLs
       cache

--- a/src/sw.js
+++ b/src/sw.js
@@ -2,6 +2,7 @@
 import { CacheableResponsePlugin } from "workbox-cacheable-response";
 import { cacheNames } from "workbox-core";
 import { ExpirationPlugin } from "workbox-expiration";
+
 import {
   registerRoute,
   setCatchHandler,
@@ -12,7 +13,6 @@ import {
   NetworkOnly,
   StaleWhileRevalidate,
 } from "workbox-strategies";
-/* eslint-enable import/no-extraneous-dependencies */
 
 const cacheName = cacheNames.runtime;
 
@@ -25,13 +25,21 @@ const otherManifest = [
     url: "/app-shell/index.html",
   },
 ];
-const manifestURLs = [...manifest, ...otherManifest].map((entry) => {
-  const url = new URL(entry.url, self.location);
-  return url.href;
-});
+const manifestURLs = [
+  ...new Set(
+    [...manifest, ...otherManifest].map((entry) => {
+      const url = new URL(entry.url, self.location);
+      return url.href;
+    }),
+  ),
+];
 self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(cacheName).then((cache) => cache.addAll(manifestURLs)),
+    (async () => {
+      const cache = await caches.open(cacheName);
+
+      await Promise.allSettled(manifestURLs.map((url) => cache.add(url)));
+    })(),
   );
 });
 

--- a/src/sw.js
+++ b/src/sw.js
@@ -44,7 +44,7 @@ self.addEventListener("install", (event) => {
 self.addEventListener("activate", (event) => {
   // - [x] clean up outdated runtime cache
   event.waitUntil(
-     // clean up those who are not listed in manifestURLs
+    // clean up those who are not listed in manifestURLs
     caches.open(cacheName).then((cache) =>
       // clean up those who are not listed in manifestURLs
       cache


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
Fixes #7738 
Fix SW install failure in Firefox by replacing cache.addAll() with Promise.allSettled() to prevent installation from failing due to individual precache errors. Also deduplicates manifest URLs before caching.

---

**What kind of change does this PR introduce?**

Code change

---

**Did you add tests for your changes?**

No.  

---

**Does this PR introduce a breaking change?**

No. 

---

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No documentation changes are required.  