### PR TITLE
fix(a11y): add accessible label to docs version select

### DIFF
--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -34,7 +34,7 @@ export default function Sidebar({ className = "", pages, currentPage }) {
             Select webpack version
           </label>
           <select
-            id="docs-version"
+            aria-label="Select webpack version"
             className="text-gray-600 text-14 px-5 py-5 appearance-none box-border border border-gray-200 border-solid flex-col flex w-full rounded-none bg-transparent bg-none"
             value={version}
             onChange={(event) => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
Before
Accessibility score: 82
Failing audit: "Select elements do not have associated label elements"
<img width="1470" height="792" alt="Screenshot 2026-02-18 at 23 50 02" src="https://github.com/user-attachments/assets/3fec573a-b95e-4630-a2eb-dbdf80471b07" />


After
Accessibility score: 88
The above audit is resolved
<img width="1470" height="792" alt="Screenshot 2026-02-19 at 00 36 00" src="https://github.com/user-attachments/assets/1a213d59-8114-4803-b6b6-5732857918bd" />


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Minor code change 

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
No
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
N/A

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
