### PR TITLE
docs: Update resource-fallback plugin entry with GitHub link

### DIFF
--- a/src/content/awesome-webpack.mdx
+++ b/src/content/awesome-webpack.mdx
@@ -178,7 +178,7 @@ _People passionate about Webpack (In no particular order)_
 - [Manifest Extraction Plugin](https://github.com/shellscape/webpack-manifest-plugin): Generates an asset manifest after compiling webpack. -- _Maintainer_: `Andrew Powell` [![Github][githubicon]](https://github.com/shellscape)
 - [Transform Async Modules Plugin](https://github.com/steverep/transform-async-modules-webpack-plugin): A Webpack plugin to transpile async module output using Babel. Allows transpiling top level await to ES5. -- _Maintainer_: `Steve Repsher` [![Github][githubicon]](https://github.com/steverep)
 - [CSS Layering Plugin](https://github.com/kburich/css-layering-webpack-plugin): Wrap CSS in cascade layers. -- _Maintainer_: `Kresimir Buric` [![Github][githubicon]](https://github.com/kburich)
-- [@resource-fallback/webpack-plugin](https://github.com/ben-lau/resource-fallback/tree/main/packages/webpack-plugin) - Runtime retry, multi-CDN fallback, and origin recovery for Vite build assets (JS/CSS chunks, dynamic import) — zero business code changes.
+- [@resource-fallback/webpack-plugin](https://github.com/ben-lau/resource-fallback/tree/main/packages/webpack-plugin) - Runtime retry, multi-CDN fallback, and origin recovery for Vite build assets (JS/CSS chunks, dynamic import) — zero business code changes.[![Github][githubicon]](https://github.com/ben-lau)
 
 ### Webpack Tools
 

--- a/src/content/awesome-webpack.mdx
+++ b/src/content/awesome-webpack.mdx
@@ -178,7 +178,7 @@ _People passionate about Webpack (In no particular order)_
 - [Manifest Extraction Plugin](https://github.com/shellscape/webpack-manifest-plugin): Generates an asset manifest after compiling webpack. -- _Maintainer_: `Andrew Powell` [![Github][githubicon]](https://github.com/shellscape)
 - [Transform Async Modules Plugin](https://github.com/steverep/transform-async-modules-webpack-plugin): A Webpack plugin to transpile async module output using Babel. Allows transpiling top level await to ES5. -- _Maintainer_: `Steve Repsher` [![Github][githubicon]](https://github.com/steverep)
 - [CSS Layering Plugin](https://github.com/kburich/css-layering-webpack-plugin): Wrap CSS in cascade layers. -- _Maintainer_: `Kresimir Buric` [![Github][githubicon]](https://github.com/kburich)
-- [@resource-fallback/webpack-plugin](https://github.com/ben-lau/resource-fallback/tree/main/packages/webpack-plugin) - Runtime retry, multi-CDN fallback, and origin recovery for Vite build assets (JS/CSS chunks, dynamic import) — zero business code changes.[![Github][githubicon]](https://github.com/ben-lau)
+- [@resource-fallback/webpack-plugin](https://github.com/ben-lau/resource-fallback/tree/main/packages/webpack-plugin) - Runtime retry, multi-CDN fallback, and origin recovery for Vite build assets (JS/CSS chunks, dynamic import) — zero business code changes. -- _Maintainer_: `Ben Lau` [![Github][githubicon]](https://github.com/ben-lau)
 
 ### Webpack Tools
 


### PR DESCRIPTION
Summary

Follow-up to #8267  — added the missing author GitHub link for `@resource-fallback/webpack-plugin`.

The plugin entry was added in the previous PR but the author link was omitted. This PR adds it to keep consistent with other entries in the list.

docs — adding a third-party plugin entry to the plugins list.

Did you add tests for your changes?

N/A — documentation-only change (one line added to the plugin list).

Does this PR introduce a breaking change?

No.

If relevant, what needs to be documented once your changes are merged or what have you already documented?

No further documentation needed. The plugin has its own documentation site.

Use of AI

No. This PR was written manually by the plugin author.