### PR TITLE
Fix blog teaser ellipsis rendering

### DIFF
--- a/src/utilities/content-tree-enhancers.mjs
+++ b/src/utilities/content-tree-enhancers.mjs
@@ -73,14 +73,16 @@ export const enhance = (tree, options) => {
 
     const isBlogItem = normalizedPath.includes("/blog/");
     if (isBlogItem) {
-      const teaser = (body || "")
+      const teaserLines = (body || "")
         .split("\n")
-        .filter((line) => line.trim() && !line.trim().startsWith("#"))
+        .filter((line) => line.trim() && !line.trim().startsWith("#"));
+      const teaserText = teaserLines
         .slice(0, 3)
         .join(" ")
-        .replaceAll(/\[([^\]]+)\]\([^)]+\)/g, "$1") // Strip markdown links but keep text
-        .slice(0, 240);
-      tree.teaser = `${teaser}...`;
+        .replaceAll(/\[([^\]]+)\]\([^)]+\)/g, "$1"); // Strip markdown links but keep text
+      const teaser = teaserText.slice(0, 240);
+      const isTruncated = teaserLines.length > 3 || teaserText.length > 240;
+      tree.teaser = isTruncated ? `${teaser}...` : teaser;
     }
 
     Object.assign(

--- a/src/utilities/content-tree-enhancers.test.mjs
+++ b/src/utilities/content-tree-enhancers.test.mjs
@@ -1,6 +1,9 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { describe, expect } from "@jest/globals";
-import { restructure } from "./content-tree-enhancers.mjs";
+import { enhance, restructure } from "./content-tree-enhancers.mjs";
 
 describe("restructure", () => {
   it("applies filter result back to children array", () => {
@@ -53,5 +56,43 @@ describe("restructure", () => {
     restructure(root, { dir: "src/content" });
 
     expect(root.children.map((item) => item.title)).toEqual(["API", "Guides"]);
+  });
+});
+
+describe("enhance", () => {
+  const createBlogTree = (body) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "webpack-blog-"));
+    const blogDir = path.join(root, "blog");
+    fs.mkdirSync(blogDir);
+    const filePath = path.join(blogDir, "example.mdx");
+    fs.writeFileSync(filePath, `---\ntitle: Example\n---\n\n${body}`);
+
+    return {
+      root,
+      tree: {
+        type: "file",
+        path: filePath,
+        extension: ".mdx",
+        name: "example.mdx",
+      },
+    };
+  };
+
+  it("does not append an ellipsis to an untruncated blog teaser", () => {
+    const { root, tree } = createBlogTree("Short body.");
+
+    enhance(tree, { dir: root });
+
+    expect(tree.teaser).toBe("Short body.");
+  });
+
+  it("appends an ellipsis when the blog teaser is truncated", () => {
+    const { root, tree } = createBlogTree(
+      ["First line.", "Second line.", "Third line.", "Fourth line."].join("\n"),
+    );
+
+    enhance(tree, { dir: root });
+
+    expect(tree.teaser).toBe("First line. Second line. Third line....");
   });
 });


### PR DESCRIPTION
This PR updates how blog teasers are generated so that an ellipsis (...) is only added when the preview text is actually truncated.

Previously, the logic in src/utilities/content-tree-enhancers.mjs always appended ... to teasers, even when the full content was already shown. This could make short blog previews look incomplete and could also result in unnecessary ellipses for empty content.

The change keeps the existing teaser rules but adds a check to determine whether truncation actually occurred — either because there were more than three non-heading lines or because the text exceeded the 240-character limit.

What kind of change does this PR introduce?

fix

Did you add tests for your changes?

Yes.

Added tests to cover:

cases where the teaser is not truncated (no ellipsis expected)
cases where the teaser is truncated (ellipsis should be present)

Also verified with:

npm run jest -- src/utilities/content-tree-enhancers.test.mjs
npm run lint:js -- src/utilities/content-tree-enhancers.mjs src/utilities/content-tree-enhancers.test.mjs
npx prettier --check src/utilities/content-tree-enhancers.mjs src/utilities/content-tree-enhancers.test.mjs
git diff --check

Pre-commit checks passed as well.

Does this PR introduce a breaking change?

No.

If relevant, what needs to be documented once your changes are merged or what have you already documented?

No documentation changes are needed. This is an internal improvement to how blog previews are generated.

Use of AI

AI was used to help review the existing logic, suggest a minimal fix, and assist in drafting test cases. The final implementation and validations were reviewed and verified manually.