### PR TITLE
chore(Page): update content PropTypes to reflect supported types

### DIFF
--- a/src/components/Page/Page.jsx
+++ b/src/components/Page/Page.jsx
@@ -188,8 +188,8 @@ Page.propTypes = {
     PropTypes.func,
     PropTypes.shape({
       // eslint-disable-next-line unicorn/no-thenable
-      then: PropTypes.func,
-      default: PropTypes.func,
+      then: PropTypes.func.isRequired,
+      default: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     }),
   ]),
 };


### PR DESCRIPTION
Update `content` PropTypes to reflect the supported content types.

The component accepts content as a string, function, or Promise-like object, but the previous PropTypes only supported a Promise shape.
