### PR TITLE
docs(guides): mention webpackExports in tree shaking and code splitting

### DIFF
--- a/src/content/guides/code-splitting.mdx
+++ b/src/content/guides/code-splitting.mdx
@@ -376,6 +376,17 @@ cacheable modules 530 KiB
 webpack 5.4.0 compiled successfully in 268 ms
 ```
 
+T> You can also use magic comment `webpackExports` with `import()` to expose specific exports from a dynamically imported module:
+
+```js
+import(
+  /* webpackExports: ["default", "namedExport"] */
+  "./module"
+);
+```
+
+This can help webpack tree shake other unused exports. See [Magic Comments](/api/module-methods/#magic-comments) for details.
+
 As `import()` returns a promise, it can be used with [`async` functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function). Here's how it would simplify the code:
 
 **src/index.js**

--- a/src/content/guides/tree-shaking.mdx
+++ b/src/content/guides/tree-shaking.mdx
@@ -187,6 +187,8 @@ The [`sideEffects`](/configuration/optimization/#optimizationsideeffects) and [`
 
 `usedExports` relies on [terser](https://github.com/terser-js/terser) to detect side effects in statements. It is a difficult task in JavaScript and not as effective as straightforward `sideEffects` flag. It also can't skip subtree/dependencies since the spec says that side effects need to be evaluated. While exporting function works fine, React's Higher Order Components (HOC) are problematic in this regard.
 
+If you're using dynamic `import()`, you can also use the `webpackExports` magic comment to specify the exports that should be exposed, allowing webpack to tree shake the others. See [Magic Comments](/api/module-methods/#magic-comments).
+
 Let's make an example:
 
 ```js


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

This PR adds `webpackExports` guidance to the Tree Shaking and Code Splitting guides, addressing #4492 .

`webpackExports` is already documented in the Magic Comments API docs, but #4492 noted that it should also be mentioned in the Tree Shaking and Code Splitting guides. This PR addresses that.

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

N/A, this PR only changes documentation.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

This PR updates the Tree Shaking and Code Splitting guides.

**Use of AI**

AI was used to assist with initial drafting and to check for errors in my edits. I reviewed the final text myself and take full responsibility for this contribution.