### PR TITLE
fix(markdown): correct invalid text-decoration declaration

### DIFF
--- a/src/components/Markdown/Markdown.css
+++ b/src/components/Markdown/Markdown.css
@@ -298,7 +298,7 @@
 
   a {
     @apply text-brand-link;
-    text-decoration: no underline;
+    text-decoration: none;
     text-underline-offset: 2px;
     text-decoration-thickness: 1px;
   }


### PR DESCRIPTION
**Summary**

This PR corrects an invalid CSS declaration in the markdown link styles by replacing `text-decoration: no underline;` with the valid `text-decoration: none;`. This keeps the intended no-underline behavior explicit in the component stylesheet and avoids relying on unrelated global styles.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

No new tests were added. This change is limited to correcting a CSS declaration and does not alter component logic.

**Does this PR introduce a breaking change?**

no.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No additional documentation is needed.

**Use of AI**

no.
