### PR TITLE
fix(remark-responsive-table): correctly extract header text for data-th

### DIFF
--- a/src/remark-plugins/remark-responsive-table/remark-responsive-table.mjs
+++ b/src/remark-plugins/remark-responsive-table/remark-responsive-table.mjs
@@ -1,4 +1,5 @@
 // this plugin was first based on https://github.com/montogeek/remark-responsive-tables
+import { toString } from "mdast-util-to-string";
 import { visit } from "unist-util-visit";
 
 export default function remarkResponsiveTable() {
@@ -29,11 +30,8 @@ export default function remarkResponsiveTable() {
           const th = thead.children[index];
           td.data = {
             hProperties: {
-              dataTh:
-                // td in th could be empty
-                th.children.length > 0 ? th.children[0].value : "",
-              // FIXME what if td in th contains complex markdown??
-              // e.g. "`code` and something else", then data-th would be wrong.
+              // td in th could be empty
+              dataTh: th.children.length > 0 ? toString(th) : "",
             },
           };
         }


### PR DESCRIPTION
Summary
the remark-responsive-table plugin reads table header text using th.children[0].value to set the data-th attribute on each cell. This only works for plain text header and when  table header contains complex markdown such as code, bold, or links, children[0] is a structural node that has no .value property, causing data-th to set to "undefined". On the mobile, the CSS uses content : attr(data-th) to show the column label before each cell  ,so any affected table would show blank or "undefined" labels instead of the header text. 

What kind of change does this PR introduce?
fix

Did you add tests for your changes?
No, the existing test continue to pass. 

Does this PR introduce a breaking change?
No

If relevant, what needs to be documented once your changes are merged or what have you already documented?
N/A

Use of AI
N/A