### PR TITLE
Docs: explain webpack error output structure

### DIFF
--- a/src/content/concepts/configuration.mdx
+++ b/src/content/concepts/configuration.mdx
@@ -66,6 +66,7 @@ _See_: [Configuration Languages](/configuration/configuration-languages/)
 When webpack encounters a configuration or build error, it prints structured information in the terminal to help diagnose the problem
 
 This output may include:
+
 - A stack trace showing where the error originated
 - Additional details providing more context
 - A cause when one error is triggered by another


### PR DESCRIPTION
This PR adds a short explanation to the configuration documentation describing how webpack formats error output, including stack traces, additional details, and underlying causes.

This should help users better understand the information shown when webpack reports configuration or build errors.