### PR TITLE
fix: remove duplicate entry in `moduleFileExtensions` in `jest.config.mjs`

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -10,7 +10,6 @@ export default {
     "tsx",
     "json",
     "node",
-    "mjs",
   ],
   testMatch: [
     "**/__tests__/**/*.[jt]s?(x)",


### PR DESCRIPTION
Summary
This PR changes `moduleFileExtensions` by removing the duplicate entry `"mjs"` in `jest.config.mjs`.

What kind of change does this PR introduce?
fix

Did you add tests for your changes?
No

Does this PR introduce a breaking change?
No

If relevant, what needs to be documented once your changes are merged or what have you already documented?
No further documentation is required for this typo fix.

Reference: #7814