### PR TITLE
fix(Navigation): add missing lang property for English dropdown item

### DIFF
--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -181,6 +181,7 @@ function Navigation({ links, pathname, hash = "", toggleSidebar }) {
               className=""
               items={[
                 {
+                  lang: "en",
                   title: "English",
                   url: `https://webpack.js.org${pathname}${locationHash}`,
                 },


### PR DESCRIPTION
Adds the missing `lang: "en"` property to the English item in the language dropdown in Navigation.jsx.

Other language entries already define a `lang` property, so this change ensures consistency across all dropdown items.