### PR TITLE
docs(typescript): add link for writing config file in typescript

### DIFF
--- a/src/content/guides/typescript.mdx
+++ b/src/content/guides/typescript.mdx
@@ -67,34 +67,6 @@ To learn more about webpack configuration, see the [configuration concepts](/con
 
 Now let's configure webpack to handle TypeScript:
 
-**webpack.config.js**
-
-```js
-const path = require("node:path");
-
-module.exports = {
-  entry: "./src/index.ts",
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        use: "ts-loader",
-        exclude: /node_modules/,
-      },
-    ],
-  },
-  resolve: {
-    extensions: [".tsx", ".ts", ".js"],
-  },
-  output: {
-    filename: "bundle.js",
-    path: path.resolve(__dirname, "dist"),
-  },
-};
-```
-
-Webpack configuration can also be written in TypeScript.
-
 First, install the required dependencies:
 
 ```bash
@@ -104,7 +76,7 @@ npm install --save-dev ts-node @types/node
 **webpack.config.ts**
 
 ```ts
-import path from "path";
+import path from "node:path";
 import webpack from "webpack";
 // in case you run into any TypeScript error when configuring `devServer`
 import "webpack-dev-server";


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
Fixes: #6106
Refrence: #6105

**Summary**
This PR adds a link inside `typescript guide` doc to clarify config can be written in a typescript file.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
docs

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
no

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->


<img width="845" height="418" alt="Screenshot from 2026-02-17 02-58-59" src="https://github.com/user-attachments/assets/a56ac264-eae4-4f41-9cf5-ed59eaf52428" />
