### PR TITLE
docs: clarify webpack loader execution order (right-to-left)

### DIFF
--- a/src/content/guides/asset-management.mdx
+++ b/src/content/guides/asset-management.mdx
@@ -13,6 +13,7 @@ contributors:
   - astonizer
   - snitin315
   - Brennvo
+  - mr-baraiya
 ---
 
 If you've been following the guides from the start, you will now have a small project that shows "Hello webpack". Now let's try to incorporate some other assets, like images, to see how they can be handled.
@@ -97,7 +98,7 @@ npm install --save-dev style-loader css-loader
 
 Module loaders can be chained. Each loader in the chain applies transformations to the processed resource. A chain is executed in reverse order. The first loader passes its result (resource with applied transformations) to the next one, and so forth. Finally, webpack expects JavaScript to be returned by the last loader in the chain.
 
-The above order of loaders should be maintained: [`'style-loader'`](/loaders/style-loader) comes first and followed by [`'css-loader'`](/loaders/css-loader). If this convention is not followed, webpack is likely to throw errors.
+The above order of loaders should be maintained: [`'style-loader'`](/loaders/style-loader) should be listed before [`'css-loader'`](/loaders/css-loader) in the `use` array, but webpack applies them from right to left—so `'css-loader'` runs first, then `'style-loader'`. If this convention is not followed, webpack is likely to throw errors.
 
 T> webpack uses a regular expression to determine which files it should look for and serve to a specific loader. In this case, any file that ends with `.css` will be served to the `style-loader` and the `css-loader`.
 

--- a/src/content/guides/asset-management.mdx
+++ b/src/content/guides/asset-management.mdx
@@ -101,8 +101,10 @@ Loaders in webpack are executed from **right to left** (i.e., from last to first
 For example:
 
 ```js
-use: ["postcss-loader", "sass-loader"];
+use: ['postcss-loader', 'sass-loader'],
 ```
+
+In this rule, `test: /\.css$/i` is a regular expression that tells webpack to apply the rule to `.css` files.
 
 Here, `sass-loader` runs first and compiles Sass into CSS, followed by `postcss-loader`, which applies further transformations.
 

--- a/src/content/guides/asset-management.mdx
+++ b/src/content/guides/asset-management.mdx
@@ -104,9 +104,9 @@ For example:
 use: ["postcss-loader", "sass-loader"];
 ```
 
-Here, `css-loader` runs first and processes the CSS, followed by `style-loader`, which injects the result into the DOM.
+Here, `sass-loader` runs first and compiles Sass into CSS, followed by `postcss-loader`, which applies further transformations.
 
-So even though `style-loader` appears before `css-loader` in the array, the execution happens in reverse order.
+So even though `postcss-loader` appears before `sass-loader` in the array, the execution happens in reverse order.
 
 If this order is not maintained, webpack may throw errors.
 

--- a/src/content/guides/asset-management.mdx
+++ b/src/content/guides/asset-management.mdx
@@ -96,19 +96,24 @@ npm install --save-dev style-loader css-loader
  };
 ```
 
-Loaders in webpack are executed from **right to left** (i.e., from last to first in the `use` array).
+Module loaders can be chained. Each loader in the chain applies transformations to the processed resource. A chain is executed in reverse order (right to left).
 
-For example:
+For example, given the following rule:
 
 ```js
-use: ['postcss-loader', 'sass-loader'],
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.scss$/i,
+        use: ["postcss-loader", "sass-loader"],
+      },
+    ],
+  },
+};
 ```
 
-In this rule, `test: /\.css$/i` is a regular expression that tells webpack to apply the rule to `.css` files.
-
-Here, `sass-loader` runs first and compiles Sass into CSS, followed by `postcss-loader`, which applies further transformations.
-
-So even though `postcss-loader` appears before `sass-loader` in the array, the execution happens in reverse order.
+Even though `postcss-loader` appears before `sass-loader` in the `use` array, webpack runs `sass-loader` first (compiling Sass into CSS), then runs `postcss-loader` on the result.
 
 If this order is not maintained, webpack may throw errors.
 

--- a/src/content/guides/asset-management.mdx
+++ b/src/content/guides/asset-management.mdx
@@ -96,15 +96,19 @@ npm install --save-dev style-loader css-loader
  };
 ```
 
-Module loaders can be chained. Each loader in the chain applies transformations to the processed resource. A chain is executed in reverse order. The first loader passes its result (resource with applied transformations) to the next one, and so forth. Finally, webpack expects JavaScript to be returned by the last loader in the chain.
+Loaders in webpack are executed from **right to left** (i.e., from last to first in the `use` array).
 
-The above order of loaders should be maintained: [`'style-loader'`](/loaders/style-loader) should be listed before [`'css-loader'`](/loaders/css-loader) in the `use` array, but webpack applies them from right to left—so `'css-loader'` runs first, then `'style-loader'`. If this convention is not followed, webpack is likely to throw errors.
+For example:
 
-T> webpack uses a regular expression to determine which files it should look for and serve to a specific loader. In this case, any file that ends with `.css` will be served to the `style-loader` and the `css-loader`.
+```js
+use: ["postcss-loader", "sass-loader"];
+```
 
-This enables you to `import './style.css'` into the file that depends on that styling. Now, when that module is run, a `<style>` tag with the stringified css will be inserted into the `<head>` of your html file.
+Here, `css-loader` runs first and processes the CSS, followed by `style-loader`, which injects the result into the DOM.
 
-Let's try it out by adding a new `style.css` file to our project and import it in our `index.js`:
+So even though `style-loader` appears before `css-loader` in the array, the execution happens in reverse order.
+
+If this order is not maintained, webpack may throw errors.
 
 **project**
 


### PR DESCRIPTION
**Summary**

Fixes a misleading explanation in `asset-management.mdx` regarding loader execution order. Clarifies that webpack applies loaders from right to left, so `css-loader` runs before `style-loader`.

---

**What kind of change does this PR introduce?**

docs

---

**Did you add tests for your changes?**

No (documentation change only)

---

**Does this PR introduce a breaking change?**

No

---

**Use of AI**

No