### PR TITLE
fix(prism-theme): fix typo .toke.variable -> .token.variable

### DIFF
--- a/src/components/Markdown/prism-theme.scss
+++ b/src/components/Markdown/prism-theme.scss
@@ -82,7 +82,7 @@ pre[class*="lang-"] {
 .token.entity,
 .token.url,
 .language-css .token.string,
-.toke.variable {
+.token.variable {
   color: #a9becc;
 }
 


### PR DESCRIPTION
Summary

 CSS selector for Prism variable tokens in the syntax highlight theme was misspelled as .toke.variable instead of .token.variable. 

What kind of change does this PR introduce?
fix

Did you add tests for your changes?

No. This is a one-character CSS typo fix.

Does this PR introduce a breaking change?
No.

If relevant, what needs to be documented once your changes are merged or what have you already documented?
N/A

Use of AI
N/A