### PR TITLE
docs: add css-utility-loader to community loaders list

### DIFF
--- a/src/content/loaders/index.mdx
+++ b/src/content/loaders/index.mdx
@@ -52,6 +52,7 @@ Loaders are activated by using `loadername!` prefixes in `import .. from "mod";`
 
 - [`style-loader`](/loaders/style-loader) Add exports of a module as style to DOM
 - [`css-loader`](/loaders/css-loader) Loads CSS file with resolved imports and returns CSS code
+- [`css-utility-loader`](https://github.com/SahilKhanWDC/css-utility-loader-webpack-.git) - Automatically parses and translates legacy CSS properties into modern utility classes (Tailwind) at build-time.
 - [`less-loader`](/loaders/less-loader) Loads and compiles a LESS file
 - [`sass-loader`](/loaders/sass-loader) Loads and compiles a SASS/SCSS file
 - [`postcss-loader`](/loaders/postcss-loader) Loads and transforms a CSS/SSS file using [PostCSS](http://postcss.org)


### PR DESCRIPTION
### What is the purpose of this pull request?
This PR adds `css-utility-loader` to the community loaders list. 

### What does this loader do?
`css-utility-loader` provides an automated migration path for legacy codebases moving to utility-first CSS frameworks (like Tailwind CSS). Instead of relying on brittle regex, it uses PostCSS to parse incoming `.css` files into an AST, maps legacy declarations to utility dictionaries, resolves pseudo-classes and media queries, and outputs a pure JavaScript module.

**Use Case:** It allows enterprise teams to seamlessly compile massive legacy CSS files into modern utility classes during the Webpack build step, removing the need for immediate manual rewrites while ensuring zero unused CSS is shipped to the browser.

### Links
* **NPM:** https://www.npmjs.com/package/css-utility-loader
* **GitHub:** https://github.com/SahilKhanWDC/css-utility-loader-webpack-.git

Thank you for your time and review!
- Sahil Khan