### PR TITLE
docs: clarify Node.js version requirement

### DIFF
--- a/src/content/guides/getting-started.mdx
+++ b/src/content/guides/getting-started.mdx
@@ -32,7 +32,7 @@ contributors:
 
 Webpack is used to compile JavaScript modules. Once [installed](/guides/installation), you can interact with webpack either from its [CLI](/api/cli) or [API](/api/node). If you're still new to webpack, please read through the [core concepts](/concepts) and [this comparison](/comparison) to learn why you might use it over the other tools that are out in the community.
 
-W> The minimum supported Node.js version required to run webpack 5 is 10.13.0 (LTS).
+W> The minimum supported Node.js version to run webpack 5 is 10.13.0 (LTS).
 
 <StackBlitzPreview example="getting-started?terminal=" />
 


### PR DESCRIPTION
Improved wording of the Node.js version requirement in the Getting Started guide for clarity.