### PR TITLE
docs: document webpack 5.107/5.108 CLI config formats and HTML module extraction

### DIFF
--- a/src/content/api/cli.mdx
+++ b/src/content/api/cli.mdx
@@ -412,7 +412,7 @@ This is the lookup priority in increasing order
 '.webpack/webpackfile',
 ```
 
-Each base name is resolved against the supported extensions — JavaScript and TypeScript variants (`.js`, `.mjs`, `.cjs`, `.ts`, `.cts`, `.mts`), the languages handled through [interpret](https://github.com/gulpjs/interpret) (e.g. `.coffee`), and, since webpack-cli 7.1.0, the [data formats](/configuration/configuration-languages/#data-formats-json5-yaml-and-toml) `.json5`, `.yaml`/`.yml` and `.toml`.
+Each base name is resolved against the supported extensions — JavaScript and TypeScript variants (`.js`, `.mjs`, `.cjs`, `.ts`, `.cts`, `.mts`), other supported languages such as `.coffee`, and, since webpack-cli 7.1.0, the [data formats](/configuration/configuration-languages/#data-formats-json5-yaml-and-toml) `.json5`, `.yaml`/`.yml` and `.toml`.
 
 ## Common Options
 

--- a/src/content/api/cli.mdx
+++ b/src/content/api/cli.mdx
@@ -412,6 +412,8 @@ This is the lookup priority in increasing order
 '.webpack/webpackfile',
 ```
 
