### PR TITLE
docs: add AssetLoggerPlugin example to writing-a-plugin guide

### DIFF
--- a/src/content/contribute/writing-a-plugin.mdx
+++ b/src/content/contribute/writing-a-plugin.mdx
@@ -367,21 +367,22 @@ Webpack applies configuration defaults after plugins defaults are applied. This 
 
 ### Example: AssetLoggerPlugin
 
-The following example shows a minimal Webpack plugin that logs all generated assets during compilation.
+The following example shows a minimal Webpack plugin that logs all generated assets using Webpack’s logger interface.
 
 ```js
 class AssetLoggerPlugin {
   apply(compiler) {
     compiler.hooks.thisCompilation.tap("AssetLoggerPlugin", (compilation) => {
+      const logger = compilation.getLogger("AssetLoggerPlugin");
       compilation.hooks.processAssets.tap(
         {
           name: "AssetLoggerPlugin",
           stage: compilation.constructor.PROCESS_ASSETS_STAGE_SUMMARIZE,
         },
         (assets) => {
-          console.log("Generated assets:");
+          logger.info("Generated assets:");
           for (const assetName of Object.keys(assets)) {
-            console.log(assetName);
+            logger.info(assetName);
           }
         },
       );


### PR DESCRIPTION
This PR adds a minimal Webpack plugin example (AssetLoggerPlugin) to the "Writing a Plugin" guide.

The example demonstrates how to use the emit hook to log generated assets during compilation. This helps beginners understand Webpack plugin hooks and plugin architecture.