### PR TITLE
docs(getting-started): add "type": "module" to package.json setup

### DIFF
--- a/src/content/guides/getting-started.mdx
+++ b/src/content/guides/getting-started.mdx
@@ -99,7 +99,7 @@ document.body.appendChild(component());
 </html>
 ```
 
-We also need to adjust our `package.json` file in order to make sure we mark our package as `private`, as well as removing the `main` entry. This is to prevent an accidental publish of your code.
+We also need to adjust our `package.json` file in order to make sure we mark our package as `private`, as well as removing the `main` entry. We also add `"type": "module"` so that Node.js knows to process our configuration files as ES Modules. This is to prevent an accidental publish of your code, as well as enabling ES Module support for our scripts.
 
 T> If you want to learn more about the inner workings of `package.json`, then we recommend reading the [npm documentation](https://docs.npmjs.com/files/package.json).
 
@@ -112,6 +112,7 @@ T> If you want to learn more about the inner workings of `package.json`, then we
    "description": "",
 -  "main": "index.js",
 +  "private": true,
++  "type": "module",
    "scripts": {
      "test": "echo \"Error: no test specified\" && exit 1"
    },


### PR DESCRIPTION
Addresses: #7772
**Summary**


Adds "type": "module" to the foundational package.json example.

Motivation The "Getting Started" guide uses ES Module syntax (import/export) for the webpack.config.js snippets. However, without specifying "type": "module" in package.json, Node.js will throw a SyntaxError when a user tries to run webpack with that configuration. This PR fixes the "silent failure" that new users encounter when following the tutorial sequentially.

What kind of change does this PR introduce? docs

Did you add tests for your changes? No (documentation change only).

Does this PR introduce a breaking change? No.

If relevant, what needs to be documented once your changes are merged or what have you already documented? Already documented within the guide in this PR
