### PR TITLE
docs(experiments): document CSS scope hoisting and @value in URLs (5.107)

### DIFF
--- a/src/content/configuration/experiments.mdx
+++ b/src/content/configuration/experiments.mdx
@@ -236,6 +236,31 @@ Experimental features:
 - CSS imports: webpack will inline CSS imports into the generated CSS file.
 - Hot Module Reload (HMR): webpack supports HMR for CSS files. This means that changes made to CSS files will be reflected in the browser without a full page reload.
 
+- <Badge text="5.107.0+" /> Scope hoisting (module concatenation) for CSS
+  Modules. When
+  [`optimization.concatenateModules`](/configuration/optimization/#optimizationconcatenatemodules)
+  is enabled, CSS Modules whose `exportType` is `text`, `css-style-sheet`,
+  `style`, or `link` are concatenated into a single module instance instead of
+  being kept as separate runtime instances. This reduces overhead and produces
+  smaller output for CSS-heavy bundles.
+
+- <Badge text="5.107.0+" /> `@value` identifiers can be used as the path
+  argument to `@import` and inside `url()` references, so shared paths and
+  assets can be defined once and reused across stylesheets. Both quoted
+  (`"./x"`, `'./x'`) and bare (`./x`) forms are accepted and resolved through
+  webpack's normal asset pipeline.
+
+  ```css
+  @value path: "./other.module.css";
+  @import path;
+
+  @value bg: "./image.png";
+
+  .a {
+    background: url(bg);
+  }
+  ```
+
 ### experiments.cacheUnaffected
 
 Enable additional in-memory caching of modules which are unchanged and reference only unchanged modules.


### PR DESCRIPTION
## Summary

Webpack 5.107 brings two additions to the `experiments.css` feature set:

- **Scope hoisting (module concatenation)** now applies to CSS Modules with `exportType` of `text`, `css-style-sheet`, `style`, or `link`, reducing runtime overhead in CSS-heavy bundles when `optimization.concatenateModules` is enabled.
- **`@value` identifiers** can be used as the path argument to `@import` and inside `url()` references, so shared paths/assets are defined once and reused. Both quoted (`"./x"`, `'./x'`) and bare (`./x`) forms are accepted and resolved through webpack's normal asset pipeline.

Adds two bullets to the existing experimental features list in `experiments.css`.

Refs:
- https://github.com/webpack/webpack/pull/20851 (scope hoisting)
- https://github.com/webpack/webpack/pull/20925 (@value in URLs)

## Test plan

- [ ] Visual check of the new bullets and code example
- [ ] Verify the badges show "5.107.0+"


## Use of AI

Drafted with Claude under human review. The contributor verified each change against the upstream webpack PR before commit.