### PR TITLE
docs(guides): convert development vagrant webpack.config.js to esm

### DIFF
--- a/src/content/guides/development-vagrant.mdx
+++ b/src/content/guides/development-vagrant.mdx
@@ -6,6 +6,7 @@ contributors:
   - chrisVillanueva
   - byzyk
   - wizardofhogwarts
+  - Brennvo
 ---
 
 If you have a more advanced project and use [Vagrant](https://www.vagrantup.com/) to run your development environment in a Virtual Machine, you'll often want to also run webpack in the VM.
@@ -29,7 +30,13 @@ npm install --save-dev webpack webpack-cli @webpack-cli/serve webpack-dev-server
 Make sure to have a `webpack.config.js` file. If you haven't already, use this as a minimal example to get started:
 
 ```js
-module.exports = {
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default {
   context: __dirname,
   entry: "./app.js",
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->
Supports #7772.

The "Getting Started" guide uses ESM syntax for webpack.config.js, but later sections switch to CommonJS, creating inconsistency. This PR converts all webpack.config.js snippets in "Development Vagrant" to ESM[^0]. Remaining sections will follow in future PRs.

Additionally, this PR uses consistent quote styles (i.e. single or double) within `webpack.config.js`.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->
A documentation refinement.

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->
No

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
N/A

[^0]: It was decided in #7776 that ESM syntax will be used throughout the guide.