### PR TITLE
fix(styles): replace :focus with :focus-visible for Copy-Button

### DIFF
--- a/src/components/CodeBlockWithCopy/CodeBlockWithCopy.scss
+++ b/src/components/CodeBlockWithCopy/CodeBlockWithCopy.scss
@@ -53,7 +53,7 @@
     background-color: #c53030;
   }
 
-  &:focus {
+  &:focus-visible {
     outline: none;
     opacity: 1;
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
This PR replaces pseudo class `:focus` with `:focus-visible` for `Copy-Button` so the copy button 
does not remain active after being clicked, while preserving keyboard accessibility.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
fix

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
no

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->

before:

[Screencast from 2026-03-05 17-16-15.webm](https://github.com/user-attachments/assets/3d1fb2e2-dbf7-4e8a-8b1b-4a8101d1f131)

----

after:

[Screencast from 2026-03-05 17-18-40.webm](https://github.com/user-attachments/assets/f42f6c7e-2dd8-422e-9bea-1157fdc8ebfc)
