### PR TITLE
fix: correct invalid PropTypes validator for isActive in Link component

### DIFF
--- a/src/components/Link/Link.jsx
+++ b/src/components/Link/Link.jsx
@@ -16,7 +16,7 @@ const Link = ({ to = "", url, ...props }) => {
 };
 
 Link.propTypes = {
-  isActive: PropTypes.boolean,
+  isActive: PropTypes.bool,
   to: PropTypes.string,
   url: PropTypes.string,
 };


### PR DESCRIPTION
Fixes the incorrect PropTypes validator for the isActive prop in the Link component.

The console was showing the following warning during development:

Warning: Failed prop type: Link: prop type `isActive` is invalid;
it must be a function, usually from the `prop-types` package, but received `undefined`.

Cause

In src/components/Link/Link.jsx, the validator was defined as:

isActive: PropTypes.boolean,


However, PropTypes.boolean is not a valid validator.
The correct validator is:

PropTypes.bool

Fix

Replaced PropTypes.boolean with PropTypes.bool, which removes the console warning and correctly validates the prop type.

Closes #7811