### PR TITLE
docs: fix grammar, list numbering, and markdown lint issues in writers guide

### DIFF
--- a/.vale/Speciesism/AnimalIdioms.yml
+++ b/.vale/Speciesism/AnimalIdioms.yml
@@ -4,29 +4,29 @@ link: https://doi.org/10.1007/s43681-023-00380-w
 level: warning
 ignorecase: true
 swap:
-  'kill two birds with one stone': accomplish two things at once
-  'killing two birds with one stone': accomplishing two things at once
-  'killed two birds with one stone': accomplished two things at once
-  'beat a dead horse': belabor the point
-  'beating a dead horse': belaboring the point
-  'flog a dead horse': belabor the point
-  'flogging a dead horse': belaboring the point
-  'bring home the bacon': bring home the results
-  'bringing home the bacon': bringing home the results
-  'brought home the bacon': brought home the results
-  'more than one way to skin a cat': more than one way to solve this
-  'many ways to skin a cat': many ways to approach this
-  'let the cat out of the bag': reveal the secret
-  'letting the cat out of the bag': revealing the secret
-  'open a can of worms': create a complicated situation
-  'opening a can of worms': creating a complicated situation
-  'opened a can of worms': created a complicated situation
-  'wild goose chase': pointless pursuit
-  'take the bull by the horns': face the challenge head-on
-  'taking the bull by the horns': facing the challenge head-on
-  'took the bull by the horns': faced the challenge head-on
-  'like shooting fish in a barrel': extremely easy
-  'straight from the horse''s mouth': directly from the source
-  'from the horse''s mouth': from a reliable source
-  'whack-a-mole': recurring problem
-  'whack a mole': recurring problem
+  "kill two birds with one stone": accomplish two things at once
+  "killing two birds with one stone": accomplishing two things at once
+  "killed two birds with one stone": accomplished two things at once
+  "beat a dead horse": belabor the point
+  "beating a dead horse": belaboring the point
+  "flog a dead horse": belabor the point
+  "flogging a dead horse": belaboring the point
+  "bring home the bacon": bring home the results
+  "bringing home the bacon": bringing home the results
+  "brought home the bacon": brought home the results
+  "more than one way to skin a cat": more than one way to solve this
+  "many ways to skin a cat": many ways to approach this
+  "let the cat out of the bag": reveal the secret
+  "letting the cat out of the bag": revealing the secret
+  "open a can of worms": create a complicated situation
+  "opening a can of worms": creating a complicated situation
+  "opened a can of worms": created a complicated situation
+  "wild goose chase": pointless pursuit
+  "take the bull by the horns": face the challenge head-on
+  "taking the bull by the horns": facing the challenge head-on
+  "took the bull by the horns": faced the challenge head-on
+  "like shooting fish in a barrel": extremely easy
+  "straight from the horse's mouth": directly from the source
+  "from the horse's mouth": from a reliable source
+  "whack-a-mole": recurring problem
+  "whack a mole": recurring problem

--- a/.vale/Speciesism/AnimalMetaphors.yml
+++ b/.vale/Speciesism/AnimalMetaphors.yml
@@ -4,11 +4,11 @@ link: https://doi.org/10.1007/s43681-023-00380-w
 level: warning
 ignorecase: true
 swap:
-  'guinea pig': test subject
-  'sacred cow': unquestioned belief
-  'sacred cows': unquestioned beliefs
-  'scapegoat(?:ed|ing)?': wrongly blamed
-  'dog-eat-dog': ruthlessly competitive
-  'dog eat dog': ruthlessly competitive
-  'rat race': competitive grind
-  'red herring': false lead
+  "guinea pig": test subject
+  "sacred cow": unquestioned belief
+  "sacred cows": unquestioned beliefs
+  "scapegoat(?:ed|ing)?": wrongly blamed
+  "dog-eat-dog": ruthlessly competitive
+  "dog eat dog": ruthlessly competitive
+  "rat race": competitive grind
+  "red herring": false lead

--- a/.vale/Speciesism/TechTerminology.yml
+++ b/.vale/Speciesism/TechTerminology.yml
@@ -3,11 +3,11 @@ message: "Consider using '%s' instead of '%s'. This technical term has a more pr
 level: suggestion
 ignorecase: true
 swap:
-  'canary deployment': progressive rollout
-  'canary release': progressive rollout
-  'canary test(?:ing)?': incremental testing
-  'monkey[- ]?patch(?:ed|ing)?': runtime patch
-  'duck[- ]?typ(?:ed|ing)': structural typing
-  'dogfood(?:ing)?': self-hosting
-  'eat(?:ing)? (?:your|our|their) own dogfood': self-testing
-  'rubber duck(?:ing)? debugging': talk-through debugging
+  "canary deployment": progressive rollout
+  "canary release": progressive rollout
+  "canary test(?:ing)?": incremental testing
+  "monkey[- ]?patch(?:ed|ing)?": runtime patch
+  "duck[- ]?typ(?:ed|ing)": structural typing
+  "dogfood(?:ing)?": self-hosting
+  "eat(?:ing)? (?:your|our|their) own dogfood": self-testing
+  "rubber duck(?:ing)? debugging": talk-through debugging

