### PR TITLE
Enhancement: Add fallback for missing SVG Rendering in SplashViz.jsx

### DIFF
--- a/src/components/SplashViz/SplashViz.jsx
+++ b/src/components/SplashViz/SplashViz.jsx
@@ -26,7 +26,9 @@ export default class SplashViz extends Component {
         </h1>
         <div
           className="splash-viz__modules"
-          dangerouslySetInnerHTML={{ __html: HomeSVG.body }}
+          dangerouslySetInnerHTML={{
+            __html: HomeSVG?.body || "<!-- SVG not available -->",
+          }}
         ></div>
         <Cube
           className="splash-viz__cube"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

This PR adds null/undefined checks with a fallback message for SVG rendering in the `SplashViz.jsx` component. It ensures that if `HomeSVG.body` is missing, the component will not break and instead display a clear fallback.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
**Enhancement:** improves resilience and user feedback in case of missing SVG data.
<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
No
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**
GitHub Copilot
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->