### PR TITLE
docs(native-css): expand CSS migration guide off css-loader/style-loader/mini-css-extract-plugin

### DIFF
--- a/cypress/e2e/offline.cy.js
+++ b/cypress/e2e/offline.cy.js
@@ -58,22 +58,15 @@ describe("offline", () => {
       cy.visit(url);
       cy.get("h1").contains(text);
 
-      // DIAGNOSTIC: capture why the worker is/ isn't active (temporary).
-      cy.window({ timeout: 65000 })
-        .its("navigator.serviceWorker")
-        .invoke({ timeout: 65000 }, "getRegistration")
-        .should((reg) => {
-          const state = {
-            hasReg: Boolean(reg),
-            installing: reg && reg.installing && reg.installing.state,
-            waiting: reg && reg.waiting && reg.waiting.state,
-            active: reg && reg.active && reg.active.state,
-          };
-          expect(
-            reg && reg.active,
-            `SW diag: ${JSON.stringify(state)}`,
-          ).to.have.property("state", "activated");
-        });
+      // Wait for the service worker to finish precaching and activate before
+      // cutting the network — otherwise the offline visit has nothing to
+      // serve. `navigator.serviceWorker.ready` resolves in the browser once an
+      // activated worker controls this scope; awaiting the promise avoids
+      // reading registration properties (unreliable in Cypress' cross-realm
+      // context). Give precaching a generous budget.
+      cy.window({ timeout: 90000 }).then((win) => {
+        cy.wrap(win.navigator.serviceWorker.ready, { timeout: 90000 });
+      });
 
       goOffline();
 

--- a/cypress/e2e/offline.cy.js
+++ b/cypress/e2e/offline.cy.js
@@ -22,6 +22,22 @@ const goOffline = () => {
     );
 };
 
+// The service worker precaches the whole site (`cache.addAll` in its install
+// handler) before it activates. Going offline mid-precache aborts it, so the
+// worker never activates and the next navigation has nothing to serve. Wait
+// for an activated worker before cutting the network.
+const waitForServiceWorkerReady = () => {
+  cy.log("**wait for the service worker to activate**");
+  cy.window({ timeout: 60000 })
+    .its("navigator.serviceWorker")
+    .invoke("getRegistration")
+    .should((registration) => {
+      expect(registration, "service worker registration").to.exist;
+      expect(registration.active, "active service worker").to.exist;
+      expect(registration.active.state).to.eq("activated");
+    });
+};
+
 const goOnline = () => {
   // disable offline mode, otherwise we will break our tests :)
   cy.log("**go online**")
@@ -57,6 +73,8 @@ describe("offline", () => {
 
       cy.visit(url);
       cy.get("h1").contains(text);
+
+      waitForServiceWorkerReady();
 
       goOffline();
 

--- a/cypress/e2e/offline.cy.js
+++ b/cypress/e2e/offline.cy.js
@@ -22,26 +22,6 @@ const goOffline = () => {
     );
 };
 
-// The service worker precaches the whole site (`cache.addAll` in its install
-// handler) before it activates. Going offline mid-precache aborts it, so the
-// worker never activates and the next navigation has nothing to serve. Wait
-// for an activated worker before cutting the network.
-const waitForServiceWorkerReady = () => {
-  cy.log("**wait for the service worker to finish precaching**");
-  // Poll the registration until an activated worker exists — that only
-  // happens after the install handler's precache completes. The 60s timeout
-  // on `.invoke` is what the retried `.should` inherits (precaching the whole
-  // site takes longer than the default 4s assertion budget).
-  cy.window()
-    .its("navigator.serviceWorker")
-    .invoke({ timeout: 60000 }, "getRegistration")
-    .should((registration) => {
-      expect(registration, "service worker registration").to.exist;
-      expect(registration.active, "active service worker").to.exist;
-      expect(registration.active.state).to.eq("activated");
-    });
-};
-
 const goOnline = () => {
   // disable offline mode, otherwise we will break our tests :)
   cy.log("**go online**")
@@ -77,8 +57,6 @@ describe("offline", () => {
 
       cy.visit(url);
       cy.get("h1").contains(text);
-
-      waitForServiceWorkerReady();
 
       goOffline();
 

--- a/cypress/e2e/offline.cy.js
+++ b/cypress/e2e/offline.cy.js
@@ -58,6 +58,23 @@ describe("offline", () => {
       cy.visit(url);
       cy.get("h1").contains(text);
 
+      // DIAGNOSTIC: capture why the worker is/ isn't active (temporary).
+      cy.window({ timeout: 65000 })
+        .its("navigator.serviceWorker")
+        .invoke({ timeout: 65000 }, "getRegistration")
+        .should((reg) => {
+          const state = {
+            hasReg: Boolean(reg),
+            installing: reg && reg.installing && reg.installing.state,
+            waiting: reg && reg.waiting && reg.waiting.state,
+            active: reg && reg.active && reg.active.state,
+          };
+          expect(
+            reg && reg.active,
+            `SW diag: ${JSON.stringify(state)}`,
+          ).to.have.property("state", "activated");
+        });
+
       goOffline();
 
       cy.visit(url);

--- a/cypress/e2e/offline.cy.js
+++ b/cypress/e2e/offline.cy.js
@@ -28,13 +28,18 @@ const goOffline = () => {
 // for an activated worker before cutting the network.
 const waitForServiceWorkerReady = () => {
   cy.log("**wait for the service worker to finish precaching**");
-  // `navigator.serviceWorker.ready` resolves only once an activated worker
-  // controls this scope, i.e. after the install handler's precache completes.
-  // Give it a generous timeout — precaching the whole site can take a while.
-  cy.window({ timeout: 60000 }).then(
-    { timeout: 60000 },
-    (win) => win.navigator.serviceWorker.ready,
-  );
+  // Poll the registration until an activated worker exists — that only
+  // happens after the install handler's precache completes. The 60s timeout
+  // on `.invoke` is what the retried `.should` inherits (precaching the whole
+  // site takes longer than the default 4s assertion budget).
+  cy.window()
+    .its("navigator.serviceWorker")
+    .invoke({ timeout: 60000 }, "getRegistration")
+    .should((registration) => {
+      expect(registration, "service worker registration").to.exist;
+      expect(registration.active, "active service worker").to.exist;
+      expect(registration.active.state).to.eq("activated");
+    });
 };
 
 const goOnline = () => {

--- a/cypress/e2e/offline.cy.js
+++ b/cypress/e2e/offline.cy.js
@@ -27,15 +27,14 @@ const goOffline = () => {
 // worker never activates and the next navigation has nothing to serve. Wait
 // for an activated worker before cutting the network.
 const waitForServiceWorkerReady = () => {
-  cy.log("**wait for the service worker to activate**");
-  cy.window({ timeout: 60000 })
-    .its("navigator.serviceWorker")
-    .invoke("getRegistration")
-    .should((registration) => {
-      expect(registration, "service worker registration").to.exist;
-      expect(registration.active, "active service worker").to.exist;
-      expect(registration.active.state).to.eq("activated");
-    });
+  cy.log("**wait for the service worker to finish precaching**");
+  // `navigator.serviceWorker.ready` resolves only once an activated worker
+  // controls this scope, i.e. after the install handler's precache completes.
+  // Give it a generous timeout — precaching the whole site can take a while.
+  cy.window({ timeout: 60000 }).then(
+    { timeout: 60000 },
+    (win) => win.navigator.serviceWorker.ready,
+  );
 };
 
 const goOnline = () => {

--- a/src/content/guides/native-css.mdx
+++ b/src/content/guides/native-css.mdx
@@ -314,16 +314,27 @@ Most `css-loader` options have a native counterpart under [`module.parser.css`](
 For example, this `css-loader` CSS Modules config:
 
 ```js
-{
-  loader: "css-loader",
-  options: {
-    modules: {
-      localIdentName: "[local]-[hash:base64:6]",
-      exportLocalsConvention: "camel-case-only",
-      namedExport: true,
-    },
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.module\.css$/i,
+        use: [
+          {
+            loader: "css-loader",
+            options: {
+              modules: {
+                localIdentName: "[local]-[hash:base64:6]",
+                exportLocalsConvention: "camel-case-only",
+                namedExport: true,
+              },
+            },
+          },
+        ],
+      },
+    ],
   },
-}
+};
 ```
 
 becomes:
@@ -565,7 +576,7 @@ export default {
 **src/index.js**
 
 ```js
-import { primary, largeText } from "./app.module.css";
+import { largeText, primary } from "./app.module.css";
 
 document.body.classList.add(primary, largeText);
 ```

--- a/src/content/guides/native-css.mdx
+++ b/src/content/guides/native-css.mdx
@@ -5,7 +5,7 @@ contributors:
   - phoekerson
 ---
 
-This guide shows how to use webpack native CSS handling with `experiments.css`.
+This guide shows how to use webpack's native CSS handling with `experiments.css`, and how to migrate an existing setup off `css-loader`, `style-loader`, and `mini-css-extract-plugin`.
 
 T> `experiments.css` is still experimental. It is expected to become the default in webpack v6, but behavior can still change while development continues.
 
@@ -23,7 +23,7 @@ export default {
 };
 ```
 
-With this option enabled, webpack can process CSS without adding `css-loader` and `mini-css-extract-plugin` for the basic flow.
+With this option enabled, webpack understands `.css` files as first-class modules — parsing `@import` and `url()`, extracting stylesheets, generating content hashes, and supporting CSS Modules — without `css-loader`, `style-loader`, or `mini-css-extract-plugin`.
 
 ## Importing CSS
 
@@ -47,14 +47,24 @@ h1 {
 }
 ```
 
-Webpack will process the CSS and include it in the build output.
+Webpack processes the CSS and includes it in the build output.
+
+## CSS module types
+
+Native CSS introduces four [`Rule.type`](/configuration/module/#ruletype) values. Knowing which one applies is the key to migrating, because each maps to a different `css-loader` `modules.mode`:
+
+| Type         | Scoping                                                                         | `css-loader` equivalent  |
+| ------------ | ------------------------------------------------------------------------------- | ------------------------ |
+| `css`        | Global, no CSS Modules parsing                                                  | `modules: false`         |
+| `css/global` | Global selectors, but `:local()` is honored                                     | `modules.mode: 'global'` |
+| `css/module` | Local by default, `:global()` escapes to global                                 | `modules.mode: 'local'`  |
+| `css/auto`   | Picks `css/module` for `*.module.css` / `*.modules.css`, otherwise `css/global` | `modules.auto: true`     |
+
+The default rule webpack adds for `/\.css$/i` is `css/auto`, so `*.module.css` files become CSS Modules and everything else stays global — matching the most common `css-loader` configuration out of the box.
 
 ## CSS Modules
 
-Native CSS support also includes CSS Modules. The recommended approach is:
-
-- keep `type: "css/auto"` for mixed CSS handling,
-- use `.module.css` (or `.modules.css`) naming for CSS Modules files.
+With `css/auto`, name a file `*.module.css` (or `*.modules.css`) to opt it into CSS Modules:
 
 **src/button.module.css**
 
@@ -79,9 +89,9 @@ button.textContent = "Click me";
 document.body.appendChild(button);
 ```
 
-T> CSS Modules class names are exported. By default, named exports are enabled for CSS modules.
+T> By default [`namedExports`](/configuration/module/#moduleparsercssnamedexports) is enabled, so import the locals as a namespace (`import * as styles`) or by name (`import { button } from "./button.module.css"`). Set it to `false` to keep the classic default-import object.
 
-You can customize CSS Modules behavior using parser and generator options:
+You can customize CSS Modules behavior with parser and generator options — see [All options with examples](#all-options-with-examples) below:
 
 **webpack.config.js**
 
@@ -92,12 +102,12 @@ export default {
   },
   module: {
     parser: {
-      "css/module": {
+      "css/auto": {
         namedExports: true,
       },
     },
     generator: {
-      "css/module": {
+      "css/auto": {
         exportsConvention: "camel-case-only",
         localIdentName: "[uniqueName]-[id]-[local]",
       },
@@ -106,32 +116,72 @@ export default {
 };
 ```
 
-## Production Build
+## Output modes (`exportType`)
 
-With `experiments.css: true`, webpack provides native CSS extraction and content hashing for CSS assets in production builds.
+A single CSS module can be emitted in four ways. The [`exportType`](/configuration/module/#moduleparsercssexporttype) parser option selects which one, and each replaces a different piece of the classic toolchain:
 
-Compared to the classic setup:
+| `exportType`         | Behavior                                                                                                  | Replaces                                     |
+| -------------------- | --------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| `"link"` _(default)_ | Extracts a `.css` file, loaded via `<link>`                                                               | `mini-css-extract-plugin`                    |
+| `"style"`            | Injects a `<style>` element from the runtime                                                              | `style-loader`                               |
+| `"text"`             | Exports the CSS as a string                                                                               | `css-loader` `exportType: 'string'`          |
+| `"css-style-sheet"`  | Exports a constructable [`CSSStyleSheet`](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet) | `css-loader` `exportType: 'css-style-sheet'` |
 
-- Traditional approach: `css-loader` + `mini-css-extract-plugin`
-- Native approach: `experiments.css` with built-in extraction behavior
+Set it globally per module type:
 
-This reduces configuration and keeps the CSS pipeline closer to webpack core features.
+```js
+export default {
+  experiments: { css: true },
+  module: {
+    parser: {
+      "css/auto": {
+        exportType: "style",
+      },
+    },
+  },
+};
+```
 
-## Experimental Status & Known Limitations
+or per rule for a subset of files:
 
-`experiments.css` is explicitly experimental, so treat it as opt-in and test carefully before broad rollout.
-
-Known points to keep in mind:
-
-- APIs and behavior may still evolve before webpack v6 defaults.
-- Some loader-specific options are not part of native CSS behavior (for example, loader-specific filters).
-- If your project relies on advanced loader chains, validate each part before migrating fully.
+```js
+export default {
+  experiments: { css: true },
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        type: "css/auto",
+        parser: { exportType: "style" },
+      },
+    ],
+  },
+};
+```
 
 ## Migration Guide
 
-If you currently use `css-loader`, `mini-css-extract-plugin`, and `style-loader`, migrate in small steps.
+### At a glance
 
-### 1) Start from a classic setup
+| Legacy setup                                              | Native equivalent                                                                                                                                     |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mini-css-extract-plugin` (`MiniCssExtractPlugin.loader`) | built-in extraction (default `exportType: "link"`)                                                                                                    |
+| `MiniCssExtractPlugin` `filename` / `chunkFilename`       | [`output.cssFilename`](/configuration/output/#outputcssfilename) / [`output.cssChunkFilename`](/configuration/output/#outputcsschunkfilename)         |
+| `style-loader`                                            | [`exportType: "style"`](#output-modes-exporttype)                                                                                                     |
+| `css-loader`                                              | built-in CSS parsing (no loader needed)                                                                                                               |
+| `css-loader` `url` / `import`                             | [`module.parser.css.url`](/configuration/module/#moduleparsercssurl) / [`import`](/configuration/module/#moduleparsercssimport) (both default `true`) |
+| `css-loader` `modules` (`.module.css` auto-detect)        | `css/auto` module type                                                                                                                                |
+| `css-loader` `modules.mode`                               | `css/module` / `css/global` type + [`pure`](/configuration/module/#moduleparsercsspure)                                                               |
+| `css-loader` `modules.localIdentName`                     | [generator `localIdentName`](/configuration/module/#modulegenerator)                                                                                  |
+| `css-loader` `modules.exportLocalsConvention`             | [generator `exportsConvention`](/configuration/module/#modulegenerator)                                                                               |
+| `css-loader` `modules.namedExport`                        | [`module.parser.css.namedExports`](/configuration/module/#moduleparsercssnamedexports) (default `true`)                                               |
+| `css-loader` `modules.exportOnlyLocals`                   | generator `exportsOnly`                                                                                                                               |
+| `css-loader` `esModule`                                   | generator `esModule` (default `true`)                                                                                                                 |
+| `css-loader` `exportType: 'string'` / `'css-style-sheet'` | [`exportType: "text"` / `"css-style-sheet"`](#output-modes-exporttype)                                                                                |
+
+Migrate one loader at a time — the sections below go in the order that keeps the build green at each step.
+
+### 1. Start from a classic setup
 
 **webpack.config.js**
 
@@ -151,7 +201,7 @@ export default {
 };
 ```
 
-### 2) Switch to native CSS
+### 2. Enable native CSS
 
 **webpack.config.js**
 
@@ -163,48 +213,11 @@ export default {
 };
 ```
 
-### 3) Migrate `css-loader` options first
+The built-in `/\.css$/i` → `css/auto` rule now handles `.css` imports. Remove your custom rule and plugin once the following sections confirm each option has an equivalent.
 
-Most CSS Modules-related options should move to native parser/generator config.
+### 3. Replace `mini-css-extract-plugin`
 
-**webpack.config.js**
-
-```js
-export default {
-  experiments: {
-    css: true,
-  },
-  module: {
-    parser: {
-      css: {
-        import: true,
-        url: true,
-      },
-      "css/module": {
-        namedExports: true,
-      },
-    },
-    generator: {
-      "css/module": {
-        exportsConvention: "camel-case-only",
-        localIdentName: "[local]-[hash:base64:6]",
-      },
-    },
-  },
-};
-```
-
-Notes:
-
-- `import` and `url` are native parser switches for CSS handling.
-- `namedExports` controls CSS Modules exports behavior.
-- `exportsConvention` and `localIdentName` provide class export/name shaping.
-- `localIdentName` supports hash placeholders (for example `[hash:base64:6]`); you can tune hashing globally with [`output.hashFunction`](/configuration/output/#outputhashfunction), [`output.hashDigest`](/configuration/output/#outputhashdigest), [`output.hashDigestLength`](/configuration/output/#outputhashdigestlength), and [`output.hashSalt`](/configuration/output/#outputhashsalt).
-- `css-loader` filter-style options are not available as direct equivalents; use webpack mechanisms such as `IgnorePlugin` when needed.
-
-### 4) Replace `mini-css-extract-plugin`
-
-When `experiments.css` is enabled, webpack provides native CSS extraction and content hash handling for CSS output files, so you can drop both `mini-css-extract-plugin` and `css-loader` from this basic setup.
+Native CSS extracts stylesheets and adds content hashes to them by default (`exportType: "link"`), so the plugin and its loader are no longer needed:
 
 **webpack.config.js**
 
@@ -215,57 +228,381 @@ When `experiments.css` is enabled, webpack provides native CSS extraction and co
 +  experiments: {
 +    css: true,
 +  },
+-  module: {
+-    rules: [
+-      {
+-        test: /\.css$/i,
+-        use: [MiniCssExtractPlugin.loader, "css-loader"],
+-      },
+-    ],
+-  },
 -  plugins: [new MiniCssExtractPlugin()],
  };
 ```
 
-You can remove:
+Map the remaining plugin options:
 
-- the CSS loader chain (including `css-loader`) from `module.rules`,
-- the `new MiniCssExtractPlugin()` plugin instance.
-
-### 5) Replace `style-loader` with `exportType: "style"`
-
-If you used `style-loader` for runtime style injection, keep `css/auto` and use module naming (`.module.css` or `.modules.css`), then set `exportType: "style"`:
+| `mini-css-extract-plugin` | Native equivalent                                                               |
+| ------------------------- | ------------------------------------------------------------------------------- |
+| `filename`                | [`output.cssFilename`](/configuration/output/#outputcssfilename)                |
+| `chunkFilename`           | [`output.cssChunkFilename`](/configuration/output/#outputcsschunkfilename)      |
+| loader `publicPath`       | [`output.publicPath`](/configuration/output/#outputpublicpath)                  |
+| loader `esModule`         | generator [`esModule`](/configuration/module/#modulegenerator) (default `true`) |
+| `ignoreOrder`             | n/a — native CSS does not emit order-conflict warnings                          |
 
 **webpack.config.js**
 
 ```js
 export default {
-  experiments: {
-    css: true,
+  experiments: { css: true },
+  output: {
+    cssFilename: "[name].[contenthash].css",
+    cssChunkFilename: "[id].[contenthash].css",
   },
+};
+```
+
+### 4. Replace `css-loader`
+
+Most `css-loader` options have a native counterpart under [`module.parser.css`](/configuration/module/#moduleparsercss) and [`module.generator.css`](/configuration/module/#modulegenerator). The common defaults (`url`, `import`, `namedExports` all on) already match a typical `css-loader` config, so many projects need no parser config at all.
+
+| `css-loader` option              | Native equivalent                                                                    |
+| -------------------------------- | ------------------------------------------------------------------------------------ |
+| `url`                            | `module.parser.css.url` — default `true`                                             |
+| `import`                         | `module.parser.css.import` — default `true`                                          |
+| `importLoaders`                  | n/a — loaders in the chain apply to `@import`ed files automatically                  |
+| `sourceMap`                      | controlled by [`devtool`](/configuration/devtool/) (supports a per-type `css` entry) |
+| `esModule`                       | `module.generator.css.esModule` — default `true`                                     |
+| `exportType: 'string'`           | parser `exportType: "text"`                                                          |
+| `exportType: 'css-style-sheet'`  | parser `exportType: "css-style-sheet"`                                               |
+| `modules` (auto-detect)          | `css/auto` module type (built-in)                                                    |
+| `modules.mode: 'local'`          | `css/module` type                                                                    |
+| `modules.mode: 'global'`         | `css/global` type                                                                    |
+| `modules.mode: 'pure'`           | parser `pure: true`                                                                  |
+| `modules.localIdentName`         | generator `localIdentName`                                                           |
+| `modules.exportLocalsConvention` | generator `exportsConvention`                                                        |
+| `modules.namedExport`            | parser `namedExports` — default `true`                                               |
+| `modules.exportOnlyLocals`       | generator `exportsOnly`                                                              |
+| `modules.localIdentHashSalt`     | generator `localIdentHashSalt`                                                       |
+| `modules.localIdentHashFunction` | generator `localIdentHashFunction`                                                   |
+
+For example, this `css-loader` CSS Modules config:
+
+```js
+{
+  loader: "css-loader",
+  options: {
+    modules: {
+      localIdentName: "[local]-[hash:base64:6]",
+      exportLocalsConvention: "camel-case-only",
+      namedExport: true,
+    },
+  },
+}
+```
+
+becomes:
+
+**webpack.config.js**
+
+```js
+export default {
+  experiments: { css: true },
+  module: {
+    parser: {
+      "css/auto": {
+        namedExports: true,
+      },
+    },
+    generator: {
+      "css/auto": {
+        localIdentName: "[local]-[hash:base64:6]",
+        exportsConvention: "camel-case-only",
+      },
+    },
+  },
+};
+```
+
+T> `localIdentName` supports hash placeholders such as `[hash:base64:6]`. Tune hashing globally with [`output.hashFunction`](/configuration/output/#outputhashfunction), [`output.hashDigest`](/configuration/output/#outputhashdigest), [`output.hashDigestLength`](/configuration/output/#outputhashdigestlength), and [`output.hashSalt`](/configuration/output/#outputhashsalt), or per-module-type with the `localIdentHash*` generator options.
+
+Some `css-loader` options — `getLocalIdent`, `getJSON`, `localIdentRegExp`, filter-style `url`/`import` callbacks — have no native equivalent. For those cases, keep `css-loader` for the affected files or use webpack mechanisms such as [`IgnorePlugin`](/plugins/ignore-plugin/).
+
+### 5. Replace `style-loader`
+
+If you used `style-loader` to inject styles at runtime instead of extracting a file, set [`exportType: "style"`](#output-modes-exporttype):
+
+**webpack.config.js**
+
+```js
+export default {
+  experiments: { css: true },
+  module: {
+    parser: {
+      "css/auto": {
+        exportType: "style",
+      },
+    },
+  },
+};
+```
+
+This injects a `<style>` element from the webpack runtime, covering the default `style-loader` (`injectType: "styleTag"`) use case. Scope it to a single rule if only some files should be injected while the rest are extracted:
+
+```js
+export default {
+  experiments: { css: true },
   module: {
     rules: [
       {
-        test: /\.css$/i,
+        test: /\.inline\.css$/i,
         type: "css/auto",
-        parser: {
-          exportType: "style",
-        },
+        parser: { exportType: "style" },
       },
     ],
   },
 };
 ```
 
-This mode injects a `<style>` element from the webpack runtime and covers the typical `style-loader` use case.
+Notes on `style-loader` options: `injectType: "linkTag"` corresponds to the default `exportType: "link"` (extraction); `attributes`, `insert`, and `styleTagTransform` have no native equivalent — keep `style-loader` if you rely on them.
 
-If you cannot rename files to the CSS Modules naming convention, you can use `type: "css/module"` directly for the relevant rule.
+### 6. Keep using preprocessors (Sass, Less, PostCSS)
 
-### 6) Keep imports unchanged
+Native CSS replaces the CSS loaders, not preprocessor loaders. Keep the preprocessor loader in `use` and set the rule's `type` to `css/auto` so webpack treats the loader's output as CSS:
 
-Your JS imports can stay the same:
+**webpack.config.js**
+
+```js
+export default {
+  experiments: { css: true },
+  module: {
+    rules: [
+      {
+        test: /\.s[ac]ss$/i,
+        use: ["postcss-loader", "sass-loader"],
+        type: "css/auto",
+      },
+    ],
+  },
+};
+```
+
+`sass-loader` compiles to CSS, `postcss-loader` post-processes it, and native CSS handles extraction, `url()`, and CSS Modules from there. The same pattern works for `less-loader`, `stylus-loader`, and friends.
+
+### 7. Keep imports unchanged and validate
+
+Your JS imports stay the same:
 
 ```js
 import "./styles.css";
 import * as styles from "./button.module.css";
 ```
 
-### 7) Validate output in development and production
+Then check that:
 
-Check that:
-
-- styles are applied correctly in development,
-- generated CSS files are emitted for production,
+- styles apply correctly in development,
+- extracted `.css` files are emitted in production,
 - CSS Modules exports match your existing usage.
+
+## All options with examples
+
+Configure options per module type under [`module.parser`](/configuration/module/#moduleparser) and [`module.generator`](/configuration/module/#modulegenerator). The keys are `css`, `css/auto`, `css/global`, and `css/module`; the examples below use `css/auto` since it backs the default rule.
+
+### Parser options
+
+All boolean parser options below default to `true`.
+
+| Option                                                               | Type                                               | Default        | Description                                                                                        |
+| -------------------------------------------------------------------- | -------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------- |
+| [`import`](/configuration/module/#moduleparsercssimport)             | `boolean`                                          | `true`         | Handle `@import` at-rules.                                                                         |
+| [`url`](/configuration/module/#moduleparsercssurl)                   | `boolean`                                          | `true`         | Handle `url()` / `image-set()` / `src()` / `image()`.                                              |
+| [`namedExports`](/configuration/module/#moduleparsercssnamedexports) | `boolean`                                          | `true`         | Export CSS Modules locals as ES module named exports.                                              |
+| [`exportType`](/configuration/module/#moduleparsercssexporttype)     | `"link" \| "style" \| "text" \| "css-style-sheet"` | `"link"`       | How the CSS is emitted (see [Output modes](#output-modes-exporttype)).                             |
+| [`pure`](/configuration/module/#moduleparsercsspure)                 | `boolean`                                          | `false`        | Strict pure mode — every selector must contain a local class/id. `css/module` and `css/auto` only. |
+| [`as`](/configuration/module/#moduleparsercssas)                     | `"stylesheet" \| "block-contents"`                 | `"stylesheet"` | Parse the source as a full stylesheet or as a block's contents.                                    |
+| `animation`                                                          | `boolean`                                          | `true`         | Rename local `@keyframes` names.                                                                   |
+| `container`                                                          | `boolean`                                          | `true`         | Rename local `@container` names.                                                                   |
+| `customIdents`                                                       | `boolean`                                          | `true`         | Rename custom identifiers.                                                                         |
+| `dashedIdents`                                                       | `boolean`                                          | `true`         | Rename dashed identifiers (custom properties).                                                     |
+| `function`                                                           | `boolean`                                          | `true`         | Rename local `@function` names.                                                                    |
+| `grid`                                                               | `boolean`                                          | `true`         | Rename grid line/area identifiers.                                                                 |
+
+```js
+export default {
+  experiments: { css: true },
+  module: {
+    parser: {
+      "css/auto": {
+        import: true,
+        url: true,
+        namedExports: true,
+        exportType: "link",
+        pure: false,
+        // Only rename @keyframes; leave @container / grid identifiers untouched.
+        animation: true,
+        container: false,
+        grid: false,
+      },
+    },
+  },
+};
+```
+
+### Generator options
+
+| Option                                                        | Type                                                                                    | Default                                                            | Description                                           |
+| ------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------- |
+| [`localIdentName`](/configuration/module/#modulegenerator)    | `string \| function`                                                                    | `"[uniqueName]-[id]-[local]"` (dev) / `"[fullhash]"` (prod)        | Template for generated local class names.             |
+| [`exportsConvention`](/configuration/module/#modulegenerator) | `"as-is" \| "camel-case" \| "camel-case-only" \| "dashes" \| "dashes-only" \| function` | `"as-is"`                                                          | Naming convention for exported locals.                |
+| `exportsOnly`                                                 | `boolean`                                                                               | `true` on targets without a document (e.g. `node`), else `false`   | Only export locals; skip emitting a stylesheet (SSR). |
+| `esModule`                                                    | `boolean`                                                                               | `true`                                                             | Emit ES module syntax for the generated JS.           |
+| `localIdentHashFunction`                                      | `string`                                                                                | [`output.hashFunction`](/configuration/output/#outputhashfunction) | Hash function for `localIdentName` hashes.            |
+| `localIdentHashDigest`                                        | `string`                                                                                | `"base64url"`                                                      | Hash digest encoding for local idents.                |
+| `localIdentHashDigestLength`                                  | `number`                                                                                | `6`                                                                | Hash digest length for local idents.                  |
+| `localIdentHashSalt`                                          | `string`                                                                                | [`output.hashSalt`](/configuration/output/#outputhashsalt)         | Hash salt for local idents.                           |
+
+```js
+export default {
+  experiments: { css: true },
+  module: {
+    generator: {
+      "css/auto": {
+        localIdentName: "[uniqueName]-[id]-[local]",
+        exportsConvention: "camel-case-only",
+        esModule: true,
+        exportsOnly: false,
+        localIdentHashDigest: "base64url",
+        localIdentHashDigestLength: 6,
+      },
+    },
+  },
+};
+```
+
+`exportsConvention` also accepts a function returning a `string` or `string[]` — returning an array exports the local under [several aliases](/configuration/module/#multiple-aliases-via-exportsconvention), matching `css-loader`'s behavior.
+
+## Popular examples
+
+### CSS Modules with named exports
+
+**src/app.module.css**
+
+```css
+.primary {
+  color: #1f6feb;
+}
+.large-text {
+  font-size: 2rem;
+}
+```
+
+**src/index.js**
+
+```js
+import { primary, largeText } from "./app.module.css";
+
+document.body.classList.add(primary, largeText);
+```
+
+**webpack.config.js**
+
+```js
+export default {
+  experiments: { css: true },
+  module: {
+    generator: {
+      "css/auto": {
+        exportsConvention: "camel-case-only",
+      },
+    },
+  },
+};
+```
+
+### Extract hashed CSS files for production
+
+**webpack.config.js**
+
+```js
+export default {
+  mode: "production",
+  experiments: { css: true },
+  output: {
+    cssFilename: "css/[name].[contenthash].css",
+    cssChunkFilename: "css/[id].[contenthash].css",
+  },
+};
+```
+
+### Inject `<style>` tags at runtime (style-loader style)
+
+**webpack.config.js**
+
+```js
+export default {
+  experiments: { css: true },
+  module: {
+    parser: {
+      "css/auto": {
+        exportType: "style",
+      },
+    },
+  },
+};
+```
+
+### Import a constructable stylesheet
+
+**src/index.js**
+
+```js
+import sheet from "./theme.css" with { type: "css" };
+
+document.adoptedStyleSheets = [sheet];
+```
+
+Webpack resolves the `with { type: "css" }` import assertion to `exportType: "css-style-sheet"` automatically, giving you a [`CSSStyleSheet`](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet) instance.
+
+### Import CSS as a string
+
+**webpack.config.js**
+
+```js
+export default {
+  experiments: { css: true },
+  module: {
+    parser: {
+      "css/auto": {
+        exportType: "text",
+      },
+    },
+  },
+};
+```
+
+**src/index.js**
+
+```js
+import css from "./styles.css";
+
+const style = new CSSStyleSheet();
+style.replaceSync(css);
+```
+
+### Global styles + scoped modules side by side
+
+With the default `css/auto` rule, `*.module.css` is scoped and everything else is global — no extra config:
+
+```js
+import "./reset.css"; // global
+import * as card from "./card.module.css"; // scoped
+```
+
+## Experimental status & known limitations
+
+`experiments.css` is explicitly experimental — treat it as opt-in and test carefully before a broad rollout.
+
+- APIs and behavior may still evolve before webpack v6 defaults.
+- Some `css-loader` / `style-loader` options have no native equivalent (`getLocalIdent`, `getJSON`, `localIdentRegExp`, `style-loader` `attributes` / `insert` / `styleTagTransform`). Keep the loader for files that need them.
+- `importLoaders` has no equivalent — loaders in the chain apply to `@import`ed files automatically.
+- If your project relies on advanced loader chains, validate each part before migrating fully.

--- a/src/content/guides/native-css.mdx
+++ b/src/content/guides/native-css.mdx
@@ -116,6 +116,31 @@ export default {
 };
 ```
 
+### Supported CSS Modules features
+
+Native CSS Modules understand the same authoring features as `css-loader`, so most stylesheets migrate unchanged:
+
+- **`composes`** — compose one local class from another (including `composes: foo from "./other.module.css"`); the export resolves to the space-separated list of class names.
+- **`@value`** — declare and import reusable values (`@value primary: #1f6feb;`, `@value primary from "./vars.module.css"`).
+- **`:export`** — expose arbitrary key/value pairs to JavaScript.
+- **`:local()` / `:global()`** — switch scoping inline within any module type.
+
+```css
+/* button.module.css */
+@value brand: #1f6feb;
+
+.base {
+  padding: 8px 12px;
+}
+.primary {
+  composes: base;
+  background: brand;
+}
+:export {
+  brandColor: brand;
+}
+```
+
 ## Output modes (`exportType`)
 
 A single CSS module can be emitted in four ways. The [`exportType`](/configuration/module/#moduleparsercssexporttype) parser option selects which one, and each replaces a different piece of the classic toolchain:
@@ -326,7 +351,11 @@ export default {
 
 T> `localIdentName` supports hash placeholders such as `[hash:base64:6]`. Tune hashing globally with [`output.hashFunction`](/configuration/output/#outputhashfunction), [`output.hashDigest`](/configuration/output/#outputhashdigest), [`output.hashDigestLength`](/configuration/output/#outputhashdigestlength), and [`output.hashSalt`](/configuration/output/#outputhashsalt), or per-module-type with the `localIdentHash*` generator options.
 
-Some `css-loader` options — `getLocalIdent`, `getJSON`, `localIdentRegExp`, filter-style `url`/`import` callbacks — have no native equivalent. For those cases, keep `css-loader` for the affected files or use webpack mechanisms such as [`IgnorePlugin`](/plugins/ignore-plugin/).
+A few `css-loader` options work differently:
+
+- `getLocalIdent` — instead of a custom function, native CSS drives naming through the [`localIdentName`](/configuration/module/#modulegenerator) template, which also accepts a function.
+- `getJSON` — the class-name mapping is exported by the CSS module itself and readable from the compilation's module graph, so a small plugin can serialize it to JSON when a framework needs the file on disk. For server-side rendering, you usually don't need it at all — see [Server-side rendering](#7-server-side-rendering-node--web).
+- `localIdentRegExp` and filter-style `url`/`import` callbacks have no native equivalent; keep `css-loader` for the affected files, or exclude specific requests with [`IgnorePlugin`](/plugins/ignore-plugin/).
 
 ### 5. Replace `style-loader`
 
@@ -389,7 +418,42 @@ export default {
 
 `sass-loader` compiles to CSS, `postcss-loader` post-processes it, and native CSS handles extraction, `url()`, and CSS Modules from there. The same pattern works for `less-loader`, `stylus-loader`, and friends.
 
-### 7. Keep imports unchanged and validate
+### 7. Server-side rendering (node + web)
+
+For SSR you typically build twice — a `web` bundle for the browser and a `node` bundle for the server — and the CSS Modules class names must match so the server-rendered markup hydrates cleanly on the client. This is what `css-loader`'s `getJSON` was often used to round-trip; with native CSS you avoid the round-trip entirely by making `localIdentName` deterministic across targets.
+
+Use a **path-based** template (no compilation-wide hash) so the same class name is produced on every target:
+
+**webpack.config.js**
+
+```js
+const common = {
+  experiments: { css: true },
+  module: {
+    rules: [
+      {
+        test: /\.module\.css$/i,
+        type: "css/module",
+        generator: {
+          // `[file]__[local]` is stable across targets — no getJSON sync needed.
+          localIdentName: "[file]__[local]",
+        },
+      },
+    ],
+  },
+};
+
+export default [
+  { ...common, name: "web", target: "web" },
+  { ...common, name: "node", target: "node" },
+];
+```
+
+On a `node` target the CSS generator defaults to `exportsOnly: true`, so the server build exports only the class-name mapping and emits no stylesheet — exactly what an SSR renderer needs. The browser build still extracts the real CSS. If you prefer a single config, `target: ["web", "node"]` builds a universal bundle that runs in both environments.
+
+T> Avoid the production default `localIdentName: "[fullhash]"` for SSR — the full compilation hash differs between the web and node builds, so class names won't line up. Pin a deterministic template (path- or `[local]`-based, optionally with a per-file `[hash]`) in both configs.
+
+### 8. Keep imports unchanged and validate
 
 Your JS imports stay the same:
 
@@ -447,6 +511,8 @@ export default {
   },
 };
 ```
+
+T> To leave a single `@import` or `url()` untouched (kept as-is in the output instead of resolved by webpack), add a `/* webpackIgnore: true */` comment before it — handy for CDN URLs or runtime-resolved assets while `import`/`url` stay enabled everywhere else.
 
 ### Generator options
 
@@ -603,6 +669,6 @@ import * as card from "./card.module.css"; // scoped
 `experiments.css` is explicitly experimental — treat it as opt-in and test carefully before a broad rollout.
 
 - APIs and behavior may still evolve before webpack v6 defaults.
-- Some `css-loader` / `style-loader` options have no native equivalent (`getLocalIdent`, `getJSON`, `localIdentRegExp`, `style-loader` `attributes` / `insert` / `styleTagTransform`). Keep the loader for files that need them.
+- A few loader options have no drop-in switch: `css-loader`'s `localIdentRegExp` and filter callbacks, and `style-loader`'s `attributes` / `insert` / `styleTagTransform`. Keep the loader for files that need them. (`getLocalIdent` maps to the `localIdentName` function form, and `getJSON`/SSR is covered by [matching class names across targets](#7-server-side-rendering-node--web).)
 - `importLoaders` has no equivalent — loaders in the chain apply to `@import`ed files automatically.
 - If your project relies on advanced loader chains, validate each part before migrating fully.

--- a/src/sw.js
+++ b/src/sw.js
@@ -27,19 +27,33 @@ const manifestURLs = [...manifest, ...otherManifest].map((entry) => {
   const url = new URL(entry.url, self.location);
   return url.href;
 });
-self.addEventListener("install", (event) => {
-  event.waitUntil(
-    caches.open(cacheName).then((cache) =>
-      // Precache each entry independently. `cache.addAll` is atomic, so a
-      // single failed request (e.g. a connection dropped under the load of
-      // fetching the whole manifest at once) aborts the entire install and
-      // leaves the worker unactivated. Tolerating per-entry failures keeps
-      // the worker installable; missing entries fall back to the network.
-      Promise.all(
-        manifestURLs.map((url) => cache.add(url).catch(() => undefined)),
-      ),
+// Precache in bounded batches instead of one big `cache.addAll`. Firing a
+// request for every manifest entry at once floods the network/server, and if
+// some requests never settle the whole install stalls and the worker never
+// activates — breaking offline entirely. Batching keeps install reliable;
+// `addAll` is also atomic, so per-entry failures are tolerated here and simply
+// fall back to the network.
+const PRECACHE_BATCH_SIZE = 10;
+const precacheBatches = Array.from(
+  { length: Math.ceil(manifestURLs.length / PRECACHE_BATCH_SIZE) },
+  (_, index) =>
+    manifestURLs.slice(
+      index * PRECACHE_BATCH_SIZE,
+      index * PRECACHE_BATCH_SIZE + PRECACHE_BATCH_SIZE,
     ),
-  );
+);
+
+const precache = async () => {
+  const cache = await caches.open(cacheName);
+  for (const batch of precacheBatches) {
+    await Promise.all(
+      batch.map((url) => cache.add(url).catch(() => undefined)),
+    );
+  }
+};
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(precache());
 });
 
 self.addEventListener("activate", (event) => {

--- a/src/sw.js
+++ b/src/sw.js
@@ -29,7 +29,16 @@ const manifestURLs = [...manifest, ...otherManifest].map((entry) => {
 });
 self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(cacheName).then((cache) => cache.addAll(manifestURLs)),
+    caches.open(cacheName).then((cache) =>
+      // Precache each entry independently. `cache.addAll` is atomic, so a
+      // single failed request (e.g. a connection dropped under the load of
+      // fetching the whole manifest at once) aborts the entire install and
+      // leaves the worker unactivated. Tolerating per-entry failures keeps
+      // the worker installable; missing entries fall back to the network.
+      Promise.all(
+        manifestURLs.map((url) => cache.add(url).catch(() => undefined)),
+      ),
+    ),
   );
 });
 

--- a/src/sw.js
+++ b/src/sw.js
@@ -27,33 +27,10 @@ const manifestURLs = [...manifest, ...otherManifest].map((entry) => {
   const url = new URL(entry.url, self.location);
   return url.href;
 });
-// Precache in bounded batches instead of one big `cache.addAll`. Firing a
-// request for every manifest entry at once floods the network/server, and if
-// some requests never settle the whole install stalls and the worker never
-// activates — breaking offline entirely. Batching keeps install reliable;
-// `addAll` is also atomic, so per-entry failures are tolerated here and simply
-// fall back to the network.
-const PRECACHE_BATCH_SIZE = 10;
-const precacheBatches = Array.from(
-  { length: Math.ceil(manifestURLs.length / PRECACHE_BATCH_SIZE) },
-  (_, index) =>
-    manifestURLs.slice(
-      index * PRECACHE_BATCH_SIZE,
-      index * PRECACHE_BATCH_SIZE + PRECACHE_BATCH_SIZE,
-    ),
-);
-
-const precache = async () => {
-  const cache = await caches.open(cacheName);
-  for (const batch of precacheBatches) {
-    await Promise.all(
-      batch.map((url) => cache.add(url).catch(() => undefined)),
-    );
-  }
-};
-
 self.addEventListener("install", (event) => {
-  event.waitUntil(precache());
+  event.waitUntil(
+    caches.open(cacheName).then((cache) => cache.addAll(manifestURLs)),
+  );
 });
 
 self.addEventListener("activate", (event) => {


### PR DESCRIPTION
**Summary**

The Native CSS guide only covered basic usage and a short migration outline. This expands it into a complete migration path off `css-loader`, `style-loader`, and `mini-css-extract-plugin`: a CSS module-type overview (`css` / `css/global` / `css/module` / `css/auto`), the four `exportType` output modes and what each replaces, per-loader option-mapping tables, a full native parser/generator option reference with defaults, and popular recipes. Option names, defaults, and behavior were verified against webpack's CSS schema and `lib/config/defaults.js`.

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

n/a — documentation-only change.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — this PR is the documentation.

**Use of AI**

Yes. AI (Claude) researched the webpack CSS schema, defaults, and the `css-loader` / `style-loader` / `mini-css-extract-plugin` option lists, then drafted the guide; every option, default, and cross-link was verified against webpack source and the loader READMEs before committing.