### PR TITLE
fix: add remark plugin to remove duplicate H1 matching frontmatter title

### DIFF
--- a/src/remark-plugins/remark-remove-duplicate-h1/index.mjs
+++ b/src/remark-plugins/remark-remove-duplicate-h1/index.mjs
@@ -1,0 +1,54 @@
+import frontMatter from "front-matter";
+
+/**
+ * Extracts plain text content from a node and its children.
+ */
+function extractText(node) {
+  if (node.type === "text") return node.value;
+  if (node.children) return node.children.map(extractText).join("");
+  return "";
+}
+
+/**
+ * Remark plugin that removes a leading H1 heading from MDX content when its
+ * text matches the page's frontmatter `title` (case-insensitive).
+ *
+ * This prevents duplicate headings on pages where both the MDX content
+ * contains an H1 AND Page.jsx renders <h1>{title}</h1> from the frontmatter.
+ *
+ * Must be registered AFTER remark-frontmatter so the yaml AST node is present.
+ */
+export default function remarkRemoveDuplicateH1() {
+  return function transformer(ast) {
+    // Extract the title from the frontmatter yaml node
+    let title = null;
+    for (const node of ast.children) {
+      if (node.type === "yaml") {
+        try {
+          const { attributes } = frontMatter(`---\n${node.value}\n---`);
+          if (attributes && attributes.title) {
+            title = String(attributes.title).trim().toLowerCase();
+          }
+        } catch {
+          // Ignore malformed frontmatter
+        }
+        break;
+      }
+    }
+
+    if (!title) return;
+
+    // Find the first h1 heading and remove it if its text matches the title
+    for (let i = 0; i < ast.children.length; i++) {
+      const node = ast.children[i];
+      if (node.type === "heading" && node.depth === 1) {
+        const headingText = extractText(node).trim().toLowerCase();
+        if (headingText === title) {
+          ast.children.splice(i, 1);
+        }
+        // Only inspect the very first h1 — stop regardless
+        break;
+      }
+    }
+  };
+}

--- a/webpack.common.mjs
+++ b/webpack.common.mjs
@@ -12,6 +12,7 @@ import refractor from "remark-refractor";
 import webpack from "webpack";
 import cleanup from "./src/remark-plugins/remark-cleanup-readme/index.mjs";
 import aside from "./src/remark-plugins/remark-custom-asides/index.mjs";
+import remarkRemoveDuplicateH1 from "./src/remark-plugins/remark-remove-duplicate-h1/index.mjs";
 import remarkRemoveHeadingId from "./src/remark-plugins/remark-remove-heading-id/index.mjs";
 import remarkResponsiveTable from "./src/remark-plugins/remark-responsive-table/remark-responsive-table.mjs";
 import slug from "./src/remark-plugins/remark-slug/index.mjs";
@@ -75,7 +76,11 @@ export default ({ ssg = false }) => ({
             loader: "@mdx-js/loader",
             /** @type {import('@mdx-js/loader').Options} */
             options: {
-              remarkPlugins: [...mdPlugins, [frontmatter]],
+              remarkPlugins: [
+                ...mdPlugins,
+                [frontmatter],
+                remarkRemoveDuplicateH1,
+              ],
               providerImportSource: path.resolve("./src/mdx-components.mjs"),
             },
           },


### PR DESCRIPTION
Linked to: https://github.com/webpack/governance/pull/11

Summary
This PR adds a remark plugin that removes a duplicate H1 heading from MDX content when it matches the frontmatter title. Pages fetched from external repos like webpack/governance (e.g. Charter, Moderation Policy) include an H1 in the content that duplicates the title already rendered by Page.jsx from frontmatter, causing the heading to appear twice on the page. The plugin runs after remark-frontmatter, reads the title from the YAML node, and removes the first H1 if it matches - case-insensitive. No new dependencies added, uses front-matter which is already in the project.

What kind of change does this PR introduce?
fix

Did you add tests for your changes?
no

Does this PR introduce a breaking change?
no

If relevant, what needs to be documented once your changes are merged or what have you already documented?
N/A

Use of AI
GitHub Copilot was used to help refine the  parts of this PR.

Images (Before & After)
<img width="1093" height="305" alt="image" src="https://github.com/user-attachments/assets/5a79e507-1045-4e0a-b1cf-57a268dc96f8" />
<img width="1066" height="218" alt="image" src="https://github.com/user-attachments/assets/1d289cef-1795-4d1e-87a5-3ff913caddc1" />
