### PR TITLE
fix: correct isActive prop mismatch in navigation

### DIFF
--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -19,17 +19,23 @@ import Tooltip from "../Tooltip/Tooltip.jsx";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import "@docsearch/css";
 
-function NavigationItem({ children, url, isactive, ariaLabel }) {
-  let obj = {};
-  // decide if the link is active or not by providing a function
-  // otherwise we'll let react-dom makes the decision for us
-  if (isactive) {
-    obj = {
-      isactive,
-    };
-  }
+function NavigationItem({
+  children,
+  url,
+  isActive: isCustomActive,
+  ariaLabel,
+}) {
+  const location = useLocation();
   const classes =
     "text-gray-100 dark:text-gray-100 text-sm font-light uppercase hover:text-blue-200";
+
+  const getActiveState = (isNavLinkActive) => {
+    if (isCustomActive) {
+      return isCustomActive({}, location);
+    }
+    return isNavLinkActive;
+  };
+
   if (url.startsWith("http") || url.startsWith("//")) {
     return (
       <a
@@ -45,9 +51,8 @@ function NavigationItem({ children, url, isactive, ariaLabel }) {
   }
   return (
     <NavLink
-      {...obj}
-      className={({ isActive }) =>
-        isActive ? `${classes} !text-blue-200` : classes
+      className={({ isActive: isNavLinkActive }) =>
+        getActiveState(isNavLinkActive) ? `${classes} !text-blue-200` : classes
       }
       to={url}
       aria-label={ariaLabel}
@@ -60,7 +65,7 @@ function NavigationItem({ children, url, isactive, ariaLabel }) {
 NavigationItem.propTypes = {
   children: PropTypes.node.isRequired,
   url: PropTypes.string.isRequired,
-  isactive: PropTypes.func,
+  isActive: PropTypes.func,
   ariaLabel: PropTypes.string,
 };
 
@@ -211,8 +216,8 @@ function Navigation({ links, pathname, hash = "", toggleSidebar }) {
           )
           .map((link) => {
             if (
-              link.isactive && // hide the children if the link is not active
-              !link.isactive({}, location)
+              link.isActive && // hide the children if the link is not active
+              !link.isActive({}, location)
             ) {
               return null;
             }

--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -228,7 +228,7 @@ function Site(props) {
               content: "Documentation",
               ariaLabel: "webpack documentation",
               url: "/concepts/",
-              isactive: (_, location) =>
+              isActive: (_, location) =>
                 /^\/(api|concepts|configuration|guides|loaders|migrate|plugins)/.test(
                   location.pathname,
                 ),


### PR DESCRIPTION
**Summary**

This PR fixes a prop name mismatch between `isactive` and `isActive` in the navigation components.

Due to this inconsistency, the custom logic responsible for highlighting navigation links (especially for sections like `/api/`, `/guides/`, `/loaders/`, `/migrate/`, and `/plugins/`) was not functioning correctly. In some cases, the issue appeared to work due to default routing behavior, leading to inconsistent UI highlighting.

---

### Before

<img width="784" height="103" alt="Before 1" src="https://github.com/user-attachments/assets/bdcbb62d-bb43-42ec-98a6-df398386b6fd" />

<img width="800" height="112" alt="Before 2" src="https://github.com/user-attachments/assets/fef2a490-fb91-4abb-bc4e-7c52f86e1090" />

---

### After

<img width="833" height="94" alt="After" src="https://github.com/user-attachments/assets/3571edc5-6bef-4573-8f05-39086039aabb" />