### PR TITLE
fix: use getElementById for hash scrolling to support digit-prefixed IDs

### DIFF
--- a/src/components/Page/Page.jsx
+++ b/src/components/Page/Page.jsx
@@ -52,13 +52,15 @@ export default function Page(props) {
         const target = document.querySelector("#md-content");
         // two cases here
         // 1. server side rendered page, so hash target is already there
-        if (document.querySelector(hash)) {
-          document.querySelector(hash).scrollIntoView();
+        // Note: Why this change because we use getElementById instead of querySelector(hash) here because
+        // CSS selectors cannot start with a digit (e.g. #11-in-scope is invalid)
+        if (document.getElementById(hash.slice(1))) {
+          document.getElementById(hash.slice(1)).scrollIntoView();
         } else {
           // 2. dynamic loaded content
           // we need to observe the dom change to tell if hash exists
           observer = new MutationObserver(() => {
-            const element = document.querySelector(hash);
+            const element = document.getElementById(hash.slice(1));
             if (element) {
               element.scrollIntoView();
             }


### PR DESCRIPTION
## Issue

Clicking certain sidebar anchor links crashes the page entirely.
Specifically, links like **"1.1: In-scope"** and **"1.2: Out-of-Scope"**
under the Charter section break the page :  nothing is clickable after that.

The bug is in the hash scrolling logic inside `Page.jsx`. It uses
`document.querySelector(hash)` to find and scroll to the target element.

When `github-slugger` processes a heading like `1.1: In-scope`, it generates
the slug `11-in-scope` (strips the dot and colon). So the hash becomes
`#11-in-scope`. The call then becomes:

```js
document.querySelector("#11-in-scope")
```
This throws a DOMException: SyntaxError  -  CSS selectors cannot start with
a digit. This uncaught error breaks the entire [useEffect], leaving the page
in a broken state.

Every other section works fine because their heading slugs happen to start
with letters.

**Fix** : 

Switch from [document.querySelector(hash)] to [document.getElementById(hash.slice(1))].

The [getElementById] API has no restrictions on IDs starting with digits, so
it handles these edge cases without throwing.

The change covers both paths inside the same [useEffect]:

Case 1 - SSR pre-rendered page where the element already exists in DOM
Case 2 - Dynamically loaded content observed via [MutationObserver]

Files Changed
Only [Page.jsx]- 3 lines changed, zero logic altered

**Steps to Reproduce :**

Run [yarn fetch:governance && yarn content]
Run yarn start
Go to /contribute/Governance-charter/
Click "1.1: In-scope" or "1.2: Out-of-Scope" in the sidebar

Page breaks entirely 

With this fix, both anchors scroll correctly and nothing breaks 

Proof of Issue : 


https://github.com/user-attachments/assets/2eac8f82-30fa-48a7-b44f-ab4bc4b2156b


After Fixing : 

https://github.com/user-attachments/assets/21ba9cbb-247a-4dbc-a6ef-c07ccde6d8bf

