### PR TITLE
fix: resolve dark theme for mobile-sidebar

### DIFF
--- a/src/components/SidebarMobile/SidebarMobile.jsx
+++ b/src/components/SidebarMobile/SidebarMobile.jsx
@@ -45,7 +45,7 @@ export default class SidebarMobile extends Component {
           onTouchEnd={this._handleTouchEnd}
         />
 
-        <div className="relative w-[285px] h-screen overflow-x-hidden py-1 bg-white shadow-[0_0_15px_rgba(0,0,0,0.2)]">
+        <div className="relative w-[285px] h-screen overflow-x-hidden py-1 bg-white dark:bg-[#121212] shadow-[0_0_15px_rgba(0,0,0,0.2)]">
           <button
             className="sidebar-mobile__close absolute cursor-pointer border-none right-[22px] top-[10px] text-[1.3em] bg-[#175d96] text-white w-[30px] h-[30px] flex items-center justify-center rounded-full transition-colors duration-150 [-webkit-tap-highlight-color:transparent] hover:bg-[#135d96]"
             onClick={toggle.bind(null, false)}
@@ -93,7 +93,8 @@ export default class SidebarMobile extends Component {
             className={clsx(
               "uppercase pt-[0.75em] px-4 pb-[0.25em] font-semibold block text-[1.1rem]",
               active ? "text-[#465E69]" : "text-[#2B3A42]",
-              index > 0 && "border-t border-gray-200",
+              index > 0 && "border-t border-gray-200 dark:border-[#343434]",
+              "dark:text-[#cadbe6]",
             )}
             key={section.url}
             to={section.url}
@@ -131,8 +132,8 @@ export default class SidebarMobile extends Component {
           className={clsx(
             "block py-[0.5em] px-[17px] capitalize [-webkit-tap-highlight-color:transparent] ml-[20px]",
             active
-              ? "text-gray-900 font-semibold bg-[#f1f4f4]"
-              : "text-gray-600 hover:text-gray-600 active:text-gray-900 active:font-semibold active:bg-[#f1f4f4]",
+              ? "text-gray-900 font-semibold bg-[#f1f4f4] dark:text-white dark:bg-[#222424]"
+              : "text-gray-600 dark:text-[#a3a3a3] hover:text-gray-600 active:text-gray-900 active:font-semibold active:bg-[#f1f4f4] dark:active:bg-[#222424] dark:active:text-white",
           )}
           to={url}
           onClick={this.props.toggle.bind(null, false)}

--- a/src/styles/dark.scss
+++ b/src/styles/dark.scss
@@ -127,26 +127,6 @@
     }
   }
 
-  // Mobile
-  .sidebar-mobile__content {
-    background-color: #121212;
-  }
-  .sidebar-mobile__section-header {
-    color: #cadbe6;
-  }
-  .sidebar-mobile__page {
-    color: #a3a3a3;
-  }
-  .sidebar-mobile__page--active,
-  .sidebar-mobile__page:active {
-    background-color: #222424;
-  }
-  .sidebar-mobile__content
-    div:not(:first-of-type)
-    .sidebar-mobile__section-header {
-    border-color: #343434;
-  }
-
   .footer-openjsf-logo {
     filter: invert(1);
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
This PR fixes the dark theme colors for `mobile-sidebar`
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
fix(styles)

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
no

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**
used ai to inject dark variant inside the required elements refrencing from dark.scss

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->

before:
<img width="739" height="692" alt="Screenshot from 2026-03-28 23-52-51" src="https://github.com/user-attachments/assets/9d541e73-ff4b-4ac1-832f-2179e5665906" />

---

after:
<img width="739" height="692" alt="Screenshot from 2026-03-28 23-52-56" src="https://github.com/user-attachments/assets/ae1c4e22-84d6-4855-a02e-ff0be10aaa09" />
