### PR TITLE
docs: clarify splitChunks request defaults

### DIFF
--- a/src/content/plugins/split-chunks-plugin.mdx
+++ b/src/content/plugins/split-chunks-plugin.mdx
@@ -46,6 +46,14 @@ Webpack will automatically split chunks based on these conditions:
 
 When trying to fulfill the last two conditions, bigger chunks are preferred.
 
+T> The default request limits are heuristic guardrails, not HTTP/1-specific
+recommendations. Browsers and transports such as HTTP/2 can handle many parallel
+requests, but extra chunks still add scheduling, header, cache lookup, parsing,
+and evaluation overhead. If your app benefits from more granular chunks, adjust
+[`splitChunks.maxAsyncRequests`](#splitchunksmaxasyncrequests) and
+[`splitChunks.maxInitialRequests`](#splitchunksmaxinitialrequests), then measure
+the result for your users.
+
 ## Configuration
 
 Webpack provides a set of options for developers that want more control over this functionality.


### PR DESCRIPTION
Clarifies that the default SplitChunksPlugin request limits are request-count heuristics, not HTTP/1-specific recommendations, and points readers to `maxAsyncRequests` / `maxInitialRequests` when their measured app benefits from more granular chunks.

Closes #3277.

Validation:

- `npm ci --ignore-scripts --prefer-offline` (with command-scoped npm cache/temp on D: and `CYPRESS_INSTALL_BINARY=0`; Cypress binary is not needed for docs checks)
- `npm exec -- prettier --check src/content/plugins/split-chunks-plugin.mdx`
- `npm exec -- markdownlint --config ./.markdownlint.json --rules ./src/utilities/markdown-lint-enforce-lang-aliases.js src/content/plugins/split-chunks-plugin.mdx`
- `git diff --check`