### PR TITLE
fix(a11y): add accessible name to navigation toggle button

### DIFF
--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -115,6 +115,7 @@ function Navigation({ links, pathname, hash = "", toggleSidebar }) {
           <button
             className="bg-transparent border-none md:hidden"
             onClick={toggleSidebar}
+            aria-label="Toggle navigation menu"
           >
             <Hamburger
               width={20}


### PR DESCRIPTION
This PR addresses only the ‘Buttons do not have an accessible name’ audit item; remaining Lighthouse items will be handled in follow-up PRs.
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->
**Before**
Lighthouse flagged: Buttons do not have an accessible name
Affected element: mobile navigation hamburger button
<img width="1470" height="792" alt="Screenshot 2026-02-18 at 23 30 36" src="https://github.com/user-attachments/assets/8486001c-290d-472b-b284-3ae58cf50e14" />
**After**
Lighthouse issue of Buttons do not have an accessible name resolved
<img width="1470" height="792" alt="Screenshot 2026-02-18 at 23 50 02" src="https://github.com/user-attachments/assets/ae2d683a-f6c8-4aaf-834c-6170905d717a" />


**What kind of change does this PR introduce?**
Minor code changes

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
Not required
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
N/A

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
