### PR TITLE
docs(parser): provide practical example for parser hooks usage

### DIFF
--- a/src/content/api/parser.mdx
+++ b/src/content/api/parser.mdx
@@ -9,6 +9,7 @@ contributors:
   - EugeneHlushko
   - chenxsan
   - snitin315
+  - moshams272
 ---
 
 The `parser` instance, found in the `compiler`, is used to parse each module
@@ -24,9 +25,17 @@ compiler.hooks.normalModuleFactory.tap("MyPlugin", (factory) => {
   factory.hooks.parser
     .for("javascript/auto")
     .tap("MyPlugin", (parser, options) => {
-      parser.hooks.someHook.tap("MyPlugin", (data) => {
-        // ...
-      });
+      // The `parser` provides many hooks, which are explained in detail below.
+      // Here is a practical example using the `call` hook to detect and warn
+      // about a deprecated API function when a developer calls it
+      // (e.g., `myCustomApiFunction()`):
+      parser.hooks.call
+        .for("myCustomApiFunction")
+        .tap("MyPlugin", (expression) => {
+          console.warn(
+            `Warning: 'myCustomApiFunction' is deprecated. Found call at line ${expression.loc.start.line}.`,
+          );
+        });
     });
 });
 ```


### PR DESCRIPTION
**Summary**

This PR replaces the confusing and non-existent `someHook` example in the `parser` hooks documentation with a practical, working example. 

I specifically chose the `call` hook for the new example because it demonstrates a highly relevant real-world scenario (detecting deprecated API functions) which makes the documentation much more engaging for readers. I also added explanatory comments to maintain the page's context for beginners without breaking the flow, and added my username to the `contributors` list.

Fixes #2015

*(Note: I am an aspiring GSoC contributor and this is my first PR to Webpack. I'm very excited to learn, improve, and contribute more to this amazing community!)*

**What kind of change does this PR introduce?**

docs (Documentation update)

**Did you add tests for your changes?**

No, this is a documentation-only change. However, I ran `yarn test` locally to ensure no formatting or build processes were broken, and everything passed successfully.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

This PR itself is a documentation update. No further documentation is needed.

**Use of AI**

Yes, I used an AI assistant to help me brainstorm a practical real-world use case for the `parser` hooks, understand the `SyncBailHook` architecture deeply, and refine the English grammar of my documentation comments. All code and explanations were thoroughly reviewed, understood, and tested by me locally before submitting.