### PR TITLE
Added missing comma in getting-started conclusion.

### DIFF
--- a/src/content/guides/getting-started.mdx
+++ b/src/content/guides/getting-started.mdx
@@ -392,7 +392,7 @@ T> Custom parameters can be passed to webpack by adding two dashes between the `
 
 ## Conclusion
 
-Now that you have a basic build together you should move on to the next guide [`Asset Management`](/guides/asset-management) to learn how to manage assets like images and fonts with webpack. At this point, your project should look like this:
+Now that you have a basic build together, you should move on to the next guide [`Asset Management`](/guides/asset-management) to learn how to manage assets like images and fonts with webpack. At this point, your project should look like this:
 
 **project**
 


### PR DESCRIPTION
What kind of change does this PR introduce?
Documentation fix  added a missing comma in the 
getting-started guide conclusion for grammatical correctness.

Did you add tests for your changes?
No this is a punctuation fix, no tests required.

Does this PR introduce a breaking change?
No.

If relevant, what needs to be documented?
No documentation needed single punctuation correction.

Use of AI
I read through and identified the grammatical issue, then asked AI to verify.
Then made the change manually.