### PR TITLE
docs(externals): clarify script externals can’t use ESM imports

### DIFF
--- a/src/content/configuration/externals.mdx
+++ b/src/content/configuration/externals.mdx
@@ -845,6 +845,10 @@ T> When loading code with HTML `<script>` tags, the webpack runtime will try to 
 
 T> Options like `output.chunkLoadTimeout`, `output.crossOriginLoading` and `output.scriptType` will also have effect on the external scripts loaded this way.
 
+W> `externalsType: "script"` loads externals using a classic (non-module) `<script src="...">` tag. The external file must be compatible with classic scripts (i.e. no top-level `import` / `export`). If the loaded script contains ESM syntax (for example, `import * as b from "b.js"`), the browser will fail to evaluate it and webpack will report a script loading failure (often surfaced as `ScriptExternalLoadError: Loading script failed.`).
+
+T> If you need module-to-module dependencies, prefer `externalsType: "import"` / `externalsType: "module"` / `externalsType: "module-import"` instead. If you must keep `externalsType: "script"`, load dependencies first and access them via globals (e.g. `globalThis.SomeLib`) rather than using `import`.
+
 ### externalsType.this
 
 Specify the default type of externals as `'this'`. Webpack will read the external as a global variable on the `this` object.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Fixes #6510 
Adds a warning that externalsType: "script" loads via classic (non-module) <script> tags, so ESM import/export inside the external will fail at runtime.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Docs change
<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
No
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
N/A
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
