### PR TITLE
docs(guides): add import.defer() context module example to lazy loadi…

### DIFF
--- a/src/content/guides/lazy-loading.mdx
+++ b/src/content/guides/lazy-loading.mdx
@@ -241,9 +241,7 @@ export const greeting = "Bonjour";
 
 **src/index.js**
 
-{/* eslint-disable */}
-
-```js
+```text
 const language = navigator.language.split("-")[0]; // "en", "fr", etc.
 const locale = import.defer("./locales/" + language + ".js");
 
@@ -252,8 +250,6 @@ document.getElementById("btn").addEventListener("click", () => {
   document.getElementById("output").textContent = locale.greeting;
 });
 ```
-
-{/* eslint-enable */}
 
 Webpack prepares all matching locale modules so they are ready for execution, but the selected module is only evaluated when `locale.greeting` is first accessed. This allows you to load multiple locale files without executing them immediately.
 


### PR DESCRIPTION
Summary

This PR replaces the incomplete import.defer() context module example in the lazy loading guide  as the previous code block contained a commented out call (// const modules = import.defer(...)) that was never finished, leaving the section without a working example. The new example shows deferred evaluation of locale modules selected via a dynamic path expression, demonstrating how webpack includes all matching modules in the module graph while deferring execution until a property is first accessed.

What kind of change does this PR introduce?

Docs change

Did you add tests for your changes?

No

Does this PR introduce a breaking change?

No

If relevant, what needs to be documented once your changes are merged or what have you already documented?

The import.defer() context module support was shipped in webpack 5.105 and documented in the release blog post, but the corresponding section in the lazy loading guide was left with a stub example and this PR closes that gap directly in the guide.

Use of AI

N/A