### PR TITLE
docs(guides): convert production webpack.config.js to esm

### DIFF
--- a/src/content/guides/production.mdx
+++ b/src/content/guides/production.mdx
@@ -23,6 +23,7 @@ contributors:
   - aholzner
   - EugeneHlushko
   - snitin315
+  - Brennvo
 ---
 
 In this guide, we'll dive into some of the best practices and utilities for building a production site or application.
@@ -61,10 +62,14 @@ npm install --save-dev webpack-merge
 **webpack.common.js**
 
 ```diff
-+ const path = require('path');
-+ const HtmlWebpackPlugin = require('html-webpack-plugin');
++ import path from 'node:path';
++ import { fileURLToPath } from 'node:url';
++ import HtmlWebpackPlugin from 'html-webpack-plugin';
 +
-+ module.exports = {
++ const __filename = fileURLToPath(import.meta.url);
++ const __dirname = path.dirname(__filename);
++
++ export default {
 +   entry: {
 +     app: './src/index.js',
 +   },
@@ -84,10 +89,10 @@ npm install --save-dev webpack-merge
 **webpack.dev.js**
 
 ```diff
-+ const { merge } = require('webpack-merge');
-+ const common = require('./webpack.common.js');
++ import { merge } from 'webpack-merge';
++ import common from './webpack.common.js';
 +
-+ module.exports = merge(common, {
++ export default merge(common, {
 +   mode: 'development',
 +   devtool: 'inline-source-map',
 +   devServer: {
@@ -99,10 +104,10 @@ npm install --save-dev webpack-merge
 **webpack.prod.js**
 
 ```diff
-+ const { merge } = require('webpack-merge');
-+ const common = require('./webpack.common.js');
++ import { merge } from 'webpack-merge';
++ import common from './webpack.common.js';
 +
-+ module.exports = merge(common, {
++ export default merge(common, {
 +   mode: 'production',
 + });
 ```
@@ -157,10 +162,10 @@ Many libraries will key off the `process.env.NODE_ENV` variable to determine wha
 **webpack.prod.js**
 
 ```diff
-  const { merge } = require('webpack-merge');
-  const common = require('./webpack.common.js');
+  import { merge } from 'webpack-merge';
+  import common from './webpack.common.js';
 
-  module.exports = merge(common, {
+  export default merge(common, {
     mode: 'production',
   });
 ```
@@ -209,10 +214,10 @@ We encourage you to have source maps enabled in production, as they are useful f
 **webpack.prod.js**
 
 ```diff
-  const { merge } = require('webpack-merge');
-  const common = require('./webpack.common.js');
+  import { merge } from 'webpack-merge';
+  import common from './webpack.common.js';
 
-  module.exports = merge(common, {
+  export default merge(common, {
     mode: 'production',
 +   devtool: 'source-map',
   });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->
Supports #7772.

The "Getting Started" guide uses ESM syntax for webpack.config.js, but later sections switch to CommonJS, creating inconsistency. This PR converts all webpack.config.js snippets in "Production" to ESM[^0]. Remaining sections will follow in future PRs.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->
A documentation refinement.

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->
No

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
N/A

[^0]: It was decided in #7776 that ESM syntax will be used throughout the guide.