### PR TITLE
docs(externals): document defer/source phase preservation in ESM externals

### DIFF
--- a/src/content/configuration/externals.mdx
+++ b/src/content/configuration/externals.mdx
@@ -493,7 +493,7 @@ Note that there will be an `import` statement in the output bundle.
 
 <Badge text="5.107.0+" />
 
-The `defer` and `source` import phase keywords are preserved on `module` externals the same way [import attributes](/configuration/module/#ruleparserimportattributes) are. A static `import defer * as ns from "mod"` against a `module` external is emitted as a native `import defer * as ...` statement, and `import source v from "mod"` becomes `import source ... from "mod"`. The same external imported with two different phases produces distinct `ExternalModule` instances, so neither phase is silently dropped.
+The `defer` and `source` import phase keywords are preserved on `module` externals the same way [import attributes](https://github.com/tc39/proposal-import-attributes) are. A static `import defer * as ns from "mod"` against a `module` external is emitted as a native `import defer * as ...` statement, and `import source v from "mod"` becomes `import source ... from "mod"`. The same external imported with two different phases produces distinct `ExternalModule` instances, so neither phase is silently dropped.
 
 {/* eslint-skip */}
 

--- a/src/content/configuration/externals.mdx
+++ b/src/content/configuration/externals.mdx
@@ -489,6 +489,24 @@ jq(".my-element").animate(/* ... */);
 
 Note that there will be an `import` statement in the output bundle.
 
+#### Preserving phase keywords
+
+<Badge text="5.107.0+" />
+
+The `defer` and `source` import phase keywords are preserved on `module` externals the same way [import attributes](/configuration/module/#ruleparserimportattributes) are. A static `import defer * as ns from "mod"` against a `module` external is emitted as a native `import defer * as ...` statement, and `import source v from "mod"` becomes `import source ... from "mod"`. The same external imported with two different phases produces distinct `ExternalModule` instances, so neither phase is silently dropped.
+
+{/* eslint-skip */}
+
+```js
+// input
+import defer * as ns from "external-mod";
+import source v from "external-mod";
+
+// emitted output (with externalsType: "module")
+import defer * as ns from "external-mod";
+import source v from "external-mod";
+```
+
 ### externalsType.import
 
 <Badge text="5.94.0+" />
@@ -535,6 +553,24 @@ async function foo() {
 ```
 
 Note that the output bundle will have an `import()` statement.
+
+#### Preserving phase keywords
+
+<Badge text="5.107.0+" />
+
+Dynamic `import.defer(...)` and `import.source(...)` are also preserved on `import` externals when the import function name is the default `"import"`. The phase keyword is emitted in the output instead of being stripped.
+
+{/* eslint-skip */}
+
+```js
+// input
+const ns = await import.defer("external-mod");
+const src = await import.source("external-mod");
+
+// emitted output (with externalsType: "import")
+const ns = await import.defer("external-mod");
+const src = await import.source("external-mod");
+```
 
 ### externalsType.module-import
 


### PR DESCRIPTION
## Summary

Webpack 5.107 preserves the `defer` and `source` import phase keywords on external dependencies the same way it preserves import attributes.

Adds two new subsections under `externalsType.module` and `externalsType.import` in `configuration/externals.mdx`, showing both the static and dynamic forms emitted in the output bundle.

Refs: https://github.com/webpack/webpack/pull/20934

## Test plan

- [ ] Visual check of both new subsections
- [ ] Verify the badges show "5.107.0+"
