### PR TITLE
docs(guide): add information on the usage of publicPath in web workers

### DIFF
--- a/src/content/guides/web-workers.mdx
+++ b/src/content/guides/web-workers.mdx
@@ -105,7 +105,17 @@ const worker = new Worker(new URL("./worker.js", import.meta.url));
 worker.postMessage({ publicPath: globalThis.__MY_GLOBAL_PUBLIC_PATH_VAR__ });
 ```
 
+**When to use this:**
+
+This pattern is only required when a worker needs to load additional chunks and the asset base URL is determined at runtime (for example, when using a CDN or a multi-domain deployment).
+
+Since workers run in an isolated global scope, the automatically detected public path may differ from the one used by the main thread. In such cases, the public path (`__webpack_public_path__`) must be explicitly passed to the worker and set inside the worker runtime.
+
+> Note: This is an advanced use case. If your worker does not load additional chunks or your assets are served from a static, same-origin path, you typically do not need to set `__webpack_public_path__` manually.
+
 ## Node.js
+
+This section describes using Web Workers in a Node.js environment via the `worker_threads` module.
 
 Similar syntax is supported in Node.js (>= 12.17.0):
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
Fixes: #6716
Closes: #7730, #7734


**Summary**
This PR improves the Web Workers guide by clarifying when setting
 `__webpack_public_path__ ` from within a worker is required and why this pattern is necessary in certain runtime setups. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
