### PR TITLE
Improve dark mode visibility for “Become a Sponsor” button

### DIFF
--- a/src/components/Support/Support.jsx
+++ b/src/components/Support/Support.jsx
@@ -285,7 +285,7 @@ export default class Support extends Component {
 
           <div className="w-full mt-4">
             <a
-              className="inline-block py-[0.4em] px-[1em] uppercase text-[#175d96] border border-[#175d96] rounded-4xl transition-all duration-[250ms] hover:bg-[#175d96] hover:text-white"
+              className="inline-block py-[0.4em] px-[1em] uppercase text-[#175d96] border border-[#175d96] rounded-4xl transition-all duration-[250ms] hover:bg-[#175d96] hover:text-white dark:text-[#4fa8ff] dark:border-[#4fa8ff] dark:hover:bg-[#4fa8ff] dark:hover:text-[#04131f]"
               href="https://opencollective.com/webpack#support"
             >
               Become a {rank === "backer" ? "backer" : "sponsor"}


### PR DESCRIPTION
## Description

Improved the visibility of the **"Become a Sponsor"** button in dark mode.

The previous styling made the button less noticeable due to low contrast. This update enhances accessibility and ensures better user experience in dark mode.

## Before 

<img width="535" height="77" alt="image" src="https://github.com/user-attachments/assets/cf0048af-8476-41be-8a50-148dd16948a3" />


## After

<img width="427" height="142" alt="image" src="https://github.com/user-attachments/assets/16590ce0-575a-44ce-be05-c3847bec915f" />


## Changes Made

- Updated button styles for dark mode
- Improved contrast and readability
- Ensured consistency with overall UI theme

## Checklist

- [x] Code follows project guidelines
- [x] Changes tested locally
- [x] No breaking changes introduced
- [x] UI is responsive and accessible
