### PR TITLE
fix(CodeBlockWithCopy): fixed token selectors for diff code blocks

### DIFF
--- a/src/components/CodeBlockWithCopy/CodeBlockWithCopy.jsx
+++ b/src/components/CodeBlockWithCopy/CodeBlockWithCopy.jsx
@@ -18,11 +18,20 @@ export default function CodeBlockWithCopy({ children }) {
 
     const clonedCodeElement = codeElement.cloneNode(true);
 
-    // Exclude +/-/unchanged tokens and removed lines
+    // Remove entire deleted lines
     for (const element of clonedCodeElement.querySelectorAll(
-      ".token.prefix.inserted, .token.prefix.unchanged, .token.deleted-sign.deleted",
+      ".token.deleted",
     )) {
       element.remove();
+    }
+
+    // Strip leading '+' from inserted lines
+    for (const element of clonedCodeElement.querySelectorAll(
+      ".token.inserted",
+    )) {
+      if (element.textContent.startsWith("+")) {
+        element.textContent = element.textContent.slice(1);
+      }
     }
 
     return clonedCodeElement.textContent || "";


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Fixes an issue where copying a diff code block also included removed lines (-). Updated getCodeText selectors to match the actual Prism.js classes
<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
Ran the existing Cypress spec code-block-with-copy.cy.js locally, confirmed it went from 1 failing to 2 passing after the fix.
<img width="1193" height="711" alt="Screenshot 2026-03-13 at 00 09 57" src="https://github.com/user-attachments/assets/92350b41-290c-4773-8e71-f27e61e76868" />


<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
N/A
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**
Copilot for understanding
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->