### PR TITLE
docs: clarify array entry behavior with examples

### DIFF
--- a/src/content/concepts/entry-points.mdx
+++ b/src/content/concepts/entry-points.mdx
@@ -73,6 +73,7 @@ Single Entry Syntax is a great choice when you are looking to quickly set up a w
 Usage: `entry: { <entryChunkName> string | [string] } | {}`
 
 **webpack.config.js**
+
 ```javascript
 module.exports = {
   entry: {


### PR DESCRIPTION
This PR improves the documentation for array entry usage by explaining
that it creates a single entry chunk and by adding common real-world
examples such as polyfills and development-only scripts.

Fixes #3788
