### PR TITLE
docs(guides): add tsconfig-paths-webpack-plugin migration diff

### DIFF
--- a/src/content/guides/typescript.mdx
+++ b/src/content/guides/typescript.mdx
@@ -246,7 +246,7 @@ If you're currently using `tsconfig-paths-webpack-plugin`, you can drop it in fa
 -     plugins: [new TsconfigPathsPlugin()],
 +     // Auto-find tsconfig.json in the project root
 +     tsconfig: true,
-+     
++
 +     // Or explicitly point to one
 +     // tsconfig: './tsconfig.app.json'
     },

--- a/src/content/guides/typescript.mdx
+++ b/src/content/guides/typescript.mdx
@@ -234,6 +234,31 @@ export default {
 
 With the above, `@/components/Button` resolves to `src/components/Button` without any additional plugins or duplicating aliases in `resolve.alias`.
 
+### Migrating from `tsconfig-paths-webpack-plugin`
+
+If you're currently using `tsconfig-paths-webpack-plugin`, you can drop it in favor of the built-in `resolve.tsconfig` option:
+
+```diff
+- import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
+
+  export default {
+    resolve: {
+-     plugins: [new TsconfigPathsPlugin()],
++     // Auto-find tsconfig.json in the project root
++     tsconfig: true,
++     
++     // Or explicitly point to one
++     // tsconfig: './tsconfig.app.json'
+    },
+  };
+```
+
+You can then remove the package from your project:
+
+```bash
+npm uninstall tsconfig-paths-webpack-plugin
+```
+
 W> `resolve.tsconfig` only handles module resolution — it does not transpile TypeScript. You still need `ts-loader`, `babel-loader` with `@babel/preset-typescript`, or another transpilation step.
 
 ## Loader


### PR DESCRIPTION
Summary 
Adds a brief migration diff to the TypeScript guide showing how to switch from tsconfig-paths-webpack-plugin to the native resolve.tsconfig option. The docs previously mentioned that the plugin was replaced, but didn't actually show users how to update their webpack config or remind them to uninstall the package.

What kind of change does this PR introduce? 
Documentation improvement.

Did you add tests for your changes?
 N/A (Documentation update only).

Does this PR introduce a breaking change?
 No.

If relevant, what needs to be documented once your changes are merged or what have you already documented? 
The migration path for resolve.tsconfig is now fully documented in the TypeScript guide as a result of this PR.

Use of AI 
NO