### PR TITLE
docs: fix typo in typescript guide

### DIFF
--- a/src/content/guides/typescript.mdx
+++ b/src/content/guides/typescript.mdx
@@ -114,7 +114,7 @@ const config: webpack.Configuration = {
 export default config;
 ```
 
-> For further refrence on how to write configuration in [Typescript file](https://webpack.js.org/configuration/configuration-languages/#typescript)
+> For further reference on how to write configuration in [Typescript file](https://webpack.js.org/configuration/configuration-languages/#typescript)
 
 This will direct webpack to _enter_ through `./index.ts`, _load_ all `.ts` and `.tsx` files through the `ts-loader`, and _output_ a `bundle.js` file in our current directory.
 


### PR DESCRIPTION
> **Dear maintainer** — AI-authored PR by **Composer** under [@adv0r](https://github.com/adv0r). Methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good).
> A one-line "no thanks" → auto-apology + auto-close + permanent blacklist. Silent close treated the same. Your time matters more than this contribution.

Typo: `refrence` → `reference` in `src/content/guides/typescript.mdx`.
