### PR TITLE
docs(awesome-webpack): add MDX to loader list

### DIFF
--- a/src/content/awesome-webpack.mdx
+++ b/src/content/awesome-webpack.mdx
@@ -89,6 +89,7 @@ _People passionate about Webpack (In no particular order)_
 - [PostHTML Loader](https://github.com/posthtml/posthtml-loader): PostHTML loader for Webpack. -- _Maintainer_: `PostHTML Team` [![Github][githubicon]](https://github.com/posthtml) [![Twitter][twittericon]](https://twitter.com/PostHTML)
 - [ELM Loader](https://github.com/rtfeldman/elm-webpack-loader): Webpack loader for the Elm programming language. -- _Maintainer_: `Richard Feldman` [![Github][githubicon]](https://github.com/rtfeldman) [![Twitter][twittericon]](https://twitter.com/rtfeldman)
 - [Fengari Loader](https://github.com/fengari-lua/fengari-loader/): Run Lua code using [Fengari](https://fengari.io). -- _Maintainer_: `Daurnimator` [![Github][githubicon]](https://github.com/daurnimator) [![Twitter][twittericon]](https://twitter.com/daurnimator)
+- [MDX Loader](https://mdxjs.com/packages/loader/): MDX loader for Webpack. -- _Maintainer_: `MDX Team` [![Github][githubicon]](https://github.com/mdx-js)
 
 #### Utility
 


### PR DESCRIPTION
**Summary**

This adds the `@mdx-js/loader` package that’s maintained by the MDX team to the `awesome-webpack` page. This is a popular integration (this repo even uses it), but it was not listed.

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

No

**Does this PR introduce a breaking change?**

No

**Use of AI**

None, but I like your [AI policy](https://github.com/webpack/governance/blob/main/AI_POLICY.md) :)