### PR TITLE
improve(Navigation): specify PropTypes shape for links prop

### DIFF
--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -271,7 +271,15 @@ function Navigation({ links, pathname, hash = "", toggleSidebar }) {
 Navigation.propTypes = {
   pathname: PropTypes.string,
   hash: PropTypes.string,
-  links: PropTypes.array,
+  links: PropTypes.arrayOf(
+    PropTypes.shape({
+      content: PropTypes.node.isRequired,
+      url: PropTypes.string.isRequired,
+      isActive: PropTypes.func,
+      ariaLabel: PropTypes.string,
+      children: PropTypes.arrayOf(PropTypes.object),
+    }),
+  ).isRequired,
   toggleSidebar: PropTypes.func,
 };
 


### PR DESCRIPTION
Improves the PropTypes definition for the `links` prop in Navigation.jsx by specifying the expected object structure using `PropTypes.shape`. This makes the expected data format clearer and improves type safety for contributors.