### PR TITLE
Improve explanation of webpack CLI output for beginners

### DIFF
--- a/src/content/guides/getting-started.mdx
+++ b/src/content/guides/getting-started.mdx
@@ -236,7 +236,7 @@ T> A couple other script loading strategies exist. Deferred loading is one such 
 
 In this setup, `index.js` explicitly requires `lodash` to be present, and binds it as `_` (no global scope pollution). By stating what dependencies a module needs, webpack can use this information to build a dependency graph. It then uses the graph to generate an optimized bundle where scripts will be executed in the correct order.
 
-With that said, let's run `npx webpack` from the project root. If webpack is installed locally, `npx` will run the local binary from `node_modules/.bin`; otherwise, it may download and execute it. This command takes our script at `src/index.js` as the [entry point](/concepts/entry-points) and generates `dist/main.js` as the [output](/concepts/output).
+With that said, let's run `npx webpack` from the project root. This command uses `src/index.js` as the entry point and generates the bundled file `dist/main.js` as output. If webpack is installed locally, `npx` will run the local binary from `node_modules/.bin`; otherwise, it may download and execute it. This command takes our script at `src/index.js` as the [entry point](/concepts/entry-points) and generates `dist/main.js` as the [output](/concepts/output).
 
 ```bash
 # npm


### PR DESCRIPTION
Improved clarity for beginners by explaining the entry point and output generated when running `npx webpack`.

Type: docs