### PR TITLE
docs(concepts): clarify container in module federation examples

### DIFF
--- a/src/content/concepts/module-federation.mdx
+++ b/src/content/concepts/module-federation.mdx
@@ -122,6 +122,8 @@ It can be leveraged to connect remote containers to a host container dynamically
 })();
 ```
 
+T> A **container** is the remote container entry object exposed by a federated build, usually through that remote's `remoteEntry.js`. It provides the `get` and `init` methods shown here. In examples like `window[scope]` or `globalThis.someContainer`, the container is expected to exist only once the remote container script has already loaded.
+
 The container tries to provide shared modules, but if the shared module has already been used, a warning and the provided shared module will be ignored. The container might still use it as a fallback.
 
 This way you could dynamically load an A/B test which provides a different version of a shared module.
@@ -137,7 +139,7 @@ function loadComponent(scope, module) {
   return async () => {
     // Initializes the shared scope. Fills it with known provided modules from this build and all remotes
     await __webpack_init_sharing__("default");
-    const container = window[scope]; // or get the container somewhere else
+    const container = window[scope]; // the remote container exposed by the loaded remoteEntry.js script
     // Initialize the container, it may provide shared modules
     await container.init(__webpack_share_scopes__.default);
     const factory = await window[scope].get(module);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

I added a clarification for what `container` refers to in the Module Federation dynamic remote examples. This PR adds a short explanation that the container is the remote entry object exposed by a federated build and updates the `window[scope]` example accordingly.

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

N/A

**Does this PR introduce a breaking change?**

No, it's only a minor documentation update.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

None needed.

**Use of AI**

AI was used to identify and draft the necessary changes. I made manual changes and reviewed the changes myself, and I take full responsibility for the changes in this PR.