### PR TITLE
fix(build): prevent rimraf glob crash on Windows by injecting --glob …

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "main": "n/a",
   "scripts": {
     "clean-dist": "rimraf ./dist",
-    "clean-printable": "rimraf --glob src/content/**/printable.mdx",
+    "clean-printable": "rimraf \"src/content/**/printable.mdx\"",
     "preclean": "run-s clean-dist clean-printable",
-    "clean": "rimraf --glob src/content/**/_*.mdx src/**/_*.json repositories/*.json",
+    "clean": "rimraf \"src/content/**/_*.mdx\" \"src/**/_*.json\" \"repositories/*.json\"",
     "start": "npm run clean-dist && webpack serve --config webpack.dev.mjs --env dev --progress --config-node-env development",
     "content": "node src/scripts/build-content-tree.mjs ./src/content ./src/_content.json",
     "bundle-analyze": "run-s clean fetch content && webpack --config webpack.prod.mjs --config-node-env production && run-s printable content && webpack --config webpack.ssg.mjs --config-node-env production --env ssg --profile --json > stats.json && webpack-bundle-analyzer stats.json",


### PR DESCRIPTION
I hit a terminal crash when trying to run npm run build locally on Windows.

The clean-printable and clean scripts throw an EINVAL (Illegal characters) error because rimraf ^6 stops globbing by default and relies on the Unix shell to expand **. On Windows, cmd passes ** literally, which causes fs.rm to crash instantly.

Adding the explicit --glob flag to these scripts lets rimraf handle the wildcards internally, fixing the build crash completely for Windows contributors.

What kind of change does this PR introduce?

build / fix

Did you add tests for your changes?

N/A (This restores the ability for Windows users to execute the existing build scripts).

Does this PR introduce a breaking change?

No.

If relevant, what needs to be documented once your changes are merged or what have you already documented?

N/A

Use of AI

Debugged locally from a custom Windows development environment.