### PR TITLE
refactor: remove unused theme and switchTheme PropTypes from Navigati…

### DIFF
--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -260,8 +260,6 @@ Navigation.propTypes = {
   hash: PropTypes.string,
   links: PropTypes.array,
   toggleSidebar: PropTypes.func,
-  theme: PropTypes.string,
-  switchTheme: PropTypes.func,
 };
 
 export default Navigation;


### PR DESCRIPTION
Refactored the [Navigation](cci:1://file:///Users/rajaryan/Projects/Web%20pack/webpack.js.org/src/components/Navigation/Navigation.jsx:101:0-255:1) component to remove unused `theme` and `switchTheme` PropTypes.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

The [Navigation](cci:1://file:///Users/rajaryan/Projects/Web%20pack/webpack.js.org/src/components/Navigation/Navigation.jsx:101:0-255:1) component had `theme` (string) and `switchTheme` (func) defined in its `propTypes`, but these were not used anywhere in the component logic. Additionally, the parent [Site](cci:1://file:///Users/rajaryan/Projects/Web%20pack/webpack.js.org/src/components/Site/Site.jsx:46:0-297:1) component was not passing these props to [Navigation](cci:1://file:///Users/rajaryan/Projects/Web%20pack/webpack.js.org/src/components/Navigation/Navigation.jsx:101:0-255:1).

Removing this dead code simplifies the component interface and prevents confusion during future maintenance.

**What kind of change does this PR introduce?**

`refactor` — removal of dead code/unused PropTypes.

**Did you add tests for your changes?**

No tests needed — this is a two-line removal of unused PropType declarations. Existing lint and unit tests pass without changes.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No documentation needed.