### PR TITLE
fix(a11y): use distinct alt text for footer license icons

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -85,7 +85,12 @@ const Footer = () => (
           Changelog
         </Link>
         <Link className="footer__link footer__license" to="/license">
-          <img alt="Creative Commons License (CC)" src={CC} width={25} height={25} />
+          <img
+            alt="Creative Commons License (CC)"
+            src={CC}
+            width={25}
+            height={25}
+          />
           <img
             alt="Creative Commons Attribution (CC BY)"
             src={BY}


### PR DESCRIPTION
Fixes #7970

The footer license link contained two images with identical alt text
("Creative Commons License").

Screen readers may announce duplicated text.

This change provides distinct alt text for each Creative Commons icon
to avoid duplicate announcements by screen readers.