### PR TITLE
fix: remove duplicate aria-label in Navigation component

### DIFF
--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -113,10 +113,9 @@ function Navigation({ links, pathname, hash = "", toggleSidebar }) {
       <header className="bg-blue-800 dark:bg-gray-900">
         <div className="flex items-center py-10 px-[16px] justify-between md:px-[24px] md:max-w-[1024px] md:mx-auto md:justify-start">
           <button
-            aria-label="Open navigation menu"
+            aria-label="Toggle navigation menu"
             className="bg-transparent border-none md:hidden"
             onClick={toggleSidebar}
-            aria-label="Toggle navigation menu"
           >
             <Hamburger
               width={20}


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix / Code quality improvement.

**Did you add tests for your changes?**
N/A (Linting fix)

**Summary**
This PR fixes an active ESLint error (`react/jsx-no-duplicate-props`) in `src/components/Navigation/Navigation.jsx`. 

The mobile hamburger `<button>` previously had two `aria-label` properties assigned to it (`"Open navigation menu"` and `"Toggle navigation menu"`). I removed the duplicate property and kept `"Toggle navigation menu"`, ensuring the component passes the `lint:js` checks without altering the compiled DOM output.

**Steps to verify:**
1. Pull branch locally.
2. Run `npm run lint:js`.
3. Verify `Navigation.jsx` passes with zero errors.