### PR TITLE
fix-Remove decorative top and bottom lines from hero rotating text

### DIFF
--- a/src/components/TextRotater/TextRotater.jsx
+++ b/src/components/TextRotater/TextRotater.jsx
@@ -40,12 +40,6 @@ export default class TextRotater extends PureComponent {
       <div
         className="
           relative inline-block overflow-hidden align-bottom px-[0.3em]
-          before:content-[''] before:absolute before:left-0 before:w-full before:h-[3px]
-          before:bottom-0 before:z-10
-          before:bg-linear-to-t before:from-[#2b3a42] before:to-transparent
-          after:content-[''] after:absolute after:left-0 after:w-full after:h-[3px]
-          after:top-0
-          after:bg-linear-to-b after:from-[#2b3a42] after:to-transparent
         "
       >
         <div


### PR DESCRIPTION
## Description

This PR removes the decorative top and bottom lines from the hero rotating text section to improve visual clarity and maintain a cleaner UI.

## Before

<img width="1030" height="266" alt="image" src="https://github.com/user-attachments/assets/871d231e-2aa0-488e-a004-557aeac2fd84" />


## After

<img width="498" height="107" alt="image" src="https://github.com/user-attachments/assets/65a77bcd-2db4-43e7-a885-0c5fda8079c3" />

## Changes Made

- Removed decorative top and bottom lines from hero rotating text
- Improved readability and UI consistency

## Why is this change needed?

The decorative lines were:
- Visually distracting
- Not aligned with the current design system
- Affecting readability of the hero text

This change improves overall user experience and keeps the design minimal and clean.

## Notes

This PR only includes UI improvements and does not affect functionality.