### PR TITLE
Docs: clarify running webpack via local installation

### DIFF
--- a/src/content/guides/getting-started.mdx
+++ b/src/content/guides/getting-started.mdx
@@ -205,7 +205,7 @@ T> A couple other script loading strategies exist. Deferred loading is one such 
 
 In this setup, `index.js` explicitly requires `lodash` to be present, and binds it as `_` (no global scope pollution). By stating what dependencies a module needs, webpack can use this information to build a dependency graph. It then uses the graph to generate an optimized bundle where scripts will be executed in the correct order.
 
-With that said, let's run `npx webpack`, from the project root. This will use the locally installed webpack (from `node_modules`) to take our script at `src/index.js` as the [entry point](/concepts/entry-points), and generate `dist/main.js` as the [output](/concepts/output).
+With that said, let's run `npx webpack` from the project root. If webpack is installed locally, `npx` will run the local binary from `node_modules/.bin`; otherwise, it may download and execute it. This command takes our script at `src/index.js` as the [entry point](/concepts/entry-points) and generates `dist/main.js` as the [output](/concepts/output).
 
 ```bash
 $ npx webpack


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
Part of #7510 
This PR clarifies the “run webpack” step in the Getting Started guide by stating that npx webpack runs the locally installed version from the project root.

This helps reduce ambiguity around global vs local installation.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Docs change

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
No

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
N/A
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
