### PR TITLE
fix(footer): align legal link hover color with adjacent nav

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -20,7 +20,7 @@ const Footer = () => (
           />
         </a>
       </div>
-      <p className="footer-legal-links mx-auto text-[15px] leading-[1.6] text-[#333333] dark:text-[#e0e0e0]">
+      <p className="mx-auto text-[15px] leading-[1.6] text-[#333333] dark:text-[#e0e0e0] [&_a]:text-[#3b7eb5] [&_a:hover]:!text-[#144f80] dark:[&_a:hover]:!text-[#82b7f6]">
         Copyright <a href="https://openjsf.org">OpenJS Foundation</a> and
         webpack contributors. All rights reserved. The{" "}
         <a href="https://openjsf.org">OpenJS Foundation</a> has registered
@@ -36,7 +36,7 @@ const Footer = () => (
         holders. Use of them does not imply any affiliation with or endorsement
         by them.
       </p>
-      <p className="footer-legal-links mx-auto mt-[18px] text-[15px] leading-[1.6] text-[#333333] dark:text-[#e0e0e0]">
+      <p className="mx-auto mt-[18px] text-[15px] leading-[1.6] text-[#333333] dark:text-[#e0e0e0] [&_a]:text-[#3b7eb5] [&_a:hover]:!text-[#144f80] dark:[&_a:hover]:!text-[#82b7f6]">
         <a href="https://openjsf.org">The OpenJS Foundation</a> |{" "}
         <a href="https://terms-of-use.openjsf.org">Terms of Use</a> |{" "}
         <a href="https://privacy-policy.openjsf.org">Privacy Policy</a> |{" "}

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -10,7 +10,7 @@ const footerLinkClasses =
 
 const Footer = () => (
   <footer className="w-full flex-[0_0_auto] print:hidden">
-    <Container className="mx-auto max-w-[900px] px-5 pb-[30px] pt-[40px] text-center [&_a]:text-[#3b7eb5]">
+    <Container className="mx-auto max-w-[900px] px-5 pb-[30px] pt-[40px] text-center">
       <div className="mb-[24px] flex justify-center">
         <a href="https://openjsf.org" target="_blank" rel="noopener noreferrer">
           <img
@@ -20,7 +20,7 @@ const Footer = () => (
           />
         </a>
       </div>
-      <p className="mx-auto text-[15px] leading-[1.6] text-[#333333] dark:text-[#e0e0e0]">
+      <p className="footer-legal-links mx-auto text-[15px] leading-[1.6] text-[#333333] dark:text-[#e0e0e0]">
         Copyright <a href="https://openjsf.org">OpenJS Foundation</a> and
         webpack contributors. All rights reserved. The{" "}
         <a href="https://openjsf.org">OpenJS Foundation</a> has registered
@@ -36,7 +36,7 @@ const Footer = () => (
         holders. Use of them does not imply any affiliation with or endorsement
         by them.
       </p>
-      <p className="mx-auto mt-[18px] text-[15px] leading-[1.6] text-[#333333] dark:text-[#e0e0e0]">
+      <p className="footer-legal-links mx-auto mt-[18px] text-[15px] leading-[1.6] text-[#333333] dark:text-[#e0e0e0]">
         <a href="https://openjsf.org">The OpenJS Foundation</a> |{" "}
         <a href="https://terms-of-use.openjsf.org">Terms of Use</a> |{" "}
         <a href="https://privacy-policy.openjsf.org">Privacy Policy</a> |{" "}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -66,3 +66,15 @@ body {
 .screen-reader-only {
   @apply sr-only;
 }
+
+.footer-legal-links a {
+  @apply text-[#3b7eb5] transition-colors duration-[250ms];
+}
+
+.footer-legal-links a:hover {
+  color: var(--color-brand-link-hover);
+}
+
+.dark .footer-legal-links a:hover {
+  color: var(--color-dark-link-hover);
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -66,15 +66,3 @@ body {
 .screen-reader-only {
   @apply sr-only;
 }
-
-.footer-legal-links a {
-  @apply text-[#3b7eb5] transition-colors duration-[250ms];
-}
-
-.footer-legal-links a:hover {
-  color: var(--color-brand-link-hover);
-}
-
-.dark .footer-legal-links a:hover {
-  color: var(--color-dark-link-hover);
-}


### PR DESCRIPTION
**Summary**

This PR fixes the hover state for the footer legal links so they match the hover color used by the adjacent page navigation links, while keeping the existing default blue link color unchanged.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

No new tests were added.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No additional documentation is needed.

**Use of AI**

no.

### before

https://github.com/user-attachments/assets/f7b0ec17-75be-4d84-ab3b-9076347d5036

### after

https://github.com/user-attachments/assets/0c8fcc25-39e4-44db-8923-204f6659d852


