### PR TITLE
docs: standardize guide directory trees using Unicode box-drawing

### DIFF
--- a/src/content/guides/getting-started.mdx
+++ b/src/content/guides/getting-started.mdx
@@ -61,11 +61,11 @@ Now we'll create the following directory structure, files and their contents:
 
 ```diff
   webpack-demo
-  |- package.json
-  |- package-lock.json
-+ |- index.html
-+ |- /src
-+   |- index.js
+  ├── package.json
+  ├── package-lock.json
++ ├── index.html
++ └── src/
++    └── index.js
 ```
 
 **src/index.js**
@@ -144,13 +144,13 @@ First we'll tweak our directory structure slightly, separating the "source" code
 
 ```diff
   webpack-demo
-  |- package.json
-  |- package-lock.json
-+ |- /dist
-+   |- index.html
-- |- index.html
-  |- /src
-    |- index.js
+   ├── package.json
+   ├── package-lock.json
++  ├── /dist
++  │   └── index.html
+-  ├── index.html
+   └── /src
+       └── index.js
 ```
 
 T> You may have noticed that `index.html` was created manually, even though it is now placed in the `dist` directory. Later on in [another guide](/guides/output-management/#setting-up-htmlwebpackplugin), we will generate `index.html` rather than edit it manually. Once this is done, it should be safe to empty the `dist` directory and to regenerate all the files within it.
@@ -241,13 +241,13 @@ Webpack configuration files can be written using either CommonJS or ECMAScript m
 
 ```diff
   webpack-demo
-  |- package.json
-  |- package-lock.json
-+ |- webpack.config.js
-  |- /dist
-    |- index.html
-  |- /src
-    |- index.js
+   ├── package.json
+   ├── package-lock.json
++  ├── webpack.config.js
+   ├── /dist
+   │   └── index.html
+   └── /src
+       └── index.js
 ```
 
 **webpack.config.js**
@@ -346,15 +346,15 @@ Now that you have a basic build together you should move on to the next guide [`
 
 ```diff
 webpack-demo
-|- package.json
-|- package-lock.json
-|- webpack.config.js
-|- /dist
-  |- main.js
-  |- index.html
-|- /src
-  |- index.js
-|- /node_modules
+ ├── package.json
+ ├── package-lock.json
+ ├── webpack.config.js
+ ├── /dist
+ │   ├── main.js
+ │   └── index.html
+ ├── /src
+ │   └── index.js
+ └── /node_modules
 ```
 
 W> Do not compile untrusted code with webpack. It could lead to execution of malicious code on your computer, remote servers, or in the web browsers of the end users of your application.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## **Summary**

This PR initiates a project-wide standardization of directory tree visualizations, starting with the **Getting Started** guide. It refactors existing ASCII-based trees (using `|-` and `|–`) to modern **Unicode Box-Drawing** characters (`├──`, `└──`, `│`).

While reviewing the documentation, I identified significant inconsistencies in how project structures are represented. For example:
- **[Asset Management (Global Assets)](https://webpack.js.org/guides/asset-management/#global-assets):** Uses a basic hyphen-based style.
- **[Asset Management (Wrapping Up)](https://webpack.js.org/guides/asset-management/#wrapping-up):** The style shifts, losing vertical alignment and continuity.

By adopting the Unicode standard (matching the output of the standard Unix `tree` utility), we provide users with a clearer mental model of the project hierarchy.


## **What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

### Visual Comparison

| Before  | After |
| :--- | :--- |
| ![Before: Inconsistent style](https://github.com/user-attachments/assets/7c20dcd0-58c7-4b10-8d00-6d94d191577e) | ![After: Unicode Standard](https://github.com/user-attachments/assets/1ef4a50a-71c4-48a1-a7b3-f1cdcc6d94f9) |
| *Issues: Mixed dashes and lack of vertical pipes make nested files appear "floating".* | *Improvements: Vertical connectors (`│`) and termination corners (`└──`) create a solid visual path.* |




### Changes Included
The following logic was applied to `src/content/guides/getting-started.md`:

- **Vertical Continuity:** Added `│` to all nested levels to track parent-child relationships.
- **Junctions:** Used `├──` for all items that have a sibling below them.
- **Terminators:** Used `└──` for the final item in any directory to clearly "close" the branch.
- **Standardized Slashes:** Ensured all directories are marked with a trailing `/` for clarity.

### Implementation Details (Example)
```diff
 webpack-demo
- ├── index.html
  ├── package.json
  ├── package-lock.json
  ├── webpack.config.js
  ├── /dist
- │   └── index.html
+ │   ├── main.js
+ │   └── index.html
  └── /src
     └── index.js
```

## **Did you add tests for your changes?**
No, it's documentation, already in the test

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

## **Does this PR introduce a breaking change?**

No, 
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

## **If relevant, what needs to be documented once your changes are merged or what have you already documented?**
### Future Work
To keep this PR focused and easy to review, I have only modified getting-started.md. Once this standard is approved, I am prepared to apply these identical fixes to:
- src/content/guides/asset-management.md
- src/content/guides/output-management.md
- Other guides identified during my audit.

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

## **Use of AI**
No, I didn't

Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->