### PR TITLE
fix(Dropdown): prevent memory leak by removing event listeners on unmount

### DIFF
--- a/src/components/Dropdown/Dropdown.jsx
+++ b/src/components/Dropdown/Dropdown.jsx
@@ -14,21 +14,18 @@ export default class Dropdown extends Component {
   };
 
   componentDidMount() {
-    document.addEventListener(
-      "keyup",
-      this._closeDropdownOnEsc.bind(this),
-      true,
-    );
-    document.addEventListener(
-      "focus",
-      this._closeDropdownIfFocusLost.bind(this),
-      true,
-    );
-    document.addEventListener(
-      "click",
-      this._closeDropdownIfFocusLost.bind(this),
-      true,
-    );
+    this._boundCloseOnEsc = this._closeDropdownOnEsc.bind(this);
+    this._boundCloseLostFocus = this._closeDropdownIfFocusLost.bind(this);
+
+    document.addEventListener("keyup", this._boundCloseOnEsc, true);
+    document.addEventListener("focus", this._boundCloseLostFocus, true);
+    document.addEventListener("click", this._boundCloseLostFocus, true);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener("keyup", this._boundCloseOnEsc, true);
+    document.removeEventListener("focus", this._boundCloseLostFocus, true);
+    document.removeEventListener("click", this._boundCloseLostFocus, true);
   }
 
   _closeDropdownOnEsc(event) {


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

This PR fixes a memory leak in the `Dropdown` component where global event listeners were not being cleaned up upon unmounting.

- Prevents memory leaks 
- Improves performance and prevents garbage collection issues

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
fix(Dropdown): memory leak 
<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
verify
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
N/A
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->