### PR TITLE
refactor(Container): migrate Container styles from SCSS to Tailwind CSS #8047

### DIFF
--- a/src/components/Container/Container.jsx
+++ b/src/components/Container/Container.jsx
@@ -1,11 +1,13 @@
 import PropTypes from "prop-types";
 
-import "./Container.scss";
-
 export default function Container(props = {}) {
   const { className = "" } = props;
 
-  return <div className={`container ${className}`}>{props.children}</div>;
+  return (
+    <div className={`w-full max-w-5xl mx-auto ${className}`}>
+      {props.children}
+    </div>
+  );
 }
 
 Container.propTypes = {

--- a/src/components/Container/Container.scss
+++ b/src/components/Container/Container.scss
@@ -1,9 +1,0 @@
-@use "../../styles/partials/vars" as *;
-@use "../../styles/partials/mixins" as *;
-@use "sass:map";
-
-.container {
-  width: 100%;
-  max-width: map.get($screens, large);
-  margin: 0 auto;
-}

--- a/src/components/Container/__snapshots__/Container.test.jsx.snap
+++ b/src/components/Container/__snapshots__/Container.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Container renders correctly with children and className 1`] = `
 <div
-  class="container test-class"
+  class="w-full max-w-5xl mx-auto test-class"
 >
   <p>
     Child content
@@ -12,7 +12,7 @@ exports[`Container renders correctly with children and className 1`] = `
 
 exports[`Container renders correctly without className 1`] = `
 <div
-  class="container "
+  class="w-full max-w-5xl mx-auto "
 >
   <span>
     Simple child

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -10,7 +10,7 @@ const footerLinkClasses =
 
 const Footer = () => (
   <footer className="w-full flex-[0_0_auto] print:hidden">
-    <Container className="mx-auto max-w-[900px] px-5 pb-[30px] pt-[40px] text-center [&_a]:text-[#3b7eb5]">
+    <Container className="mx-auto max-w-5xl px-5 pb-[30px] pt-[40px] text-center [&_a]:text-[#3b7eb5]">
       <div className="mb-[24px] flex justify-center">
         <a href="https://openjsf.org" target="_blank" rel="noopener noreferrer">
           <img


### PR DESCRIPTION
Part of https://github.com/webpack/webpack.js.org/issues/8047

### Description

This PR migrates the **Container component** styles from SCSS to Tailwind CSS.

### Changes Made

- Replaced SCSS-based styling with Tailwind utility classes
- Removed `Container.scss` file and its import
- Updated Container layout using Tailwind:
- Updated snapshot tests to reflect new class names
- Adjusted Footer component to align with updated Container width

### Testing

- Verified Container renders correctly with and without custom `className`
- Ensured layout consistency across pages using Container
- Updated and validated snapshot tests

### Notes

- Maintained existing component structure
- Tailwind classes were chosen to closely match previous SCSS behavior
- This is part of the incremental migration from SCSS to Tailwind CSS