### PR TITLE
docs(getting-started): align webpack.config.js CommonJS example

### DIFF
--- a/src/content/guides/getting-started.mdx
+++ b/src/content/guides/getting-started.mdx
@@ -250,7 +250,7 @@ As of version 4, webpack doesn't require any configuration, but most projects wi
 **webpack.config.js**
 
 ```javascript
-const path = require("path");
+const path = require("node:path");
 
 module.exports = {
   entry: "./src/index.js",


### PR DESCRIPTION
fix:#7772
This PR updates the **Getting Started** guide to use a consistent
CommonJS syntax for `webpack.config.js`.

Previously, the guide mixed ESM (`import` / `export`) and CommonJS
(`require` / `module.exports`) examples, which could confuse beginners
following the tutorial step by step.

Closes #7772
