### PR TITLE
docs: fix typo 'CSS/SSS' → 'CSS/SCSS'

### DIFF
--- a/src/content/loaders/index.mdx
+++ b/src/content/loaders/index.mdx
@@ -11,6 +11,7 @@ contributors:
   - anshumanv
   - jamesgeorge007
   - chenxsan
+  - mr-baraiya
 ---
 
 Webpack enables use of [loaders](/concepts/loaders) to preprocess files. This allows you to bundle any static resource way beyond JavaScript. You can easily write your own loaders using Node.js.
@@ -54,7 +55,7 @@ Loaders are activated by using `loadername!` prefixes in `require()` statements,
 - [`css-loader`](/loaders/css-loader) Loads CSS file with resolved imports and returns CSS code
 - [`less-loader`](/loaders/less-loader) Loads and compiles a LESS file
 - [`sass-loader`](/loaders/sass-loader) Loads and compiles a SASS/SCSS file
-- [`postcss-loader`](/loaders/postcss-loader) Loads and transforms a CSS/SSS file using [PostCSS](http://postcss.org)
+- [`postcss-loader`](/loaders/postcss-loader) Loads and transforms a CSS/SCSS file using [PostCSS](http://postcss.org)
 - [`stylus-loader`](/loaders/stylus-loader/) Loads and compiles a Stylus file
 
 ## Frameworks


### PR DESCRIPTION
This PR fixes a typo in the documentation where **`CSS/SSS`** was written instead of **`CSS/SCSS`**.

Correcting the term improves clarity and ensures the documentation accurately reflects the intended technologies.
