### PR TITLE
docs(package-exports): fixed incorrect other-prefix pattern example(#5820)

### DIFF
--- a/src/content/guides/package-exports.mdx
+++ b/src/content/guides/package-exports.mdx
@@ -39,14 +39,14 @@ An example:
 }
 ```
 
-| Module request                      | Result                                           |
-| ----------------------------------- | ------------------------------------------------ |
-| `package`                           | `.../package/main.js`                            |
-| `package/sub/path`                  | `.../package/secondary.js`                       |
-| `package/prefix/some/file.js`       | `.../package/directory/some/file.js`             |
-| `package/prefix/deep/file.js`       | `.../package/other-directory/file.js`            |
+| Module request                   | Result                                           |
+| -------------------------------- | ------------------------------------------------ |
+| `package`                        | `.../package/main.js`                            |
+| `package/sub/path`               | `.../package/secondary.js`                       |
+| `package/prefix/some/file.js`    | `.../package/directory/some/file.js`             |
+| `package/prefix/deep/file.js`    | `.../package/other-directory/file.js`            |
 | `package/other-prefix/deep/file` | `.../package/yet-another/deep/file/deep/file.js` |
-| `package/main.js`                   | Error                                            |
+| `package/main.js`                | Error                                            |
 
 ## Alternatives
 


### PR DESCRIPTION
The example for the pattern

  "./other-prefix/*": "./yet-another/*/*.js"

previously showed the request:

  package/other-prefix/deep/file.js

resolving to:

  .../package/yet-another/deep/file/deep/file.js

However, according to the documented substitution rule, `*` matches the full
subpath including file extensions. With `.js` included in the request, the
substitution would produce an invalid path.

The example has been corrected to:

  package/other-prefix/deep/file

which correctly resolves to:

  .../package/yet-another/deep/file/deep/file.js

Additionally, a clarification was added noting that `*` substitution does not
strip file extensions automatically.