### PR TITLE
docs(contrib): specify to use only 1.x yarn version

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,6 +10,10 @@ Start by ensuring that you have Node.js installed and forking the repository:
 
 - Install [Node.js][1] if you have not already.
 - Install [Yarn][13] if you have not already. Yarn is an alternative to npm, and it is required for building the site as we use `yarn` specific features like `resolutions` which are not available in other package managers like `pnpm`.
+
+  > This project uses **Yarn Classic (v1)**.
+  > Ensure you are using **Yarn 1.x** version.
+
 - Fork the **webpack.js.org** repo from [the main repository][2].
 - `git clone <your-clone-url> && cd webpack.js.org`
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
Fixes: #7803, #7789 
Closes: #7793, #7790, #7804


**Summary**
This PR specifies that project should be set up using `yarn classic v(1)` as `yarn berry (v2)/(v3)/(v4)` changes the yarn.lock file, don't executes the scripts properly, and produces runtime error.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
docs

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
no

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
