### PR TITLE
Raginipatel17 patch 1

### DIFF
--- a/src/content/configuration/optimization.mdx
+++ b/src/content/configuration/optimization.mdx
@@ -41,7 +41,8 @@ export default {
 
 ## optimization.chunkIds
 
-`boolean | natural | named | size | total-size | deterministic`
+`boolean: false`
+`string: 'natural' | 'named' | 'size' | 'total-size' | 'deterministic'`
 
 - `false`: disable webpack's built-in chunk id algorithm
 - one of the following values:


### PR DESCRIPTION
**Summary**

Fix incorrect type formatting for `optimization.chunkIds` in the documentation.

The previous format was unclear:
`false | natural | named | size | total-size | deterministic`

Updated it to clearly distinguish types:
- `boolean: false`
- `string: 'natural' | 'named' | 'size' | 'total-size' | 'deterministic'`