### PR TITLE
docs: add inline explanations for plugin hooks

### DIFF
--- a/src/content/contribute/writing-a-plugin.mdx
+++ b/src/content/contribute/writing-a-plugin.mdx
@@ -62,6 +62,7 @@ Plugins are instantiated objects with an `apply` method on their prototype. This
 ```js
 class HelloWorldPlugin {
   apply(compiler) {
+    // This hook runs when the build process is fully completed
     compiler.hooks.done.tap(
       "Hello World Plugin",
       (


### PR DESCRIPTION
Added a small inline comment to explain when the `done` hook runs in the plugin example.

This makes it easier for beginners to understand the plugin lifecycle and when this hook is triggered during the build process.

Documentation only, no functional changes.