### PR TITLE
add next steps and pro-tip to getting-started guide

### DIFF
--- a/src/content/guides/getting-started.mdx
+++ b/src/content/guides/getting-started.mdx
@@ -412,3 +412,15 @@ webpack-demo
 W> Do not compile untrusted code with webpack. It could lead to execution of malicious code on your computer, remote servers, or in the web browsers of the end users of your application.
 
 If you want to learn more about webpack's design, you can check out the [basic concepts](/concepts) and [configuration](/configuration) pages. Furthermore, the [API](/api) section digs into the various interfaces webpack offers.
+
+---
+
+### What's Next?
+
+Now that you've completed your first build, dive deeper into these core concepts:
+
+- **[Entry Points](/concepts/entry-points/):** Learn how webpack starts building your dependency graph.
+- **[Output](/concepts/output/):** Understand how to tell webpack where to emit your bundles.
+- **[Loaders](/concepts/loaders/):** See how to process non-JavaScript files like CSS or images.
+
+> **Pro Tip:** Keep your `webpack.config.js` clean and modular as your project grows!


### PR DESCRIPTION
**Summary**
In the "Getting Started" guide, I have added a "What's Next?" section and a "Pro Tip" immediately after the conclusion. 

**Motivation**
Currently, the guide ends abruptly. Adding these navigation links helps beginners know exactly where to go next (Core Concepts, Loaders, etc.), making the onboarding experience much smoother.

**What kind of change does this PR introduce?**
- Docs contribution

**Did you add tests for your changes?**
N/A (Documentation change only)