### PR TITLE
docs(guides): fix package exports example

### DIFF
--- a/src/content/guides/package-exports.mdx
+++ b/src/content/guides/package-exports.mdx
@@ -39,14 +39,14 @@ An example:
 }
 ```
 
-| Module request                   | Result                                 |
-| -------------------------------- | -------------------------------------- |
-| `package`                        | `.../package/main.js`                  |
-| `package/sub/path`               | `.../package/secondary.js`             |
-| `package/prefix/some/file.js`    | `.../package/directory/some/file.js`   |
-| `package/prefix/deep/file.js`    | `.../package/other-directory/file.js`  |
-| `package/other-prefix/deep/file` | `.../package/yet-another/deep/file.js` |
-| `package/main.js`                | Error                                  |
+| Module request                   | Result                                           |
+| -------------------------------- | ------------------------------------------------ |
+| `package`                        | `.../package/main.js`                            |
+| `package/sub/path`               | `.../package/secondary.js`                       |
+| `package/prefix/some/file.js`    | `.../package/directory/some/file.js`             |
+| `package/prefix/deep/file.js`    | `.../package/other-directory/file.js`            |
+| `package/other-prefix/deep/file` | `.../package/yet-another/deep/file/deep/file.js` |
+| `package/main.js`                | Error                                            |
 
 ## Alternatives
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

This one addresses #5820 by correcting the example for package exports.

**What kind of change does this PR introduce?**

Corrected the line:

`| `package/other-prefix/deep/file.js` | `.../package/yet-another/deep/file/deep/file.js` |`

It now correctly has `file` for `package/other-prefix/deep` and removes the extra `deep/file` from the other side.

**Did you add tests for your changes?**

N/A - docs change.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

N/A.

**Use of AI**

AI was used to identify the correct file to edit and to verify that the manual changes were correct. I take full responsibility for all changes in this PR.