--- a/src/content/contribute/Governance-Overview.mdx
+++ b/src/content/contribute/Governance-Overview.mdx
@@ -1,0 +1,124 @@
+---
+title: Governance Overview
+group: Contribute
+sort: 0
+source: https://github.com/webpack/governance/blob/main/README.md
+edit: https://github.com/webpack/governance/edit/main/README.md
+---
+# webpack Project Governance
+
+webpack is an open source project that depends on contributions from the community. Anyone may contribute to the project at any time by submitting code, participating in discussions, making suggestions, or any other contribution they see fit. This document describes how various types of contributors work within the webpack project.
+
+* [Roles and Responsibilities](#roles-and-responsibilities)
+  * [Contributors](#contributors)
+  * [Committers](#committers)
+  * [Reviewers](#reviewers)
+* [Technical steering committee](#technical-steering-committee)
+  * [TSC meetings](#tsc-meetings)
+* [Consensus seeking process](#consensus-seeking-process)
+
+## Roles and Responsibilities
+
+### Contributors
+
+Contributors are community members who contribute in concrete ways to the project, most often in the form of code and/or documentation. Anyone can become a Contributor, and contributions can take many forms. There is no expectation of commitment to the project, no specific skill requirements, and no selection process.
+
+Contributors have read-only access to source code and so submit changes via pull requests. Contributor pull requests have their contribution reviewed and merged by a TSC member. TSC members and Committers work with Contributors to review their code and prepare it for merging.
+
+As Contributors gain experience and familiarity with the project, their profile within, and commitment to, the community will increase. At some stage, they may find themselves being nominated as either a Website Team Member or Committer by an existing Website Team Member or Committer.
+
+### Committers
+
+Committers are community members who have shown that they are committed to the continued development of the project through ongoing engagement with the community. Committers are given push access to the project's GitHub repos and must abide by the project's [Contribution Guidelines](https://github.com/webpack/webpack/blob/main/CONTRIBUTING.md)
+
+To become a Committer:
+
+* One must have shown a willingness and ability to participate in the project as a team player. Typically, a potential Committer will need to show that they have an understanding of and alignment with the project, its objectives, and its strategy.
+* Committers are expected to be respectful of every community member and to work collaboratively in the spirit of inclusion.
+
+New Committers can be nominated by any existing Committer. Once they have been nominated, there will be a vote by the TSC members.
+
+It is important to recognize that committership is a privilege, not a right. That privilege must be earned and once earned it can be removed by the TSC members by a standard TSC motion. However, under normal circumstances committership exists for as long as the Committer wishes to continue engaging with the project.
+
+A Committer who shows an above-average level of contribution to the project, particularly with respect to its strategic direction and long-term health, may be nominated to become a reviewer, described below.
+
+### Reviewers
+
+Reviewers are community members who have contributed a significant amount of time to the project through triaging of issues, fixing bugs, implementing enhancements/features, and are trusted community leaders.
+
+Reviewers may perform all of the duties of Committers, and also:
+
+* May merge external pull requests for accepted issues upon reviewing and approving the changes.
+* May merge their own pull requests once they have collected the feedback they deem necessary. (No pull request should be merged without at least one Committer/Reviewer/TSC member comment stating they've looked at the code.)
+
+To become a Reviewer:
+
+* Work in a helpful and collaborative way with the community.
+* Have given good feedback on others' submissions and displayed an overall understanding of the code quality standards for the project.
+* Commit to being a part of the community for the long-term.
+
+A Committer is invited to become a Reviewer by existing Reviewers and TSC members. A nomination will result in discussion and then a decision by the TSC.
+
+## Technical Steering Committee
+
+A subset of the collaborators forms the Technical Steering Committee (TSC).
+The TSC has final authority over this project, including:
+
+* Technical direction
+* Project governance and process (including this policy)
+* Contribution policy
+* GitHub repository hosting
+* Conduct guidelines
+* Maintaining the list of collaborators
+
+The current list of TSC members is in
+[the project README](https://github.com/webpack/webpack/blob/main/README.md#current-project-members).
+
+The [TSC Charter][] governs the operations of the TSC. All changes to the
+Charter need approval by the OpenJS Foundation Cross-Project Council (CPC).
+
+### TSC meetings
+
+The TSC meets in a Discord conference call or Discord thread. Each year,
+the TSC elects a chair to run the meetings.
+
+Any community member can create a GitHub issue asking that the TSC review
+something.
+
+The TSC may invite people to take part in a non-voting capacity.
+
+During the meeting, the TSC chair ensures that someone takes minutes. After the
+meeting, the TSC chair ensures that someone opens a pull request with the
+minutes.
+
+The TSC seeks to resolve as many issues as possible outside meetings using
+[the webpack's governance repository issue tracker](https://github.com/webpack/governance/issues).
+
+The process in the issue tracker is:
+
+* A TSC member opens an issue explaining the proposal/issue and @-mentions
+  @webpack/tsc.
+* The proposal passes if, after 72 hours, there are two or more TSC voting
+  member approvals and no TSC voting member opposition.
+* If there is an extended impasse, a TSC member may make a motion for a vote.
+
+## Consensus Seeking Process
+
+The TSC follows a
+[Consensus Seeking](https://en.wikipedia.org/wiki/Consensus-seeking_decision-making)
+decision making model.
+
+When an agenda item has appeared to reach a consensus, the moderator
+will ask "Does anyone object?" as a final call for dissent from the
+consensus.
+
+If an agenda item cannot reach a consensus, a TSC member can call for
+either a closing vote or a vote to table the issue to the next
+meeting. The call for a vote must be approved by a majority of the TSC
+or else the discussion will continue. Simple majority wins.
+
+----
+
+_This document is an adaption of the [Node.js project Governance Model](https://github.com/nodejs/node/blob/main/GOVERNANCE.md) and the [ESlint project Governance Model](https://github.com/eslint/eslint/blob/main/docs/src/contribute/governance.md)_
+
+[TSC Charter]: https://github.com/nodejs/TSC/blob/HEAD/TSC-Charter.md

--- a/src/content/contribute/Governance-ai-policy.mdx
+++ b/src/content/contribute/Governance-ai-policy.mdx
@@ -1,0 +1,64 @@
+---
+title: Ai Policy
+group: Contribute
+sort: 10
+source: https://github.com/webpack/governance/blob/main/AI_POLICY.md
+edit: https://github.com/webpack/governance/edit/main/AI_POLICY.md
+---
+# AI Usage Policy
+
+Contributors can use whatever tools they would like to
+craft their contributions, but there must be a **human in the loop**.
+**Contributors must read and review all LLM-generated code or text before they
+ask other project members to review it.** The contributor is always the author
+and is fully accountable for their contributions. Contributors should be
+sufficiently confident that the contribution is high enough quality that asking
+for a review is a good use of scarce maintainer time, and they should be **able
+to answer questions about their work** during review.
+
+We expect that new contributors will be less confident in their contributions,
+and our guidance to them is to **start with small contributions** that they can
+fully understand to build confidence. We aspire to be a welcoming community
+that helps new contributors grow their expertise, but learning involves taking
+small steps, getting feedback, and iterating. Passing maintainer feedback to an
+LLM doesn't help anyone grow, and does not sustain our community.
+
+This policy includes, but is not limited to, the following kinds of
+contributions:
+
+- Code, usually in the form of a pull request
+- Issues or security vulnerabilities
+- Comments and feedback on pull requests
+
+## Extractive Contributions
+
+The reason for our "human-in-the-loop" contribution policy is that processing
+patches, PRs, RFCs, and comments is not free -- it takes a lot of
+maintainer time and energy to review those contributions! Sending the
+unreviewed output of an LLM to open source project maintainers *extracts* work
+from them in the form of design and code review, so we call this kind of
+contribution an "extractive contribution".
+
+## Transparency
+
+For contributions involving significant AI assistance, we encourage you to disclose 
+its use and explain your process. If a submission appears to rely heavily on AI 
+without disclosure, we may doubt that the **human-in-the-loop** requirement has
+been met. Please show awareness of your use of AI.
+
+## Copyright
+
+Artificial intelligence systems raise many questions around copyright that have
+yet to be answered. Our policy on AI tools is similar to our copyright policy:
+Contributors are responsible for ensuring that they have the right to
+contribute code under the terms of our license, typically meaning that either
+they, their employer, or their collaborators hold the copyright. Using AI tools
+to regenerate copyrighted material does not remove the copyright, and
+contributors are responsible for ensuring that such material does not appear in
+their contributions. Contributions found to violate this policy will be removed
+just like any other offending contribution.
+
+## Reference
+
+- [Simdutf](https://github.com/simdutf/simdutf/blob/master/AI_USAGE_POLICY.md)
+- [LLVM AI Tool Use Policy](https://discourse.llvm.org/t/rfc-llvm-ai-tool-policy-human-in-the-loop/89159)

--- a/src/content/contribute/Governance-charter.mdx
+++ b/src/content/contribute/Governance-charter.mdx
@@ -1,0 +1,139 @@
+---
+title: Charter
+group: Contribute
+sort: 1
+source: https://github.com/webpack/governance/blob/main/CHARTER.md
+edit: https://github.com/webpack/governance/edit/main/CHARTER.md
+---
+# webpack TSC Charter
+
+## Section 0. Guiding Principle
+
+The webpack project is part of the OpenJS Foundation. The project operates transparently, openly, collaboratively,
+and ethically. Project proposals, timelines, and status must not merely be open, but also easily visible to outsiders.
+
+## Section 1. Scope
+
+The webpack project is a highly flexible and efficient module bundler for modern JavaScript applications. Its primary
+purpose is to transform and bundle various modules (JavaScript, CSS, images, etc.) into a format suitable for web
+applications. Webpack focuses on enhancing the developer experience, providing optimizations for production environments,
+and enabling configurations to support a wide range of use cases and edge cases for specific projects.
+
+With this, webpack not only simplifies the process of managing application dependencies, but it also offers tools to
+optimize performance, maintainability, and scalability. The webpack community contributes solutions to common challenges
+in modern web development, helping developers streamline their workflows and build robust applications.
+
+### 1.1: In-scope
+
+- Bundling JavaScript files and their dependencies into a single output (or multiple outputs) for browser environments
+- Handling of asset files such as CSS, images, fonts, and other static resources
+- Optimization of assets for production, including minification, compression, and tree shaking (removal of unused code)
+- Enabling hot module replacement (HMR) for faster development feedback loops
+- Configuration and extensibility through plugins and loaders
+- Support for code splitting and lazy loading to enhance performance
+- Integrating with modern JavaScript frameworks (e.g., React, Vue, Angular)
+- Providing detailed build reports and debugging tools for development and production
+- Supporting multiple output formats (e.g., AMD, CommonJS, ES Modules) for compatibility with various environments
+- Community-driven tools and best practices provided through
+  [plugins](https://webpack.js.org/plugins/) and [guides](https://webpack.js.org/guides/)
+- Technical help and discussions via community platforms such as
+  [GitHub Discussions](https://github.com/webpack/webpack/discussions)
+
+In addition to the main repository, `webpack` (bundler), the organization maintains and manages several other core
+projects that are integral to the ecosystem such as `webpack-dev-server`, `webpack-cli`,  and `webpack-contrib` projects.
+
+These repositories, along with others housed within the `github.com/webpack` and `github.com/webpack-contrib` are owned by the webpack project.
+
+### 1.2: Out-of-Scope
+
+- Testing frameworks (e.g., unit, integration, or end-to-end testing tools).
+- APIs and tools that uses webpack in any way and are not in the webpack organization.
+- Server-side rendering directly (although it can integrate with SSR frameworks).
+- `webpack`-related frameworks and libraries that operate in their own capacity.
+
+## Section 2. Relationship with OpenJS Foundation CPC.
+
+Most large, complex open source communities have both a business and a technical governance model. Technical leadership
+for the projects within the OpenJS Foundation is delegated to the projects through their project charters by the OpenJS
+Cross Project Council (CPC). In the case of the webpack project, it is delegated to the webpack Technical Steering
+Committee ("TSC"). OpenJS Foundation's business leadership is the Board of Directors (the "Board").
+
+This charter can only be amended with the approval of the CPC.
+
+## Section 3. Establishment of the TSC
+
+TSC members can be either _regular_ members or _voting_ members. Regular members can attend meetings and participate in
+TSC discussions, but do not vote. Voting members can do everything regular members can do, and also have the ability to
+cast votes when consensus is not reached on an issue.
+
+TSC memberships are not time-limited. There is no maximum size of the TSC. The TSC must have at least four voting
+members.
+
+The TSC may add additional voting members to the TSC through meeting consensus. The consensus requires at least five TSC members to be present to approve a new voting member.  A TSC member can be removed from the TSC by voluntary
+resignation or by consensus with at least five voting members to be present. A vote in a TSC meeting can be used to change a regular TSC member to a voting
+TSC member, or to change a voting TSC member to a regular TSC member.
+
+No more than one-fourth of the TSC voting members may be affiliated with the same employer. If a change in TSC voting
+membership or a change of employment by a TSC voting member creates a situation where more than one-fourth of the TSC
+voting membership shares an employer, then the situation must be immediately remedied by the removal of voting member
+status from one or more TSC voting members affiliated with the over-represented employer(s).
+
+The TSC shall meet regularly using tools that enable participation by the community (e.g. weekly on a Google Hangout On
+Air, or through any other appropriate means selected by the TSC). The meeting shall be directed by the TSC Chairperson.
+Responsibility for directing individual meetings may be delegated by the TSC Chairperson to any other TSC voting member.
+Minutes or an appropriate recording shall be taken and made available to the community through accessible public
+postings.
+
+TSC voting members are expected to regularly participate in TSC meetings and issue triaging.
+
+A TSC voting member is automatically converted to a TSC regular member if they do not participate in three consecutive
+TSC votes.
+
+## Section 4. Roles & Responsibilities of the TSC
+
+Subject to such policies as may be set by the CPC, the TSC voting members are responsible for all technical development
+within the webpack project, including:
+
+* Setting release dates.
+* Release quality standards.
+* Technical direction.
+* Project governance and process.
+* GitHub repository management.
+* Conduct and maintain guidelines defined by the OpenJS Foundation Cross Project Council.
+* Maintaining the list of additional collaborators.
+* Development process and any coding standards.
+* Mediating technical conflicts between collaborators or `webpack` projects.
+
+The TSC voting members will define webpack project's release vehicles.
+
+### Section 4.1. webpack Project Operations
+
+The TSC voting members will establish and maintain a development process for the webpack project. The development
+process will establish guidelines for how the developers and community will operate. It will, for example, establish
+appropriate timelines for TSC review (e.g. agenda items must be published at least a certain number of hours in advance
+of a TSC meeting).
+
+Note that project operations remain subject to any relevant policy or process specified by the OpenJS Foundation board or Cross Project Council.
+
+### Section 4.2. Decision-making, Voting, and/or Elections
+
+#### Section 4.2.1. Elections
+
+These processes are described in webpack's [GOVERNANCE](GOVERNANCE/) document.
+
+#### Section 4.2.2. Decision Making
+
+For webpack projects' decisions, Collaborators and TSC voting members shall operate under Lazy Consensus ([consensus seeking][]). When an agenda item has appeared to reach a
+consensus, the moderator will ask "Does anyone object?" as a final call for dissent from the consensus. For all votes, a simple majority of all TSC voting members for, or against, the issue wins. A TSC voting member may
+choose to participate in any vote through abstention. Votes are needed to add new members, remove members from the TSC or deciding in project critical issues, such as roadmapping major versions of webpack core.
+
+
+## Section 5. Definitions
+
+* **Project**: a technical collaboration effort, e.g. a subsystem, that is organized through the webpack organization creation.
+
+----
+
+This work is a derivative of the [Node.js Project TSC Charter](https://github.com/nodejs/node/blob/main/TSC_CHARTER.md).
+
+[consensus seeking]: https://en.wikipedia.org/wiki/Consensus-seeking_decision-making

--- a/src/content/contribute/Governance-member-expectations.mdx
+++ b/src/content/contribute/Governance-member-expectations.mdx
@@ -1,0 +1,62 @@
+---
+title: Member Expectations
+group: Contribute
+sort: 2
+source: https://github.com/webpack/governance/blob/main/MEMBER_EXPECTATIONS.md
+edit: https://github.com/webpack/governance/edit/main/MEMBER_EXPECTATIONS.md
+---
+All participants in the webpack project must follow the
+[Code of Conduct][]. There are further expectations for members of the [TSC][].
+
+When decisions are made within the established guidelines and policies of the
+project, those in leadership roles have a responsibility to uphold and respect
+the decision even if they disagree with it. This is especially important in
+external communications, for example in social media. Should the member be
+unwilling or unable to do so, then they should resign their leadership position.
+This does not mean that decisions cannot be revisited and discussed within the
+team at a later time.
+
+Everyone participating in the webpack project must conduct themselves in
+a professional and respectful manner in accordance with our
+[Code of Conduct][]. In addition, some general guidelines for
+leadership group members include:
+
+- Remediate quickly when you realize you made a mistake. Leaders are human,
+  and they will make mistakes. However they should act swiftly to
+  acknowledge mistakes and correct them.
+- Aim to remediate first and then discuss.  If other members of the
+  team express concerns about actions, acknowledge their concerns by
+  stopping the actions in question and then discuss within the team
+  to come to a common agreement.
+- Treat all community members with respect, consideration, and highest
+  standards of ethical conduct.
+- Value a diversity of views and opinions. Avoid preferential
+  treatment, and hold everyone (including ourselves) accountable to the same
+  set of standards.  Everyone gets to speak up.
+- Deal with issues directly with the person in question. Resist complaining
+  about others in the project in a public sphere.
+- Build trust by keeping your promises.
+- Be the model of accountability and leadership. Provide the example of
+  ownership and stewardship that everyone can follow to success.
+- Commit to ongoing development and learning best practices for governing.
+- Criticize ideas rather than people, discussing any concerns in person
+  whenever possible, and taking responsibility for our statements.
+
+While the guidelines above focus primarily on the spaces where
+we participate in official foundation work (GitHub, IRC, meetings,
+conferences), it is important to recognize that the public behavior
+of members also reflects on the webpack project.
+
+If you're interested in an introduction to diversity, inclusion, and unconscious bias,
+[try this free training offered by our partners at the Linux Foundation](https://training.linuxfoundation.org/linux-courses/open-source-compliance-courses/inclusive-speaker-orientation).
+
+If it appears that any member of the project leadership is acting outside
+of the expectations set above please refer to our [moderation policy](./MODERATION_POLICY.md)
+which outlines the process of making an official complaint.
+
+---
+
+_This document is an adaption of the Node.js project [Member Expectations](https://github.com/nodejs/admin/blob/main/MemberExpectations.md)_
+
+[Code of Conduct]: https://github.com/webpack/webpack/blob/main/CODE_OF_CONDUCT.md
+[TSC]: ./CHARTER.md

--- a/src/content/contribute/Governance-moderation-policy.mdx
+++ b/src/content/contribute/Governance-moderation-policy.mdx
@@ -1,0 +1,304 @@
+---
+title: Moderation Policy
+group: Contribute
+sort: 3
+source: https://github.com/webpack/governance/blob/main/MODERATION_POLICY.md
+edit: https://github.com/webpack/governance/edit/main/MODERATION_POLICY.md
+---
+# Moderation policy
+
+If you are not a member of the webpack GitHub Organization and wish to submit a
+moderation request, please see [Requesting Moderation][]
+
+* [Applicability][]
+* [Terms][]
+* [Grounds for Moderation][]
+* [Requesting Moderation][]
+* [Consideration of Intent][]
+* [Guidelines and Requirements][]
+  * [Collaborator Posts][]
+  * [Non-Collaborator Posts][]
+  * [Temporary Interaction Limits][]
+  * [Temporary and Indefinite Blocks][]
+* [Privacy of the webpack/moderation Repository][]
+* [Escalation of Issues][]
+* [Modifications to This Policy][]
+
+## Applicability
+
+This policy applies to all repositories under the `webpack` and `webpack-contrib`
+GitHub Organizations and all webpack Working Groups. This policy also
+applies to the [webpack Slack Community](https://webpack.slack.com),
+supported by the Admin team of the Slack organization.
+
+## Terms
+
+* *Collaborator* refers to any individual with configured triage role or higher
+  in any webpack GitHub organizations repositories. See
+  [GitHub's Repository roles documentation][] for more information.
+* *TSC* refers to the [webpack Technical Steering Committee][].
+* *Post* refers to the content and titles of any issue, pull request, comment,
+  discussion, or wiki page.
+* *Moderate* means to modify, lock, or delete one or more Posts to correct or
+  address Code of Conduct violations.
+* *Remove* refers to the act of removing the configured write (commit)
+  permissions for an individual Collaborator's GitHub account from *all*
+  webpack GitHub Organizations repositories as well as removing the account from
+  the webpack GitHub Organizations membership.
+* *Block* refers to the act of prohibiting an individual GitHub account from any
+  further participation in the webpack GitHub Organizations. A block may be
+  *temporary* or *indefinite*.
+  * This Moderation Policy applies only to blocking from the organization.
+    Individuals may choose to
+    [block other individuals from their personal GitHub accounts][]. This policy
+    does not restrict blocking from personal GitHub accounts.
+* *Requester* refers to an individual requesting Moderation on a Post.
+
+## Grounds for Moderation
+
+Any Post in violation of the webpack [Code of Conduct][] is subject
+to Moderation.
+
+The TSC is responsible for deciding what constitutes inappropriate
+behavior that may be subject to Moderation.
+
+## Requesting Moderation
+
+Anyone may request Moderation of a Post. Requesting Moderation of a Post can be
+accomplished in one of four ways:
+
+* Via the [webpack-security@openjsf.org][] email address,
+* Via private email to individual TSC members,
+* Via a new Post in the same thread as the Post being requested for Moderation,
+* Via a new Post in the private webpack/moderation repository.
+
+Note that Collaborators may Moderate non-Collaborator Posts at any time without
+submitting an initial request (see: [Non-Collaborator Posts][]).
+
+Use of the [webpack-security@openjsf.org][] email address -- or private email to individual
+TSC members -- is appropriate when the individual requesting the
+Moderation does not feel comfortable directly or publicly making the request.
+All emails sent to the [webpack-security@openjsf.org][] address are currently forwarded
+to all members of the TSC.
+
+Requests should contain as much information and context as possible, including
+the URL and a screenshot of the Post in question. Screenshots may be modified
+to obscure obscene or offensive content.
+
+External public venues or social media services such as Twitter must never be
+used to request Moderation.
+
+Collaborators must never discuss the specific details of a Moderation request
+in any public forum or any social media service outside of the webpack GitHub
+Organization.
+
+Note that quoting the original content of a Post within a Moderation request or
+webpack/moderation repository issue is not a violation of the
+[Code of Conduct][]. However, discretion is advised when including such quotes
+in requests posted to public repositories.
+
+Requests for Moderation that do not appear to have been submitted in good faith
+with intent to address a legitimate [Code of Conduct][] violation will be
+ignored.
+
+## Consideration of Intent
+
+Before Moderating a Post, Collaborators should carefully consider the possible
+intent of the author. It may be that the author has simply made an error or is
+not yet familiar with the [Code of Conduct][]; or it may be that cultural
+differences exist, or that the author is unaware that certain content is
+inappropriate. In such cases, the author should be given an
+opportunity to correct any error that may have been made.
+
+Note, however, that unfamiliarity with the [Code of Conduct][] does not excuse
+a Post from Moderation.
+
+## Guidelines and Requirements
+
+* All Posts are expected to respect the webpack [Code of Conduct][].
+* Any Collaborator with triage permission to a given repository (except
+  webpack/moderation) may Moderate Posts within that repository's issue tracker.
+  Only the TSC is allowed to moderate posts on webpack/moderation.
+* The TSC serves as the final arbiter for all Moderation issues.
+* TSC members may Remove or Block an individual from the webpack
+  GitHub Organizations.
+* For any Removal or Blocking action, an issue describing the reasons for the
+  action, and identifying the Github account being acted upon, must be posted
+  to the Moderation Repository with an explanation provided by the Moderation
+  Team member performing the action.
+* Any individual Blocked from the webpack GitHub Organizations will be recommended
+  for exclusion from any webpack Foundation sponsored event or activity.
+* Minor edits to the formatting of a Post or to correct typographical errors
+  are not "Moderation". Such edits and their intent must
+  still be documented with a short note indicating who made the edit and why.
+
+### Collaborator Posts
+
+* Prior to Moderating any Post authored by a Collaborator, the author must be
+  given a reasonable opportunity to modify or remove the Post on their own.
+* If the author of the Post disagrees that Moderation is required, the matter
+  can be escalated to the TSC for resolution. In such cases, no Moderation
+  action may be taken until a decision by the TSC is made.
+* When Moderating any Post authored by another Collaborator, the moderating
+  Collaborator must:
+  * Explain the justification for Moderating the post,
+  * Identify all changes made to the Post, and
+  * Identify the steps previously taken to resolve the issue.
+  * If the Moderation action included Blocking, an indication of whether the Block
+    is temporary or indefinite is required, along with an issue posted to the
+    moderation repository justifying the action.
+* Explanations of Moderation actions on Collaborator Posts must be provided in:
+  * A new post within the original thread, or
+  * A new issue within the private webpack/moderation repository.
+* Any Collaborator habitually violating the Code of Conduct or this Moderation
+  policy may be Blocked temporarily or, in extreme cases, Removed and Blocked
+  indefinitely.
+
+### Non-Collaborator Posts
+
+* Posts authored by non-Collaborators are always subject to immediate Moderation
+by any Collaborator if the content is intentionally disruptive or in violation
+of the [Code of Conduct][].
+* When moderating non-Collaborator posts, the moderating Collaborator must:
+  * Explain the justification for Moderating the post, and
+  * Identify all changes made to the Post.
+  * If the Moderation action included Blocking, an indication of whether the Block
+    is temporary or indefinite is required, along with a note justifying the
+    action.
+* If an explanation of a Moderation action for a non-Collaborator Post is
+  provided, it must be provided in:
+  * The original Post being modified (as replacement or appended content),
+  * A new post within the original thread, or
+  * A new issue within the private webpack/moderation repository.
+* Moderation of Posts authored by non-Collaborators may result in those
+  non-Collaborators being Blocked temporarily or indefinitely from further
+  participation in the webpack GitHub organizations.
+* If it is clear that there is no intention to collaborate in good faith,
+  it is possible to hide comments of non-Collaborators. In that case there is
+  an exception to the reporting requirement described above.
+* Accounts that are reasonably believed to be bots (other than bots authorized
+  by the TSC) are subject to immediate Blocking.
+* Issues, pull requests, discussions, and comments that are spam (job posting,
+  service advertising, etc.) are subject to immediate moderation.
+* Issues, pull requests, discussions, and comments that are believed to be
+  LLM-generated (e.g a PR coming from a new contributor changing a single file
+  without clear motivation) should be closed with a comment such as "It seems
+  you are using a LLM, please stop, this is not bringing any value and is
+  wasting our time. If you are not using one, please read and follow our
+  contributing guidelines." Report the user to the moderation repository so they
+  get blocked if they do it again.
+* Collaborators may use the Hide feature in the GitHub interface for off-topic
+  posts by non-Collaborators.
+* TSC members can delete any issues or comments posted by accounts that have
+  been deleted by GitHub. These accounts show up in the GitHub interface as
+  user `ghost`. There is no need to screenshot or document these deletions.
+
+There are a few examples of moderating non-Collaborator posts:
+
+Scenario 1:
+ * A non-Collaborator posts a comment that indicates that they are a bot.
+ * A collaborator sees the post and hides it.
+ * No further action is necessary.
+
+Scenario 2:
+ * A non-Collaborator posts a comment that is against the Code of Conduct.
+ * A Collaborator sees the comment and asks the author to edit it.
+ * The author refuses to edit their comment.
+ * The Collaborator deletes the comment and posts an issue in the moderation
+   repository explaining their actions.
+
+Scenario 3:
+ * A non-Collaborator opens a pull request with comments indicating they are a
+   bot.
+ * A Collaborator sees that pull requests, closes it, deletes the comments
+   and posts an issue in the moderation repository explaining their actions.
+ * A TSC member sees the issue and decides to block the user from the
+   organization.
+
+Scenario 4:
+ * A non-Collaborator posts a comment on an old commit that is against the
+   Code of Conduct.
+ * A Collaborator sees the comment, takes a screenshot, and deletes it.
+ * The Collaborator posts an issue in the moderation repository explaining
+   their actions.
+
+### Temporary Interaction Limits
+
+The TSC may, at their discretion, choose to enable [GitHub's
+Temporary Interaction Limits][] on any GitHub repository in the webpack GitHub
+Organization.
+
+Any Collaborator may request that the TSC enable the Temporary
+Interaction Limits by posting an issue to the moderation repository. If the
+TSC chooses not to do so, then a comment explaining why that decision was made
+must be added to the moderation repository thread.
+
+### Temporary and Indefinite Blocks
+
+A Temporary Block is time limited, with the timeframe decided on by the Moderation
+Team at the time of issuing, depending on the severity of the issue. Recommended
+default options are 24-hour, 48-hour, and 7-day periods.
+
+An Indefinite Block is set for an unspecified period of time and may only be
+lifted for an individual through a simple majority vote of the Moderation
+Team.
+
+## Privacy of the webpack/moderation Repository
+
+The webpack/moderation Repository is used to discuss the potentially sensitive
+details of any specific moderation issue. The repository is private but
+accessible to all Collaborators. The details of any issue discussed within the
+webpack/moderation repository are expected to remain confidential and are not to
+be discussed in any public forum or social media service.
+
+Any Collaborator found to be violating the privacy of the webpack/moderation
+repository by repeatedly sharing or discussing the details of webpack/moderation
+issues in any public forum or social media service risks being permanently
+removed from the webpack GitHub organizations.
+
+## Escalation of Issues
+
+Moderation issue disputes not involving a TSC member may be escalated
+to the TSC for review by tagging the
+original issue, pull request, or associated webpack/moderation repository.
+Any such Moderation action may be overturned through a TSC vote.
+
+TSC members directly involved in a Moderation
+issue (as either the Requester or author of the Post in question) are
+required to recuse themselves from any decisions required to resolve the
+issue.
+
+Moderation disputes involving TSC members, including questions of whether a TSC
+member has violated the Code of Conduct, *shall* be referred to an
+Independent Mediator selected by the OpenJS Foundation.
+
+## Modifications to This Policy
+
+Modifications to this policy are subject to approval by the TSC.
+When modifications are proposed, if there are no objections after
+72 hours, the modifications are accepted. If there any objections to
+any proposed change, a TSC vote in favor of the change is required.
+
+---
+
+_This document is an adaption of the Node.js project [Moderation Policy](https://github.com/nodejs/admin/blob/HEAD/Moderation-Policy.md)_
+
+[Code of Conduct]: https://github.com/webpack/webpack/blob/main/CODE_OF_CONDUCT.md
+[webpack Technical Steering Committee]: ./CHARTER.md
+[GitHub's Repository roles documentation]: https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#repository-roles-for-organizations
+[GitHub's Temporary Interaction Limits]: https://github.com/blog/2370-introducing-temporary-interaction-limits
+[Applicability]: #applicability
+[Terms]: #terms
+[Grounds for Moderation]: #grounds-for-moderation
+[Requesting Moderation]: #requesting-moderation
+[Consideration of Intent]: #consideration-of-intent
+[Guidelines and Requirements]: #guidelines-and-requirements
+[Collaborator Posts]: #collaborator-posts
+[Non-Collaborator Posts]: #non-collaborator-posts
+[Temporary Interaction Limits]: #temporary-interaction-limits
+[Temporary and Indefinite Blocks]: #temporary-and-indefinite-blocks
+[Privacy of the webpack/moderation Repository]: #privacy-of-the-webpackmoderation-repository
+[Escalation of Issues]: #escalation-of-issues
+[Modifications to This Policy]: #modifications-to-this-policy
+[webpack-security@openjsf.org]: mailto:webpack-security@openjsf.org
+[block other individuals from their personal GitHub accounts]: https://help.github.com/en/articles/blocking-a-user-from-your-personal-account

--- a/src/content/contribute/Governance-working-groups.mdx
+++ b/src/content/contribute/Governance-working-groups.mdx
@@ -1,0 +1,223 @@
+---
+title: Working Groups
+group: Contribute
+sort: 4
+source: https://github.com/webpack/governance/blob/main/WORKING_GROUPS.md
+edit: https://github.com/webpack/governance/edit/main/WORKING_GROUPS.md
+---
+# webpack Working Groups
+
+webpack Working Groups are autonomous projects created by the
+[Technical Steering Committee (TSC)][].
+
+Working Groups can be formed at any time but must be ratified by the TSC.
+Once formed the work defined in the Working Group charter is the
+responsibility of the WG rather than the TSC.
+
+It is important that Working Groups are not formed prematurely. Working
+Groups are not formed to begin a set of tasks but instead are formed
+once that work is already underway and the contributors
+think it would benefit from being done as an autonomous project.
+
+If the work defined in a Working Group's charter is complete, the charter
+should be revoked.
+
+A Working Group's charter can be revoked either by consent of the Working
+Group's members or by a TSC vote. Once revoked, any future work that arises
+becomes the responsibility of the TSC.
+
+## Joining a WG
+
+To find out how to join a working group, consult the [GOVERNANCE.md][] in
+the working group's repository.
+
+## Starting a Working Group
+
+A Working Group is established by first defining a charter that can be
+ratified by the TSC. A charter is a statement of purpose and a
+list of responsibilities. When requesting that a working group be chartered, it
+is also necessary to provide a list of initial membership.
+
+A working group needs 3 initial members. These should be individuals
+already undertaking the work described in the charter.
+
+The list of responsibilities should be specific. Once established, these
+responsibilities are no longer governed by the TSC and therefore should
+not be broad or subjective. The only recourse the TSC has over the working
+group is to revoke the entire charter.
+
+If the responsibilities described in the charter are currently undertaken by
+another working group then the charter will additionally have to be ratified by
+that working group.
+
+You can submit the working group charter for ratification by sending
+a pull request to this document to add the charter it to the
+list of current Working Groups. Once ratified, the list of
+members should be maintained in the Working Group's
+README.
+
+## Bootstrap Governance
+
+Once the TSC ratifies a charter, the working group inherits the following
+documentation for governance, contribution, conduct and an MIT
+LICENSE. The working group is free to change these documents through their own
+governance process, hence the term "bootstrap."
+
+```markdown
+### *[insert WG name]* Working Group
+
+The webpack *[insert WG name]* is governed by a Working Group (WG)
+that is responsible for high-level guidance of the project.
+
+The WG has final authority over this project including:
+
+* Technical direction
+* Project governance and process (including this policy)
+* Contribution policy
+* GitHub repository hosting
+* Conduct guidelines
+* Maintaining the list of additional Collaborators
+
+For the current list of WG members, see the project
+[README.md](https://github.com/webpack/webpack/blob/main/README.md#current-project-members).
+
+### Collaborators
+
+The *[insert WG name]* GitHub repository is
+maintained by the WG and additional Collaborators who are added by the
+WG on an ongoing basis.
+
+Individuals making significant and valuable contributions are made
+Collaborators and given commit-access to the project. These
+individuals are identified by the WG and their addition as
+Collaborators is discussed during the weekly WG meeting.
+
+Modifications of the contents of the *[insert WG repo]* repository are made on
+a collaborative basis. Anybody with a GitHub account may propose a
+modification via pull request and it will be considered by the project
+Collaborators. All pull requests must be reviewed and accepted by a
+Collaborator with sufficient expertise who is able to take full
+responsibility for the change. In the case of pull requests proposed
+by an existing Collaborator, an additional Collaborator is required
+for sign-off. Consensus should be sought if additional Collaborators
+participate and there is disagreement around a particular
+modification. See _Consensus Seeking Process_ below for further detail
+on the consensus model used for governance.
+
+For the current list of Collaborators, see the project
+[README.md](https://github.com/webpack/webpack/blob/main/README.md#current-project-members).
+
+### WG Membership
+
+WG seats are not time-limited.  There is no fixed size of the WG.
+However, the expected target is between 6 and 12, to ensure adequate
+coverage of important areas of expertise, balanced with the ability to
+make decisions efficiently.
+
+There is no specific set of requirements or qualifications for WG
+membership beyond these rules.
+
+The WG may add additional members to the WG by unanimous consensus.
+
+A WG member may be removed from the WG by voluntary resignation, or by
+unanimous consensus of all other WG members.
+
+Changes to WG membership should be posted in the agenda, and may be
+suggested as any other agenda item (see "WG Meetings" below).
+
+If an addition or removal is proposed during a meeting, and the full
+WG is not in attendance to participate, then the addition or removal
+is added to the agenda for the subsequent meeting.  This is to ensure
+that all members are given the opportunity to participate in all
+membership decisions.  If a WG member is unable to attend a meeting
+where a planned membership decision is being made, then their consent
+is assumed.
+
+No more than 1/3 of the WG members may be affiliated with the same
+employer.  If removal or resignation of a WG member, or a change of
+employment by a WG member, creates a situation where more than 1/3 of
+the WG membership shares an employer, then the situation must be
+immediately remedied by the resignation or removal of one or more WG
+members affiliated with the over-represented employer(s).
+
+### Consensus Seeking Process
+
+The WG follows a [Consensus Seeking][] decision-making model.
+
+If an agenda item cannot reach a consensus a WG member can call for
+either a closing vote or a vote to table the issue to the next
+meeting. The call for a vote must be seconded by a majority of the WG
+or else the discussion will continue. Simple majority wins.
+
+Note that changes to WG membership require unanimous consensus. See
+"WG Membership" above.
+
+<a id="developers-certificate-of-origin"></a>
+## Developer's Certificate of Origin 1.1
+
+Use of a CLA or DCO is mandatory for all all OpenJS Foundation projects.
+The webpack project has chosen to use the DCO 1.1
+
+By making a contribution to this project, I certify that:
+
+* (a) The contribution was created in whole or in part by me and I
+  have the right to submit it under the open source license
+  indicated in the file; or
+
+* (b) The contribution is based upon previous work that, to the best
+  of my knowledge, is covered under an appropriate open source
+  license and I have the right under that license to submit that
+  work with modifications, whether created in whole or in part
+  by me, under the same open source license (unless I am
+  permitted to submit under a different license), as indicated
+  in the file; or
+
+* (c) The contribution was provided directly to me by some other
+  person who certified (a), (b) or (c) and I have not modified
+  it.
+
+* (d) I understand and agree that this project and the contribution
+  are public and that a record of the contribution (including all
+  personal information I submit with it, including my sign-off) is
+  maintained indefinitely and may be redistributed consistent with
+  this project or the open source license(s) involved.
+
+### Moderation Policy
+
+The [webpack Moderation Policy] applies to this WG.
+
+### Code of Conduct
+
+The [webpack Code of Conduct][] applies to this WG.
+
+[webpack Code of Conduct]: https://github.com/webpack/webpack/blob/main/CODE_OF_CONDUCT.md
+[webpack Moderation Policy]: https://github.com/webpack/governance/blob/main/MODERATION_POLICY.md
+[Consensus Seeking]: https://en.wikipedia.org/wiki/Consensus-seeking_decision-making
+```
+
+## Current Working Groups
+
+* [Core](#core)
+
+### [Core](https://github.com/webpack/webpack)
+
+The Core Working Group is responsible for the development and
+maintenance of the webpack bundler and its technical direction.
+
+Responsibilities include:
+
+* Maintaining the core of the webpack bundler
+* Reviewing and merging pull requests
+* Managing releases and versioning
+* Ensuring code quality and consistency
+* Addressing issues and bugs reported by the community
+* Developing new features and enhancements
+* Writing and maintaining documentation
+* Coordinating with other working groups and the TSC
+* Ensuring compliance with the project's code of conduct and governance policies
+
+---
+
+_This document is an adaption of the Node.js project [Working Groups Charter](https://github.com/nodejs/TSC/blob/main/WORKING_GROUPS.md)_
+
+[Technical Steering Committee (TSC)]: ./CHARTER.md

--- a/src/content/contribute/writers-guide.mdx
+++ b/src/content/contribute/writers-guide.mdx
@@ -6,7 +6,7 @@ contributors:
   - EugeneHlushko
 ---
 
-The following sections contain all you need to know about editing and formatting the content within this site. Make sure to do some research before starting your edits or additions. Sometimes the toughest part is finding where the content should live and determining whether or not it already exists.
+The following sections contain all you need to know about editing and formatting the content within this site. Make sure to do some research before starting your edits or additions. Sometimes the hardest part is finding where the content should live and determining whether or not it already exists.
 
 ## Process
 
@@ -43,10 +43,9 @@ Note that `related` will generate a **Further Reading** section at the bottom of
 
 ## Article Structure
 
-1. Brief Introduction - a paragraph or two so you get the basic idea about the what and why.
-2. Outline Remaining Content – how the content will be presented.
-3. Main Content - tell what you promised to tell.
-4. Conclusion - tell what you told and recap the main points.
+1. Brief Introduction - A paragraph or two to provide the basic idea of what and why.
+2. Main Content – explain the topic in detail as introduced earlier.
+3. Conclusion - tell what you told and recap the main points.
 
 ## Typesetting
 


### PR DESCRIPTION
## Description
Improved grammar, clarity, and formatting in the writers guide and related contribution documentation.

## Changes
- Fixed grammatical issues
- Improved sentence clarity
- Corrected ordered list formatting
- Minor formatting improvements

## Type of change
- Documentation update

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project's style guidelines
- [x] Lint checks pass