### PR TITLE
docs: correct lodash dependency usage in authoring libraries guide

### DIFF
--- a/src/content/guides/author-libraries.mdx
+++ b/src/content/guides/author-libraries.mdx
@@ -33,14 +33,15 @@ The basic project structure would look like this:
 +     └── ref.json
 ```
 
-Initialize the project with npm, then install `webpack`, `webpack-cli` and `lodash`:
+Initialize the project with npm, then install `webpack` and `webpack-cli` as development dependencies, and `lodash` as a runtime dependency:
 
 ```bash
 npm init -y
-npm install --save-dev webpack webpack-cli lodash
+npm install --save-dev webpack webpack-cli
+npm install lodash
 ```
 
-We install `lodash` as `devDependencies` instead of `dependencies` because we don't want to bundle it into our library, or our library could be easily bloated.
+We install `lodash` as a `dependency` because it is required at runtime by our library. However, to prevent our library from becoming bloated, we will configure webpack to treat it as an external module rather than bundling it.
 
 **src/ref.json**
 
@@ -252,7 +253,7 @@ T> Note that the `library` setup is tied to the `entry` configuration. For most 
 
 ## Externalize Lodash
 
-Now, if you run `npx webpack`, you will find that a largish bundle is created. If you inspect the file, you'll see that lodash has been bundled along with your code. In this case, we'd prefer to treat `lodash` as a _peer dependency_. Meaning that the consumer should already have `lodash` installed. Hence you would want to give up control of this external library to the consumer of your library.
+Now, if you run `npx webpack`, you will find that a largish bundle is created. If you inspect the file, you'll see that lodash has been bundled along with your code. Since `lodash` is listed as a `dependency` in your `package.json`, package managers will install it automatically for consumers of your library. This means you can rely on the consumer's environment to provide it, rather than bundling it directly.
 
 This can be done using the [`externals`](/configuration/externals/) configuration:
 

--- a/src/content/guides/author-libraries.mdx
+++ b/src/content/guides/author-libraries.mdx
@@ -33,15 +33,14 @@ The basic project structure would look like this:
 +     └── ref.json
 ```
 
-Initialize the project with npm, then install `webpack` and `webpack-cli` as development dependencies, and `lodash` as a runtime dependency:
+Initialize the project with npm, then install `webpack`, `webpack-cli`, and `lodash` as development dependencies:
 
 ```bash
 npm init -y
-npm install --save-dev webpack webpack-cli
-npm install lodash
+npm install --save-dev webpack webpack-cli lodash
 ```
 
-We install `lodash` as a `dependency` because it is required at runtime by our library. However, to prevent our library from becoming bloated, we will configure webpack to treat it as an external module rather than bundling it.
+We install `lodash` as a `devDependency` because we will initially bundle it into our library. Since it is included in the final output, consumers of our library won't need to install it themselves.
 
 **src/ref.json**
 
@@ -253,7 +252,7 @@ T> Note that the `library` setup is tied to the `entry` configuration. For most 
 
 ## Externalize Lodash
 
-Now, if you run `npx webpack`, you will find that a largish bundle is created. If you inspect the file, you'll see that lodash has been bundled along with your code. Since `lodash` is listed as a `dependency` in your `package.json`, package managers will install it automatically for consumers of your library. This means you can rely on the consumer's environment to provide it, rather than bundling it directly.
+Now, if you run `npx webpack`, you will find that a largish bundle is created. If you inspect the file, you'll see that lodash has been bundled along with your code. To avoid bundling `lodash` and bloating our library, we can configure webpack to treat it as an external module. Since we are no longer bundling it, the consumer will need to provide it. Therefore, you should move `lodash` from `devDependencies` to `dependencies` (or `peerDependencies`) so package managers will install it automatically for consumers of your library.
 
 This can be done using the [`externals`](/configuration/externals/) configuration:
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

The "Authoring Libraries" documentation incorrectly guides developers to install runtime dependencies like `lodash` as `devDependencies` and to classify them as `peerDependencies` when externalizing them. 

This PR solves this by:
- Updating the installation instructions to place `lodash` in `dependencies` rather than `devDependencies`.
- Rewriting the explanation to clarify that it's a runtime dependency, but we still exclude it from the bundle to prevent bloat.
- Removing the misleading terminology regarding "peer dependency" from the `externals` explanation.

Fixes #7903

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

- [x] docs

**Did you add tests for your changes?**

- [x] No, this is a documentation-only change.

**Does this PR introduce a breaking change?**

- [x] No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

This PR itself is a documentation update. No further documentation is needed.

**Use of AI**

No AI was used to generate this documentation change.
