### PR TITLE
docs(guides): update outdated package versions in code examples

### DIFF
--- a/src/content/guides/development.mdx
+++ b/src/content/guides/development.mdx
@@ -171,9 +171,9 @@ Let's add an npm script that will start webpack's Watch Mode:
    "author": "",
    "license": "ISC",
    "devDependencies": {
-     "html-webpack-plugin": "^4.5.0",
+     "html-webpack-plugin": "^5.0.0",
      "webpack": "^5.4.0",
-     "webpack-cli": "^4.2.0"
+     "webpack-cli": "^6.0.0"
    },
    "dependencies": {
      "lodash": "^4.17.20"
@@ -273,10 +273,10 @@ Let's add a script to easily run the dev server as well:
    "author": "",
    "license": "ISC",
    "devDependencies": {
-     "html-webpack-plugin": "^4.5.0",
+     "html-webpack-plugin": "^5.0.0",
      "webpack": "^5.4.0",
-     "webpack-cli": "^4.2.0",
-     "webpack-dev-server": "^3.11.0"
+     "webpack-cli": "^6.0.0",
+     "webpack-dev-server": "^5.0.0"
    },
    "dependencies": {
      "lodash": "^4.17.20"
@@ -400,11 +400,11 @@ Now add an npm script to make it a little easier to run the server:
    "license": "ISC",
    "devDependencies": {
      "express": "^4.17.1",
-     "html-webpack-plugin": "^4.5.0",
+     "html-webpack-plugin": "^5.0.0",
      "webpack": "^5.4.0",
-     "webpack-cli": "^4.2.0",
+     "webpack-cli": "^6.0.0",
      "webpack-dev-middleware": "^4.0.2",
-     "webpack-dev-server": "^3.11.0"
+     "webpack-dev-server": "^5.0.0"
    },
    "dependencies": {
      "lodash": "^4.17.20"

--- a/src/content/guides/getting-started.mdx
+++ b/src/content/guides/getting-started.mdx
@@ -121,7 +121,7 @@ T> If you want to learn more about the inner workings of `package.json`, then we
    "license": "MIT",
    "devDependencies": {
      "webpack": "^5.38.1",
-     "webpack-cli": "^4.7.2"
+     "webpack-cli": "^6.0.0"
    }
  }
 ```
@@ -310,7 +310,7 @@ Given it's not particularly fun to run a local copy of webpack from the CLI, we 
    "license": "ISC",
    "devDependencies": {
      "webpack": "^5.4.0",
-     "webpack-cli": "^4.2.0"
+     "webpack-cli": "^6.0.0"
    },
    "dependencies": {
      "lodash": "^4.17.20"


### PR DESCRIPTION
Summary

Updating the  outdated package version numbers in the Getting Started and Development guide code examples. The **package.json** snippets shown to users referenced packages that were 1-2 major versions behind current release.

What kind of change does this PR introduce?

Documentation fix - no code changes.

Did you add tests for your changes?

No tests needed .

Does this PR introduce a breaking change?

No.

If relevant, what needs to be documented?

N/A 

Use of AI

N/A