### PR TITLE
docs(guides): convert tree shaking webpack.config.js to esm

### DIFF
--- a/src/content/guides/tree-shaking.mdx
+++ b/src/content/guides/tree-shaking.mdx
@@ -19,6 +19,7 @@ contributors:
   - rahul3v
   - snitin315
   - vansh5632
+  - Brennvo
 related:
   - title: Debugging Optimization Bailouts
     url: https://webpack.js.org/plugins/module-concatenation-plugin/#debugging-optimization-bailouts
@@ -69,9 +70,13 @@ Set the `mode` configuration option to [development](/configuration/mode/#mode-d
 **webpack.config.js**
 
 ```diff
-const path = require('path');
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-module.exports = {
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default {
   entry: './src/index.js',
   output: {
     filename: 'bundle.js',
@@ -517,9 +522,13 @@ So we've cued up our "dead code" to be dropped by using the `import` and `export
 **webpack.config.js**
 
 ```diff
-const path = require('path');
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-module.exports = {
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default {
   entry: './src/index.js',
   output: {
     filename: 'bundle.js',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->
Supports #7772.

The "Getting Started" guide uses ESM syntax for webpack.config.js, but later sections switch to CommonJS, creating inconsistency. This PR converts all webpack.config.js snippets in "Tree Shaking" to ESM[^0]. Remaining sections will follow in future PRs.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->
A documentation refinement.

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->
No

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
N/A

[^0]: It was decided in #7776 that ESM syntax will be used throughout the guide.