### PR TITLE
fix: replace invalid anchor with button in PageLinks

### DIFF
--- a/src/components/PageLinks/PageLinks.jsx
+++ b/src/components/PageLinks/PageLinks.jsx
@@ -26,9 +26,9 @@ export default function PageLinks({ page = {} }) {
         Edit this page
       </a>
       <Separator />
-      <a className={classes} onClick={_handlePrintClick}>
+      <button type="button" className={classes} onClick={_handlePrintClick}>
         Print this page
-      </a>
+      </button>
       {page.repo ? (
         <>
           <Separator />


### PR DESCRIPTION
Fixes #7998

In `PageLinks.jsx`, the **"Print this page"** action was rendered as an `<a>` element without an `href`, which creates invalid link semantics and may cause accessibility and keyboard navigation issues.

This PR replaces it with a semantic `<button type="button">` while preserving the existing styling and behavior.

