### PR TITLE
docs(configuration): document default conditionNames by mode, target, and dependency type

### DIFF
--- a/src/content/configuration/resolve.mdx
+++ b/src/content/configuration/resolve.mdx
@@ -316,13 +316,13 @@ The base conditions always include:
 
 Additional conditions are appended depending on the [`target`](/configuration/target/):
 
-| Target property  | Condition    |
-| ---------------- | ------------ |
-| `webworker`      | `"worker"`   |
-| `node`           | `"node"`     |
-| `web`            | `"browser"`  |
-| `electron`       | `"electron"` |
-| `nwjs`           | `"nwjs"`     |
+| Target property | Condition    |
+| --------------- | ------------ |
+| `webworker`     | `"worker"`   |
+| `node`          | `"node"`     |
+| `web`           | `"browser"`  |
+| `electron`      | `"electron"` |
+| `nwjs`          | `"nwjs"`     |
 
 For example, with `target: "web"` (the default) and `mode: "production"`, the base `conditionNames` defaults to `["webpack", "production", "browser"]`.
 
@@ -330,12 +330,12 @@ For example, with `target: "web"` (the default) and `mode: "production"`, the ba
 
 Webpack further adjusts `conditionNames` through [`resolve.byDependency`](/configuration/resolve/#resolvebydependency) depending on how a module is imported. The `"..."` token inherits from the base conditions above.
 
-| Dependency type                    | `conditionNames`                    | Used for                                        |
-| ---------------------------------- | ----------------------------------- | ----------------------------------------------- |
-| `esm`, `wasm`, `loaderImport`      | `["import", "module", "..."]`       | ESM `import` statements, WebAssembly, loader imports |
-| `commonjs`, `amd`, `loader`, `unknown`, `undefined` | `["require", "module", "..."]` | `require()` calls, AMD, and other dependency types |
-| `worker`                           | `["worker", "import", "module", "..."]` | `new Worker()` expressions                  |
-| `css-import`                       | `["webpack", <mode>, "style"]`      | CSS `@import` statements                        |
+| Dependency type                                     | `conditionNames`                        | Used for                                             |
+| --------------------------------------------------- | --------------------------------------- | ---------------------------------------------------- |
+| `esm`, `wasm`, `loaderImport`                       | `["import", "module", "..."]`           | ESM `import` statements, WebAssembly, loader imports |
+| `commonjs`, `amd`, `loader`, `unknown`, `undefined` | `["require", "module", "..."]`          | `require()` calls, AMD, and other dependency types   |
+| `worker`                                            | `["worker", "import", "module", "..."]` | `new Worker()` expressions                           |
+| `css-import`                                        | `["webpack", <mode>, "style"]`          | CSS `@import` statements                             |
 
 For instance, when a file uses `import` in a project with `target: "web"` and `mode: "production"`, the final resolved conditions are `["import", "module", "webpack", "production", "browser"]`.
 


### PR DESCRIPTION
## Summary

The `resolve.conditionNames` documentation currently lacks information about its default values. This PR adds comprehensive documentation explaining:

- **Base conditions**: `"webpack"` is always present, `"production"`/`"development"` is added based on `mode`, and target-specific conditions (`"browser"`, `"node"`, `"worker"`, `"electron"`, `"nwjs"`) are added based on `target`.
- **Per-dependency type conditions**: A table showing how `conditionNames` varies depending on how a module is imported (ESM `import`, CommonJS `require()`, `new Worker()`, CSS `@import`), using `resolve.byDependency`.
- **resolveLoader defaults**: A note referencing the different defaults used by `resolveLoader` (`["loader", "require", "node"]`).

The information is derived from [`lib/config/defaults.js`](https://github.com/webpack/webpack/blob/main/lib/config/defaults.js#L1930-L2068) in the webpack source.

Closes https://github.com/webpack/webpack.js.org/issues/7560

## What kind of change does this PR introduce?

Documentation improvement — no code changes.

## Did you add tests for your changes?

N/A (documentation only).

## Does this PR introduce a breaking change?

No.

## If relevant, what needs to be documented once your changes are merged or what have you already documented?

This PR is the documentation itself.

## Use of AI

AI tools were used to assist with reading the webpack source code and drafting the documentation.


Made with [Cursor](https://cursor.com)