### PR TITLE
docs(module): document module.parser.javascript.anonymousDefaultExportName

### DIFF
--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -631,6 +631,33 @@ export default {
 
 It's allowed to configure those options in [`Rule.parser`](/configuration/module/#ruleparser) as well to target specific modules.
 
+#### module.parser.javascript.anonymousDefaultExportName
+
+<Badge text="5.107.0+" />
+
+Controls whether webpack sets `.name` to `"default"` for anonymous default-export functions and classes, matching the ES spec for native ESM. When enabled, webpack injects a small runtime helper (`__webpack_require__.dn`) that calls `Object.defineProperty(...)` on the export to set the `.name` value.
+
+- Type: `boolean`
+- Default: `true` for applications, `false` for libraries (when [`output.library`](/configuration/output/#outputlibrary) is set).
+
+Applications stay spec-compliant by default. Libraries skip the helper to keep bundle size small, since library consumers rarely rely on `.name === "default"`.
+
+To override the default explicitly:
+
+**webpack.config.js**
+
+```js
+export default {
+  module: {
+    parser: {
+      javascript: {
+        anonymousDefaultExportName: false,
+      },
+    },
+  },
+};
+```
+
 #### module.parser.javascript.commonjsMagicComments
 
 Enable [magic comments](/api/module-methods/#magic-comments) support for CommonJS.


### PR DESCRIPTION
## Summary

Webpack 5.107 introduces a new JS parser option (`module.parser.javascript.anonymousDefaultExportName`) that controls whether webpack sets `.name` to `"default"` on anonymous default-export functions and classes (per the ES spec).

The fix-up was added in 5.106 but the extra `Object.defineProperty` calls inflate bundles, so the option defaults to:
- `true` for applications
- `false` for libraries (when `output.library` is set)

Documents the option under `module.parser.javascript` in `configuration/module.mdx`.

Refs: https://github.com/webpack/webpack/pull/20894

## Test plan

- [ ] Visual check of the new section
- [ ] Verify the badge shows "5.107.0+"


## Use of AI

Drafted with Claude under human review. The contributor verified each change against the upstream webpack PR before commit.