### PR TITLE
docs(magic-comments): document webpackIgnore support in HTML modules

### DIFF
--- a/src/content/api/module-methods.mdx
+++ b/src/content/api/module-methods.mdx
@@ -183,6 +183,22 @@ We support `webpackIgnore` in the following cases:
 
 T> For other CSS scenarios, [`css-loader` fully supports `webpackIgnore`](/loaders/css-loader/#disable-url-resolving-using-the--webpackignore-true--comment), allowing more flexibility if needed.
 
+**HTML Usage**
+
+<Badge text="5.107.0+" />
+
+When [`experiments.html`](/configuration/experiments/#experimentshtml) is enabled, `webpackIgnore` can be placed as an HTML comment immediately before a tag to skip URL resolution for that tag's `src`, `href`, `srcset`, and similar attributes. The tag is left untouched in the emitted HTML. This mirrors the behavior provided by `html-loader`.
+
+```html
+<!-- webpackIgnore: true -->
+<img src="https://cdn.example.com/logo.png" />
+
+<!-- webpackIgnore: true -->
+<script src="/legacy/external.js"></script>
+```
+
+The magic-comment value is parsed with the same context used by the JS and CSS parsers; non-boolean values emit an `UnsupportedFeatureWarning`.
+
 ##### webpackChunkName
 
 A name for the new chunk. Since webpack 2.6.0, the placeholders `[index]` and `[request]` are supported within the given string to an incremented number or the actual resolved filename respectively. Adding this comment will cause our separate chunk to be named [my-chunk-name].js instead of [id].js.


### PR DESCRIPTION
## Summary

Webpack 5.107 supports the `webpackIgnore` magic comment inside HTML modules (when `experiments.html` is enabled). Placing `<!-- webpackIgnore: true -->` before a tag skips URL resolution for its `src` / `href` / `srcset` attributes, leaving the tag untouched in the emitted HTML.

Adds a new "HTML Usage" section under the existing `webpackIgnore` docs in `api/module-methods.mdx`, mirroring the existing JavaScript Usage and CSS Usage sections.

Refs: https://github.com/webpack/webpack/pull/20950

## Test plan

- [ ] Visual check of the new HTML Usage section
- [ ] Verify the badge shows "5.107.0+"
