### PR TITLE
docs: update `resolve.plugins` supported plugin types

### DIFF
--- a/src/content/configuration/resolve.mdx
+++ b/src/content/configuration/resolve.mdx
@@ -19,6 +19,7 @@ contributors:
   - jamesgeorge007
   - snitin315
   - sapenlei
+  - Mazen050
 ---
 
 These options change how modules are resolved. Webpack provides reasonable defaults, but it is possible to change the resolving in detail. Have a look at [Module Resolution](/concepts/module-resolution) for more explanation of how the resolver works.
@@ -62,7 +63,7 @@ module.exports = {
 };
 ```
 
-Now, instead of using relative paths when importing like so:
+Now, instead of using relative paths when  like so:
 
 ```js
 import Utility from "../../utilities/utility";
@@ -319,7 +320,7 @@ module.exports = {
 };
 ```
 
-importing
+
 
 - `'foo'` will resolve to `'foo/index-require.js'`
 - `'foo/bar'` will resolve to `'foo/bar-node.js'` as the `"node"` key comes before `"require"` key in the conditional exports object.
@@ -439,7 +440,7 @@ module.exports = {
 };
 ```
 
-which is what enables users to leave off the extension when importing:
+which is what enables users to leave off the extension when :
 
 ```js
 import File from "../path/to/file";
@@ -549,7 +550,7 @@ module.exports = {
 
 `[string]`
 
-When importing from an npm package, e.g. `import * as D3 from 'd3'`, this option will determine which fields in its `package.json` are checked. The default values will vary based upon the [`target`](/concepts/targets) specified in your webpack configuration.
+When  from an npm package, e.g. `import * as D3 from 'd3'`, this option will determine which fields in its `package.json` are checked. The default values will vary based upon the [`target`](/concepts/targets) specified in your webpack configuration.
 
 When the `target` property is set to `webworker`, `web`, or left unspecified:
 
@@ -642,12 +643,18 @@ module.exports = {
   },
 };
 ```
-
 ### resolve.plugins
 
-[`[Plugin]`](/plugins/)
+[`[Plugin | Function]`](/plugins/)
 
-A list of additional resolve plugins which should be applied. It allows plugins such as [`DirectoryNamedWebpackPlugin`](https://www.npmjs.com/package/directory-named-webpack-plugin).
+A list of additional resolve plugins which should be applied.
+
+Each entry can be either:
+
+- A plugin object with an `apply(resolver)` method
+- Or a function plugin, which will be called with the resolver as both `this` and the first argument
+
+It allows plugins such as [`DirectoryNamedWebpackPlugin`](https://www.npmjs.com/package/directory-named-webpack-plugin).
 
 **webpack.config.js**
 
@@ -655,16 +662,28 @@ A list of additional resolve plugins which should be applied. It allows plugins 
 module.exports = {
   // ...
   resolve: {
-    plugins: [new DirectoryNamedWebpackPlugin()],
+    plugins: [
+      // Object-style plugin
+      {
+        apply(resolver) {
+          // custom logic
+        },
+      },
+
+      // Function-style plugin
+      function (resolver) {
+        // `this` is also the resolver
+      },
+    ],
   },
 };
-```
+``` 
 
 ### resolve.preferAbsolute
 
 `boolean`
 
-<Badge text="5.13.0+" />
+<h text="5.13.0+" />
 
 Prefer absolute paths to [`resolve.roots`](#resolveroots) when resolving.
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
Updated the `resolve.plugins` documentation to reflect that webpack supports both object-style plugins with an apply method and function-style resolve plugins, as introduced in [webpack/webpack#18154](https://github.com/webpack/webpack/issues/18150).

This aligns the documentation with the current TypeScript types and behavior.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
docs
<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
No
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
No

