### PR TITLE
docs: fix package exports example

### DIFF
--- a/src/content/guides/package-exports.mdx
+++ b/src/content/guides/package-exports.mdx
@@ -39,14 +39,14 @@ An example:
 }
 ```
 
-| Module request                      | Result                                           |
-| ----------------------------------- | ------------------------------------------------ |
-| `package`                           | `.../package/main.js`                            |
-| `package/sub/path`                  | `.../package/secondary.js`                       |
-| `package/prefix/some/file.js`       | `.../package/directory/some/file.js`             |
-| `package/prefix/deep/file.js`       | `.../package/other-directory/file.js`            |
-| `package/other-prefix/deep/file.js` | `.../package/yet-another/deep/file/deep/file.js` |
-| `package/main.js`                   | Error                                            |
+| Module request                   | Result                                           |
+| -------------------------------- | ------------------------------------------------ |
+| `package`                        | `.../package/main.js`                            |
+| `package/sub/path`               | `.../package/secondary.js`                       |
+| `package/prefix/some/file.js`    | `.../package/directory/some/file.js`             |
+| `package/prefix/deep/file.js`    | `.../package/other-directory/file.js`            |
+| `package/other-prefix/deep/file` | `.../package/yet-another/deep/file/deep/file.js` |
+| `package/main.js`                | Error                                            |
 
 ## Alternatives
 


### PR DESCRIPTION
Fix the package exports example in the documentation.

The documented module request included `.js`, which does not match the wildcard substitution shown by the example. This changes the request to `package/other-prefix/deep/file` so that the documented result matches the export pattern.

Fixes #5820