### PR TITLE
docs: add pnpm command to webpack 5 migration guide

### DIFF
--- a/src/content/migrate/5.mdx
+++ b/src/content/migrate/5.mdx
@@ -119,6 +119,8 @@ Now let's upgrade webpack to version 5:
 
 - Yarn: `yarn add webpack@latest`
 
+- pnpm: `pnpm add webpack@latest`
+
 If you were not able to upgrade some plugins/loaders to the latest in Upgrade webpack 4 and its plugins/loaders step, don't forget to upgrade them now.
 
 ### Clean up configuration


### PR DESCRIPTION
Adds pnpm equivalent for npm and yarn install commands in the webpack 5 migration guide