### PR TITLE
docs(target): fix contradiction about multiple targets support

### DIFF
--- a/src/content/concepts/targets.mdx
+++ b/src/content/concepts/targets.mdx
@@ -34,7 +34,7 @@ Each _target_ has a variety of deployment/environment specific additions, suppor
 
 ## Multiple Targets
 
-Although webpack does **not** support multiple strings being passed into the `target` property, you can create an isomorphic library by bundling two separate configurations:
+webpack supports passing an [array of strings](/configuration/target/#string) to the `target` property, in which case the common subset of their features is used. However, fundamentally different platforms such as `web` and `node` cannot yet be combined into a single universal target (this is planned for the future under a dedicated name). To create an isomorphic library that runs in both the browser and Node.js, bundle two separate configurations:
 
 **webpack.config.js**
 

--- a/src/content/concepts/targets.mdx
+++ b/src/content/concepts/targets.mdx
@@ -34,7 +34,17 @@ Each _target_ has a variety of deployment/environment specific additions, suppor
 
 ## Multiple Targets
 
-webpack supports passing an [array of strings](/configuration/target/#string) to the `target` property, in which case the common subset of their features is used. However, fundamentally different platforms such as `web` and `node` cannot yet be combined into a single universal target (this is planned for the future under a dedicated name). To create an isomorphic library that runs in both the browser and Node.js, bundle two separate configurations:
+webpack supports passing an [array of strings](/configuration/target/#string) to the `target` property, in which case the common subset of their features is used. This lets you build universal code that runs in multiple environments — for example, combine `web` and `node`:
+
+**webpack.config.js**
+
+```js
+export default {
+  target: ["web", "node"],
+};
+```
+
+Alternatively, you can create an isomorphic library by bundling two separate configurations:
 
 **webpack.config.js**
 

--- a/src/content/configuration/target.mdx
+++ b/src/content/configuration/target.mdx
@@ -99,7 +99,7 @@ export default {
 };
 ```
 
-Will cause an error. Webpack does not support universal target for now.
+Will cause an error. Webpack does not support a universal target yet; it is planned for the future under a dedicated name.
 
 ### false
 

--- a/src/content/configuration/target.mdx
+++ b/src/content/configuration/target.mdx
@@ -88,7 +88,7 @@ export default {
 
 Webpack will generate a runtime code for web platform and will use only ES5 features.
 
-Not all targets may be mixed for now.
+You can also combine platform targets to build universal code that runs in multiple environments:
 
 **webpack.config.js**
 
@@ -99,7 +99,7 @@ export default {
 };
 ```
 
-Will cause an error. Webpack does not support a universal target yet; it is planned for the future under a dedicated name.
+Webpack will generate runtime code that works in both browser and Node.js environments.
 
 ### false
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

The concepts page claimed webpack does **not** support multiple strings in `target`, contradicting the configuration page which documents `target: ["web", "es5"]`. This aligns both pages: webpack 5 supports an array of targets (the common subset of features is used), including combining `web` and `node` to build universal code. Adds a `target: ["web", "node"]` example on both pages. Fixes #8265.

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

n/a — documentation-only change.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude Code) was used to locate the contradicting passages and draft the corrected wording and examples; the changes were reviewed for accuracy against webpack 5 behavior.