### PR TITLE
docs(dependency-management): add import() and import.meta.webpackContext

### DIFF
--- a/src/content/guides/dependency-management.mdx
+++ b/src/content/guides/dependency-management.mdx
@@ -9,13 +9,7 @@ contributors:
   - AnayaDesign
 ---
 
-> es6 modules
-
-> commonjs
-
-> amd
-
-## require with expression
+## Dynamic expressions in import() or require()
 
 A context is created if your request contains expressions, so the **exact** module is not known on compile time.
 
@@ -32,13 +26,14 @@ example_directory
 │       │   another.ejs
 ```
 
-When following `require()` call is evaluated:
+When following `import()` or `require()` call is evaluated:
 
 ```javascript
+import(`./template/${name}.ejs`);
 require(`./template/${name}.ejs`);
 ```
 
-Webpack parses the `require()` call and extracts some information:
+Webpack parses the `import()` or `require()` call and extracts some information:
 
 ```code
 Directory: ./template
@@ -61,7 +56,21 @@ Example map:
 
 The context module also contains some runtime logic to access the map.
 
-This means dynamic requires are supported but will cause all matching modules to be included in the bundle.
+This means dynamic calls are supported but will cause all matching modules to be included in the bundle.
+
+## import.meta.webpackContext
+
+The ESM equivalent of `require.context` is `import.meta.webpackContext`.
+
+```javascript
+import.meta.webpackContext(directory, {
+  recursive: true,
+  regExp: /^\.\/.*$/,
+  mode: "sync",
+});
+```
+
+W> The arguments passed to `import.meta.webpackContext` must be literals!
 
 ## require.context
 
@@ -115,7 +124,12 @@ function importAll(r) {
   r.keys().forEach(r);
 }
 
-importAll(require.context("../components/", true, /\.js$/));
+importAll(
+  import.meta.webpackContext("../components/", {
+    recursive: true,
+    regExp: /\.js$/,
+  }),
+);
 ```
 
 ```javascript
@@ -125,8 +139,13 @@ function importAll(r) {
   for (const key of r.keys()) cache[key] = r(key);
 }
 
-importAll(require.context("../components/", true, /\.js$/));
+importAll(
+  import.meta.webpackContext("../components/", {
+    recursive: true,
+    regExp: /\.js$/,
+  }),
+);
 // At build-time cache will be populated with all required modules.
 ```
 
-- `id` is the module id of the context module. This may be useful for `module.hot.accept`.
+- `id` is the module id of the context module. This may be useful for `import.meta.webpackHot.accept` or `module.hot.accept`.

--- a/src/content/plugins/context-exclusion-plugin.mdx
+++ b/src/content/plugins/context-exclusion-plugin.mdx
@@ -5,7 +5,7 @@ contributors:
   - jeffin
 ---
 
-_Context_ refers to a [require with an expression](/guides/dependency-management/#require-with-expression) such as `require('./locale/' + name + '.json')`.
+_Context_ refers to [dynamic expressions in import() or require()](/guides/dependency-management/#dynamic-expressions-in-import-or-require) such as `require('./locale/' + name + '.json')`.
 
 The `ContextExclusionPlugin` allows you to exclude context. Provide RegExp as an argument when initializing the Plugin to exclude all context that matches it.
 

--- a/src/content/plugins/context-replacement-plugin.mdx
+++ b/src/content/plugins/context-replacement-plugin.mdx
@@ -13,7 +13,7 @@ related:
     url: https://github.com/date-fns/date-fns/blob/master/docs/webpack.md
 ---
 
-_Context_ refers to a [require with an expression](/guides/dependency-management/#require-with-expression) such as `require('./locale/' + name + '.json')`. When encountering such an expression, webpack infers the directory (`'./locale/'`) and a regular expression (`/^.*\.json$/`). Since the `name` is not known at compile time, webpack includes every file as module in the bundle.
+_Context_ refers to [dynamic expressions in import() or require()](/guides/dependency-management/#dynamic-expressions-in-import-or-require) such as `require('./locale/' + name + '.json')`. When encountering such an expression, webpack infers the directory (`'./locale/'`) and a regular expression (`/^.*\.json$/`). Since the `name` is not known at compile time, webpack includes every file as module in the bundle.
 
 The `ContextReplacementPlugin` allows you to override the inferred information. There are various ways to configure the plugin:
 


### PR DESCRIPTION
Address #7772

**Summary**


This pull request modernizes the "Dependency Management" guide by introducing native ESM alternatives to legacy CommonJS patterns. While the repository is currently undergoing a migration to ESM configuration files, the core concepts in this specific guide were still relying on legacy `require()`.

Changes include:
- Adding `import()` alongside `require()` for dynamic expressions in context modules.
- Introducing `import.meta.webpackContext` (the official ESM alternative to `require.context`).
- Updating the context module API examples to reflect modern ESM usage.
- Clarifying the use of `import.meta.webpackHot` for HMR within ESM modules.

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

No (Documentation only change). Verified that the Markdown structure and code block syntax are valid via local build and linting.

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

The modernization of dynamic imports and context modules is already fully documented within the changes made to `src/content/guides/dependency-management.mdx` in this PR.