### PR TITLE
docs(guides): convert author-libraries webpack.config.js to esm

### DIFF
--- a/src/content/guides/author-libraries.mdx
+++ b/src/content/guides/author-libraries.mdx
@@ -102,9 +102,13 @@ Let's start with this basic webpack configuration:
 **webpack.config.js**
 
 ```js
-const path = require("node:path");
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-module.exports = {
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default {
   entry: "./src/index.js",
   output: {
     path: path.resolve(__dirname, "dist"),
@@ -122,14 +126,18 @@ So far everything should be the same as bundling an application, and here comes 
 **webpack.config.js**
 
 ```diff
-  const path = require('path');
+  import path from 'node:path';
+  import { fileURLToPath } from 'node:url';
 
-  module.exports = {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+
+  export default {
     entry: './src/index.js',
     output: {
       path: path.resolve(__dirname, 'dist'),
       filename: 'webpack-numbers.js',
-+     library: "webpackNumbers",
++     library: 'webpackNumbers',
     },
   };
 ```
@@ -186,9 +194,13 @@ As a library author, we want it to be compatible in different environments, i.e.
 Let's update the `output.library` option with its `type` set to [`'umd'`](/configuration/output/#type-umd):
 
 ```diff
- const path = require('path');
+ import path from 'node:path';
+ import { fileURLToPath } from 'node:url';
 
- module.exports = {
+ const __filename = fileURLToPath(import.meta.url);
+ const __dirname = path.dirname(__filename);
+
+ export default {
    entry: './src/index.js',
    output: {
      path: path.resolve(__dirname, 'dist'),
@@ -216,16 +228,20 @@ This can be done using the [`externals`](/configuration/externals/) configuratio
 **webpack.config.js**
 
 ```diff
-  const path = require('path');
+  import path from 'node:path';
+  import { fileURLToPath } from 'node:url';
 
-  module.exports = {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+
+  export default {
     entry: './src/index.js',
     output: {
       path: path.resolve(__dirname, 'dist'),
       filename: 'webpack-numbers.js',
       library: {
-        name: "webpackNumbers",
-        type: "umd"
+        name: 'webpackNumbers',
+        type: 'umd',
       },
     },
 +   externals: {
@@ -255,7 +271,7 @@ import B from "library/two";
 You won't be able to exclude them from the bundle by specifying `library` in the externals. You'll either need to exclude them one by one or by using a regular expression.
 
 ```js
-module.exports = {
+export default {
   // ...
   externals: [
     "library/one",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->
Supports #7772.

The "Getting Started" guide uses ESM syntax for webpack.config.js, but later sections switch to CommonJS, creating inconsistency. This PR converts all webpack.config.js snippets in "Authoring Libraries" to ESM[^0]. Remaining sections will follow in future PRs.

Additionally, this PR uses consistent quote styles (i.e. single or double) within `webpack.config.js`.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->
A documentation refinement.

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->
No

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
N/A

[^0]: It was decided in #7776 that ESM syntax will be used throughout the guide.