### PR TITLE
fix: improve language dropdown visibility and z-index

### DIFF
--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -33,8 +33,10 @@
   right: 0;
   font-size: getFontSize(-1);
   margin: auto;
-  background-color: #2b3a42;
-  z-index: 1;
+  background-color: #526b78;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  z-index: 9999;
 
   ul {
     padding-top: 0.25em;


### PR DESCRIPTION
Summary :
This PR fixes the language selector dropdown in the navigation bar which had two visual issues: it rendered behind the hero section on the homepage due to a z-index of 1, and it had no visual separation from the navbar because its background color was identical to the navigation bar.

What kind of change does this PR introduce?
fix

Did you add tests for your changes?
No - the change is purely visual (CSS only). 

Does this PR introduce a breaking change?
No

If relevant, what needs to be documented once your changes are merged or what have you already documented?
N/A

Use of AI
No

Images (Before & After)
![IMAGE CHANGES BEFORE AND AFTER](https://github.com/user-attachments/assets/267f307e-7c26-4be2-959c-3a2a937b0f2f)
