### PR TITLE
fix(a11y): improve keyboard accessibility for sidebar and external links

### DIFF
--- a/src/components/Link/Link.jsx
+++ b/src/components/Link/Link.jsx
@@ -8,7 +8,10 @@ const Link = ({ to = "", url, ...props }) => {
 
   if (to.startsWith("http") || to.startsWith("//")) {
     return (
-      <a href={to} target="_blank" rel="noopener noreferrer" {...others} />
+      <a href={to} target="_blank" rel="noopener noreferrer" {...others}>
+        {others.children}
+        <span className="screen-reader-only">(opens in a new tab)</span>
+      </a>
     );
   }
 

--- a/src/components/SidebarItem/SidebarItem.jsx
+++ b/src/components/SidebarItem/SidebarItem.jsx
@@ -64,13 +64,19 @@ export default class SidebarItem extends Component {
     return (
       <div className={`${block} ${openMod} ${disabledMod}`}>
         {anchors.length > 0 ? (
-          <ChevronRightIcon
-            width={15}
-            height={17}
-            fill="#175d96"
-            className={`${block}__toggle`}
+          <button
+            className={`${block}__toggle-button`}
             onClick={this._toggle.bind(this)}
-          />
+            aria-label={`Toggle ${title} section`}
+            aria-expanded={this.state.open}
+          >
+            <ChevronRightIcon
+              width={15}
+              height={17}
+              fill="#175d96"
+              className={`${block}__toggle`}
+            />
+          </button>
         ) : (
           <BarIcon
             className={`${block}__toggle`}

--- a/src/components/SidebarItem/SidebarItem.scss
+++ b/src/components/SidebarItem/SidebarItem.scss
@@ -21,6 +21,14 @@
     }
   }
 
+  &__toggle-button {
+    background: none;
+    border: none;
+    padding: 0;
+    display: flex;
+    align-items: center;
+  }
+
   &__title {
     flex: 1 1 auto;
     color: getColor(elephant);

--- a/src/components/SidebarMobile/SidebarMobile.jsx
+++ b/src/components/SidebarMobile/SidebarMobile.jsx
@@ -40,13 +40,13 @@ export default class SidebarMobile extends Component {
         />
 
         <div className="sidebar-mobile__content">
-          <span
-            role="button"
+          <button
             className="sidebar-mobile__close"
             onClick={toggle.bind(null, false)}
+            aria-label="Close navigation menu"
           >
             <CloseIcon fill="#fff" width={20} />
-          </span>
+          </button>
 
           {this._getSections()}
         </div>

--- a/src/components/SidebarMobile/SidebarMobile.scss
+++ b/src/components/SidebarMobile/SidebarMobile.scss
@@ -53,6 +53,7 @@
 .sidebar-mobile__close {
   position: absolute;
   cursor: pointer;
+  border: none;
   right: 22px;
   top: 10px;
   font-size: 1.3em;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -66,3 +66,15 @@ body {
     }
   }
 }
+
+.screen-reader-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Found a few accessibility issues while using the site with keyboard-only navigation and a screen reader. These changes fix them:

Sidebar toggle (SidebarItem) — The chevron icons (▶) next to sidebar items were raw <svg> elements with onClick. They couldn't be reached with Tab or activated with Enter/Space, which blocks keyboard-only users from expanding sidebar sections. Wrapped them in <button> and added aria-label + aria-expanded.

Mobile close button (SidebarMobile) — The close button was a <span role="button"> instead of a real <button>. Using a <span> with role="button" is an anti-pattern — real <button> elements are keyboard-accessible by default and don't need the ARIA role workaround. Added aria-label.

External links (Link) — All external links use target="_blank" but don't warn screen reader users that the link opens in a new tab. Added a visually hidden "(opens in a new tab)" text per WCAG H83 guidelines.



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix — accessibility improvement, no logic or visual changes.

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

No new unit tests — these components don't have existing tests. Verified manually: sidebar toggles are keyboard-focusable and operable via Enter/Space.

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No. Zero visual difference.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

AI was used to identify accessibility issues by auditing the component source code against WCAG guidelines, and to suggest the appropriate ARIA attributes (aria-label, aria-expanded). All code changes were written and reviewed manually.

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->