### PR TITLE
fix: remove stray backtick from Print component className

### DIFF
--- a/src/components/Print/Print.jsx
+++ b/src/components/Print/Print.jsx
@@ -32,7 +32,7 @@ export default function Print(props) {
   }
 
   return (
-    <div className="sidebar-item sidebar-item--disabled`">
+    <div className="sidebar-item sidebar-item--disabled">
       <BarIcon
         className="sidebar-item__toggle"
         width={15}


### PR DESCRIPTION
The `className` in [Print.jsx](cci:7://file:///Users/rajaryan/Projects/Web%20pack/webpack.js.org/src/components/Print/Print.jsx:0:0-0:0) had a stray backtick — `"sidebar-item sidebar-item--disabled\`"` — preventing the CSS rule in `dark.scss:118` from matching. This caused the Print Section sidebar item to lose its dark mode styling.

**Summary**

[src/components/Print/Print.jsx](cci:7://file:///Users/rajaryan/Projects/Web%20pack/webpack.js.org/src/components/Print/Print.jsx:0:0-0:0) line 35 had a trailing backtick character inside the className string:

```jsx
// Before
<div className="sidebar-item sidebar-item--disabled`">

// After
<div className="sidebar-item sidebar-item--disabled">
```
The CSS rule .sidebar-item--disabled .sidebar-item__toggle in dark.scss:118 was never applied because the rendered class name contained a literal backtick, so it never matched the selector.

What kind of change does this PR introduce?

fix — one-character typo correction. No logic or behavior changes.

Did you add tests for your changes?

No tests needed — this is a single-character typo fix in a className string.

Does this PR introduce a breaking change?

No.

If relevant, what needs to be documented once your changes are merged or what have you already documented?
N/A