### PR TITLE
fix: replace reserved import prop with loadContent

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import Site from "./components/Site/Site.jsx";
 
 export default function App() {
-  return <Site import={(path) => import(`./content/${path}`)} />;
+  return <Site loadContent={(path) => import(`./content/${path}`)} />;
 }

--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -46,6 +46,7 @@ import "./Site.scss";
 import clientSideRedirections from "./clientSideRedirections.js";
 
 function Site(props) {
+  const { loadContent } = props;
   const location = useLocation();
   const navigate = useNavigate();
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
@@ -298,7 +299,7 @@ function Site(props) {
                     page={page}
                     next={next}
                     previous={previous}
-                    import={props.import}
+                    loadContent={loadContent}
                     path={path}
                   />
                 }
@@ -314,14 +315,15 @@ function Site(props) {
 }
 
 Site.propTypes = {
-  import: PropTypes.func,
+  loadContent: PropTypes.func,
 };
 
 export default Site;
 
 function PageElement(props) {
-  const { currentPage, sidebarPages, page, previous, next } = props;
-  const content = props.import(props.path);
+  const { currentPage, sidebarPages, page, previous, next, loadContent, path } =
+    props;
+  const content = loadContent(path);
   return (
     <Fragment>
       <Sponsors />
@@ -348,6 +350,6 @@ PageElement.propTypes = {
   previous: PropTypes.object,
   next: PropTypes.object,
   page: PropTypes.object,
-  import: PropTypes.func,
+  loadContent: PropTypes.func,
   path: PropTypes.string,
 };

--- a/src/server.jsx
+++ b/src/server.jsx
@@ -26,7 +26,7 @@ export default (locals) => {
               // note that here we use require instead of import
               // i.e., can't  reuse App.jsx
               // eslint-disable-next-line no-undef
-              import={(path) => require(`./content/${path}`)}
+              loadContent={(path) => require(`./content/${path}`)}
             />
           </div>
           {isPrintPage(locals.path) ? (


### PR DESCRIPTION
## Summary
This PR resolves a naming conflict caused by using the reserved JavaScript keyword `import` as a prop. The prop has been renamed to `loadContent` across the relevant components to avoid compatibility issues with modern JavaScript engines.

## Changes
- Replaced `import` prop with `loadContent`
- Updated references in:
  - App.jsx
  - server.jsx
  - Site.jsx

