### PR TITLE
docs(guides): convert caching webpack.config.js to esm

### DIFF
--- a/src/content/guides/caching.mdx
+++ b/src/content/guides/caching.mdx
@@ -47,24 +47,28 @@ webpack-demo
 **webpack.config.js**
 
 ```diff
-  const path = require('path');
-  const HtmlWebpackPlugin = require('html-webpack-plugin');
+ import path from 'node:path';
+ import { fileURLToPath } from 'node:url';
+ import HtmlWebpackPlugin from 'html-webpack-plugin';
 
-  module.exports = {
-    entry: './src/index.js',
-    plugins: [
-      new HtmlWebpackPlugin({
--       title: 'Output Management',
-+       title: 'Caching',
-      }),
-    ],
-    output: {
--     filename: 'bundle.js',
-+     filename: '[name].[contenthash].js',
-      path: path.resolve(__dirname, 'dist'),
-      clean: true,
-    },
-  };
+ const __filename = fileURLToPath(import.meta.url);
+ const __dirname = path.dirname(__filename);
+
+ export default {
+   entry: './src/index.js',
+   plugins: [
+     new HtmlWebpackPlugin({
+-      title: 'Output Management',
++      title: 'Caching',
+     }),
+   ],
+   output: {
+-    filename: 'bundle.js',
++    filename: '[name].[contenthash].js',
+     path: path.resolve(__dirname, 'dist'),
+     clean: true,
+   },
+ };
 ```
 
 Running our build script, `npm run build`, with this configuration should produce the following output:
@@ -98,25 +102,29 @@ As we learned in [code splitting](/guides/code-splitting), the [`SplitChunksPlug
 **webpack.config.js**
 
 ```diff
-  const path = require('path');
-  const HtmlWebpackPlugin = require('html-webpack-plugin');
+ import path from 'node:path';
+ import { fileURLToPath } from 'node:url';
+ import HtmlWebpackPlugin from 'html-webpack-plugin';
 
-  module.exports = {
-    entry: './src/index.js',
-    plugins: [
-      new HtmlWebpackPlugin({
-      title: 'Caching',
-      }),
-    ],
-    output: {
-      filename: '[name].[contenthash].js',
-      path: path.resolve(__dirname, 'dist'),
-      clean: true,
-    },
-+   optimization: {
-+     runtimeChunk: 'single',
-+   },
-  };
+ const __filename = fileURLToPath(import.meta.url);
+ const __dirname = path.dirname(__filename);
+
+ export default {
+   entry: './src/index.js',
+   plugins: [
+     new HtmlWebpackPlugin({
+       title: 'Caching',
+     }),
+   ],
+   output: {
+     filename: '[name].[contenthash].js',
+     path: path.resolve(__dirname, 'dist'),
+     clean: true,
+   },
++  optimization: {
++    runtimeChunk: 'single',
++  },
+ };
 ```
 
 Let's run another build to see the extracted `runtime` bundle:
@@ -141,34 +149,38 @@ This can be done by using the [`cacheGroups`](/plugins/split-chunks-plugin/#spli
 **webpack.config.js**
 
 ```diff
-  const path = require('path');
-  const HtmlWebpackPlugin = require('html-webpack-plugin');
+ import path from 'node:path';
+ import { fileURLToPath } from 'node:url';
+ import HtmlWebpackPlugin from 'html-webpack-plugin';
 
-  module.exports = {
-    entry: './src/index.js',
-    plugins: [
-      new HtmlWebpackPlugin({
-      title: 'Caching',
-      }),
-    ],
-    output: {
-      filename: '[name].[contenthash].js',
-      path: path.resolve(__dirname, 'dist'),
-      clean: true,
-    },
-    optimization: {
-      runtimeChunk: 'single',
-+     splitChunks: {
-+       cacheGroups: {
-+         vendor: {
-+           test: /[\\/]node_modules[\\/]/,
-+           name: 'vendors',
-+           chunks: 'all',
-+         },
-+       },
-+     },
-    },
-  };
+ const __filename = fileURLToPath(import.meta.url);
+ const __dirname = path.dirname(__filename);
+
+ export default {
+   entry: './src/index.js',
+   plugins: [
+     new HtmlWebpackPlugin({
+       title: 'Caching',
+     }),
+   ],
+   output: {
+     filename: '[name].[contenthash].js',
+     path: path.resolve(__dirname, 'dist'),
+     clean: true,
+   },
+   optimization: {
+     runtimeChunk: 'single',
++    splitChunks: {
++      cacheGroups: {
++        vendor: {
++          test: /[\\/]node_modules[\\/]/,
++          name: 'vendors',
++          chunks: 'all',
++        },
++      },
++    },
+   },
+ };
 ```
 
 Let's run another build to see our new `vendor` bundle:
@@ -253,35 +265,39 @@ The first and last are expected, it's the `vendor` hash we want to fix. Let's us
 **webpack.config.js**
 
 ```diff
-  const path = require('path');
-  const HtmlWebpackPlugin = require('html-webpack-plugin');
+ import path from 'node:path';
+ import { fileURLToPath } from 'node:url';
+ import HtmlWebpackPlugin from 'html-webpack-plugin';
 
-  module.exports = {
-    entry: './src/index.js',
-    plugins: [
-      new HtmlWebpackPlugin({
-        title: 'Caching',
-      }),
-    ],
-    output: {
-      filename: '[name].[contenthash].js',
-      path: path.resolve(__dirname, 'dist'),
-      clean: true,
-    },
-    optimization: {
-+     moduleIds: 'deterministic',
-      runtimeChunk: 'single',
-      splitChunks: {
-        cacheGroups: {
-          vendor: {
-            test: /[\\/]node_modules[\\/]/,
-            name: 'vendors',
-            chunks: 'all',
-          },
-        },
-      },
-    },
-  };
+ const __filename = fileURLToPath(import.meta.url);
+ const __dirname = path.dirname(__filename);
+
+ export default {
+   entry: './src/index.js',
+   plugins: [
+     new HtmlWebpackPlugin({
+       title: 'Caching',
+     }),
+   ],
+   output: {
+     filename: '[name].[contenthash].js',
+     path: path.resolve(__dirname, 'dist'),
+     clean: true,
+   },
+   optimization: {
++    moduleIds: 'deterministic',
+     runtimeChunk: 'single',
+     splitChunks: {
+       cacheGroups: {
+         vendor: {
+           test: /[\\/]node_modules[\\/]/,
+           name: 'vendors',
+           chunks: 'all',
+         },
+       },
+     },
+   },
+ };
 ```
 
 Now, despite any new local dependencies, our `vendor` hash should stay consistent between builds:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->
Supports #7772.

The "Getting Started" guide uses ESM syntax for webpack.config.js, but later sections switch to CommonJS, creating inconsistency. This PR converts all webpack.config.js snippets in "Caching" to ESM[^0]. Remaining sections will follow in future PRs.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->
A documentation refinement.

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->
No

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
N/A

[^0]: It was decided in #7776 that ESM syntax will be used throughout the guide.