### PR TITLE
docs(configuration): document module.parser.javascript.importMeta 'preserve-unknown' value (5.105)

### DIFF
--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -821,11 +821,12 @@ Accepted values:
   };
   ```
 
-  With this configuration, custom properties on `import.meta` are preserved in the generated output:
+  With this configuration, custom properties on `import.meta` set by the build tool or runtime are preserved in the generated output:
 
   ```js
-  if (!import.meta.UNKNOWN_PROPERTY) {
-    import.meta.UNKNOWN_PROPERTY = "HELLO";
+  // import.meta.customProp is set externally (e.g. by a build tool or runtime)
+  if (import.meta.customProp) {
+    console.log(import.meta.customProp);
   }
   ```
 


### PR DESCRIPTION
Summary

The module.parser.javascript.importMeta option was documented only as a boolean, but webpack 5.105 added a third value 'preserve-unknown'. The 5.105 release blog post links to this configuration page, but the page hadn't been updated. This PR adds the new value to the type signature, explains the behavior of all three accepted values, and adds two code examples : one for false and one for 'preserve-unknown'.

What kind of change does this PR introduce?

Docs change

Did you add tests for your changes?

No

Does this PR introduce a breaking change?

No

If relevant, what needs to be documented once your changes are merged or what have you already documented?

The 'preserve-unknown' value was shipped in webpack 5.105 and mentioned in the release blog post, but the configuration reference had not been updated this PR closes that gap.

Use of AI

N/A