### PR TITLE
docs: clarify entry syntax and output filename behavior

### DIFF
--- a/src/content/concepts/entry-points.mdx
+++ b/src/content/concepts/entry-points.mdx
@@ -32,6 +32,9 @@ T> When running webpack without a configuration file, the entry defaults to `'./
 
 Usage: `entry: string | [string]`
 
+- `string`: a single entry file
+- `[string]`: multiple entry files
+
 **webpack.config.js**
 
 ```js
@@ -83,6 +86,11 @@ Single Entry Syntax is a great choice when you are looking to quickly set up a w
 ## Object Syntax
 
 Usage: `entry: { <entryChunkName> string | [string] } | {}`
+
+- `<entryChunkName>`: name of the entry chunk
+- `string`: single entry file
+- `[string]`: multiple entry files
+- `{}`: empty object
 
 **webpack.config.js**
 
@@ -192,22 +200,26 @@ export default {
 };
 ```
 
+When building in `production` mode:
+
 **webpack.prod.js**
 
 ```js
 export default {
   output: {
-    filename: "[name].[contenthash].bundle.js",
+    filename: "[name].[contenthash].bundle.js", // eg: main.abc123.bundle.js, vendor.abc123.bundle.js
   },
 };
 ```
+
+When building in `development` mode:
 
 **webpack.dev.js**
 
 ```js
 export default {
   output: {
-    filename: "[name].bundle.js",
+    filename: "[name].bundle.js", // eg: main.bundle.js, vendor.bundle.js
   },
 };
 ```


### PR DESCRIPTION
Ref: [Use an HTML file as an entry point?](https://github.com/webpack/webpack/issues/536)

Summary
Improve the documentation of Webpack entry configuration and output filenames by clarifying type definitions, entry object usage, and filename behavior for production and development builds.

What kind of change does this PR introduce?
Documentation update.

Did you add tests for your changes?
No

Does this PR introduce a breaking change?
No.

If relevant, what needs to be documented once your changes are merged or what have you already documented?

- Clarified usage of `entry`: single file, multiple files, named object entries, and empty object.
- Explained `<entryChunkName>` meaning.
- Documented production vs development output filenames with examples.

Use of AI
Used AI assistance to help refine the wording