### PR TITLE
refactor: remove unused propTypes and defaultProps from HelloDarkness…

### DIFF
--- a/src/components/HelloDarkness.jsx
+++ b/src/components/HelloDarkness.jsx
@@ -1,4 +1,3 @@
-import PropTypes from "prop-types";
 import { useEffect, useSyncExternalStore } from "react";
 import { useLocalStorage } from "react-use";
 import { THEME_LOCAL_STORAGE_KEY, Theme } from "../constants/theme.mjs";
@@ -69,12 +68,3 @@ export default function HelloDarkness() {
     </Tooltip>
   );
 }
-
-HelloDarkness.propTypes = {
-  theme: PropTypes.oneOf([DARK, LIGHT]),
-  switchTheme: PropTypes.func,
-};
-
-HelloDarkness.defaultProps = {
-  theme: LIGHT,
-};


### PR DESCRIPTION
## Changes
- Removed unused `propTypes` and `defaultProps` from the HelloDarkness component.

## Reason
The component does not accept any props and manages the theme state internally using `useLocalStorage`, so these definitions were unnecessary.

## Impact
No functional changes. This improves code readability and removes redundant code.