### PR TITLE
The documentation currently suggests installing lodash as a devDependency to avoid bundling it into the library. however bundling behavior is controlled by webpack externals not by dependency type. This PR clarifies the explanation in the Authoring Libraries guide.clarify lodash dependency usage in authoring libraries guide

### DIFF
--- a/src/content/guides/author-libraries.mdx
+++ b/src/content/guides/author-libraries.mdx
@@ -39,7 +39,12 @@ npm init -y
 npm install --save-dev webpack webpack-cli lodash
 ```
 
-We install `lodash` as `devDependencies` instead of `dependencies` because we don't want to bundle it into our library, or our library could be easily bloated.
+Since the library directly imports lodash, it should normally
+be listed as a dependency in package.json.
+
+If you do not want lodash to be bundled into the library output,
+you can configure webpack's externals option so that lodash
+is treated as an external dependency.
 
 **src/ref.json**
 


### PR DESCRIPTION
Clarify the usage of lodash in the library and its configuration in webpack.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->