### PR TITLE
refactor: remove non-functional UA tracking code in favor of future G…

### DIFF
--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -138,36 +138,6 @@ function Site(props) {
     }
   }, []);
 
-  useEffect(() => {
-    if (process.env.NODE_ENV === "production") {
-      const GA_ID = "UA-46921629-2";
-
-      if (!window.ga) {
-        window.ga ||= function ga() {
-          (ga.q = ga.q || []).push(arguments); // eslint-disable-line
-        };
-        ga.l = +new Date(); // eslint-disable-line
-
-        const gads = document.createElement("script");
-        gads.async = true;
-        gads.type = "text/javascript";
-        gads.src = "//www.google-analytics.com/analytics.js";
-        const [head] = document.getElementsByTagName("head");
-        head.appendChild(gads);
-
-        window.ga("create", GA_ID, "auto");
-      }
-
-      const path = location.pathname + location.search;
-      window.ga("set", {
-        page: path,
-        title: document.title,
-        location: document.location,
-      });
-      window.ga("send", { hitType: "pageview" });
-    }
-  }, [location]);
-
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {


### PR DESCRIPTION
**Summary**

The current Google Analytics implementation uses a Universal Analytics (UA) ID (`UA-46921629-2`), which was officially sunsetted by Google in July 2023. This code is no longer functional and no data is being collected. Removing this dead code cleans up the bundle and prepares the codebase for a future GA4 migration.

**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

No, this is a removal of non-functional third-party code.

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

N/A

**Use of AI**

Yes, I used AI for research purpose
