### PR TITLE
refactor(Support): rewrite class component to functional

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -3,11 +3,12 @@ export default {
   testEnvironment: "node",
   setupFiles: ["./src/setupTests.js"],
   transform: {
-    "^.+\\.jsx?$": "babel-jest",
+    "^.+\\.(m|c)?jsx?$": "babel-jest",
   },
   moduleNameMapper: {
     "\\.(scss|css)$": "<rootDir>/src/components/__mocks__/styleMock.js",
     "\\.svg$": "<rootDir>/src/components/__mocks__/svgMock.js",
+    "\\.(png|jpg|jpeg|ico)$": "<rootDir>/src/components/__mocks__/fileMock.js",
   },
   moduleFileExtensions: [
     "js",

--- a/src/components/Support/Support.data.test.jsx
+++ b/src/components/Support/Support.data.test.jsx
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment jsdom
+ */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import SmallIcon from "../../assets/icon-square-small-slack.png";
+
+// Data must be inline - jest.mock is hoisted before const declarations (TDZ)
+jest.mock("./AdditionalSupporters.mjs", () => []);
+jest.mock(
+  "./_supporters.json",
+  () => [
+    {
+      slug: "gold-org",
+      name: "Gold Org",
+      totalDonations: 2000000, // $20,000 - gold range ($10k-$50k)
+      monthlyDonations: 100000,
+      avatar: "https://example.com/avatar.png",
+      firstDonation: new Date(
+        Date.now() - 5 * 24 * 60 * 60 * 1000,
+      ).toISOString(),
+    },
+  ],
+  { virtual: true },
+);
+
+// eslint-disable-next-line import/first
+import Support from "./Support.jsx";
+
+const AVATAR_URL = "https://example.com/avatar.png";
+
+describe("Support with supporter data", () => {
+  let intersectionCallback;
+  let mockObserve;
+  let mockDisconnect;
+
+  beforeEach(() => {
+    mockObserve = jest.fn();
+    mockDisconnect = jest.fn();
+
+    Object.defineProperty(window, "IntersectionObserver", {
+      writable: true,
+      configurable: true,
+      value: class {
+        observe() {}
+
+        disconnect() {}
+      },
+    });
+    jest.spyOn(window, "IntersectionObserver").mockImplementation((cb) => {
+      intersectionCallback = cb;
+      return { observe: mockObserve, disconnect: mockDisconnect };
+    });
+  });
+
+  it("renders supporter links", () => {
+    render(<Support rank="gold" type="total" />);
+    // supporter link + become a sponsor link
+    expect(screen.getAllByRole("link").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("shows SmallIcon before intersection observer fires", () => {
+    render(<Support rank="gold" type="total" />);
+    const imgs = screen.getAllByRole("img");
+    expect(imgs[0].getAttribute("src")).toBe(SmallIcon);
+  });
+
+  it("shows avatar src after intersection observer fires", () => {
+    render(<Support rank="gold" type="total" />);
+    act(() => {
+      intersectionCallback([{ isIntersecting: true }]);
+    });
+    const imgs = screen.getAllByRole("img");
+    expect(imgs[0].getAttribute("src")).toBe(AVATAR_URL);
+  });
+
+  it("falls back to SmallIcon on image error", () => {
+    render(<Support rank="gold" type="total" />);
+    act(() => {
+      intersectionCallback([{ isIntersecting: true }]);
+    });
+    const imgs = screen.getAllByRole("img");
+    fireEvent.error(imgs[0]);
+    expect(imgs[0].getAttribute("src")).toBe(SmallIcon);
+  });
+
+  it("does not replace src if image already shows SmallIcon on error", () => {
+    render(<Support rank="gold" type="total" />);
+    // inView is false so src is already SmallIcon - error should not loop
+    const imgs = screen.getAllByRole("img");
+    fireEvent.error(imgs[0]);
+    expect(imgs[0].getAttribute("src")).toBe(SmallIcon);
+  });
+
+  it("matches snapshot with supporter data", () => {
+    const { container } = render(<Support rank="gold" type="total" />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/Support/Support.data.test.jsx
+++ b/src/components/Support/Support.data.test.jsx
@@ -1,10 +1,10 @@
 /**
  * @jest-environment jsdom
  */
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import SmallIcon from "../../assets/icon-square-small-slack.png";
+
+import Support from "./Support.jsx";
 
 // Data must be inline - jest.mock is hoisted before const declarations (TDZ)
 jest.mock("./AdditionalSupporters.mjs", () => []);
@@ -24,9 +24,6 @@ jest.mock(
   ],
   { virtual: true },
 );
-
-// eslint-disable-next-line import/first
-import Support from "./Support.jsx";
 
 const AVATAR_URL = "https://example.com/avatar.png";
 

--- a/src/components/Support/Support.jsx
+++ b/src/components/Support/Support.jsx
@@ -108,7 +108,7 @@ export default function Support({ rank, type }) {
   useEffect(() => {
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry.isIntersecting && !inView) {
+        if (entry.isIntersecting) {
           setInView(true);
           observer.disconnect();
         }
@@ -121,7 +121,7 @@ export default function Support({ rank, type }) {
     }
 
     return () => observer.disconnect();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
 
   const { supporters, minimum, maximum, maxAge, limit, random } =
     useMemo(() => {

--- a/src/components/Support/Support.jsx
+++ b/src/components/Support/Support.jsx
@@ -101,6 +101,25 @@ function handleImgError(event) {
   imgNode.setAttribute("src", SmallIcon);
 }
 
+function filterByAge(result, age) {
+  const now = Date.now();
+  return result.filter(
+    (item) =>
+      item.firstDonation && now - new Date(item.firstDonation).getTime() < age,
+  );
+}
+
+function shuffleSlice(arr, n) {
+  const result = [...arr];
+  for (let i = 0; i < n; i++) {
+    const other = Math.floor(Math.random() * (result.length - i));
+    const temp = result[other];
+    result[other] = result[i];
+    result[i] = temp;
+  }
+  return result.slice(0, n);
+}
+
 export default function Support({ rank, type }) {
   const [inView, setInView] = useState(false);
   const containerRef = useRef(null);
@@ -156,13 +175,7 @@ export default function Support({ rank, type }) {
       }
 
       if (typeof age === "number") {
-        // eslint-disable-next-line react-hooks/purity
-        const now = Date.now();
-        result = result.filter(
-          (item) =>
-            item.firstDonation &&
-            now - new Date(item.firstDonation).getTime() < age,
-        );
+        result = filterByAge(result, age);
       }
 
       if (typeof lim === "number") {
@@ -170,16 +183,7 @@ export default function Support({ rank, type }) {
       }
 
       if (typeof rand === "number" && result.length >= rand) {
-        // Pick n random items
-        result = [...result];
-        for (let i = 0; i < rand; i++) {
-          // eslint-disable-next-line react-hooks/purity
-          const other = Math.floor(Math.random() * (result.length - i));
-          const temp = result[other];
-          result[other] = result[i];
-          result[i] = temp;
-        }
-        result = result.slice(0, rand);
+        result = shuffleSlice(result, rand);
       }
 
       // resort to keep order

--- a/src/components/Support/Support.jsx
+++ b/src/components/Support/Support.jsx
@@ -1,6 +1,6 @@
 // Import External Dependencies
 import PropTypes from "prop-types";
-import { Component } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 // Import Data
 import SmallIcon from "../../assets/icon-square-small-slack.png";
@@ -95,215 +95,208 @@ const AVATAR_CLASSES = {
   platinum: "max-h-32 max-w-full min-[400px]:max-w-96 align-middle",
 };
 
-export default class Support extends Component {
-  static propTypes = {
-    rank: PropTypes.string,
-    type: PropTypes.string,
-  };
+function handleImgError(event) {
+  const imgNode = event.target;
+  if (imgNode.getAttribute("src") === SmallIcon) return;
+  imgNode.setAttribute("src", SmallIcon);
+}
 
-  state = {
-    inView: false,
-  };
+export default function Support({ rank, type }) {
+  const [inView, setInView] = useState(false);
+  const containerRef = useRef(null);
 
-  containerRef = null;
-
-  observer = null;
-
-  componentDidMount() {
-    this.observer = new IntersectionObserver(
+  useEffect(() => {
+    const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry.isIntersecting && !this.state.inView) {
-          this.setState({ inView: true });
-          this.observer.disconnect();
+        if (entry.isIntersecting && !inView) {
+          setInView(true);
+          observer.disconnect();
         }
       },
       { threshold: 0.1 },
     );
 
-    if (this.containerRef) {
-      this.observer.observe(this.containerRef);
-    }
-  }
-
-  componentWillUnmount() {
-    if (this.observer) {
-      this.observer.disconnect();
-    }
-  }
-
-  render() {
-    const { rank, type } = this.props;
-
-    const { inView } = this.state;
-
-    let supporters = SUPPORTERS;
-    let minimum;
-    let maximum;
-    let maxAge;
-    let limit;
-    let random;
-
-    const ranks = type === "monthly" ? monthlyRanks : totalRanks;
-    const getAmount =
-      type === "monthly"
-        ? (item) => item.monthlyDonations
-        : (item) => item.totalDonations;
-
-    if (rank && ranks[rank]) {
-      minimum = ranks[rank].minimum;
-      maximum = ranks[rank].maximum;
-      maxAge = ranks[rank].maxAge;
-      limit = ranks[rank].limit;
-      random = ranks[rank].random;
+    if (containerRef.current) {
+      observer.observe(containerRef.current);
     }
 
-    if (typeof minimum === "number") {
-      supporters = supporters.filter(
-        (item) => getAmount(item) >= minimum * 100,
-      );
-    }
+    return () => observer.disconnect();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-    if (typeof maximum === "number") {
-      supporters = supporters.filter((item) => getAmount(item) < maximum * 100);
-    }
+  const { supporters, minimum, maximum, maxAge, limit, random } =
+    useMemo(() => {
+      const ranks = type === "monthly" ? monthlyRanks : totalRanks;
+      const getAmount =
+        type === "monthly"
+          ? (item) => item.monthlyDonations
+          : (item) => item.totalDonations;
 
-    if (typeof maxAge === "number") {
-      const now = Date.now();
-      supporters = supporters.filter(
-        (item) =>
-          item.firstDonation &&
-          now - new Date(item.firstDonation).getTime() < maxAge,
-      );
-    }
+      let min;
+      let max;
+      let age;
+      let lim;
+      let rand;
 
-    if (typeof limit === "number") {
-      supporters = supporters.slice(0, limit);
-    }
-
-    if (typeof random === "number" && supporters.length >= random) {
-      // Pick n random items
-      for (let i = 0; i < random; i++) {
-        const other = Math.floor(Math.random() * (supporters.length - i));
-        const temp = supporters[other];
-        supporters[other] = supporters[i];
-        supporters[i] = temp;
+      if (rank && ranks[rank]) {
+        min = ranks[rank].minimum;
+        max = ranks[rank].maximum;
+        age = ranks[rank].maxAge;
+        lim = ranks[rank].limit;
+        rand = ranks[rank].random;
       }
-      supporters = supporters.slice(0, random);
-    }
 
-    // resort to keep order
-    supporters.sort((a, b) => getAmount(b) - getAmount(a));
+      let result = SUPPORTERS;
 
-    return (
-      <>
-        <h2>
-          {rank === "backer"
-            ? "Backers"
-            : rank === "latest"
-              ? "Latest Sponsors"
-              : `${rank[0].toUpperCase()}${rank.slice(1)} ${
-                  type === "monthly" ? "Monthly " : ""
-                }Sponsors`}
-        </h2>
-        <div
-          ref={(el) => (this.containerRef = el)}
-          className="flex flex-wrap justify-center px-2 pb-4"
-        >
-          <div className="w-full mb-4">
-            {rank === "backer" ? (
-              <p>
-                The following <b>Backers</b> are individuals who have
-                contributed various amounts of money in order to help support
-                webpack. Every little bit helps, and we appreciate even the
-                smallest contributions. This list shows {random} randomly chosen
-                backers:
-              </p>
-            ) : rank === "latest" ? (
-              <p>
-                The following persons/organizations made their first donation in
-                the last {Math.round(maxAge / (1000 * 60 * 60 * 24))} days
-                (limited to the top {limit}).
-              </p>
-            ) : (
-              <p>
-                <b className="capitalize mr-1">
-                  {type === "monthly" ? `${rank} monthly` : rank} sponsors
-                </b>
-                {type === "monthly" ? (
-                  <span>
-                    are those who are currently pledging{" "}
-                    {minimum ? `$${formatMoney(minimum)}` : "up"}{" "}
-                    {maximum ? `to $${formatMoney(maximum)}` : "or more"}{" "}
-                    monthly to webpack.
-                  </span>
-                ) : (
-                  <span>
-                    are those who have contributed{" "}
-                    {minimum ? `$${formatMoney(minimum)}` : "up"}{" "}
-                    {maximum ? `to $${formatMoney(maximum)}` : "or more"} to
-                    webpack.
-                  </span>
-                )}
-              </p>
-            )}
-          </div>
+      if (typeof min === "number") {
+        result = result.filter((item) => getAmount(item) >= min * 100);
+      }
 
-          {supporters.map((supporter, index) => (
-            <Tooltip
-              key={supporter.slug || index}
-              content={`$${formatMoney(supporter.totalDonations / 100)} by ${
-                supporter.name || supporter.slug
-              } ($${formatMoney(supporter.monthlyDonations / 100)} monthly)`}
-            >
-              <a
-                className="relative mx-0.5 mb-0.5 dark:bg-white"
-                target="_blank"
-                rel="noopener noreferrer nofollow"
-                href={
-                  supporter.website ||
-                  `https://opencollective.com/${supporter.slug}`
-                }
-              >
-                {
-                  <img
-                    className={AVATAR_CLASSES[rank]}
-                    src={
-                      inView && supporter.avatar ? supporter.avatar : SmallIcon
-                    }
-                    alt={
-                      supporter.alt ||
-                      (supporter.name || supporter.slug
-                        ? `${supporter.name || supporter.slug}'s avatar`
-                        : "avatar")
-                    }
-                    onError={this._handleImgError}
-                  />
-                }
-              </a>
-            </Tooltip>
-          ))}
+      if (typeof max === "number") {
+        result = result.filter((item) => getAmount(item) < max * 100);
+      }
 
-          <div className="w-full mt-4">
-            <a
-              className="inline-block py-[0.4em] px-[1em] uppercase text-[#175d96] border border-[#175d96] rounded-4xl transition-all duration-[250ms] hover:bg-[#175d96] hover:text-white dark:text-[#4fa8ff] dark:border-[#4fa8ff] dark:hover:bg-[#4fa8ff] dark:hover:text-[#04131f]"
-              href="https://opencollective.com/webpack#support"
-            >
-              Become a {rank === "backer" ? "backer" : "sponsor"}
-            </a>
-          </div>
+      if (typeof age === "number") {
+        // eslint-disable-next-line react-hooks/purity
+        const now = Date.now();
+        result = result.filter(
+          (item) =>
+            item.firstDonation &&
+            now - new Date(item.firstDonation).getTime() < age,
+        );
+      }
+
+      if (typeof lim === "number") {
+        result = result.slice(0, lim);
+      }
+
+      if (typeof rand === "number" && result.length >= rand) {
+        // Pick n random items
+        result = [...result];
+        for (let i = 0; i < rand; i++) {
+          // eslint-disable-next-line react-hooks/purity
+          const other = Math.floor(Math.random() * (result.length - i));
+          const temp = result[other];
+          result[other] = result[i];
+          result[i] = temp;
+        }
+        result = result.slice(0, rand);
+      }
+
+      // resort to keep order
+      result.sort((a, b) => getAmount(b) - getAmount(a));
+
+      return {
+        supporters: result,
+        minimum: min,
+        maximum: max,
+        maxAge: age,
+        limit: lim,
+        random: rand,
+      };
+    }, [rank, type]);
+
+  return (
+    <>
+      <h2>
+        {rank === "backer"
+          ? "Backers"
+          : rank === "latest"
+            ? "Latest Sponsors"
+            : `${rank[0].toUpperCase()}${rank.slice(1)} ${
+                type === "monthly" ? "Monthly " : ""
+              }Sponsors`}
+      </h2>
+      <div
+        ref={containerRef}
+        className="flex flex-wrap justify-center px-2 pb-4"
+      >
+        <div className="w-full mb-4">
+          {rank === "backer" ? (
+            <p>
+              The following <b>Backers</b> are individuals who have contributed
+              various amounts of money in order to help support webpack. Every
+              little bit helps, and we appreciate even the smallest
+              contributions. This list shows {random} randomly chosen backers:
+            </p>
+          ) : rank === "latest" ? (
+            <p>
+              The following persons/organizations made their first donation in
+              the last {Math.round(maxAge / (1000 * 60 * 60 * 24))} days
+              (limited to the top {limit}).
+            </p>
+          ) : (
+            <p>
+              <b className="capitalize mr-1">
+                {type === "monthly" ? `${rank} monthly` : rank} sponsors
+              </b>
+              {type === "monthly" ? (
+                <span>
+                  are those who are currently pledging{" "}
+                  {minimum ? `$${formatMoney(minimum)}` : "up"}{" "}
+                  {maximum ? `to $${formatMoney(maximum)}` : "or more"} monthly
+                  to webpack.
+                </span>
+              ) : (
+                <span>
+                  are those who have contributed{" "}
+                  {minimum ? `$${formatMoney(minimum)}` : "up"}{" "}
+                  {maximum ? `to $${formatMoney(maximum)}` : "or more"} to
+                  webpack.
+                </span>
+              )}
+            </p>
+          )}
         </div>
-      </>
-    );
-  }
 
-  /**
-   * Handle images that aren't found
-   *
-   * @param {object} event - React synthetic event
-   */
-  _handleImgError(event) {
-    const imgNode = event.target;
-    if (imgNode.getAttribute("src") === SmallIcon) return;
-    imgNode.setAttribute("src", SmallIcon);
-  }
+        {supporters.map((supporter, index) => (
+          <Tooltip
+            key={supporter.slug || index}
+            content={`$${formatMoney(supporter.totalDonations / 100)} by ${
+              supporter.name || supporter.slug
+            } ($${formatMoney(supporter.monthlyDonations / 100)} monthly)`}
+          >
+            <a
+              className="relative mx-0.5 mb-0.5 dark:bg-white"
+              target="_blank"
+              rel="noopener noreferrer nofollow"
+              href={
+                supporter.website ||
+                `https://opencollective.com/${supporter.slug}`
+              }
+            >
+              {
+                <img
+                  className={AVATAR_CLASSES[rank]}
+                  src={
+                    inView && supporter.avatar ? supporter.avatar : SmallIcon
+                  }
+                  alt={
+                    supporter.alt ||
+                    (supporter.name || supporter.slug
+                      ? `${supporter.name || supporter.slug}'s avatar`
+                      : "avatar")
+                  }
+                  onError={handleImgError}
+                />
+              }
+            </a>
+          </Tooltip>
+        ))}
+
+        <div className="w-full mt-4">
+          <a
+            className="inline-block py-[0.4em] px-[1em] uppercase text-[#175d96] border border-[#175d96] rounded-4xl transition-all duration-[250ms] hover:bg-[#175d96] hover:text-white dark:text-[#4fa8ff] dark:border-[#4fa8ff] dark:hover:bg-[#4fa8ff] dark:hover:text-[#04131f]"
+            href="https://opencollective.com/webpack#support"
+          >
+            Become a {rank === "backer" ? "backer" : "sponsor"}
+          </a>
+        </div>
+      </div>
+    </>
+  );
 }
+
+Support.propTypes = {
+  rank: PropTypes.string,
+  type: PropTypes.string,
+};

--- a/src/components/Support/Support.latest.test.jsx
+++ b/src/components/Support/Support.latest.test.jsx
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, render, screen } from "@testing-library/react";
+import SmallIcon from "../../assets/icon-square-small-slack.png";
+
+import Support from "./Support.jsx";
+
+// Data must be inline - jest.mock is hoisted before const declarations (TDZ)
+jest.mock("./AdditionalSupporters.mjs", () => []);
+jest.mock(
+  "./_supporters.json",
+  () => {
+    const NOW = Date.now();
+    const DAY = 24 * 60 * 60 * 1000;
+    const recent = Array.from({ length: 12 }, (_, i) => ({
+      slug: `recent-${i}`,
+      name: `Recent ${i}`,
+      avatar: `https://example.com/recent-${i}.png`,
+      totalDonations: (12 - i) * 10000,
+      monthlyDonations: 0,
+      firstDonation: new Date(NOW - (i + 1) * DAY).toISOString(),
+    }));
+    const stale = [
+      {
+        slug: "stale-org",
+        name: "Stale Org",
+        avatar: "https://example.com/stale.png",
+        totalDonations: 9999999,
+        monthlyDonations: 0,
+        firstDonation: new Date(NOW - 30 * DAY).toISOString(),
+      },
+    ];
+    return [...recent, ...stale];
+  },
+  { virtual: true },
+);
+
+describe("Support with rank='latest'", () => {
+  let intersectionCallback;
+
+  beforeEach(() => {
+    Object.defineProperty(window, "IntersectionObserver", {
+      writable: true,
+      configurable: true,
+      value: class {
+        observe() {}
+
+        disconnect() {}
+      },
+    });
+    jest.spyOn(window, "IntersectionObserver").mockImplementation((cb) => {
+      intersectionCallback = cb;
+      return { observe: jest.fn(), disconnect: jest.fn() };
+    });
+  });
+
+  it("renders supporters within the 14-day window, capped at the limit", () => {
+    render(<Support rank="latest" type="total" />);
+    expect(screen.getAllByRole("img")).toHaveLength(10);
+  });
+
+  it("excludes supporters whose firstDonation is older than 14 days", () => {
+    render(<Support rank="latest" type="total" />);
+    expect(screen.queryByAltText("Stale Org's avatar")).toBeNull();
+  });
+
+  it("shows SmallIcon for every supporter before intersection observer fires", () => {
+    render(<Support rank="latest" type="total" />);
+    const imgs = screen.getAllByRole("img");
+    for (const img of imgs) {
+      expect(img.getAttribute("src")).toBe(SmallIcon);
+    }
+  });
+
+  it("swaps in supporter avatars after intersection observer fires", () => {
+    render(<Support rank="latest" type="total" />);
+    act(() => {
+      intersectionCallback([{ isIntersecting: true }]);
+    });
+    const imgs = screen.getAllByRole("img");
+    for (const img of imgs) {
+      expect(img.getAttribute("src")).toMatch(
+        /^https:\/\/example\.com\/recent-/,
+      );
+    }
+  });
+});

--- a/src/components/Support/Support.test.jsx
+++ b/src/components/Support/Support.test.jsx
@@ -57,6 +57,18 @@ describe("Support", () => {
     ).toBeTruthy();
   });
 
+  it("renders a heading for platinum rank", () => {
+    render(<Support rank="platinum" type="total" />);
+    expect(
+      screen.getByRole("heading", { name: "Platinum Sponsors" }),
+    ).toBeTruthy();
+  });
+
+  it("renders monthly description text", () => {
+    render(<Support rank="gold" type="monthly" />);
+    expect(screen.getByText(/pledging/i)).toBeTruthy();
+  });
+
   it("renders the become a sponsor link for sponsor ranks", () => {
     render(<Support rank="gold" type="total" />);
     expect(

--- a/src/components/Support/Support.test.jsx
+++ b/src/components/Support/Support.test.jsx
@@ -1,15 +1,12 @@
 /**
  * @jest-environment jsdom
  */
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { render, screen } from "@testing-library/react";
+
+import Support from "./Support.jsx";
 
 jest.mock("./AdditionalSupporters.mjs", () => []);
 jest.mock("./_supporters.json", () => [], { virtual: true });
-
-// eslint-disable-next-line import/first
-import Support from "./Support.jsx";
 
 describe("Support", () => {
   let mockObserve;

--- a/src/components/Support/Support.test.jsx
+++ b/src/components/Support/Support.test.jsx
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment jsdom
+ */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("./AdditionalSupporters.mjs", () => []);
+jest.mock("./_supporters.json", () => [], { virtual: true });
+
+// eslint-disable-next-line import/first
+import Support from "./Support.jsx";
+
+describe("Support", () => {
+  let mockObserve;
+  let mockDisconnect;
+
+  beforeEach(() => {
+    mockObserve = jest.fn();
+    mockDisconnect = jest.fn();
+    Object.defineProperty(window, "IntersectionObserver", {
+      writable: true,
+      configurable: true,
+      value: class {
+        observe() {}
+
+        disconnect() {}
+      },
+    });
+    jest.spyOn(window, "IntersectionObserver").mockImplementation(() => ({
+      observe: mockObserve,
+      disconnect: mockDisconnect,
+    }));
+  });
+
+  it("renders a heading for backer rank", () => {
+    render(<Support rank="backer" type="total" />);
+    expect(screen.getByRole("heading", { name: "Backers" })).toBeTruthy();
+  });
+
+  it("renders a heading for latest rank", () => {
+    render(<Support rank="latest" type="total" />);
+    expect(
+      screen.getByRole("heading", { name: "Latest Sponsors" }),
+    ).toBeTruthy();
+  });
+
+  it("renders a heading for gold rank", () => {
+    render(<Support rank="gold" type="total" />);
+    expect(screen.getByRole("heading", { name: "Gold Sponsors" })).toBeTruthy();
+  });
+
+  it("renders a heading for gold monthly rank", () => {
+    render(<Support rank="gold" type="monthly" />);
+    expect(
+      screen.getByRole("heading", { name: "Gold Monthly Sponsors" }),
+    ).toBeTruthy();
+  });
+
+  it("renders the become a sponsor link for sponsor ranks", () => {
+    render(<Support rank="gold" type="total" />);
+    expect(
+      screen.getByRole("link", { name: /become a sponsor/i }),
+    ).toBeTruthy();
+  });
+
+  it("renders the become a backer link for backer rank", () => {
+    render(<Support rank="backer" type="total" />);
+    expect(screen.getByRole("link", { name: /become a backer/i })).toBeTruthy();
+  });
+
+  it("sets up IntersectionObserver on mount", () => {
+    render(<Support rank="gold" type="total" />);
+    expect(window.IntersectionObserver).toHaveBeenCalled();
+    expect(mockObserve).toHaveBeenCalled();
+  });
+
+  it("disconnects IntersectionObserver on unmount", () => {
+    const { unmount } = render(<Support rank="gold" type="total" />);
+    unmount();
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  it("matches snapshot for backer rank", () => {
+    const { container } = render(<Support rank="backer" type="total" />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/Support/Support.test.jsx
+++ b/src/components/Support/Support.test.jsx
@@ -42,6 +42,17 @@ describe("Support", () => {
     ).toBeTruthy();
   });
 
+  it("renders maxAge days and limit in latest description", () => {
+    render(<Support rank="latest" type="total" />);
+    expect(screen.getByText(/last 14 days/i)).toBeTruthy();
+    expect(screen.getByText(/top 10/i)).toBeTruthy();
+  });
+
+  it("renders no supporter images when latest data is empty", () => {
+    render(<Support rank="latest" type="total" />);
+    expect(screen.queryAllByRole("img")).toHaveLength(0);
+  });
+
   it("renders a heading for gold rank", () => {
     render(<Support rank="gold" type="total" />);
     expect(screen.getByRole("heading", { name: "Gold Sponsors" })).toBeTruthy();

--- a/src/components/Support/__snapshots__/Support.data.test.jsx.snap
+++ b/src/components/Support/__snapshots__/Support.data.test.jsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Support with supporter data matches snapshot with supporter data 1`] = `
+<h2>
+  Gold Sponsors
+</h2>
+`;

--- a/src/components/Support/__snapshots__/Support.test.jsx.snap
+++ b/src/components/Support/__snapshots__/Support.test.jsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Support matches snapshot for backer rank 1`] = `
+<h2>
+  Backers
+</h2>
+`;

--- a/src/components/__mocks__/fileMock.js
+++ b/src/components/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = "file-mock";


### PR DESCRIPTION
**Summary**

Part of #8161. Converts Support from a class component to a functional component using hooks. Moves the supporters computation into `useMemo` to satisfy the `react-hooks/purity` lint rule. Also adds tests.

**What kind of change does this PR introduce?**

Refactor. No behavior or visual changes.

**Did you add tests for your changes?**

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

N/A

**Use of AI**

No.