### PR TITLE
docs: fix lodash dependency guidance in authoring libraries guide

### DIFF
--- a/src/content/guides/author-libraries.mdx
+++ b/src/content/guides/author-libraries.mdx
@@ -36,10 +36,11 @@ Initialize the project with npm, then install `webpack`, `webpack-cli` and `loda
 
 ```bash
 npm init -y
-npm install --save-dev webpack webpack-cli lodash
+npm install --save-dev webpack webpack-cli
+npm install --save lodash
 ```
 
-We install `lodash` as `devDependencies` instead of `dependencies` because we don't want to bundle it into our library, or our library could be easily bloated.
+We install `lodash` as a `dependency` because our library directly imports it — any `import` or `require` of a package means it is a direct dependency. We will use the [`externals`](/configuration/externals/) configuration later to avoid bundling it into our library output.
 
 **src/ref.json**
 
@@ -221,7 +222,7 @@ T> Note that the `library` setup is tied to the `entry` configuration. For most 
 
 ## Externalize Lodash
 
-Now, if you run `npx webpack`, you will find that a largish bundle is created. If you inspect the file, you'll see that lodash has been bundled along with your code. In this case, we'd prefer to treat `lodash` as a _peer dependency_. Meaning that the consumer should already have `lodash` installed. Hence you would want to give up control of this external library to the consumer of your library.
+Now, if you run `npx webpack`, you will find that a largish bundle is created. If you inspect the file, you'll see that lodash has been bundled along with your code. In this case, we'd prefer to _externalize_ `lodash`, meaning it won't be included in the output bundle. Instead, the consumer of your library is expected to have `lodash` available in their environment. Since `lodash` is listed in your library's `dependencies`, it will be automatically installed when a user installs your library, and their bundler can deduplicate it with other versions.
 
 This can be done using the [`externals`](/configuration/externals/) configuration:
 


### PR DESCRIPTION
lodash is a direct dependency of the library (imported via require/import), so it should be listed in dependencies, not devDependencies. It should also not be referred to as a peerDependency. The externals config prevents it from being bundled, while listing it in dependencies ensures it gets installed when users install the library.

Fixes #6896

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->