### PR TITLE
fix: eliminate dark mode Flash of Unstyled Content (FOUC)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html lang="en">
-  <head> </head>
+  <head>
+    <script>(function(){try{var d=document.documentElement;var s=localStorage.getItem('theme');var isDark=false;if(s){isDark=s==='"dark"'||s==='dark'}else{isDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(isDark){localStorage.setItem('theme','"dark"')}}if(isDark){d.setAttribute('data-theme','dark');d.classList.add('dark')}}catch(e){}})();</script>
+  </head>
   <body>
     <div id="root"></div>
   </body>

--- a/src/index.html
+++ b/src/index.html
@@ -1,7 +1,27 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <script>(function(){try{var d=document.documentElement;var s=localStorage.getItem('theme');var isDark=false;if(s){isDark=s==='"dark"'||s==='dark'}else{isDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(isDark){localStorage.setItem('theme','"dark"')}}if(isDark){d.setAttribute('data-theme','dark');d.classList.add('dark')}}catch(e){}})();</script>
+    <script>
+      (function () {
+        try {
+          var d = document.documentElement;
+          var s = localStorage.getItem("theme");
+          var isDark = false;
+          if (s) {
+            isDark = s === '"dark"' || s === "dark";
+          } else {
+            isDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+            if (isDark) {
+              localStorage.setItem("theme", '"dark"');
+            }
+          }
+          if (isDark) {
+            d.setAttribute("data-theme", "dark");
+            d.classList.add("dark");
+          }
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/server.jsx
+++ b/src/server.jsx
@@ -42,5 +42,9 @@ export default (locals) => {
   const hoistedTags = headTagsMatch ? headTagsMatch[1] : "";
   const bodyHtml = renderedHtml.slice(hoistedTags.length);
 
-  return `<!DOCTYPE html><html><head>${css}${hoistedTags}</head><body><div id="root">${bodyHtml}</div>${scripts}</body></html>`;
+  // Blocking inline script to prevent dark mode FOUC
+  const themeScript =
+    "<script>(function(){try{var d=document.documentElement;var s=localStorage.getItem('theme');var isDark=false;if(s){isDark=s==='\"dark\"'||s==='dark'}else{isDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(isDark){localStorage.setItem('theme','\"dark\"')}}if(isDark){d.setAttribute('data-theme','dark');d.classList.add('dark')}}catch(e){}})();</script>";
+
+  return `<!DOCTYPE html><html lang="en"><head>${themeScript}${css}${hoistedTags}</head><body><div id="root">${bodyHtml}</div>${scripts}</body></html>`;
 };


### PR DESCRIPTION
Summary 
Fixes the dark mode flash on page load by injecting a very short blocking script into the HTML head.

What kind of change does this PR introduce? 
Bug fix

Did you add tests for your changes? 
No, but existing tests were run to ensure nothing broke.

Does this PR introduce a breaking change?
No.

If relevant, what needs to be documented once your changes are merged or what have you already documented? 
Nothing needs to be documented.

Use of AI?
No
