### PR TITLE
docs: clarify that loaders are ecosystem extensions of webpack

### DIFF
--- a/src/content/guides/getting-started.mdx
+++ b/src/content/guides/getting-started.mdx
@@ -253,9 +253,6 @@ As of version 4, webpack doesn't require any configuration, but most projects wi
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-// In Node.js versions prior to native support for import.meta.dirname,
-// derive __dirname from import.meta.url.
-// (Node 20.11+ supports import.meta.dirname and import.meta.filename.)
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Address point 8 of #7510
Clarifies that loaders are separate ecosystem packages that extend webpack’s capabilities, to reduce confusion around “third-party” wording in the docs.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Docs change
<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
No
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
N/A
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
