### PR TITLE
docs: fix grammar and punctuation in loaders and optimization documen…

### DIFF
--- a/src/content/api/loaders.mdx
+++ b/src/content/api/loaders.mdx
@@ -651,7 +651,7 @@ T> Loaders were originally designed to also work as Babel transforms. Therefore,
 
 ## Webpack specific properties
 
-The loader interface provides all module relate information. However in rare cases you might need access to the compiler api itself.
+The loader interface provides all module relate information. However, in rare cases you might need access to the compiler API itself.
 
 W> Please note that using these webpack specific properties will have a negative impact on your loaders compatibility.
 

--- a/src/content/concepts/loaders.mdx
+++ b/src/content/concepts/loaders.mdx
@@ -44,7 +44,7 @@ export default {
 };
 ```
 
-T> While in the previous examples we used a loader to load CSS files, webpack has an experimental option ([`experiments.css`](https://webpack.js.org/configuration/experiments/)) that allows Webpack to process CSS and automatically inject the styles into the webpage.
+T> While in the previous examples we used a loader to load CSS files, webpack has an experimental option ([`experiments.css`](https://webpack.js.org/configuration/experiments/)) that allows webpack to process CSS and automatically inject the styles into the webpage.
 
 ## Using Loaders
 

--- a/src/content/configuration/optimization.mdx
+++ b/src/content/configuration/optimization.mdx
@@ -152,7 +152,7 @@ export default {
 };
 ```
 
-W> The `⁠optimization.avoidEntryIife` option can negatively affect build performance, if you prioritize build performance over these optimizations, consider disabling this option.
+W> The `optimization.avoidEntryIife` option can negatively affect build performance. If you prioritize build performance over these optimizations, consider disabling this option.
 
 ## optimization.flagIncludedChunks
 
@@ -378,7 +378,7 @@ export default {
 };
 ```
 
-`deterministic` option is useful for long term caching, but still results in smaller bundles compared to `hashed`. Length of the numeric value is chosen to fill a maximum of 80% of the id space. By default a minimum length of 3 digits is used when `optimization.moduleIds` is set to `deterministic`. To override the default behaviour set `optimization.moduleIds` to `false` and use the `webpack.ids.DeterministicModuleIdsPlugin`.
+The `deterministic` option is useful for long term caching, but still results in smaller bundles compared to `hashed`. Length of the numeric value is chosen to fill a maximum of 80% of the id space. By default a minimum length of 3 digits is used when `optimization.moduleIds` is set to `deterministic`. To override the default behaviour set `optimization.moduleIds` to `false` and use the `webpack.ids.DeterministicModuleIdsPlugin`.
 
 **webpack.config.js**
 


### PR DESCRIPTION
**Summary**

Fix minor grammar, punctuation, and capitalization issues across three documentation files:

- `src/content/api/loaders.mdx`: Added missing comma after "However" and capitalized "API"
- `src/content/concepts/loaders.mdx`: Lowercased "Webpack" to "webpack" for consistency
- `src/content/configuration/optimization.mdx`: Fixed a comma splice and removed a hidden U+2060 (word joiner) character in the `avoidEntryIife` warning; added missing article "The" before `deterministic` option description

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

No — documentation-only changes, no tests needed.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

N/A — these are corrections to existing documentation, not new content.

**Use of AI**

Claude (claude-sonnet-4-6) was used to help identify issues in the documentation files and suggest fixes. All changes were reviewed and verified manually before submission.
