### PR TITLE
Optimize flattenContent to avoid repeated array spreading

### DIFF
--- a/src/utilities/content-utils.mjs
+++ b/src/utilities/content-utils.mjs
@@ -21,16 +21,24 @@ export const walkContent = (tree, callback) => {
  * @return {array}       - A flattened list of leaf node descendants
  */
 export const flattenContent = (tree) => {
-  if (tree.children) {
-    return tree.children.reduce(
-      (flat, item) => [
-        ...flat,
-        ...(Array.isArray(item.children) ? flattenContent(item) : [item]),
-      ],
-      [],
-    );
+  const flat = [];
+  const walk = (node) => {
+    if (node && Array.isArray(node.children)) {
+      for (const child of node.children) {
+        walk(child);
+      }
+    } else {
+      flat.push(node);
+    }
+  };
+
+  if (tree && Array.isArray(tree.children)) {
+    for (const child of tree.children) {
+      walk(child);
+    }
   }
-  return [];
+
+  return flat;
 };
 
 /**


### PR DESCRIPTION
## Summary
Refactors the `flattenContent` utility to avoid repeated array spreading during tree flattening.

## Problem
The previous implementation used the spread operator inside a `reduce` callback:
`[...flat, ...flattenContent(item)]`.

This created a new array on every iteration, causing unnecessary memory allocations
and potentially leading to O(N²) time complexity for larger content trees.

## Solution
Replaced the spread-based approach with a more efficient traversal that accumulates
results in a single array. This reduces array copying and improves performance
while keeping the same behavior and output structure.

## Impact
- Improves performance for large content trees
- Reduces unnecessary array allocations
- No functional changes to the output