### PR TITLE
docs: explain deriving __dirname in ESM config

### DIFF
--- a/src/content/guides/getting-started.mdx
+++ b/src/content/guides/getting-started.mdx
@@ -253,7 +253,9 @@ As of version 4, webpack doesn't require any configuration, but most projects wi
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-// __dirname isn't available in ESM; derive it from import.meta.url
+// In Node.js versions prior to native support for import.meta.dirname,
+// derive __dirname from import.meta.url.
+// (Node 20.11+ supports import.meta.dirname and import.meta.filename.)
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
Part of #7510. Fixes subpart of point 3

Adds a short comment to the ESM webpack.config.js example in Getting Started explaining why __dirname is derived from import.meta.url. No behavioral changes.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Docs change
<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
No
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
N/A
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
