### PR TITLE
refactor: replace deprecated url.resolve() with WHATWG URL API

### DIFF
--- a/src/components/PageLinks/PageLinks.jsx
+++ b/src/components/PageLinks/PageLinks.jsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line n/prefer-node-protocol
-import Url from "url";
 import PropTypes from "prop-types";
 
 const baseURL = "https://github.com/webpack/webpack.js.org/edit/main/";
@@ -21,8 +19,7 @@ function _handlePrintClick(event) {
 }
 
 export default function PageLinks({ page = {} }) {
-  // eslint-disable-next-line n/no-deprecated-api
-  const editLink = page.edit || Url.resolve(baseURL, page.path);
+  const editLink = page.edit || new URL(page.path, baseURL).href;
 
   return (
     <div className="print:hidden mt-8">

--- a/src/utilities/process-readme.mjs
+++ b/src/utilities/process-readme.mjs
@@ -1,4 +1,3 @@
-import url from "node:url";
 import { excludedLoaders, excludedPlugins } from "./constants.mjs";
 
 const beginsWithDocsDomainRegex = /^(?:https?:)\/\/webpack\.js\.org/;
@@ -40,8 +39,7 @@ function linkFixerFactory(sourceUrl) {
         .replace(/raw.githubusercontent.com/, "github.com")
         .replace(/master/, "blob/master");
 
-      // eslint-disable-next-line n/no-deprecated-api
-      href = url.resolve(renderedUrl, href);
+      href = new URL(href, renderedUrl).href;
     }
 
     // Modify absolute documentation links to be root relative


### PR DESCRIPTION
Summary 
Replaces the deprecated Node.js url.resolve() calls with the modern WHATWG URL API (new URL()) in PageLinks.jsx and process-readme.mjs. This also removes two eslint-disable comments and an unused import that were only there to suppress the deprecation warnings.

What kind of change does this PR introduce? 
Refactor

Did you add tests for your changes? 
No, but existing tests cover both files and were verified to still pass.

Does this PR introduce a breaking change? 
No. Both base URLs are always absolute https:// strings, so the stricter new URL() constructor is safe to use here.

If relevant, what needs to be documented once your changes are merged or what have you already documented? 
Nothing needs to be documented.

Use of AI? 
No