### PR TITLE
docs: fix getting started UX issues from #7510

### DIFF
--- a/src/components/Splash/second/left.mdx
+++ b/src/components/Splash/second/left.mdx
@@ -8,6 +8,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 export default {
+  mode: "development",
   entry: "./src/index.js",
   output: {
     path: path.resolve(__dirname, "dist"),
@@ -16,4 +17,4 @@ export default {
 };
 ```
 
-Prefer a video walkthrough? **[Without config](https://youtu.be/3Nv9muOkb6k?t=21293)**
+Prefer a video walkthrough instead? See the **[Without config](https://youtu.be/3Nv9muOkb6k?t=21293)** guide.

--- a/src/content/index.mdx
+++ b/src/content/index.mdx
@@ -39,7 +39,7 @@ import Install from "../components/Splash/install/install.mdx";
   </div>
 </div>
 
-Then run `npx webpack` on the command-line to create `bundle.js`.
+Then run `webpack` on the command-line to create `bundle.js`.
 
 ## Awesome, isn't it? Let's dive in!
 

--- a/src/content/index.mdx
+++ b/src/content/index.mdx
@@ -39,7 +39,7 @@ import Install from "../components/Splash/install/install.mdx";
   </div>
 </div>
 
-Then run `webpack` on the command-line to create `bundle.js`.
+Then run `npx webpack` on the command-line to create `bundle.js`.
 
 ## Awesome, isn't it? Let's dive in!
 


### PR DESCRIPTION
## Summary

Fixes several documentation UX issues reported in #7510 by a user
who walked through webpack.js.org from scratch and hit multiple
stumbling blocks as a first-time user.

## Changes made

### `src/components/Splash/second/left.mdx`
- Added `mode: "development"` to the sample `webpack.config.js`
- Without this, running the sample config from the front page
  produces a red warning: `"mode option has not been set"` — 
  confusing for new users following the getting started example

### `src/components/Splash/second/right.mdx`
- Reworded the video walkthrough line from:
  `"Prefer a video walkthrough?"` 
  to:
  `"Prefer a video walkthrough instead? See the ... guide."`
- The original phrasing made the video feel like the primary
  instruction rather than an optional alternative

### `src/content/index.mdx`
- Changed `webpack` to `npx webpack` in the run command
- New users do not have `webpack` in their $PATH — `npx webpack`
  works out of the box without a global install

## What was NOT changed

The `css-loader` page (`webpack.js.org/loaders/css-loader/`) also 
has issues mentioned in #7510 — specifically:
- `import * as css from "file.css"` should be `import "./file.css"`
  (bare path causes `Can't resolve 'file.css'` error)
- `webpack.config.js` example needs `// ...` ellipsis lines
- "You may need to install style-loader" should be "You must also
  install style-loader"

However, the css-loader docs live in the separate `webpack/css-loader`
repository (not in `webpack.js.org`), so those fixes will be submitted
as a separate PR to that repo.

## Related
Closes #7510 (partial — items 2, 3, 4 from the original report)

## Output
<img width="1153" height="509" alt="Screenshot from 2026-03-25 14-59-54" src="https://github.com/user-attachments/assets/9ef7245e-6651-4406-8e37-fdf3228b82e4" />

