### PR TITLE
docs: add MergeDuplicateChunksPlugin page

### DIFF
--- a/src/content/plugins/index.mdx
+++ b/src/content/plugins/index.mdx
@@ -31,6 +31,7 @@ Webpack has a rich plugin interface. Most of the features within webpack itself 
 | [`HtmlWebpackPlugin`](/plugins/html-webpack-plugin)                             | Easily create HTML files to serve your bundles                                         |
 | [`IgnorePlugin`](/plugins/ignore-plugin)                                        | Exclude certain modules from bundles                                                   |
 | [`LimitChunkCountPlugin`](/plugins/limit-chunk-count-plugin)                    | Set min/max limits for chunking to better control chunking                             |
+| [`MergeDuplicateChunksPlugin`](/plugins/merge-duplicate-chunks-plugin)          | Merge chunks that contain the same modules                                             |
 | [`MinChunkSizePlugin`](/plugins/min-chunk-size-plugin)                          | Keep chunk size above the specified limit                                              |
 | [`MiniCssExtractPlugin`](/plugins/mini-css-extract-plugin)                      | creates a CSS file per JS file which requires CSS                                      |
 | [`NoEmitOnErrorsPlugin`](/configuration/optimization/#optimizationemitonerrors) | Skip the emitting phase when there are compilation errors                              |

--- a/src/content/plugins/merge-duplicate-chunks-plugin.mdx
+++ b/src/content/plugins/merge-duplicate-chunks-plugin.mdx
@@ -1,0 +1,37 @@
+---
+title: MergeDuplicateChunksPlugin
+group: webpack
+contributors:
+  - shivxmsharma
+---
+
+Merges chunks that contain the same modules. This plugin is enabled by default as part of webpack's internal optimizations. Exporting it publicly allows developers to configure the `stage` at which merging occurs — useful when chunk merging needs to run after [`SplitChunksPlugin`](/plugins/split-chunks-plugin).
+
+```js
+new webpack.optimize.MergeDuplicateChunksPlugin({
+  // Options...
+});
+```
+
+## Options
+
+### stage
+
+`number`
+
+Controls the optimization stage at which duplicate chunk merging runs. By default, merging occurs before `SplitChunksPlugin`. Setting a higher `stage` value causes merging to run _after_ other optimizations such as `SplitChunksPlugin`.
+
+**webpack.config.js**
+
+```js
+import webpack from "webpack";
+
+export default {
+  // ...
+  plugins: [
+    new webpack.optimize.MergeDuplicateChunksPlugin({
+      stage: 10, // run after SplitChunksPlugin
+    }),
+  ],
+};
+```


### PR DESCRIPTION
**Summary**

Adds a documentation page for `MergeDuplicateChunksPlugin`, which was made publicly accessible in webpack/webpack#18965. Previously this plugin was internal only — now that it is exported, users need documentation to understand how to configure it.

Closes #7467

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

No — this is a documentation-only change.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

This PR adds the full documentation for `MergeDuplicateChunksPlugin`:
- A new page at `src/content/plugins/merge-duplicate-chunks-plugin.mdx` covering the `stage` option with a usage example
- An entry added to the plugins index table at `src/content/plugins/index.mdx`

**Use of AI**

I used Claude (claude.ai) as a coding assistant to help structure the MDX page consistent with existing plugin pages. All technical content (plugin API, `stage` option behavior) was verified against the webpack source in webpack/webpack#18965. Final review and decisions were made by me.
