### PR TITLE
fix(process-readme): fix broken npm URL normalization

### DIFF
--- a/src/utilities/process-readme.mjs
+++ b/src/utilities/process-readme.mjs
@@ -30,7 +30,7 @@ function linkFixerFactory(sourceUrl) {
     const oldHref = href;
 
     if (href.includes("//npmjs.com")) {
-      href = href.replace("//www.npmjs.com");
+      href = href.replace("//npmjs.com", "//www.npmjs.com");
     }
 
     // Only resolve non-absolute urls from their source if they are not a document fragment link


### PR DESCRIPTION
Summary
 a broken npm url normalization in process-readme.mjs , The linkFixer function is used during build time to process all upstream loader and plugin READMEs fetched from GitHub and any npmjs.com link (without www.) in those READMEs was being silently corrupted into https:undefined/package/...    a completely broken URL.

What kind of change does this PR introduce?

Bug fix. 

Did you add tests for your changes?

The existing tests in process-readme.test.mjs all pass but still a  targeted test for npm URL normalization could be added as a follow-up.

Does this PR introduce a breaking change?

No. 

If relevant, what needs to be documented?

No need.

Use of AI
 Slightly for refining my words .