### PR TITLE
docs(guide): convert asset management webpack.config.js to esm

### DIFF
--- a/src/content/guides/asset-management.mdx
+++ b/src/content/guides/asset-management.mdx
@@ -12,6 +12,7 @@ contributors:
   - wizardofhogwarts
   - astonizer
   - snitin315
+  - Brennvo
 ---
 
 If you've been following the guides from the start, you will now have a small project that shows "Hello webpack". Now let's try to incorporate some other assets, like images, to see how they can be handled.
@@ -44,9 +45,13 @@ Let's make a minor change to our project before we get started:
 **webpack.config.js**
 
 ```diff
- const path = require('path');
+ import path from 'node:path';
+ import { fileURLToPath } from 'node:url';
 
- module.exports = {
+ const __filename = fileURLToPath(import.meta.url);
+ const __dirname = path.dirname(__filename);
+
+ export default {
    entry: './src/index.js',
    output: {
 -    filename: 'main.js',
@@ -67,9 +72,13 @@ npm install --save-dev style-loader css-loader
 **webpack.config.js**
 
 ```diff
- const path = require('path');
+ import path from 'node:path';
+ import { fileURLToPath } from 'node:url';
 
- module.exports = {
+ const __filename = fileURLToPath(import.meta.url);
+ const __dirname = path.dirname(__filename);
+
+ export default {
    entry: './src/index.js',
    output: {
      filename: 'bundle.js',
@@ -171,9 +180,13 @@ So now we're pulling in our CSS, but what about our images like backgrounds and 
 **webpack.config.js**
 
 ```diff
- const path = require('path');
+ import path from 'node:path';
+ import { fileURLToPath } from 'node:url';
 
- module.exports = {
+ const __filename = fileURLToPath(import.meta.url);
+ const __dirname = path.dirname(__filename);
+
+ export default {
    entry: './src/index.js',
    output: {
      filename: 'bundle.js',
@@ -284,9 +297,13 @@ So what about other assets like fonts? The Asset Modules will take any file you 
 **webpack.config.js**
 
 ```diff
- const path = require('path');
+ import path from 'node:path';
+ import { fileURLToPath } from 'node:url';
 
- module.exports = {
+ const __filename = fileURLToPath(import.meta.url);
+ const __dirname = path.dirname(__filename);
+
+ export default {
    entry: './src/index.js',
    output: {
      filename: 'bundle.js',
@@ -395,9 +412,13 @@ npm install --save-dev csv-loader xml-loader
 **webpack.config.js**
 
 ```diff
- const path = require('path');
+ import path from 'node:path';
+ import { fileURLToPath } from 'node:url';
 
- module.exports = {
+ const __filename = fileURLToPath(import.meta.url);
+ const __dirname = path.dirname(__filename);
+
+ export default {
    entry: './src/index.js',
    output: {
      filename: 'bundle.js',
@@ -581,12 +602,16 @@ And configure them in your webpack configuration:
 **webpack.config.js**
 
 ```diff
- const path = require('path');
-+const toml = require('toml');
-+const yaml = require('yamljs');
-+const json5 = require('json5');
+ import path from 'node:path';
+ import { fileURLToPath } from 'node:url';
++import toml from 'toml';
++import yaml from 'yamljs';
++import json5 from 'json5';
 
- module.exports = {
+ const __filename = fileURLToPath(import.meta.url);
+ const __dirname = path.dirname(__filename);
+
+ export default {
    entry: './src/index.js',
    output: {
      filename: 'bundle.js',
@@ -734,12 +759,16 @@ For the next guides we won't be using all the different assets we've used in thi
 **webpack.config.js**
 
 ```diff
- const path = require('path');
--const toml = require('toml');
--const yaml = require('yamljs');
--const json5 = require('json5');
+ import path from 'node:path';
+ import { fileURLToPath } from 'node:url';
+-import toml from 'toml';
+-import yaml from 'yamljs';
+-import json5 from 'json5';
 
- module.exports = {
+ const __filename = fileURLToPath(import.meta.url);
+ const __dirname = path.dirname(__filename);
+
+ export default {
    entry: './src/index.js',
    output: {
      filename: 'bundle.js',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->
Supports #7772.

The "Getting Started" guide uses ESM syntax for webpack.config.js, but later sections switch to CommonJS, creating inconsistency. This PR converts all webpack.config.js snippets in "Asset Management" to ESM[^0]. Remaining sections will follow in future PRs.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->
A documentation refinement.

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->
No

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
N/A

[^0]: It was decided in #7776 that ESM syntax will be used throughout the guide.