### PR TITLE
fix: remove invalid alt attribute from anchor tag in Print component

### DIFF
--- a/src/components/Print/Print.jsx
+++ b/src/components/Print/Print.jsx
@@ -43,7 +43,6 @@ export default function Print(props) {
         className="sidebar-item__title sidebar-link__print"
         href={printUrl}
         rel="nofollow noopener noreferrer"
-        alt="Print"
         title="Print"
         target="_blank"
       >


### PR DESCRIPTION
Summary
Removes an invalid attribute from the "<a>" tag in the Print sidebar component. "alt" is not a valid HTML attribute for anchor elements  : -  browsers silently ignore it but it fails HTML validation. link already has its title="Print"  for the tooltip and the nested image already has alt="Printer Icon" .

What kind of change does this PR introduce?
fix

Did you add tests for your changes?
No , removing an attribute which was already  ignored cannot affect behavior.

Does this PR introduce a breaking change?
No

If relevant, what needs to be documented once your changes are merged or what have you already documented?
N/A

Use of AI
N/A

