### PR TITLE
fix: handle numbers above 6 digits in formatMoney (#7956)

### DIFF
--- a/src/components/Support/Support.jsx
+++ b/src/components/Support/Support.jsx
@@ -85,12 +85,7 @@ const monthlyRanks = {
 };
 
 function formatMoney(number) {
-  let str = `${Math.round(number)}`;
-
-  if (str.length > 3) {
-    str = `${str.slice(0, -3)},${str.slice(-3)}`;
-  }
-  return str;
+  return Math.round(number).toLocaleString("en-US");
 }
 
 export default class Support extends Component {


### PR DESCRIPTION
**Summary**

Fixes the [formatMoney](cci:1://file:///D:/GSoC%202026/Webpack/webpack.js.org/src/components/Support/Support.jsx:86:0-93:1) helper in [Support.jsx](cci:7://file:///D:/GSoC%202026/Webpack/webpack.js.org/src/components/Support/Support.jsx:0:0-0:0) which only inserted a single comma, incorrectly formatting numbers above 6 digits (e.g. `1234567` → `1234,567` instead of `1,234,567`).

Replaced the manual string slicing with `Number.toLocaleString('en-US')` which correctly handles thousands separators for any number length.

Closes #7956

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

No — this is a one-line utility fix. The function behavior can be verified visually on the Support/Sponsors page.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No documentation changes needed.

**Use of AI**

AI (Gemini CLI) was used to navigate the codebase and identify the bug location. The fix was determined through code analysis. I follow webpack's [AI Policy](https://github.com/webpack/governance/blob/main/AI_POLICY.md).
