### PR TITLE
docs(concepts): clarify zero-config entry default and error message

### DIFF
--- a/src/content/concepts/entry-points.mdx
+++ b/src/content/concepts/entry-points.mdx
@@ -12,6 +12,7 @@ contributors:
   - adyjs
   - anshumanv
   - ritikbanger
+  - saishankar404
 ---
 
 As mentioned in [Getting Started](/guides/getting-started/#using-a-configuration), there are multiple ways to define the `entry` property in your webpack configuration. We will show you the ways you **can** configure the `entry` property, in addition to explaining why it may be useful to you.
@@ -24,6 +25,8 @@ what should be included in the final bundle.
 The result of this process is later written to disk according to the
 `output` configuration, which controls where and how the bundled
 files are emitted.
+
+T> When running webpack without a configuration file, the entry defaults to `'./src/index.js'`. If that file is missing — even if your `src/` directory exists — webpack will throw: <br /> **`ERROR in Entry module not found: Error: Can't resolve './src'`** <br /><br /> The error says `'./src'` rather than `'./src/index.js'` because webpack resolves the directory first, then fails to find `index.js` inside it. To use a different entry filename, configure the `entry` option as shown in the sections below.
 
 ## Single Entry (Shorthand) Syntax
 

--- a/src/content/concepts/index.mdx
+++ b/src/content/concepts/index.mdx
@@ -20,6 +20,7 @@ contributors:
   - muhmushtaha
   - chenxsan
   - RyanGreyling2
+  - saishankar404
 ---
 
 At its core, **webpack** is a _static module bundler_ for modern JavaScript applications. When webpack processes your application, it internally builds a [dependency graph](/concepts/dependency-graph/) from one or more _entry points_ and then combines every module your project needs into one or more _bundles_, which are static assets to serve your content from.
@@ -58,6 +59,8 @@ export default {
   entry: "./path/to/my/entry/file.js",
 };
 ```
+
+T> When running webpack without a configuration file, the entry defaults to `'./src/index.js'`. If that file does not exist — even if your `src/` directory does — webpack will throw: <br /> **`ERROR in Entry module not found: Error: Can't resolve './src'`** <br /><br /> The error says `'./src'` rather than `'./src/index.js'` because webpack resolves the directory first and then fails to find the default `index.js` inside it. To use a different entry filename, add a `webpack.config.js` as shown in the example above.
 
 T> Learn more in the [entry points](/concepts/entry-points) section.
 


### PR DESCRIPTION
## what this does

adds a tip block to `concepts/index.mdx` and `concepts/entry-points.mdx` that explains:

- when running webpack without a config file, the entry defaults to `./src/index.js`
- if that file is missing, webpack throws `ERROR in Entry module not found: Error: Can't resolve './src'`
- why the error says `./src` rather than `./src/index.js` (webpack resolves the directory first, then looks for `index.js` inside it)
- how to fix it by pointing `entry` to the actual filename in a `webpack.config.js`

## why

the 2018 PR #2058 added a one-liner naming the default but didn't address the confusing mismatch between the error message (`./src`) and the actual missing file (`./src/index.js`). users still hit this confusion as noted in the last comment on the issue. the tip on the entry-points page also helps users who land there directly.

closes #2035