+Each base name is resolved against the supported extensions — JavaScript and TypeScript variants (`.js`, `.mjs`, `.cjs`, `.ts`, `.cts`, `.mts`), the languages handled through [interpret](https://github.com/gulpjs/interpret) (e.g. `.coffee`), and, since webpack-cli 7.1.0, the [data formats](/configuration/configuration-languages/#data-formats-json5-yaml-and-toml) `.json5`, `.yaml`/`.yml` and `.toml`.
+
 ## Common Options
 
 W> Note that Command Line Interface has a higher precedence for the arguments you use it with than your configuration file. For instance, if you pass [`--mode="production"`](/configuration/mode/#usage) to webpack CLI and your configuration file uses `development`, `production` will be used.

--- a/src/content/configuration/configuration-languages.mdx
+++ b/src/content/configuration/configuration-languages.mdx
@@ -298,10 +298,10 @@ npx webpack --config webpack.config.toml
 ```json5
 {
   // JSON5 allows comments, unquoted keys and trailing commas
-  mode: 'production',
-  entry: './src/index.js',
+  mode: "production",
+  entry: "./src/index.js",
   output: {
-    filename: 'bundle.js',
+    filename: "bundle.js",
   },
 }
 ```

--- a/src/content/configuration/configuration-languages.mdx
+++ b/src/content/configuration/configuration-languages.mdx
@@ -17,7 +17,7 @@ contributors:
   - snitin315
 ---
 
-Webpack accepts configuration files written in multiple programming and data languages. The list of supported file extensions can be found in the [node-interpret](https://github.com/gulpjs/interpret) package. Using [node-interpret](https://github.com/gulpjs/interpret), webpack can handle many different types of configuration files.
+Webpack accepts configuration files written in multiple programming and data languages, so you can author your config in whichever format suits your project — JavaScript, TypeScript, CoffeeScript, or a plain data file like JSON5, YAML or TOML.
 
 ## defineConfig
 
@@ -277,7 +277,7 @@ When your configuration is purely static data — no functions, no `process.env`
 | `.yaml`, `.yml` | `js-yaml`      |
 | `.toml`         | `toml`         |
 
-The parsers are **not bundled** with webpack-cli. Install the one you need for your format — they are declared as optional `peerDependencies`, so they resolve correctly under Yarn PnP. If the parser is missing, webpack-cli exits and tells you exactly which package to install.
+The parser is **not bundled** with webpack-cli — install the one your format needs as a dev dependency. If it is missing, webpack-cli stops and tells you exactly which package to install.
 
 ```bash
 npm install --save-dev json5

--- a/src/content/configuration/configuration-languages.mdx
+++ b/src/content/configuration/configuration-languages.mdx
@@ -264,3 +264,65 @@ export default (
 ```
 
 W> If you are using Babel elsewhere and have `modules` set to `false`, you will have to either maintain two separate `.babelrc` files or use `const jsxobj = require('jsxobj');` and `module.exports` instead of the new `import` and `export` syntax. This is because while Node does support many new ES6 features, they don't yet support ES6 module syntax.
+
+## Data formats (JSON5, YAML and TOML)
+
+<Badge text="webpack-cli v7.1.0+" />
+
+When your configuration is purely static data — no functions, no `process.env` reads, no computed values — you can write it as a data file instead of JavaScript. webpack-cli parses the following extensions directly:
+
+| Extension       | Parser package |
+| --------------- | -------------- |
+| `.json5`        | `json5`        |
+| `.yaml`, `.yml` | `js-yaml`      |
+| `.toml`         | `toml`         |
+
+The parsers are **not bundled** with webpack-cli. Install the one you need for your format — they are declared as optional `peerDependencies`, so they resolve correctly under Yarn PnP. If the parser is missing, webpack-cli exits and tells you exactly which package to install.
+
+```bash
+npm install --save-dev json5
+# or
+npm install --save-dev js-yaml
+# or
+npm install --save-dev toml
+```
+
+Point `--config` at the file, or name it so it is picked up as a [default config](/api/cli/#default-configurations) (e.g. `webpack.config.json5`):
+
+```bash
+npx webpack --config webpack.config.toml
+```
+
+**webpack.config.json5**
+
+```json5
+{
+  // JSON5 allows comments, unquoted keys and trailing commas
+  mode: 'production',
+  entry: './src/index.js',
+  output: {
+    filename: 'bundle.js',
+  },
+}
+```
+
+**webpack.config.yaml**
+
+```yaml
+mode: production
+entry: ./src/index.js
+output:
+  filename: bundle.js
+```
+
+**webpack.config.toml**
+
+```toml
+mode = "production"
+entry = "./src/index.js"
+
+[output]
+filename = "bundle.js"
+```
+
+T> These formats describe plain data only. When you need dynamic configuration — environment-based branches, plugin instances, or a function form — use a JavaScript or TypeScript config instead.

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -200,6 +200,13 @@ export default {
         // Use `JSON.parse` when the JSON string is longer than 20 characters.
         parse: JSONParse,
       },
+      html: {
+        // Generator options for html modules, requires `experiments.html`, available since webpack 5.107.0
+
+        // Emit the parsed and URL-rewritten HTML as a standalone .html output file.
+        // type: boolean | 'inline'
+        extract: true,
+      },
       // others…
     },
   },
@@ -233,6 +240,35 @@ import styles from "./button.module.css";
 
 console.log(styles.btn); // hashed class
 console.log(styles.BTN); // same hashed class, uppercase alias
+```
+
+### module.generator.html.extract
+
+<Badge text="5.107.0+" />
+
+`boolean = true` `'inline'`
+
+Controls whether an [HTML module](/configuration/experiments/#experimentshtml) emits its parsed and URL-rewritten HTML as a standalone `.html` output file alongside the module's JavaScript export, mirroring the CSS extraction pipeline. Requires [`experiments.html`](/configuration/experiments/#experimentshtml).
+
+- `true` - always emit the `.html` file.
+- `false` - never emit it.
+- `'inline'` - expose the processed HTML for inline write-back (e.g. `<iframe srcdoc>`) without emitting a standalone file.
+
+When unset, extraction defaults to `true` for HTML modules used as compilation entries (HTML entry points) and `false` for HTML modules imported from JavaScript. The emitted filenames follow [`output.htmlFilename`](/configuration/output/#outputhtmlfilename) and [`output.htmlChunkFilename`](/configuration/output/#outputhtmlchunkfilename).
+
+**webpack.config.js**
+
+```js
+export default {
+  experiments: { html: true },
+  module: {
+    generator: {
+      html: {
+        extract: true,
+      },
+    },
+  },
+};
 ```
 
 ## module.parser

--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -904,6 +904,44 @@ export default {
 
 It can be overridden per entry through the [entry descriptor](/configuration/entry-context/#entry-descriptor) `html` option.
 
+## output.htmlFilename
+
+<Badge text="5.107.0+" />
+
+`string = output.filename with '.js' replaced by '.html'` `function (pathData, assetInfo) => string`
+
+The filename template for HTML files emitted by [extracted HTML modules](/configuration/module/#modulegeneratorhtmlextract) (initial chunks). It works like [`output.filename`](#outputfilename) and supports the same [template strings](#template-strings). When unset, it is derived from `output.filename` by swapping the `.js` extension for `.html` (falling back to `[name].html` when `output.filename` is a function), mirroring how `cssFilename` derives from `filename`.
+
+```js
+// webpack.config.js
+export default {
+  experiments: { html: true },
+  output: {
+    htmlFilename: "[name].html",
+  },
+};
+```
+
+W> You must **not** specify an absolute path here. The path may contain folders separated by `/`, and is joined with [`output.path`](#outputpath) to determine the location on disk.
+
+## output.htmlChunkFilename
+
+<Badge text="5.107.0+" />
+
+`string = output.chunkFilename with '.js' replaced by '.html'` `function (pathData, assetInfo) => string`
+
+The filename template for HTML files emitted by [extracted HTML modules](/configuration/module/#modulegeneratorhtmlextract) for non-initial (on-demand) chunks. It defaults from [`output.chunkFilename`](#outputchunkfilename) the same way `htmlFilename` defaults from `filename`.
+
+```js
+// webpack.config.js
+export default {
+  experiments: { html: true },
+  output: {
+    htmlChunkFilename: "[name].chunk.html",
+  },
+};
+```
+
 ## output.iife
 
 `boolean = true`


### PR DESCRIPTION
**Summary**

Documents user-facing options from the latest webpack and webpack-cli releases that were missing from the site:

- **webpack-cli 7.1.0** — loading a config from static data files (`.json5`, `.yaml`/`.yml`, `.toml`): a new "Data formats" section on the Configuration Languages page covering the extension→parser mapping, on-demand parser packages (optional `peerDependencies`), the missing-parser error, and `--config`/default-config usage with an example per format; plus the supported extensions in the CLI "Default Configurations" section. (webpack-cli [#4777](https://github.com/webpack/webpack-cli/pull/4777))
- **webpack 5.107.0** — the experimental HTML-module extraction pipeline: `module.generator.html.extract` and the matching `output.htmlFilename` / `output.htmlChunkFilename` filename templates (which mirror the CSS pipeline).

The other 5.107/5.108 features (`defineConfig`, `universal`/`bun`/`deno` targets, `output.html`, `optimization.inlineExports`, `experiments.typescript`, etc.) were already documented in #8276 on this branch.

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

n/a (documentation only)

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

Documented here in `configuration/configuration-languages.mdx`, `api/cli.mdx`, `configuration/module.mdx`, and `configuration/output.mdx`.

**Use of AI**

AI (Claude) was used to draft these docs. Every option's semantics, defaults, and behavior were verified against the webpack-cli 7.1.0 source / `config-format` tests and the webpack `WebpackOptions.json` schema + `lib/config/defaults.js`, not the changelog alone.