### PR TITLE
fix(seo): add title and noindex meta to 404 page

### DIFF
--- a/src/components/PageNotFound/PageNotFound.jsx
+++ b/src/components/PageNotFound/PageNotFound.jsx
@@ -1,3 +1,4 @@
+import { Helmet } from "react-helmet-async";
 import { Link } from "react-router-dom";
 
 // Styles
@@ -6,6 +7,10 @@ import "./PageNotFound.scss";
 export default function PageNotFound() {
   return (
     <div className="page markdown">
+      <Helmet>
+        <title>Page Not Found | webpack</title>
+        <meta name="robots" content="noindex,nofollow" />
+      </Helmet>
       <h1>Page Not Found</h1>
       <p>Oops! The page you are looking for has been removed or relocated.</p>
       <Link className="button" to="/">


### PR DESCRIPTION
The 404 page ([PageNotFound.jsx](cci:7://file:///Users/rajaryan/Projects/Web%20pack/webpack.js.org/src/components/PageNotFound/PageNotFound.jsx:0:0-0:0)) was missing critical SEO metadata. Without a unique title and robots directive, search engines could index broken URLs as real content.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

This PR adds `<Helmet>` support to the 404 component to ensure:
1. The browser tab shows a descriptive title: **"Page Not Found | webpack"**.
2. Search engines are instructed not to index the page using a **`noindex,nofollow`** robots meta tag.

This follows the established pattern of using `react-helmet-async` seen in other parts of the site (like [Site.jsx](cci:7://file:///Users/rajaryan/Projects/Web%20pack/webpack.js.org/src/components/Site/Site.jsx:0:0-0:0)).

**What kind of change does this PR introduce?**

`fix(seo)` — adds missing SEO metadata to the 404 page.

**Did you add tests for your changes?**

Verified manually in the browser console.

| Property | Console Output | Status |
| :--- | :--- | :--- |
| `document.title` | `"Page Not Found | webpack"` | ✅ Verified |
| `robots meta` | `"noindex,nofollow"` | ✅ Verified |

**Preview:**

<img width="" height="" alt="image" src="https://github.com/user-attachments/assets/261fa561-3300-419c-87fd-ceddb12c461d" />

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No documentation needed.