### PR TITLE
docs: replace non-inclusive terminology

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -7,7 +7,7 @@ StylesPath = .vale
 MinAlertLevel = warning
 
 [*.{md,mdx}]
-BasedOnStyles = proselint
+BasedOnStyles = proselint, Speciesism
 
 proselint.But = NO
 proselint.Typography = NO

--- a/.vale/Speciesism/AnimalIdioms.yml
+++ b/.vale/Speciesism/AnimalIdioms.yml
@@ -1,0 +1,32 @@
+extends: substitution
+message: "Consider using '%s' instead of '%s'. This phrase normalizes violence toward animals."
+link: https://doi.org/10.1007/s43681-023-00380-w
+level: warning
+ignorecase: true
+swap:
+  'kill two birds with one stone': accomplish two things at once
+  'killing two birds with one stone': accomplishing two things at once
+  'killed two birds with one stone': accomplished two things at once
+  'beat a dead horse': belabor the point
+  'beating a dead horse': belaboring the point
+  'flog a dead horse': belabor the point
+  'flogging a dead horse': belaboring the point
+  'bring home the bacon': bring home the results
+  'bringing home the bacon': bringing home the results
+  'brought home the bacon': brought home the results
+  'more than one way to skin a cat': more than one way to solve this
+  'many ways to skin a cat': many ways to approach this
+  'let the cat out of the bag': reveal the secret
+  'letting the cat out of the bag': revealing the secret
+  'open a can of worms': create a complicated situation
+  'opening a can of worms': creating a complicated situation
+  'opened a can of worms': created a complicated situation
+  'wild goose chase': pointless pursuit
+  'take the bull by the horns': face the challenge head-on
+  'taking the bull by the horns': facing the challenge head-on
+  'took the bull by the horns': faced the challenge head-on
+  'like shooting fish in a barrel': extremely easy
+  'straight from the horse''s mouth': directly from the source
+  'from the horse''s mouth': from a reliable source
+  'whack-a-mole': recurring problem
+  'whack a mole': recurring problem

--- a/.vale/Speciesism/AnimalMetaphors.yml
+++ b/.vale/Speciesism/AnimalMetaphors.yml
@@ -1,0 +1,14 @@
+extends: substitution
+message: "Consider using '%s' instead of '%s'. This term references animals as objects or tools."
+link: https://doi.org/10.1007/s43681-023-00380-w
+level: warning
+ignorecase: true
+swap:
+  'guinea pig': test subject
+  'sacred cow': unquestioned belief
+  'sacred cows': unquestioned beliefs
+  'scapegoat(?:ed|ing)?': wrongly blamed
+  'dog-eat-dog': ruthlessly competitive
+  'dog eat dog': ruthlessly competitive
+  'rat race': competitive grind
+  'red herring': false lead

--- a/.vale/Speciesism/TechTerminology.yml
+++ b/.vale/Speciesism/TechTerminology.yml
@@ -1,0 +1,13 @@
+extends: substitution
+message: "Consider using '%s' instead of '%s'. This technical term has a more precise alternative."
+level: suggestion
+ignorecase: true
+swap:
+  'canary deployment': progressive rollout
+  'canary release': progressive rollout
+  'canary test(?:ing)?': incremental testing
+  'monkey[- ]?patch(?:ed|ing)?': runtime patch
+  'duck[- ]?typ(?:ed|ing)': structural typing
+  'dogfood(?:ing)?': self-hosting
+  'eat(?:ing)? (?:your|our|their) own dogfood': self-testing
+  'rubber duck(?:ing)? debugging': talk-through debugging

--- a/src/content/guides/csp.mdx
+++ b/src/content/guides/csp.mdx
@@ -33,7 +33,7 @@ __webpack_nonce__ = "c29tZSBjb29sIHN0cmluZyB3aWxsIHBvcCB1cCAxMjM=";
 
 ## Enabling CSP
 
-Please note that CSPs are not enabled by default. A corresponding header `Content-Security-Policy` or meta tag `<meta http-equiv="Content-Security-Policy" ...>` needs to be sent with the document to instruct the browser to enable the CSP. Here's an example of what a CSP header including a CDN white-listed URL might look like:
+Please note that CSPs are not enabled by default. A corresponding header `Content-Security-Policy` or meta tag `<meta http-equiv="Content-Security-Policy" ...>` needs to be sent with the document to instruct the browser to enable the CSP. Here's an example of what a CSP header including a CDN allow-listed URL might look like:
 
 ```html
 Content-Security-Policy: default-src 'self'; script-src 'self'


### PR DESCRIPTION
## Summary

Addresses #7879. Per @alexander-akait's go-ahead, this PR:

- **Fixes the one existing instance** of non-inclusive prose: "white-listed" → "allow-listed" in the CSP guide (`src/content/guides/csp.mdx` line 36). The third-party paper title ("On the Insecurity of Whitelists...") is left as-is since it's a citation.

- **Adds a `Speciesism` Vale style** (3 rules from [Open-Paws/speciesist-language-scanner](https://github.com/Open-Paws/speciesist-language-scanner)) to catch non-inclusive language in future contributions:
  - `AnimalIdioms.yml` — flags phrases like "kill two birds with one stone" → "accomplish two things at once" (warning)
  - `AnimalMetaphors.yml` — flags terms like "guinea pig" → "test subject" (warning)
  - `TechTerminology.yml` — flags terms like "monkey patch" → "runtime patch" (suggestion)

The Vale style slots directly into the existing `.vale/` setup alongside proselint. All rules use `warning` or `suggestion` level (not `error`), so they guide contributors without blocking.

## Changes

| File | Change |
|---|---|
| `src/content/guides/csp.mdx` | "white-listed" → "allow-listed" |
| `.vale.ini` | Added `Speciesism` to `BasedOnStyles` |
| `.vale/Speciesism/AnimalIdioms.yml` | New rule — speciesist idioms |
| `.vale/Speciesism/AnimalMetaphors.yml` | New rule — animal-as-object metaphors |
| `.vale/Speciesism/TechTerminology.yml` | New rule — tech terms with clearer alternatives |

## References

- Hagendorff et al. 2023, "Speciesist bias in AI," *AI and Ethics* ([DOI: 10.1007/s43681-023-00380-w](https://doi.org/10.1007/s43681-023-00380-w))
- [Open-Paws/speciesist-language-scanner](https://github.com/Open-Paws/speciesist-language-scanner)