### PR TITLE
fix(sw): return inner promise in activate cache cleanup

### DIFF
--- a/src/sw.js
+++ b/src/sw.js
@@ -38,16 +38,18 @@ self.addEventListener("install", (event) => {
 self.addEventListener("activate", (event) => {
   // - [x] clean up outdated runtime cache
   event.waitUntil(
-    caches.open(cacheName).then((cache) => {
+    caches.open(cacheName).then((cache) =>
       // clean up those who are not listed in manifestURLs
-      cache.keys().then((keys) => {
-        for (const request of keys) {
-          if (!manifestURLs.includes(request.url)) {
-            cache.delete(request);
-          }
-        }
-      });
-    }),
+      cache
+        .keys()
+        .then((keys) =>
+          Promise.all(
+            keys
+              .filter((request) => !manifestURLs.includes(request.url))
+              .map((request) => cache.delete(request)),
+          ),
+        ),
+    ),
   );
 });
 


### PR DESCRIPTION
Summary
In the service worker's activate event handler, the inner cache.keys().then() promise was never returned from the outer .then() callback. this caused event.waitUntil() to resolve immediately with undefined before any stale cache entries were deleted. Old previous cache entries from previous deployment would be accumulated in users browsers with no guaranteed of cleanup. this fix returns the full promise chain and replaces the for loop with Promise.all() so all deletions run in parallel and event.waitUntil() only resolves once all stale entries are gone.

What kind of change does this PR introduce?
fix

Did you add tests for your changes?
No, the service worker runs in a browser context outside the Jest test environment. 

Does this PR introduce a breaking change?
No

If relevant, what needs to be documented once your changes are merged or what have you already documented?
N/A

Use of AI
N/A

