### PR TITLE
fix(content-tree): apply filtered children during restructure

### DIFF
--- a/src/utilities/content-tree-enhancers.mjs
+++ b/src/utilities/content-tree-enhancers.mjs
@@ -144,7 +144,7 @@ export function restructure(item, options) {
   if (item.children) {
     for (const child of item.children) restructure(child, options);
 
-    item.children.filter(filter);
+    item.children = item.children.filter(filter);
     item.children.sort(sort);
   }
 

--- a/src/utilities/content-tree-enhancers.test.mjs
+++ b/src/utilities/content-tree-enhancers.test.mjs
@@ -1,0 +1,57 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { describe, expect } from "@jest/globals";
+import { restructure } from "./content-tree-enhancers.mjs";
+
+describe("restructure", () => {
+  it("applies filter result back to children array", () => {
+    const originalChildren = [
+      {
+        type: "directory",
+        path: "src/content/guides",
+        title: "Guides",
+      },
+      {
+        type: "directory",
+        path: "src/content/api",
+        title: "API",
+      },
+    ];
+
+    const root = {
+      type: "directory",
+      path: "src/content",
+      children: originalChildren,
+    };
+
+    restructure(root, { dir: "src/content" });
+
+    // Filter creates a new array; restructure must assign that result back.
+    expect(root.children).not.toBe(originalChildren);
+    expect(root.children).toHaveLength(2);
+  });
+
+  it("sorts children after restructuring", () => {
+    const root = {
+      type: "directory",
+      path: "src/content",
+      children: [
+        {
+          type: "directory",
+          path: "src/content/guides",
+          title: "Guides",
+          sort: 20,
+        },
+        {
+          type: "directory",
+          path: "src/content/api",
+          title: "API",
+          sort: 10,
+        },
+      ],
+    };
+
+    restructure(root, { dir: "src/content" });
+
+    expect(root.children.map((item) => item.title)).toEqual(["API", "Guides"]);
+  });
+});


### PR DESCRIPTION
Summary
The content tree restructuring pipeline called item.children.filter(filter) but discarded the returned array and this made filtering a no-op and it could silently break future filter rules in navigation/content generation.
So this PR assigns the filtered result back to item.children before sorting, so the pipeline behavior matches its contract.

What kind of change does this PR introduce?
Bug fix

Did you add tests for your changes?
Yes

Does this PR introduce a breaking change?
No

If relevant, what needs to be documented once your changes are merged or what have you already documented?
No additional docs required.

Use of AI
Yes, I used an Ai collaborator to help review my initial logic and to assist in debugging the Jest ESM environment configuration but still, the identification of the no-op filter bug and the final implementation of the unit tests were manually verified and tested locally to ensure the pipeline correctness.