### PR TITLE
docs(guides): fix lodash classification from peerDependency to depend…

### DIFF
--- a/src/content/guides/author-libraries.mdx
+++ b/src/content/guides/author-libraries.mdx
@@ -252,7 +252,15 @@ T> Note that the `library` setup is tied to the `entry` configuration. For most 
 
 ## Externalize Lodash
 
-Now, if you run `npx webpack`, you will find that a largish bundle is created. If you inspect the file, you'll see that lodash has been bundled along with your code. In this case, we'd prefer to treat `lodash` as a _peer dependency_. Meaning that the consumer should already have `lodash` installed. Hence you would want to give up control of this external library to the consumer of your library.
+Now, if you run `npx webpack`, you will find that a largish bundle is created because `lodash` is bundled directly into your code. 
+
+To prevent duplicate bundles, you can externalize `lodash` in your webpack config. How you classify `lodash` in your `package.json` then depends entirely on your library's architecture:
+
+* **`peerDependencies`**: Use this if your library expects the host application to provide a single, shared instance of `lodash` at runtime (standard for UI components and singletons).
+* **`dependencies`**: Use this if you are not pre-bundling the library, and instead rely strictly on the consumer's package manager (npm/yarn) to resolve the dependency tree.
+* **`devDependencies`**: Use this if you are intentionally compiling a standalone, fully-bundled artifact where `lodash` is swallowed inside your final output file.
+
+For this guide's scenario, where we want to externalize the utility to prevent consumer bundle bloat, we will classify it as a `peerDependency`.
 
 This can be done using the [`externals`](/configuration/externals/) configuration:
 


### PR DESCRIPTION
Fixes #6896.

(Incorrect advice to use peerDependencies for utility libraries).

The Authoring Libraries guide was advising developers to treat utility libraries like lodash as peerDependencies to avoid bundle bloat when externalizing them. However, a in the issue, if a library relies on lodash internally at runtime, it must be listed in dependencies.

peerDependencies are strictly for packages that a consumer must install directly in their own app to satisfy the library's environment (eg React for a UI component library). dependencies guarantees the package manager installs the utility library automatically.

This PR simply correctly updates the text to advise using dependencies instead, while keeping the explanation of how to externalize it in the webpack config to prevent duplication.

What kind of change does this PR introduce?

Fix / Documentation

Did you add tests for your changes?

NA

Does this PR introduce a breaking change?

No.

If relevant, what needs to be documented once your changes are merged or what have you already documented?

N/A

Use of AI

None.