### PR TITLE
docs: add mode defaults tables for optimization.chunkIds and optimization.moduleIds

### DIFF
--- a/src/content/configuration/optimization.mdx
+++ b/src/content/configuration/optimization.mdx
@@ -45,8 +45,13 @@ export default {
 
 Tells webpack which algorithm to use when choosing chunk ids. Setting `optimization.chunkIds` to `false` tells webpack that none of built-in algorithms should be used, as custom one can be provided via plugin. There are a couple of defaults for `optimization.chunkIds`:
 
-- Also if the environment is development then `optimization.chunkIds` is set to `'named'`, while in production it is set to `'deterministic'`
-- if none of the above, `optimization.chunkIds` will be defaulted to `'natural'`
+The default value of `optimization.chunkIds` depends on the [`mode`](/configuration/mode/):
+
+| Mode          | Default           |
+| ------------- | ----------------- |
+| `development` | `'named'`         |
+| `production`  | `'deterministic'` |
+| `none`        | `'natural'`       |
 
 The following string values are supported:
 
@@ -344,6 +349,14 @@ Basically, `'...'` is [a shortcut to access the default configuration value](htt
 `boolean: false` `string: 'natural' | 'named' | 'deterministic' | 'size'`
 
 Tells webpack which algorithm to use when choosing module ids. Setting `optimization.moduleIds` to `false` tells webpack that none of built-in algorithms should be used, as custom one can be provided via plugin.
+
+The default value of `optimization.moduleIds` depends on the [`mode`](/configuration/mode/):
+
+| Mode          | Default           |
+| ------------- | ----------------- |
+| `development` | `'named'`         |
+| `production`  | `'deterministic'` |
+| `none`        | `'natural'`       |
 
 The following string values are supported:
 


### PR DESCRIPTION
## Summary

This PR addresses issue #6356 by replacing the confusing bullet point format for default values with clean, easy-to-read tables.

## What kind of change does this PR introduce?
docs

## Changes made
- Replaced bullet points in `optimization.chunkIds` with a defaults table showing values for development, production and none modes
- Added missing defaults table for `optimization.moduleIds`

## Did you add tests for your changes?
No - this is a documentation-only change.

## Does this PR introduce a breaking change?
No.

## If relevant, what needs to be documented?
N/A - this PR IS the documentation change.

## Use of AI
I used Claude (claude.ai) as a learning assistant to help me understand the codebase, navigate the repo, and understand what changes were needed. The actual code changes and decisions were guided by the existing issue #6356 proposal. I reviewed and understood every change before applying it.