### PR TITLE
 improve clarity of type notation in writer's guide

### DIFF
--- a/src/content/contribute/writers-guide.mdx
+++ b/src/content/contribute/writers-guide.mdx
@@ -237,18 +237,21 @@ The default value of `configuration.example.flag` depends on the [`mode`](/confi
 If the object's key is dynamic, user-defined, use `<key>` to describe it:
 
 `object = { <key> string }`
-
 ### Options shortlists and their typing
 
-Sometimes, we want to describe certain properties of objects and functions in lists. When applicable add typing directly to the list where properties are enlisted:
+Sometimes, we want to describe certain properties of objects and functions in lists. When applicable, add typing directly to the list where properties are enlisted:
 
 - `madeUp` (`boolean = true`): short description
 - `shortText` (`string = 'i am text'`): another short description
 
 W> `:` is not a necessity here, note the property, type and default.
 
+In general, prefer consistent and familiar notation styles when documenting types.
+
+For function signatures, use a clear argument and return type format:
+
+`function (arg1: string, arg2: number) => boolean`
+
+Avoid mixing multiple type styles (e.g., JSDoc and inline notation) within the same section, as it can reduce readability and consistency.
+
 An example can be found on the [`options` section of the EvalSourceMapDevToolPlugin's page](/plugins/eval-source-map-dev-tool-plugin/#options).
-
-### Adding links
-
-Please use relative URLs (such as `/concepts/mode/`) to link our own content instead of absolute URLs (such as `https://webpack.js.org/concepts/mode/`).


### PR DESCRIPTION
- Improved explanation of type notation usage
- Added clear example for function signatures
- Introduced consistency guideline to avoid mixing type styles