### PR TITLE
docs: add llms.txt for LLM-friendly documentation index

### DIFF
--- a/src/assets/llms.txt
+++ b/src/assets/llms.txt
@@ -1,0 +1,94 @@
+# webpack
+
+> webpack is a static module bundler for modern JavaScript applications. When webpack processes your application, it internally builds a dependency graph from one or more entry points and then combines every module your project needs into one or more bundles.
+
+Documentation is versioned; this index covers the current (webpack 5) docs at https://webpack.js.org.
+
+## Getting Started
+
+- [Concepts](https://webpack.js.org/concepts/): Core ideas — entry, output, loaders, plugins, mode.
+- [Why webpack](https://webpack.js.org/concepts/why-webpack/): Motivation and problem webpack solves.
+- [Getting Started](https://webpack.js.org/guides/getting-started/): First bundle walkthrough.
+- [Installation](https://webpack.js.org/guides/installation/): Install webpack and the CLI.
+- [Asset Management](https://webpack.js.org/guides/asset-management/): Bundling images, fonts, and other files.
+- [Output Management](https://webpack.js.org/guides/output-management/): Managing multiple entry/output files.
+- [Development](https://webpack.js.org/guides/development/): Dev workflow, source maps, watch mode.
+- [Hot Module Replacement](https://webpack.js.org/guides/hot-module-replacement/): Live module swapping without a full reload.
+- [Production](https://webpack.js.org/guides/production/): Production build best practices.
+
+## Core Concepts
+
+- [Entry Points](https://webpack.js.org/concepts/entry-points/)
+- [Output](https://webpack.js.org/concepts/output/)
+- [Loaders](https://webpack.js.org/concepts/loaders/)
+- [Plugins](https://webpack.js.org/concepts/plugins/)
+- [Module Resolution](https://webpack.js.org/concepts/module-resolution/)
+- [Module Federation](https://webpack.js.org/concepts/module-federation/)
+- [Manifest](https://webpack.js.org/concepts/manifest/)
+- [Under the Hood](https://webpack.js.org/concepts/under-the-hood/)
+
+## Guides
+
+- [Code Splitting](https://webpack.js.org/guides/code-splitting/)
+- [Tree Shaking](https://webpack.js.org/guides/tree-shaking/)
+- [Lazy Loading](https://webpack.js.org/guides/lazy-loading/)
+- [Caching](https://webpack.js.org/guides/caching/)
+- [Environment Variables](https://webpack.js.org/guides/environment-variables/)
+- [Dependency Management](https://webpack.js.org/guides/dependency-management/)
+- [TypeScript](https://webpack.js.org/guides/typescript/)
+- [Progressive Web Application](https://webpack.js.org/guides/progressive-web-application/)
+- [Build Performance](https://webpack.js.org/guides/build-performance/)
+- [Author Libraries](https://webpack.js.org/guides/author-libraries/)
+- [Shimming](https://webpack.js.org/guides/shimming/)
+- [Web Workers](https://webpack.js.org/guides/web-workers/)
+
+## Configuration
+
+- [Configuration Overview](https://webpack.js.org/configuration/)
+- [Entry and Context](https://webpack.js.org/configuration/entry-context/)
+- [Output](https://webpack.js.org/configuration/output/)
+- [Module](https://webpack.js.org/configuration/module/)
+- [Resolve](https://webpack.js.org/configuration/resolve/)
+- [DevServer](https://webpack.js.org/configuration/dev-server/)
+- [DevTool](https://webpack.js.org/configuration/devtool/)
+- [Optimization](https://webpack.js.org/configuration/optimization/)
+- [Target](https://webpack.js.org/configuration/target/)
+- [Externals](https://webpack.js.org/configuration/externals/)
+- [Stats](https://webpack.js.org/configuration/stats/)
+- [Mode](https://webpack.js.org/configuration/mode/)
+- [Experiments](https://webpack.js.org/configuration/experiments/)
+
+## Loaders and Plugins
+
+- [Loaders Index](https://webpack.js.org/loaders/): Full loader reference.
+- [Plugins Index](https://webpack.js.org/plugins/): Full plugin reference.
+- [DefinePlugin](https://webpack.js.org/plugins/define-plugin/)
+- [HtmlWebpackPlugin](https://webpack.js.org/plugins/html-webpack-plugin/)
+- [SplitChunksPlugin](https://webpack.js.org/plugins/split-chunks-plugin/)
+- [ModuleFederationPlugin](https://webpack.js.org/plugins/module-federation-plugin/)
+- [HotModuleReplacementPlugin](https://webpack.js.org/plugins/hot-module-replacement-plugin/)
+
+## API Reference
+
+- [API Overview](https://webpack.js.org/api/)
+- [Command Line Interface](https://webpack.js.org/api/cli/)
+- [Compiler Hooks](https://webpack.js.org/api/compiler-hooks/)
+- [Compilation Hooks](https://webpack.js.org/api/compilation-hooks/)
+- [Module Methods](https://webpack.js.org/api/module-methods/)
+- [Node.js API](https://webpack.js.org/api/node/)
+- [Stats Data](https://webpack.js.org/api/stats/)
+- [Loader API](https://webpack.js.org/api/loaders/)
+- [Plugin API](https://webpack.js.org/api/plugins/)
+
+## Migration
+
+- [Migration Guides Index](https://webpack.js.org/migrate/)
+- [Migrating to webpack 5](https://webpack.js.org/migrate/5/)
+- [Migrating to webpack 4](https://webpack.js.org/migrate/4/)
+
+## Optional
+
+- [Glossary](https://webpack.js.org/glossary/): Terminology reference.
+- [Comparison](https://webpack.js.org/comparison/): webpack vs. other bundlers.
+- [Contribute](https://webpack.js.org/contribute/): Contributing to webpack docs and core.
+- [Awesome webpack](https://webpack.js.org/awesome-webpack/): Curated list of resources, loaders, and plugins.


### PR DESCRIPTION
## What

Adds `llms.txt` at the site root (via `src/assets/llms.txt`, following the same static-passthrough convention already used for `robots.txt`), so it will be served at `https://webpack.js.org/llms.txt`.

## Why

[llms.txt](https://llmstxt.org/) is an emerging convention — a curated, Markdown-formatted index of a site's key documentation pages, meant to help LLM tools and AI coding assistants navigate the docs efficiently without crawling the full HTML site. It's the same idea as `robots.txt` or `sitemap.xml`, but curated for LLM consumption rather than crawlers.

webpack is one of the most widely used JavaScript build tools and has an extensive docs site; a curated `llms.txt` covering Concepts, Guides, Configuration, Loaders/Plugins, API Reference, and Migration guides gives AI tools (and their users asking webpack questions) a reliable, low-noise entry point into the real docs.

## Verification

- Confirmed no existing `llms.txt` at `webpack.js.org/llms.txt` (404 before this PR).
- Confirmed the `robots.txt` precedent: `src/assets/robots.txt` is served at the site root, so `src/assets/llms.txt` should follow the same build-time passthrough.
- Verified every URL listed in the file returns `200` on the live site before including it.
- Checked `.github/CONTRIBUTING.md` — no AI-contribution restrictions found.

Happy to adjust the file location, format, or link selection per maintainer preference.