### PR TITLE
docs: clarify emit hook usage in writing-a-plugin guide

### DIFF
--- a/src/content/contribute/writing-a-plugin.mdx
+++ b/src/content/contribute/writing-a-plugin.mdx
@@ -32,22 +32,25 @@ class MyExampleWebpackPlugin {
   // Define `apply` as its prototype method which is supplied with compiler as its argument
   apply(compiler) {
     // Hook into the compilation
-    compiler.hooks.thisCompilation.tap("MyExampleWebpackPlugin", (compilation) => {
-      // Specify the asset processing hook
-      compilation.hooks.processAssets.tap(
-        {
-          name: "MyExampleWebpackPlugin",
-          stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
-        },
-        (assets) => {
-          console.log("This is an example plugin!");
-          console.log(
-            "Here’s the `compilation` object which represents a single build of assets:",
-            compilation
-          );
-        }
-      );
-    });
+    compiler.hooks.thisCompilation.tap(
+      "MyExampleWebpackPlugin",
+      (compilation) => {
+        // Specify the asset processing hook
+        compilation.hooks.processAssets.tap(
+          {
+            name: "MyExampleWebpackPlugin",
+            stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
+          },
+          (assets) => {
+            console.log("This is an example plugin!");
+            console.log(
+              "Here’s the `compilation` object which represents a single build of assets:",
+              compilation,
+            );
+          },
+        );
+      },
+    );
   }
 }
 ```


### PR DESCRIPTION
This PR adds a clarification note to the "Writing a Plugin" guide.
Some examples in the guide use the `emit` hook for simplicity.
However, modern Webpack plugins often use `compilation.hooks.processAssets`
for asset processing.
This note helps readers understand the modern approach without modifying
the existing example code.