### PR TITLE
improvement: make search shortcut less visually distracting

### DIFF
--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -36,17 +36,30 @@
   --docsearch-primary-color: #1d78c1 !important;
 }
 .DocSearch-Button {
-  @apply bg-transparent! lg:bg-gray-500! transition! duration-200! lg:rounded-full!;
+  @apply bg-transparent! lg:bg-gray-500! lg:border! lg:border-white/80! transition! duration-200! lg:rounded-full!;
 }
 .DocSearch-Button-Placeholder {
-  @apply hidden! lg:font-light! lg:text-sm! lg:block! lg:text-gray-200! lg:dark:text-gray-300! transition! duration-200!;
+  @apply hidden! lg:font-light! lg:text-sm! lg:block! lg:text-gray-200!  transition! duration-200!;
 }
 .DocSearch-Button:hover .DocSearch-Button-Placeholder {
   @apply lg:text-gray-100!;
 }
 .DocSearch-Button-Keys {
-  @apply hidden! lg:flex!;
+  @apply hidden! lg:flex! items-center! gap-x-px!;
+  font-size: 12px;
 }
+.DocSearch-Button-Keys kbd {
+  @apply inline-flex items-center justify-center
+    h-[18px] leading-none
+    bg-transparent
+    text-white/80
+    border border-white/50
+    rounded-md
+    shadow-none
+    font-normal
+    text-[12px];
+}
+
 .DocSearch-Button .DocSearch-Search-Icon {
   @apply text-white! lg:text-gray-100!;
 }

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -36,13 +36,13 @@
   --docsearch-primary-color: #1d78c1 !important;
 }
 .DocSearch-Button {
-  @apply bg-transparent! lg:bg-gray-500! lg:border! lg:border-white/80! transition! duration-200! lg:rounded-full!;
+  @apply bg-transparent! lg:bg-gray-600! lg:border! lg:border-white/80! transition! duration-200! lg:rounded-full!;
 }
 .DocSearch-Button-Placeholder {
-  @apply hidden! lg:font-light! lg:text-sm! lg:block! lg:text-gray-200!  transition! duration-200!;
+  @apply hidden! lg:font-light! lg:text-sm! lg:block! lg:text-gray-200 transition! duration-200!;
 }
 .DocSearch-Button:hover .DocSearch-Button-Placeholder {
-  @apply lg:text-gray-100!;
+  @apply lg:text-white!;
 }
 .DocSearch-Button-Keys {
   @apply hidden! lg:flex! items-center! gap-x-px!;
@@ -52,7 +52,7 @@
   @apply inline-flex items-center justify-center
     h-[18px] leading-none
     bg-transparent
-    text-white/80
+    text-white/100
     border border-white/50
     rounded-md
     shadow-none

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -39,7 +39,7 @@
   @apply bg-transparent! lg:bg-gray-600! lg:border! lg:border-white/80! transition! duration-200! lg:rounded-full!;
 }
 .DocSearch-Button-Placeholder {
-  @apply hidden! lg:font-light! lg:text-sm! lg:block! lg:text-gray-200 transition! duration-200!;
+  @apply hidden! lg:font-light! lg:text-sm! lg:block! lg:text-gray-200! transition! duration-200!;
 }
 .DocSearch-Button:hover .DocSearch-Button-Placeholder {
   @apply lg:text-white!;


### PR DESCRIPTION
### Summary

This PR reduces the visual prominence of the `Ctrl K` shortcut inside the DocSearch search bar.

Previously, the shortcut keys appeared highly contrasted and button-like, which made them visually distracting and could give the impression that they were clickable elements rather than passive keyboard hints.

This update softens the styling by:

* reducing contrast,
* using subtler borders,
* improving blending with the search bar background,
* and keeping the shortcut discoverable without dominating the visual hierarchy.

Fixes #8254

---

### Before

* Shortcut keys appeared visually dominant and button-like
* High contrast drew attention away from the search input

<img width="288" height="85" alt="image" src="https://github.com/user-attachments/assets/e1bfa614-ca31-48ab-98d9-c03c50185ba6" />
<img width="266" height="78" alt="image" src="https://github.com/user-attachments/assets/29b50d92-d6ae-4e94-87ed-3686a7a5693c" />



### After

* Shortcut keys blend more naturally with the search bar
* Softer borders and reduced contrast improve visual hierarchy
* Maintains discoverability while feeling less distracting

<img width="296" height="90" alt="image" src="https://github.com/user-attachments/assets/4403e552-54f8-4f1f-b445-3f7b330a6868" />
<img width="285" height="80" alt="image" src="https://github.com/user-attachments/assets/47d124f4-6bb3-407e-86dd-e6b52670382a" />


---

**What kind of change does this PR introduce?**

style

---

**Did you add tests for your changes?**

No. This change is purely visual/UI-related and does not affect functionality.

---

**Does this PR introduce a breaking change?**

No.

---

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No additional documentation is required.

---

**Use of AI**

AI assistance was used for wording refinement and discussion around UI/UX considerations.
The implementation, styling decisions, testing, and final modifications were reviewed and adjusted manually.
