### PR TITLE
refactor(Cube): migrate from SCSS to Tailwind CSS

### DIFF
--- a/src/components/Cube/Cube.jsx
+++ b/src/components/Cube/Cube.jsx
@@ -160,15 +160,6 @@ export default class Cube extends Component {
       },
     };
 
-    // Base classes applied to all faces
-    const baseFaceClasses = "absolute w-full h-full border-white";
-
-    // Distinguish styles for inner vs outer faces natively via Tailwind
-    const isOuter = type === "outer";
-    const variantClasses = isOuter
-      ? "border bg-blue-200/50 transition-[border-width] duration-200 delay-200"
-      : "border-2 bg-blue-400";
-
     return [
       "rotateX(0deg)",
       "rotateX(-90deg)",
@@ -177,14 +168,15 @@ export default class Cube extends Component {
       "rotateY(90deg)",
       "rotateY(180deg)",
     ].map((rotation, i) => {
-      const borderStyles = isOuter
-        ? {
-            borderTopWidth: borderWidthMap[i].top[iteration],
-            borderRightWidth: borderWidthMap[i].right[iteration],
-            borderBottomWidth: borderWidthMap[i].bottom[iteration],
-            borderLeftWidth: borderWidthMap[i].left[iteration],
-          }
-        : {};
+      const borderStyles =
+        type === "outer"
+          ? {
+              borderTopWidth: borderWidthMap[i].top[iteration],
+              borderRightWidth: borderWidthMap[i].right[iteration],
+              borderBottomWidth: borderWidthMap[i].bottom[iteration],
+              borderLeftWidth: borderWidthMap[i].left[iteration],
+            }
+          : {};
 
       return (
         <section


### PR DESCRIPTION
**Summary**

This PR migrates the Cube component from SCSS to Tailwind CSS as part of the effort described in #8047.

The goal is to gradually reduce SASS usage and move towards Tailwind-based styling.  
In this PR:
- Replaced SCSS styles with Tailwind utility classes
- Removed the `Cube.scss` file
- Preserved the existing UI and behavior of the component

---

**What kind of change does this PR introduce?**
refactor

---

**Did you add tests for your changes?**
No

---

**Does this PR introduce a breaking change?**
No

---

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
No 