### PR TITLE
docs(guides): add source map example for libraries

### DIFF
--- a/src/content/guides/author-libraries.mdx
+++ b/src/content/guides/author-libraries.mdx
@@ -12,6 +12,7 @@ contributors:
   - AnayaDesign
   - chenxsan
   - wizardofhogwarts
+  - Debraj2024
 ---
 
 Aside from applications, webpack can also be used to bundle JavaScript libraries. The following guide is meant for library authors looking to streamline their bundling strategy.
@@ -118,6 +119,36 @@ export default {
 ```
 
 In the above example, we're telling webpack to bundle `src/index.js` into `dist/webpack-numbers.js`.
+
+### Adding Source Maps
+
+When bundling a library, it is recommended to generate source maps. Source maps
+allow consumers of your library to debug your original source code rather than
+the minified bundle. This can be done using the
+[`devtool`](/configuration/devtool/) option:
+
+**webpack.config.js**
+
+```diff
+  import path from 'node:path';
+  import { fileURLToPath } from 'node:url';
+
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+
+  export default {
+    entry: './src/index.js',
++   devtool: 'source-map',
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'webpack-numbers.js',
+    },
+  };
+```
+
+T> Using `'source-map'` as the `devtool` value generates a separate `.map` file
+alongside your bundle. Make sure to also publish this `.map` file so consumers
+can use it for debugging.
 
 ## Expose the Library
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

: Adds a section explaining how to configure source maps when authoring
libraries using the `devtool` option. Closes #3028

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

: docs

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

: No, this is a documentation-only change.

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

: No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

: This PR itself is the documentation change. Added a source map example
with a diff block showing how to add `devtool: 'source-map'` to the
webpack config when authoring libraries.

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

: Yes, I used Claude (claude.ai) to help me review the content for accuracy.
The final content was written and verified by me.

<img width="600" alt="Screenshot 2026-03-17 003054" src="https://github.com/user-attachments/assets/e8124fbb-1bba-41db-81f6-d3f6a083bba2" />


<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->