### PR TITLE
Fix missing quotes in CSS <link> tags and refactor redundant template#7993

### DIFF
--- a/src/server.jsx
+++ b/src/server.jsx
@@ -28,7 +28,7 @@ export default (locals) => {
   );
 
   const css = assets.css
-    .map((path) => `<link rel="stylesheet" href=${`${path}`} />`)
+    .map((path) => `<link rel="stylesheet" href="${path}" />`)
     .join("");
 
   const scripts = isPrintPage(locals.path)


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Issue closes: #7993 

This PR fixes a syntax issue in the SSG (Server-Side Generation) script where CSS `<link>` tags were being generated with unquoted `href` attributes. While most browsers handle unquoted attributes gracefully, it can lead to parsing errors if asset paths contain special characters or spaces.

Additionally, this PR simplifies the mapping logic by removing redundant template literal nesting (`${path}`) in favor of a cleaner string interpolation.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

**Bug fix** (Fixing invalid HTML syntax)
**Code cleanup** (Refactoring redundant template literals)
<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
No, as this is a minor syntax adjustment to a template literal within the HTML
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
N/A
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**
GitHub Copilot 
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->