### PR TITLE
docs: native HTML guide and expanded native CSS coverage

### DIFF
--- a/src/content/api/module-methods.mdx
+++ b/src/content/api/module-methods.mdx
@@ -181,7 +181,7 @@ We support `webpackIgnore` in the following cases:
 }
 ```
 
-T> For other CSS scenarios, [`css-loader` fully supports `webpackIgnore`](/loaders/css-loader/#disable-url-resolving-using-the--webpackignore-true--comment), allowing more flexibility if needed.
+T> The same comment works in CSS handled by webpack's [built-in CSS support](/guides/native-css/): put `/* webpackIgnore: true */` before an `@import` or a `url()` to leave it as written.
 
 **HTML Usage**
 

--- a/src/content/concepts/hot-module-replacement.mdx
+++ b/src/content/concepts/hot-module-replacement.mdx
@@ -44,7 +44,7 @@ The compiler ensures that module IDs and chunk IDs are consistent between these 
 
 ### In a Module
 
-HMR is an opt-in feature that only affects modules containing HMR code. One example would be patching styling through the [`style-loader`](https://github.com/webpack/style-loader). In order for patching to work, the `style-loader` implements the HMR interface; when it receives an update through HMR, it replaces the old styles with the new ones.
+HMR is an opt-in feature that only affects modules containing HMR code. Styling is one example: webpack's [built-in CSS support](/guides/native-css/) implements the HMR interface for you, so when a stylesheet update arrives it replaces the old styles with the new ones without a full reload.
 
 Similarly, when implementing the HMR interface in a module, you can describe what should happen when the module is updated. However, in most cases, it's not mandatory to write HMR code in every module. If a module has no HMR handlers, the update bubbles up. This means that a single handler can update a complete module tree. If a single module from the tree is updated, the entire set of dependencies is reloaded.
 

--- a/src/content/concepts/loaders.mdx
+++ b/src/content/concepts/loaders.mdx
@@ -23,13 +23,13 @@ Loaders are transformations that are applied to the source code of a module. The
 
 ## Example
 
-For example, you can use loaders to tell webpack to load a CSS file or to convert TypeScript to JavaScript. To do this, you would start by installing the loaders you need:
+For example, you can use loaders to compile Sass to CSS or to convert TypeScript to JavaScript. To do this, you would start by installing the loaders you need:
 
 ```bash
-npm install --save-dev css-loader ts-loader
+npm install --save-dev sass-loader ts-loader
 ```
 
-And then instruct webpack to use the [`css-loader`](/loaders/css-loader) for every `.css` file and the [`ts-loader`](https://github.com/TypeStrong/ts-loader) for all `.ts` files:
+And then instruct webpack to use the [`sass-loader`](/loaders/sass-loader) for every `.scss` file and the [`ts-loader`](https://github.com/TypeStrong/ts-loader) for all `.ts` files:
 
 **webpack.config.js**
 
@@ -37,14 +37,14 @@ And then instruct webpack to use the [`css-loader`](/loaders/css-loader) for eve
 export default {
   module: {
     rules: [
-      { test: /\.css$/, use: "css-loader" },
+      { test: /\.scss$/, use: "sass-loader", type: "css/auto" },
       { test: /\.ts$/, use: "ts-loader" },
     ],
   },
 };
 ```
 
-T> While in the previous examples we used a loader to load CSS files, webpack has an experimental option ([`experiments.css`](https://webpack.js.org/configuration/experiments/)) that allows webpack to process CSS and automatically inject the styles into the webpage.
+T> Plain `.css` files need no loader at all: webpack parses, extracts and minifies CSS itself — see [`experiments.css`](/configuration/experiments/#experimentscss) and the [Native CSS](/guides/native-css/) guide. A preprocessor still needs its loader, and `type: 'css/auto'` hands what the loader produces to webpack's CSS pipeline.
 
 ## Using Loaders
 
@@ -60,24 +60,24 @@ Note that loaders can be used from CLI under webpack v4, but the feature was dep
 [`module.rules`](/configuration/module/#modulerules) allows you to specify several loaders within your webpack configuration.
 This is a concise way to display loaders, and helps to maintain clean code. It also offers you a full overview of each respective loader.
 
-Loaders are evaluated/executed from right to left (or from bottom to top). In the example below execution starts with sass-loader, continues with css-loader and finally ends with style-loader. See ["Loader Features"](/concepts/loaders/#loader-features) for more information about loaders order.
+Loaders are evaluated/executed from right to left (or from bottom to top). In the example below execution starts with sass-loader and ends with postcss-loader. See ["Loader Features"](/concepts/loaders/#loader-features) for more information about loaders order.
 
 ```js
 export default {
   module: {
     rules: [
       {
-        test: /\.css$/,
+        test: /\.scss$/,
         use: [
-          { loader: "style-loader" },
+          { loader: "postcss-loader" },
           {
-            loader: "css-loader",
+            loader: "sass-loader",
             options: {
-              modules: true,
+              sourceMap: true,
             },
           },
-          { loader: "sass-loader" },
         ],
+        type: "css/auto",
       },
     ],
   },
@@ -91,7 +91,7 @@ It's possible to specify loaders in an `import` statement, or any [equivalent "i
 T> The `loader1!loader2!./file` syntax is shown for illustration. In most projects, prefer configuring loaders via `module.rules` and importing styles for their side effects (e.g. `import "./styles.css"`).
 
 ```js
-import * as styles from "style-loader!css-loader?modules!./styles.css";
+import * as styles from "postcss-loader!sass-loader!./styles.scss";
 ```
 
 It's possible to override any loaders, preLoaders and postLoaders from the [configuration](/configuration) by prefixing the inline `import` statement:
@@ -99,19 +99,19 @@ It's possible to override any loaders, preLoaders and postLoaders from the [conf
 - Prefixing with `!` will disable all configured normal loaders
 
   ```js
-  import * as styles from "!style-loader!css-loader?modules!./styles.css";
+  import * as styles from "!postcss-loader!sass-loader!./styles.scss";
   ```
 
 - Prefixing with `!!` will disable all configured loaders (preLoaders, loaders, postLoaders)
 
   ```js
-  import * as styles from "!!style-loader!css-loader?modules!./styles.css";
+  import * as styles from "!!postcss-loader!sass-loader!./styles.scss";
   ```
 
 - Prefixing with `-!` will disable all configured preLoaders and loaders but not postLoaders
 
   ```js
-  import * as styles from "-!style-loader!css-loader?modules!./styles.css";
+  import * as styles from "-!postcss-loader!sass-loader!./styles.scss";
   ```
 
 Options can be passed with a query parameter, e.g. `?key=value&foo=bar`, or a JSON object, e.g. `?{"key":"value","foo":"bar"}`.

--- a/src/content/configuration/entry-context.mdx
+++ b/src/content/configuration/entry-context.mdx
@@ -96,6 +96,22 @@ export default {
 
 Descriptor syntax might be used to pass additional options to an entry point.
 
+The `html` option <Badge text="5.108.0+" /> generates an HTML file for this entrypoint with its JS and CSS output chunks injected. It accepts the same values as [`output.html`](/configuration/output/#outputhtml) and overrides it option by option for this entry, so a single entry can opt out of page generation or change just its title:
+
+```js
+export default {
+  entry: {
+    app: "./src/app.js",
+    admin: { import: "./src/admin.js", html: { title: "Admin" } },
+    worker: { import: "./src/worker.js", html: false },
+  },
+  output: { html: true },
+  experiments: { html: true },
+};
+```
+
+T> [`output.html.inline`](/configuration/output/#outputhtmlinline) is resolved once per generated page and can only be set on `output.html`.
+
 T> The `worker` flag (added in webpack 5.108.0) marks an entry as a worker so its output file uses [`output.workerChunkFilename`](/configuration/output/#outputworkerchunkfilename) instead of the regular chunk filename. webpack sets it automatically for entries it creates from `new Worker(new URL(...))`, so you rarely set it by hand.
 
 ### Output filename

--- a/src/content/configuration/extending-configurations.mdx
+++ b/src/content/configuration/extending-configurations.mdx
@@ -28,8 +28,9 @@ export default {
         exclude: /node_modules/,
       },
       {
-        test: /\.css$/,
-        use: ["style-loader", "css-loader"],
+        test: /\.scss$/,
+        use: ["sass-loader"],
+        type: "css/auto",
       },
     ],
   },
@@ -89,8 +90,9 @@ export default {
   module: {
     rules: [
       {
-        test: /\.css$/,
-        use: ["style-loader", "css-loader"],
+        test: /\.scss$/,
+        use: ["sass-loader"],
+        type: "css/auto",
       },
     ],
   },
@@ -202,8 +204,9 @@ export default {
   module: {
     rules: [
       {
-        test: /\.css$/,
-        use: ["style-loader", "css-loader"],
+        test: /\.scss$/,
+        use: ["sass-loader"],
+        type: "css/auto",
       },
     ],
   },
@@ -230,8 +233,9 @@ export default {
 
       // From webpack.config.js (appended)
       {
-        test: /\.css$/,
-        use: ["style-loader", "css-loader"],
+        test: /\.scss$/,
+        use: ["sass-loader"],
+        type: "css/auto",
       },
     ],
   },

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -2422,7 +2422,7 @@ Starting with webpack 5.87.0 falsy values such as `undefined` `null` can be used
 
 `Rule.use` can be an array of [UseEntry](#useentry) which are applied to modules. Each entry specifies a loader to be used.
 
-Passing a string (i.e. `use: [ 'style-loader' ]`) is a shortcut to the loader property (i.e. `use: [ { loader: 'style-loader '} ]`).
+Passing a string (i.e. `use: [ 'sass-loader' ]`) is a shortcut to the loader property (i.e. `use: [ { loader: 'sass-loader '} ]`).
 
 Loaders can be chained by passing multiple loaders, which will be applied from right to left (last to first configured).
 
@@ -2436,13 +2436,7 @@ export default {
       {
         // ...
         use: [
-          "style-loader",
-          {
-            loader: "css-loader",
-            options: {
-              importLoaders: 1,
-            },
-          },
+          "postcss-loader",
           {
             loader: "less-loader",
             options: {
@@ -2450,6 +2444,7 @@ export default {
             },
           },
         ],
+        type: "css/auto",
       },
     ],
   },
@@ -2467,7 +2462,7 @@ The `info` object parameter has the following fields:
 - `realResource`: Always the path to the module being loaded
 - `resource`: The path to the module being loaded, it is usually equal to `realResource` except when the resource name is overwritten via `!=!` in request string
 
-The same shortcut as an array can be used for the return value (i.e. `use: [ 'style-loader' ]`).
+The same shortcut as an array can be used for the return value (i.e. `use: [ 'sass-loader' ]`).
 
 **webpack.config.js**
 

--- a/src/content/configuration/optimization.mdx
+++ b/src/content/configuration/optimization.mdx
@@ -406,7 +406,7 @@ export default {
 
 ## optimization.minimize
 
-`boolean`
+`boolean` `object`
 
 Tell webpack to minimize the bundle using the [MinimizerPlugin](/plugins/minimizer-webpack-plugin/) or the plugin(s) specified in [`optimization.minimizer`](#optimizationminimizer).
 
@@ -430,6 +430,111 @@ export default {
 ```
 
 T> Learn how [mode](/configuration/mode/) works.
+
+### Per-asset-type options
+
+<Badge text="5.110.0+" />
+
+An object enables minimizing and configures the built-in minimizer per asset type. An absent type is minimized with its defaults, and `false` disables minimizing that type alone:
+
+**webpack.config.js**
+
+```js
+export default {
+  // ...
+  optimization: {
+    minimize: {
+      javascript: {
+        /* handed to the JavaScript minimizer as-is */
+      },
+      css: {
+        comments: false,
+      },
+      html: false,
+    },
+  },
+};
+```
+
+#### optimization.minimize.css
+
+`false` `object`
+
+What the built-in CSS minimizer may do beyond the transforms that always apply. Every transform that preserves what the stylesheet means is on by default; the ones that change text a script can read back, or that rarely pay for themselves once the asset is compressed, are off until asked for.
+
+| Option                    | Type                                                         | Default  | Description                                                                                                                         |
+| ------------------------- | ------------------------------------------------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `comments`                | `boolean \| 'all' \| 'some' \| string \| RegExp \| function` | `'some'` | Which comments survive. `'some'` keeps a `/*!` banner and `@license` / `@preserve`; a pattern or predicate stands in for that rule. |
+| `mergeLonghands`          | `boolean`                                                    | `true`   | Write a family of longhands as the one shorthand that sets them.                                                                    |
+| `mergeRules`              | `boolean`                                                    | `true`   | Join rules nothing stands between, and fold at-rules sharing a prelude.                                                             |
+| `normalizeQuotes`         | `boolean`                                                    | `true`   | Use whichever quoting needs fewer escapes, and drop quotes where the value is still one token.                                      |
+| `reduceFunctions`         | `boolean`                                                    | `true`   | Compute `calc()` and other math over constants, identity transforms, implied gradient stops, and named easings.                     |
+| `removeDeadRules`         | `boolean`                                                    | `true`   | Drop a rule or declaration nothing can read.                                                                                        |
+| `shortenColors`           | `boolean`                                                    | `true`   | Write each color in the shortest spelling of the same value.                                                                        |
+| `shortenMediaQueries`     | `boolean`                                                    | `true`   | Write a media feature in its range spelling where the target reads one.                                                             |
+| `shortenNumbers`          | `boolean`                                                    | `true`   | Write each number in its shortest equal spelling.                                                                                   |
+| `shortenSelectors`        | `boolean`                                                    | `true`   | Rewrite a selector into an equal, shorter one.                                                                                      |
+| `shortenValues`           | `boolean`                                                    | `true`   | Write a value the shortest way its property's grammar allows.                                                                       |
+| `vendorPrefixes`          | `boolean`                                                    | `true`   | Maintain vendor prefixes for the [browserslist](/configuration/target/) target — add what a selected browser needs, drop the rest.  |
+| `convertLengthUnits`      | `boolean`                                                    | `false`  | Rewrite a length into a shorter unit it is exactly equal in (`16px` → `1pc`).                                                       |
+| `rewriteCustomProperties` | `boolean`                                                    | `false`  | Shorten custom property values, which are otherwise written back exactly as authored.                                               |
+
+T> `vendorPrefixes` only has an effect for a `browserslist` [target](/configuration/target/) — any other target names no browsers to prefix for.
+
+#### optimization.minimize.html
+
+`false` `object`
+
+What the built-in HTML minimizer may do. As with CSS, everything that keeps the document's DOM is on by default and the transforms that change what a script or a selector reads back are opt-in.
+
+| Option                          | Type                                                         | Default   | Description                                                                                                              |
+| ------------------------------- | ------------------------------------------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `collapseBooleanAttributes`     | `boolean`                                                    | `true`    | Write `disabled="disabled"` as the bare name the spec canonicalizes it to.                                               |
+| `collapseWhitespace`            | `boolean \| 'conservative' \| 'smart' \| 'all'`              | `true`    | Collapse runs of whitespace. `'smart'` also drops it against a block element's edge; `'all'` at every text node's edges. |
+| `comments`                      | `boolean \| 'all' \| 'some' \| string \| RegExp \| function` | `'some'`  | Which comments survive — `'some'` keeps none, since every comment an HTML parser reads is inert.                         |
+| `minifyJson`                    | `boolean`                                                    | `true`    | Strip whitespace between the tokens of a JSON `<script>`, copying every literal byte for byte.                           |
+| `minifyStyles`                  | `boolean`                                                    | `true`    | Run the CSS minimizer over inline `<style>` and every `style=""`, with the `css` options above.                          |
+| `normalizeAttributeQuotes`      | `boolean`                                                    | `true`    | Write an attribute value with whichever delimiters cost least.                                                           |
+| `normalizeEnumeratedAttributes` | `boolean`                                                    | `true`    | Fold an enumerated attribute's value to the keyword it names.                                                            |
+| `normalizeListAttributes`       | `boolean`                                                    | `true`    | Normalize list-shaped attribute values (`class`, `rel`, `srcset`, the viewport `content`, …).                            |
+| `normalizeNumericAttributes`    | `boolean`                                                    | `true`    | Write an integer attribute the one way its own rules read it.                                                            |
+| `removeImpliedTags`             | `boolean \| 'smart' \| 'all'`                                | `'smart'` | How much of the `<html>` / `<head>` / `<body>` shell may be left out.                                                    |
+| `removeOptionalTags`            | `boolean`                                                    | `true`    | Leave out other tags the parser can imply.                                                                               |
+| `mergeStyles`                   | `boolean`                                                    | `false`   | Print a run of adjacent `<style>` elements as one sheet.                                                                 |
+| `minifyConditionalComments`     | `boolean`                                                    | `false`   | Minify the markup inside a downlevel-hidden conditional comment.                                                         |
+| `minifySrcdoc`                  | `boolean`                                                    | `false`   | Minify the document held in an `<iframe srcdoc>`.                                                                        |
+| `removeEmptyAttributes`         | `boolean`                                                    | `false`   | Drop an attribute whose empty value leaves it in the state its absence gives.                                            |
+| `removeEmptyElements`           | `boolean`                                                    | `false`   | Drop an element with no children and no attributes.                                                                      |
+| `removeRedundantAttributes`     | `boolean \| 'smart' \| 'all'`                                | `false`   | Drop an attribute whose value is the element's own default. `'smart'` only touches non-rendering markers.                |
+| `sortAttributes`                | `boolean`                                                    | `false`   | Print attributes in a fixed order so shared runs compress better across pages.                                           |
+| `sortTokenLists`                | `boolean`                                                    | `false`   | Print set-like token lists (`class`, `rel`, …) in token order, for the same reason.                                      |
+
+**webpack.config.js**
+
+```js
+export default {
+  mode: "production",
+  experiments: { html: true, css: true },
+  optimization: {
+    minimize: {
+      html: {
+        collapseWhitespace: "smart",
+        removeRedundantAttributes: "smart",
+        sortAttributes: true,
+        sortTokenLists: true,
+      },
+    },
+  },
+};
+```
+
+T> A `comments` predicate is handed to the minimizer's worker pool as source, so it must not close over anything.
+
+#### optimization.minimize.javascript
+
+`false` `object`
+
+Handed to the JavaScript minimizer as-is; `false` disables JavaScript minimizing while leaving CSS and HTML minimized.
 
 ## optimization.minimizer
 

--- a/src/content/glossary.mdx
+++ b/src/content/glossary.mdx
@@ -15,7 +15,7 @@ This index lists common terms used throughout the webpack ecosystem.
 
 ## A
 
-- [**Asset**](/guides/asset-management/): This is a general term for the images, fonts, media, and any other kind of files that are typically used in websites and other applications. These typically end up as individual files within the [output](/glossary/#o) but can also be inlined via things like the [style-loader](/loaders/style-loader) or [url-loader](/loaders/url-loader).
+- [**Asset**](/guides/asset-management/): This is a general term for the images, fonts, media, and any other kind of files that are typically used in websites and other applications. These typically end up as individual files within the [output](/glossary/#o) but can also be inlined via [Asset Modules](/guides/asset-modules/).
 
 ## B
 

--- a/src/content/guides/asset-management.mdx
+++ b/src/content/guides/asset-management.mdx
@@ -64,39 +64,17 @@ Let's make a minor change to our project before we get started:
 
 ## Loading CSS
 
-In order to `import` a CSS file from within a JavaScript module, you need to install and add the [style-loader](/loaders/style-loader) and [css-loader](/loaders/css-loader) to your [`module` configuration](/configuration/module):
+Webpack understands CSS on its own, so you can `import` a CSS file from a JavaScript module with nothing to install and nothing to configure:
 
-```bash
-npm install --save-dev style-loader css-loader
+```js
+import "./style.css";
 ```
 
-**webpack.config.js**
+Webpack parses the file — resolving its `@import` and `url()` references — and extracts it into a `.css` output file next to your bundle. CSS Modules, minification and content hashes all come from the same built-in support; the [Native CSS](/guides/native-css/) guide covers the whole feature set.
 
-```diff
- import path from 'node:path';
- import { fileURLToPath } from 'node:url';
+T> Built-in CSS is controlled by [`experiments.css`](/configuration/experiments/#experimentscss), which defaults to `'auto'`: it turns itself on unless a `module.rules` entry with a loader already matches your `.css` files. That means an existing `css-loader` / `style-loader` setup keeps working untouched — see [migrating off the CSS loaders](/guides/native-css/#migration-guide).
 
- const __filename = fileURLToPath(import.meta.url);
- const __dirname = path.dirname(__filename);
-
- export default {
-   entry: './src/index.js',
-   output: {
-     filename: 'bundle.js',
-     path: path.resolve(__dirname, 'dist'),
-   },
-+  module: {
-+    rules: [
-+      {
-+        test: /\.css$/i,
-+        use: ['style-loader', 'css-loader'],
-+      },
-+    ],
-+  },
- };
-```
-
-Module loaders can be chained. Each loader in the chain applies transformations to the processed resource. A chain is executed in reverse order (right to left).
+Preprocessors still use loaders, and module loaders can be chained. Each loader in the chain applies transformations to the processed resource. A chain is executed in reverse order (right to left).
 
 For example, given the following rule:
 
@@ -107,13 +85,14 @@ export default {
       {
         test: /\.scss$/i,
         use: ["postcss-loader", "sass-loader"],
+        type: "css/auto",
       },
     ],
   },
 };
 ```
 
-Even though `postcss-loader` appears before `sass-loader` in the `use` array, webpack runs `sass-loader` first (compiling Sass into CSS), then runs `postcss-loader` on the result.
+Even though `postcss-loader` appears before `sass-loader` in the `use` array, webpack runs `sass-loader` first (compiling Sass into CSS), then runs `postcss-loader` on the result. The `type: 'css/auto'` tells webpack to take the CSS that comes out of the chain through its own CSS pipeline.
 
 If this order is not maintained, webpack may throw errors.
 
@@ -167,23 +146,39 @@ $ npm run build
 
 ...
 [webpack-cli] Compilation finished
-asset bundle.js 72.6 KiB [emitted] [minimized] (name: main) 1 related asset
-runtime modules 1000 bytes 5 modules
-orphan modules 326 bytes [orphan] 1 module
-cacheable modules 539 KiB
-  modules by path ./node_modules/ 538 KiB
-    ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
-    ./node_modules/style-loader/dist/runtime/injectStylesIntoStyleTag.js 6.67 KiB [built] [code generated]
-    ./node_modules/css-loader/dist/runtime/api.js 1.57 KiB [built] [code generated]
-  modules by path ./src/ 965 bytes
-    ./src/index.js + 1 modules 639 bytes [built] [code generated]
-    ./node_modules/css-loader/dist/cjs.js!./src/style.css 326 bytes [built] [code generated]
-webpack 5.x.x compiled successfully in 2231 ms
+asset bundle.js 69.6 KiB [emitted] [minimized] (name: main) 1 related asset
+asset bundle.css 17 bytes [emitted] [minimized] (name: main)
+runtime modules 1020 bytes 6 modules
+cacheable modules 533 KiB (javascript) 23 bytes (css)
+  ./src/index.js + 1 modules 313 bytes [built] [code generated]
+  ./node_modules/lodash/lodash.js 533 KiB [built] [code generated]
+  css ./src/style.css 23 bytes [built] [code generated]
+webpack 5.x.x compiled successfully in 1689 ms
 ```
 
-Open up `dist/index.html` in your browser again and you should see that `Hello webpack` is now styled in red. To see what webpack did, inspect the page (don't view the page source, as it won't show you the result, because the `<style>` tag is dynamically created by JavaScript) and look at the page's head tags. It should contain the style block that we imported in `index.js`.
+Webpack extracted the CSS into its own file, `bundle.css` — the name follows [`output.cssFilename`](/configuration/output/#outputcssfilename), which defaults from `output.filename`. Link it from the page:
 
-Note that you can, and in most cases should, [minimize css](/plugins/mini-css-extract-plugin/#minimizing-for-production) for better load times in production. On top of that, loaders exist for pretty much any flavor of CSS you can think of – [postcss](/loaders/postcss-loader), [sass](/loaders/sass-loader), and [less](/loaders/less-loader) to name a few.
+**dist/index.html**
+
+```diff
+ <!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="utf-8" />
+     <title>Asset Management</title>
++    <link rel="stylesheet" href="bundle.css" />
+   </head>
+   <body>
+     <script src="bundle.js"></script>
+   </body>
+ </html>
+```
+
+Open up `dist/index.html` in your browser again and you should see that `Hello webpack` is now styled in red.
+
+T> A separate stylesheet is the default because the browser can fetch it in parallel with the bundle and cache it on its own. If you would rather have the styles injected from JavaScript at runtime — what `style-loader` did — set [`exportType: 'style'`](/guides/native-css/#output-modes-exporttype) and no `<link>` is needed.
+
+Minification is built in too: in [`mode: 'production'`](/configuration/mode/) webpack minifies the emitted CSS with no extra plugin, and can maintain vendor prefixes for your browserslist target — see [Minification](/guides/native-css/#minification). On top of that, loaders exist for pretty much any flavor of CSS you can think of – [postcss](/loaders/postcss-loader), [sass](/loaders/sass-loader), and [less](/loaders/less-loader) to name a few.
 
 ## Loading Images
 
@@ -204,22 +199,18 @@ So now we're pulling in our CSS, but what about our images like backgrounds and 
      filename: 'bundle.js',
      path: path.resolve(__dirname, 'dist'),
    },
-   module: {
-     rules: [
-       {
-         test: /\.css$/i,
-         use: ['style-loader', 'css-loader'],
-       },
++  module: {
++    rules: [
 +      {
 +        test: /\.(png|svg|jpg|jpeg|gif)$/i,
 +        type: 'asset/resource',
 +      },
-     ],
-   },
++    ],
++  },
  };
 ```
 
-Now, when you `import MyImage from './my-image.png'`, that image will be processed and added to your `output` directory _and_ the `MyImage` variable will contain the final url of that image after processing. When using the [css-loader](/loaders/css-loader), as shown above, a similar process will occur for `url('./my-image.png')` within your CSS. The loader will recognize this is a local file, and replace the `'./my-image.png'` path with the final path to the image in your `output` directory. The [html-loader](/loaders/html-loader) handles `<img src="./my-image.png" />` in the same manner.
+Now, when you `import MyImage from './my-image.png'`, that image will be processed and added to your `output` directory _and_ the `MyImage` variable will contain the final url of that image after processing. The same happens for a `url('./my-image.png')` inside your CSS: webpack recognizes it as a local file and rewrites the path to the final one in your `output` directory. With [`experiments.html`](/configuration/experiments/#experimentshtml) enabled, `<img src="./my-image.png" />` in an HTML file is handled the same way — see [Native HTML](/guides/native-html/).
 
 Let's add an image to our project and see how this works, you can use any image you like:
 
@@ -282,25 +273,20 @@ $ npm run build
 
 ...
 [webpack-cli] Compilation finished
-assets by status 9.88 KiB [cached] 1 asset
-asset bundle.js 73.4 KiB [emitted] [minimized] (name: main) 1 related asset
-runtime modules 1.82 KiB 6 modules
-orphan modules 326 bytes [orphan] 1 module
-cacheable modules 540 KiB (javascript) 9.88 KiB (asset)
-  modules by path ./node_modules/ 539 KiB
-    modules by path ./node_modules/css-loader/dist/runtime/*.js 2.38 KiB
-      ./node_modules/css-loader/dist/runtime/api.js 1.57 KiB [built] [code generated]
-      ./node_modules/css-loader/dist/runtime/getUrl.js 830 bytes [built] [code generated]
-    ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
-    ./node_modules/style-loader/dist/runtime/injectStylesIntoStyleTag.js 6.67 KiB [built] [code generated]
-  modules by path ./src/ 1.45 KiB (javascript) 9.88 KiB (asset)
-    ./src/index.js + 1 modules 794 bytes [built] [code generated]
-    ./src/icon.png 42 bytes (javascript) 9.88 KiB (asset) [built] [code generated]
-    ./node_modules/css-loader/dist/cjs.js!./src/style.css 648 bytes [built] [code generated]
-webpack 5.x.x compiled successfully in 1972 ms
+asset bundle.js 70.1 KiB [emitted] [minimized] (name: main) 1 related asset
+asset 86c447381066a936d5c5.png 7.67 KiB [emitted] [immutable] [from: src/icon.png] (auxiliary name: main)
+asset bundle.css 58 bytes [emitted] [minimized] (name: main)
+runtime modules 1.95 KiB 7 modules
+cacheable modules 534 KiB (javascript) 58 bytes (css) 7.67 KiB (asset) 42 bytes (asset-url)
+  javascript modules 534 KiB
+    ./src/index.js + 1 modules 511 bytes [built] [code generated]
+    ./node_modules/lodash/lodash.js 533 KiB [built] [code generated]
+  css ./src/style.css 58 bytes [built] [code generated]
+  ./src/icon.png 7.67 KiB (asset) 42 bytes (javascript) 42 bytes (asset-url) [built] [code generated]
+webpack 5.x.x compiled successfully in 1684 ms
 ```
 
-If all went well, you should now see your icon as a repeating background, as well as an `img` element beside our `Hello webpack` text. If you inspect this element, you'll see that the actual filename has changed to something like `29822eaa871e8eadeaa4.png`. This means webpack found our file in the `src` folder and processed it!
+If all went well, you should now see your icon as a repeating background, as well as an `img` element beside our `Hello webpack` text. If you inspect this element, you'll see that the actual filename has changed to something like `86c447381066a936d5c5.png`. This means webpack found our file in the `src` folder and processed it!
 
 ## Loading Fonts
 
@@ -323,10 +309,6 @@ So what about other assets like fonts? The Asset Modules will take any file you 
    },
    module: {
      rules: [
-       {
-         test: /\.css$/i,
-         use: ['style-loader', 'css-loader'],
-       },
        {
          test: /\.(png|svg|jpg|jpeg|gif)$/i,
          type: 'asset/resource',
@@ -361,7 +343,7 @@ Add some font files to your project:
    └── /node_modules
 ```
 
-With the loader configured and fonts in place, you can incorporate them via an `@font-face` declaration. The local `url(...)` directive will be picked up by webpack, as it was with the image:
+With the rule configured and fonts in place, you can incorporate them via an `@font-face` declaration. The local `url(...)` directive will be picked up by webpack, as it was with the image:
 
 **src/style.css**
 
@@ -388,27 +370,22 @@ $ npm run build
 
 ...
 [webpack-cli] Compilation finished
-assets by status 9.88 KiB [cached] 1 asset
-assets by info 33.2 KiB [immutable]
-  asset 55055dbfc7c6a83f60ba.woff 18.8 KiB [emitted] [immutable] [from: src/my-font.woff] (auxiliary name: main)
-  asset 8f717b802eaab4d7fb94.woff2 14.5 KiB [emitted] [immutable] [from: src/my-font.woff2] (auxiliary name: main)
-asset bundle.js 73.7 KiB [emitted] [minimized] (name: main) 1 related asset
-runtime modules 1.82 KiB 6 modules
-orphan modules 326 bytes [orphan] 1 module
-cacheable modules 541 KiB (javascript) 43.1 KiB (asset)
-  javascript modules 541 KiB
-    modules by path ./node_modules/ 539 KiB
-      modules by path ./node_modules/css-loader/dist/runtime/*.js 2.38 KiB 2 modules
-      ./node_modules/lodash/lodash.js 530 KiB [built] [code generated]
-      ./node_modules/style-loader/dist/runtime/injectStylesIntoStyleTag.js 6.67 KiB [built] [code generated]
-    modules by path ./src/ 1.98 KiB
-      ./src/index.js + 1 modules 794 bytes [built] [code generated]
-      ./node_modules/css-loader/dist/cjs.js!./src/style.css 1.21 KiB [built] [code generated]
-  asset modules 126 bytes (javascript) 43.1 KiB (asset)
-    ./src/icon.png 42 bytes (javascript) 9.88 KiB (asset) [built] [code generated]
-    ./src/my-font.woff2 42 bytes (javascript) 14.5 KiB (asset) [built] [code generated]
-    ./src/my-font.woff 42 bytes (javascript) 18.8 KiB (asset) [built] [code generated]
-webpack 5.x.x compiled successfully in 2142 ms
+assets by status 7.67 KiB [cached] 1 asset
+assets by status 33.5 KiB [emitted]
+  asset f32e23c95fbf20947766.woff 18.8 KiB [emitted] [immutable] [from: src/my-font.woff] (auxiliary name: main)
+  asset f8668ded30a04fd1aed7.woff2 14.5 KiB [emitted] [immutable] [from: src/my-font.woff2] (auxiliary name: main)
+  asset bundle.css 237 bytes [emitted] [minimized] (name: main)
+asset bundle.js 70.1 KiB [compared for emit] [minimized] (name: main) 1 related asset
+runtime modules 1.95 KiB 7 modules
+cacheable modules 534 KiB (javascript) 41 KiB (asset) 126 bytes (asset-url) 255 bytes (css)
+  modules by path ./src/ 553 bytes (javascript) 41 KiB (asset) 126 bytes (asset-url)
+    ./src/index.js + 1 modules 511 bytes [built] [code generated]
+    ./src/icon.png 7.67 KiB (asset) 42 bytes (javascript) 42 bytes (asset-url) [built] [code generated]
+    ./src/my-font.woff2 14.5 KiB (asset) 42 bytes (asset-url) [built] [code generated]
+    ./src/my-font.woff 18.8 KiB (asset) 42 bytes (asset-url) [built] [code generated]
+  ./node_modules/lodash/lodash.js 533 KiB [built] [code generated]
+  css ./src/style.css 255 bytes [built] [code generated]
+webpack 5.x.x compiled successfully in 1644 ms
 ```
 
 Open up `dist/index.html` again and see if our `Hello webpack` text has changed to the new font. If all is well, you should see the changes.
@@ -438,10 +415,6 @@ npm install --save-dev csv-loader xml-loader
    },
    module: {
      rules: [
-       {
-         test: /\.css$/i,
-         use: ['style-loader', 'css-loader'],
-       },
        {
          test: /\.(png|svg|jpg|jpeg|gif)$/i,
          type: 'asset/resource',
@@ -632,10 +605,6 @@ And configure them in your webpack configuration:
    module: {
      rules: [
        {
-         test: /\.css$/i,
-         use: ['style-loader', 'css-loader'],
-       },
-       {
          test: /\.(png|svg|jpg|jpeg|gif)$/i,
          type: 'asset/resource',
        },
@@ -789,10 +758,6 @@ For the next guides we won't be using all the different assets we've used in thi
 -  module: {
 -    rules: [
 -      {
--        test: /\.css$/i,
--        use: ['style-loader', 'css-loader'],
--      },
--      {
 -        test: /\.(png|svg|jpg|jpeg|gif)$/i,
 -        type: 'asset/resource',
 -      },
@@ -880,7 +845,7 @@ For the next guides we won't be using all the different assets we've used in thi
 And remove those dependencies we added before:
 
 ```bash
-npm uninstall css-loader csv-loader json5 style-loader toml xml-loader yamljs
+npm uninstall csv-loader json5 toml xml-loader yamljs
 ```
 
 ## Next guide

--- a/src/content/guides/author-libraries.mdx
+++ b/src/content/guides/author-libraries.mdx
@@ -343,4 +343,4 @@ W> The `module` property should point to a script that utilizes ES2015 module sy
 
 Now you can [publish it as an npm package](https://docs.npmjs.com/getting-started/publishing-npm-packages) and find it at [unpkg.com](https://unpkg.com/#/) to distribute it to your users.
 
-T> To expose stylesheets associated with your library, the [`MiniCssExtractPlugin`](/plugins/mini-css-extract-plugin) should be used. Users can then consume and load these as they would any other stylesheet.
+T> To expose stylesheets associated with your library, import the CSS from your entry and let webpack's [built-in CSS support](/guides/native-css/) extract it — the emitted `.css` file is named by [`output.cssFilename`](/configuration/output/#outputcssfilename), and users consume and load it as they would any other stylesheet.

--- a/src/content/guides/code-splitting.mdx
+++ b/src/content/guides/code-splitting.mdx
@@ -274,9 +274,7 @@ cacheable modules 530 KiB
 webpack 5.x.x compiled successfully in 241 ms
 ```
 
-Here are some other useful plugins and loaders provided by the community for splitting code:
-
-- [`mini-css-extract-plugin`](/plugins/mini-css-extract-plugin): Useful for splitting CSS out from the main application.
+CSS is split the same way: webpack extracts a stylesheet per chunk on its own, so a lazily imported CSS file arrives with the chunk that needs it — see [Native CSS](/guides/native-css/).
 
 ## Dynamic Imports
 

--- a/src/content/guides/entry-advanced.mdx
+++ b/src/content/guides/entry-advanced.mdx
@@ -35,13 +35,11 @@ console.log("account page type");
 // account page individual styles
 ```
 
-We will use [`MiniCssExtractPlugin`](/plugins/mini-css-extract-plugin/) in `production` mode for css as a best practice.
+Webpack extracts CSS on its own, so `sass-loader` is the only loader needed — give the rule a [CSS module type](/guides/native-css/#css-module-types) and webpack takes it from there.
 
 **webpack.config.js**
 
 ```js
-import MiniCssExtractPlugin from "mini-css-extract-plugin";
-
 export default {
   mode: process.env.NODE_ENV,
   entry: {
@@ -50,27 +48,20 @@ export default {
   },
   output: {
     filename: "[name].js",
+    cssFilename: "[name].css",
   },
   module: {
     rules: [
       {
         test: /\.scss$/,
-        use: [
-          // fallback to style-loader in development
-          process.env.NODE_ENV !== "production"
-            ? "style-loader"
-            : MiniCssExtractPlugin.loader,
-          "css-loader",
-          "sass-loader",
-        ],
+        use: ["sass-loader"],
+        type: "css/auto",
       },
     ],
   },
-  plugins: [
-    new MiniCssExtractPlugin({
-      filename: "[name].css",
-    }),
-  ],
+  experiments: {
+    css: true,
+  },
 };
 ```
 

--- a/src/content/guides/native-css.mdx
+++ b/src/content/guides/native-css.mdx
@@ -1,8 +1,10 @@
 ---
 title: Native CSS
+description: Bundle CSS with webpack's built-in support, and migrate off css-loader, style-loader and mini-css-extract-plugin.
 sort: 27
 contributors:
   - phoekerson
+  - alexander-akait
 ---
 
 This guide shows how to use webpack's native CSS handling with `experiments.css`, and how to migrate an existing setup off `css-loader`, `style-loader`, and `mini-css-extract-plugin`.
@@ -23,7 +25,9 @@ export default {
 };
 ```
 
-With this option enabled, webpack understands `.css` files as first-class modules — parsing `@import` and `url()`, extracting stylesheets, generating content hashes, and supporting CSS Modules — without `css-loader`, `style-loader`, or `mini-css-extract-plugin`.
+With this option enabled, webpack understands `.css` files as first-class modules — parsing `@import` and `url()`, extracting stylesheets, generating content hashes, minifying, and supporting CSS Modules — without `css-loader`, `style-loader`, `mini-css-extract-plugin`, or `css-minimizer-webpack-plugin`.
+
+T> Since webpack 5.109.0 the option defaults to `'auto'`: built-in CSS support turns on unless a [`module.rules`](/configuration/module/#modulerules) entry with a loader (or an explicit module type) already matches `.css` files. An existing `css-loader` setup therefore keeps working untouched, and you can migrate one rule at a time. Set it to `true` to force the native support, or `false` to switch it off.
 
 ## Importing CSS
 
@@ -184,6 +188,141 @@ export default {
 };
 ```
 
+## Custom media and custom selectors
+
+Native CSS resolves `@custom-media` and `@custom-selector` at build time, so the two rules people most often reach for a PostCSS plugin for need no plugin:
+
+**src/styles.css**
+
+```css
+@custom-media --narrow (width <= 40rem);
+@custom-selector :--heading h1, h2, h3;
+
+@media (--narrow) {
+  :--heading {
+    font-size: 1.25rem;
+  }
+}
+```
+
+Resolution is file-local — a definition applies to the file that declares it (and to what that file `@import`s) rather than to the whole project. Both are on by default and can be switched off individually with [`module.parser.css.customMedia`](/configuration/module/#moduleparsercsscustommedia) and [`module.parser.css.customSelectors`](/configuration/module/#moduleparsercsscustomselectors), which is what you want if a PostCSS plugin in your chain already handles them.
+
+## Minification
+
+CSS assets are minified by the built-in minimizer whenever [`optimization.minimize`](/configuration/optimization/#optimizationminimize) is on — which it is by default in `mode: 'production'`. There is nothing to install and nothing to wire up:
+
+**webpack.config.js**
+
+```js
+export default {
+  mode: "production",
+  experiments: { css: true },
+};
+```
+
+That replaces `css-minimizer-webpack-plugin` and the `cssnano` chain behind it. Every transform that preserves what the stylesheet means is on by default — shortening colors, numbers, values and selectors, merging longhands and rules, dropping dead rules, folding `calc()` and other math over constants, normalizing quotes, and writing media queries in their range spelling. Two are off because they change text a script can read back (`rewriteCustomProperties`) or rarely pay for themselves once compressed (`convertLengthUnits`).
+
+Configure them through the object form of `optimization.minimize`:
+
+```js
+export default {
+  mode: "production",
+  experiments: { css: true },
+  optimization: {
+    minimize: {
+      css: {
+        comments: false,
+        // `getComputedStyle().getPropertyValue()` hands custom property text
+        // back as authored — opt in only if nothing reads it.
+        rewriteCustomProperties: true,
+      },
+    },
+  },
+};
+```
+
+Disable CSS minification alone with `minimize: { css: false }`, leaving JavaScript minification in place.
+
+### Vendor prefixes
+
+The minimizer maintains vendor prefixes for your [browserslist](https://github.com/browserslist/browserslist) target: it adds the `-webkit-` / `-moz-` / `-ms-` spelling of a property, at-rule or pseudo-selector a selected browser still needs, and drops the ones none of them do. For most projects that is `autoprefixer` — and so `postcss-loader` — off the dependency list:
+
+**.browserslistrc**
+
+```text
+> 0.5%
+last 2 versions
+not dead
+```
+
+**webpack.config.js**
+
+```js
+export default {
+  mode: "production",
+  target: "browserslist",
+  experiments: { css: true },
+};
+```
+
+T> Prefixing is only in effect for a `browserslist` [target](/configuration/target/) — any other target names no browsers to prefix for. Turn it off with `optimization.minimize.css.vendorPrefixes: false` when a PostCSS chain already does it.
+
+## Resource hints and font preloading
+
+Assets referenced from CSS can be given `<link rel="preload">` / `prefetch` hints without a plugin. [`module.parser.css.fontPreload`](/configuration/module/#moduleparsercssfontpreload) seeds one preload for each `@font-face` reachable from an HTML entry's initial CSS — the primary `src` URL only, since preloading every format would download the font twice:
+
+**webpack.config.js**
+
+```js
+export default {
+  experiments: { css: true, html: true },
+  output: {
+    // A preload must match the font's CORS fetch.
+    crossOriginLoading: "anonymous",
+  },
+  module: {
+    parser: {
+      css: {
+        fontPreload: true,
+      },
+    },
+  },
+};
+```
+
+[`module.parser.css.urlHints`](/configuration/module/#moduleparsercssurlhints) gives per-asset rules for anything else reached through `url(...)`, and [`output.resourceHints`](/configuration/output/#outputresourcehints) sets them project-wide:
+
+```js
+export default {
+  experiments: { css: true, html: true },
+  module: {
+    parser: {
+      css: {
+        urlHints: [
+          { test: /\.woff2$/, preload: true, as: "font" },
+          { test: /hero\.avif$/, preload: true, as: "image" },
+        ],
+      },
+    },
+  },
+};
+```
+
+## CSS referenced from HTML
+
+With [`experiments.html`](/configuration/experiments/#experimentshtml) enabled, a `<link rel="stylesheet">` in an HTML page becomes a CSS chunk entry and inline `<style>` bodies (and `style=""` attributes) run through this same CSS pipeline — `@import` and `url()` inside them resolve relative to the HTML file, and the minimizer options above apply to them too:
+
+**webpack.config.js**
+
+```js
+export default {
+  entry: "./src/index.html",
+  experiments: { css: true, html: true },
+};
+```
+
+See the [Native HTML](/guides/native-html/) guide for the whole HTML story.
+
 ## Migration Guide
 
 ### Automated migration (codemod)
@@ -213,6 +352,10 @@ It requires webpack 5.109.0 or later, since it relies on the [`experiments.css: 
 | `css-loader` `modules.exportOnlyLocals`                   | generator `exportsOnly`                                                                                                                               |
 | `css-loader` `esModule`                                   | generator `esModule` (default `true`)                                                                                                                 |
 | `css-loader` `exportType: 'string'` / `'css-style-sheet'` | [`exportType: "text"` / `"css-style-sheet"`](#output-modes-exporttype)                                                                                |
+| `css-minimizer-webpack-plugin` / `cssnano`                | [`optimization.minimize`](#minification) — on by default in production                                                                                |
+| `postcss-loader` + `autoprefixer`                         | [`optimization.minimize.css.vendorPrefixes`](#vendor-prefixes) — on by default for a `browserslist` target                                            |
+| `postcss-custom-media` / `postcss-custom-selectors`       | [built-in `@custom-media` / `@custom-selector`](#custom-media-and-custom-selectors)                                                                   |
+| `preload-webpack-plugin` (fonts)                          | [`module.parser.css.fontPreload`](#resource-hints-and-font-preloading)                                                                                |
 
 Migrate one loader at a time — the sections below go in the order that keeps the build green at each step.
 
@@ -474,7 +617,28 @@ On a `node` target the CSS generator defaults to `exportsOnly: true`, so the ser
 
 T> Avoid the production default `localIdentName: "[fullhash]"` for SSR — the full compilation hash differs between the web and node builds, so class names won't line up. Pin a deterministic template (path- or `[local]`-based, optionally with a per-file `[hash]`) in both configs.
 
-### 8. Keep imports unchanged and validate
+### 8. Drop the CSS minimizer and `autoprefixer`
+
+`optimization.minimize` covers both in production, so the minimizer plugin and — for most projects — the PostCSS chain that only ran `autoprefixer` can go:
+
+**webpack.config.js**
+
+```diff
+-import CssMinimizerPlugin from "css-minimizer-webpack-plugin";
+-
+ export default {
+   mode: "production",
++  target: "browserslist",
++  experiments: { css: true },
+-  optimization: {
+-    minimizer: ["...", new CssMinimizerPlugin()],
+-  },
+ };
+```
+
+See [Minification](#minification) for what the built-in minimizer does and how to tune it.
+
+### 9. Keep imports unchanged and validate
 
 Your JS imports stay the same:
 
@@ -495,22 +659,26 @@ Configure options per module type under [`module.parser`](/configuration/module/
 
 ### Parser options
 
-All boolean parser options below default to `true`.
+Boolean parser options default to `true` unless the table says otherwise.
 
-| Option                                                               | Type                                               | Default        | Description                                                                                        |
-| -------------------------------------------------------------------- | -------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------- |
-| [`import`](/configuration/module/#moduleparsercssimport)             | `boolean`                                          | `true`         | Handle `@import` at-rules.                                                                         |
-| [`url`](/configuration/module/#moduleparsercssurl)                   | `boolean`                                          | `true`         | Handle `url()` / `image-set()` / `src()` / `image()`.                                              |
-| [`namedExports`](/configuration/module/#moduleparsercssnamedexports) | `boolean`                                          | `true`         | Export CSS Modules locals as ES module named exports.                                              |
-| [`exportType`](/configuration/module/#moduleparsercssexporttype)     | `"link" \| "style" \| "text" \| "css-style-sheet"` | `"link"`       | How the CSS is emitted (see [Output modes](#output-modes-exporttype)).                             |
-| [`pure`](/configuration/module/#moduleparsercsspure)                 | `boolean`                                          | `false`        | Strict pure mode — every selector must contain a local class/id. `css/module` and `css/auto` only. |
-| [`as`](/configuration/module/#moduleparsercssas)                     | `"stylesheet" \| "block-contents"`                 | `"stylesheet"` | Parse the source as a full stylesheet or as a block's contents.                                    |
-| `animation`                                                          | `boolean`                                          | `true`         | Rename local `@keyframes` names.                                                                   |
-| `container`                                                          | `boolean`                                          | `true`         | Rename local `@container` names.                                                                   |
-| `customIdents`                                                       | `boolean`                                          | `true`         | Rename custom identifiers.                                                                         |
-| `dashedIdents`                                                       | `boolean`                                          | `true`         | Rename dashed identifiers (custom properties).                                                     |
-| `function`                                                           | `boolean`                                          | `true`         | Rename local `@function` names.                                                                    |
-| `grid`                                                               | `boolean`                                          | `true`         | Rename grid line/area identifiers.                                                                 |
+| Option                                                                     | Type                                               | Default        | Description                                                                                        |
+| -------------------------------------------------------------------------- | -------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------- |
+| [`import`](/configuration/module/#moduleparsercssimport)                   | `boolean`                                          | `true`         | Handle `@import` at-rules.                                                                         |
+| [`url`](/configuration/module/#moduleparsercssurl)                         | `boolean`                                          | `true`         | Handle `url()` / `image-set()` / `src()` / `image()`.                                              |
+| [`namedExports`](/configuration/module/#moduleparsercssnamedexports)       | `boolean`                                          | `true`         | Export CSS Modules locals as ES module named exports.                                              |
+| [`exportType`](/configuration/module/#moduleparsercssexporttype)           | `"link" \| "style" \| "text" \| "css-style-sheet"` | `"link"`       | How the CSS is emitted (see [Output modes](#output-modes-exporttype)).                             |
+| [`pure`](/configuration/module/#moduleparsercsspure)                       | `boolean`                                          | `false`        | Strict pure mode — every selector must contain a local class/id. `css/module` and `css/auto` only. |
+| [`as`](/configuration/module/#moduleparsercssas)                           | `"stylesheet" \| "block-contents"`                 | `"stylesheet"` | Parse the source as a full stylesheet or as a block's contents.                                    |
+| `animation`                                                                | `boolean`                                          | `true`         | Rename local `@keyframes` names.                                                                   |
+| `container`                                                                | `boolean`                                          | `true`         | Rename local `@container` names.                                                                   |
+| `customIdents`                                                             | `boolean`                                          | `true`         | Rename custom identifiers.                                                                         |
+| `dashedIdents`                                                             | `boolean`                                          | `true`         | Rename dashed identifiers (custom properties).                                                     |
+| `function`                                                                 | `boolean`                                          | `true`         | Rename local `@function` names.                                                                    |
+| `grid`                                                                     | `boolean`                                          | `true`         | Rename grid line/area identifiers.                                                                 |
+| [`customMedia`](/configuration/module/#moduleparsercsscustommedia)         | `boolean`                                          | `true`         | Resolve `@custom-media` at build time.                                                             |
+| [`customSelectors`](/configuration/module/#moduleparsercsscustomselectors) | `boolean`                                          | `true`         | Resolve `@custom-selector` at build time.                                                          |
+| [`fontPreload`](/configuration/module/#moduleparsercssfontpreload)         | `boolean`                                          | `false`        | Preload each `@font-face`'s primary `src` from an HTML entry.                                      |
+| [`urlHints`](/configuration/module/#moduleparsercssurlhints)               | `UrlHintRule[]`                                    | —              | Resource-hint rules for assets referenced via `url(...)`.                                          |
 
 ```js
 export default {
@@ -684,6 +852,127 @@ With the default `css/auto` rule, `*.module.css` is scoped and everything else i
 import "./reset.css"; // global
 import * as card from "./card.module.css"; // scoped
 ```
+
+### Tailwind CSS (or any PostCSS chain)
+
+Native CSS replaces the CSS loaders, not PostCSS. Keep `postcss-loader` and give the rule a CSS module type so webpack handles what comes out of it:
+
+**webpack.config.js**
+
+```js
+export default {
+  experiments: { css: true },
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        use: ["postcss-loader"],
+        type: "css/auto",
+      },
+    ],
+  },
+};
+```
+
+T> Setting `experiments.css: true` explicitly matters here: with the `'auto'` default, a rule that names a loader for `.css` files keeps the native support off for them.
+
+### Sass with CSS Modules
+
+**webpack.config.js**
+
+```js
+export default {
+  experiments: { css: true },
+  module: {
+    rules: [
+      {
+        test: /\.module\.s[ac]ss$/i,
+        use: ["sass-loader"],
+        type: "css/module",
+      },
+      {
+        test: /\.s[ac]ss$/i,
+        exclude: /\.module\.s[ac]ss$/i,
+        use: ["sass-loader"],
+        type: "css/global",
+      },
+    ],
+  },
+};
+```
+
+### Group every stylesheet into one file
+
+By default CSS follows the chunk graph, so each entry gets its own stylesheet. A [cache group](/plugins/split-chunks-plugin/#splitchunkscachegroups) keyed on the CSS module type collects them all into one instead:
+
+**webpack.config.js**
+
+```js
+export default {
+  mode: "production",
+  entry: { home: "./src/home.js", about: "./src/about.js" },
+  experiments: { css: true },
+  output: {
+    cssFilename: "css/[name].[contenthash].css",
+  },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        styles: {
+          type: "css/auto",
+          name: "styles",
+          chunks: "all",
+          enforce: true,
+        },
+      },
+    },
+  },
+};
+```
+
+### Theme switching with constructable stylesheets
+
+**src/index.js**
+
+```js
+import dark from "./theme-dark.css" with { type: "css" };
+import light from "./theme-light.css" with { type: "css" };
+
+const media = matchMedia("(prefers-color-scheme: dark)");
+const apply = () => {
+  document.adoptedStyleSheets = [media.matches ? dark : light];
+};
+
+media.addEventListener("change", apply);
+apply();
+```
+
+Each theme is a separate `CSSStyleSheet`, so swapping them costs no re-parse and no flash of unstyled content.
+
+### Development server with hot-reloaded styles
+
+**webpack.config.js**
+
+```js
+export default {
+  mode: "development",
+  experiments: { css: true },
+  devServer: {
+    hot: true,
+  },
+};
+```
+
+CSS changes are applied in place; there is no `style-loader` to configure and no separate HMR wiring.
+
+### Importing a package's stylesheet
+
+```css
+/* src/styles.css */
+@import "bootstrap";
+```
+
+Webpack looks for a `style` field in the package's `package.json` and falls back to `main`, so bare specifiers work in CSS the way they do in JavaScript.
 
 ## Experimental status & known limitations
 

--- a/src/content/guides/native-html.mdx
+++ b/src/content/guides/native-html.mdx
@@ -1,0 +1,971 @@
+---
+title: Native HTML
+description: Bundle HTML with webpack's built-in HTML support, and migrate off html-loader and html-webpack-plugin.
+sort: 28
+contributors:
+  - alexander-akait
+---
+
+This guide shows how to use webpack's native HTML handling with `experiments.html`, and how to migrate an existing setup off `html-loader` and `html-webpack-plugin`.
+
+T> `experiments.html` is still experimental. It is expected to become the default in webpack v6, but behavior can still change while development continues. The overall effort is tracked in issue [#536](https://github.com/webpack/webpack/issues/536).
+
+## Getting Started
+
+Enable native HTML support in your webpack configuration:
+
+**webpack.config.js**
+
+```js
+export default {
+  experiments: {
+    html: true,
+  },
+};
+```
+
+With this option enabled, webpack understands `.html` files as first-class modules — parsing tags, resolving every URL they reference, bundling inline `<script>` and `<style>` bodies, emitting hashed assets, and writing the rewritten HTML back out — without `html-loader` or `html-webpack-plugin`.
+
+T> Since webpack 5.109.0 the option defaults to `'auto'`: built-in HTML support turns on unless a [`module.rules`](/configuration/module/#modulerules) entry with a loader (or an explicit module type) already matches `.html` files. An existing `html-loader` setup therefore keeps working untouched, and you can migrate one rule at a time. [`experiments.futureDefaults`](/configuration/experiments/#experimentsfuturedefaults) resolves it to `true`.
+
+## Three ways to use HTML
+
+Native HTML covers three separate jobs that used to need two different packages. Pick the one that matches your project — they can be combined.
+
+| Use case                                                                                                            | What you write                   | Replaces                                |
+| ------------------------------------------------------------------------------------------------------------------- | -------------------------------- | --------------------------------------- |
+| [**HTML entry point**](#1-html-as-an-entry-point) — the page drives the build                                       | `entry: './src/index.html'`      | `html-webpack-plugin` with a `template` |
+| [**Generated page**](#2-a-generated-page-for-a-javascript-entry) — webpack scaffolds a document around your bundles | `output.html: true`              | `html-webpack-plugin` with no template  |
+| [**HTML imported from JavaScript**](#3-html-imported-from-javascript) — a partial used as a string                  | `import page from './page.html'` | `html-loader`                           |
+
+### 1. HTML as an entry point
+
+Point [`entry`](/configuration/entry-context/) at an `.html` file and webpack builds the page itself: every `<script src>`, `<link rel="stylesheet">`, `<img src>`, inline `<style>` and inline `<script>` becomes part of the module graph, and the emitted page has all of its URLs rewritten to the built (hashed) filenames.
+
+**src/index.html**
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>My App</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <img src="./logo.png" alt="Logo" />
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>
+```
+
+**webpack.config.js**
+
+```js
+export default {
+  entry: "./src/index.html",
+  experiments: {
+    html: true,
+    css: true,
+  },
+};
+```
+
+This is the HTML-first model Vite and Parcel use: the page is the source of truth about which scripts and styles it needs, so there is no second list of entry points to keep in sync.
+
+T> When `experiments.html` is enabled, `.html` is added to the default [`resolve.extensions`](/configuration/resolve/#resolveextensions) ahead of the JavaScript extensions, so `entry: './src'` resolves `./src/index.html` even when `./src/index.js` exists.
+
+### 2. A generated page for a JavaScript entry
+
+If you would rather keep a JavaScript entry and have webpack write the document for you, set [`output.html`](/configuration/output/#outputhtml). Webpack generates one HTML file per non-HTML entrypoint and injects that entrypoint's initial JS and CSS chunks — including chunks shared through [`dependOn`](/configuration/entry-context/#dependencies):
+
+**webpack.config.js**
+
+```js
+export default {
+  entry: {
+    main: "./src/main.js",
+  },
+  output: {
+    html: true,
+  },
+  experiments: {
+    html: true,
+  },
+};
+```
+
+This is the part of `html-webpack-plugin` that scaffolds a document around your bundles. Set `output.html` to an object to configure the [generated page](#configuring-the-generated-page).
+
+### 3. HTML imported from JavaScript
+
+Importing an `.html` file from JavaScript gives you the processed HTML as a string, with every asset reference resolved through webpack — the role `html-loader` has played for years:
+
+**src/index.js**
+
+```js
+import page from "./page.html";
+
+document.querySelector("#app").innerHTML = page;
+```
+
+An HTML module imported this way is **not** emitted as a standalone file by default; an HTML module used as an entry is. Override either with [`module.generator.html.extract`](/configuration/module/#modulegeneratorhtmlextract).
+
+## What webpack bundles from a page
+
+By default the parser treats a known set of URL-bearing attributes as dependencies. Everything below is handled with no configuration:
+
+| Markup                                                | What happens                                                                       |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `<script src>`                                        | Becomes a classic chunk entry; the `src` is rewritten to the emitted chunk         |
+| `<script type="module" src>`                          | Becomes an ES module chunk entry                                                   |
+| `<script>…</script>` (inline)                         | The body becomes its own entry; the tag is rewritten to `<script src>`             |
+| `<style>…</style>` (inline)                           | Routed through the CSS pipeline; `@import` / `url()` resolved, text written back   |
+| `style="…"` attribute                                 | Routed through the CSS pipeline as a declaration list                              |
+| `<link rel="stylesheet">`                             | Becomes a CSS chunk entry                                                          |
+| `<link rel="modulepreload">`                          | Becomes an independent entry (preloaded, never executed by a sibling)              |
+| `<link rel="preload">` / `<link rel="prefetch">`      | Its script/style is bundled and the `href` rewritten                               |
+| `<link rel="icon">`, `<link rel="manifest">`          | Emitted as hashed assets; the manifest's `icons` / `screenshots` / `shortcuts` too |
+| `<img src>`, `<img srcset>`, `<source srcset>`        | Emitted as hashed assets                                                           |
+| `<iframe srcdoc>`                                     | The document inside is bundled through the HTML pipeline                           |
+| SVG references (`fill`, `cursor`, `font-face-uri`, …) | `url(...)` targets are emitted as assets                                           |
+| `<meta name="twitter:player:stream">`                 | Emitted as a hashed asset                                                          |
+
+Two rules make the JavaScript side predictable:
+
+- Multiple `<script src>` tags on the same page **share a single runtime**. Within each group (classic or `type="module"`), the leader holds the runtime and the rest declare `dependOn` on it.
+- With [`output.module`](/configuration/output/#outputmodule) enabled, classic `<script>` tags are auto-upgraded to `type="module"` so the emitted ES module chunks load in the right mode.
+
+Non-JS script types (`application/ld+json`, `importmap`, …), data URIs, and `<style>` with a non-CSS `type` flow through unchanged.
+
+### Skipping a single URL
+
+Put a `webpackIgnore` comment immediately before a tag to leave its URLs alone — useful for CDN assets or URLs a server rewrites at runtime:
+
+```html
+<!-- webpackIgnore: true -->
+<script src="https://cdn.example.com/analytics.js"></script>
+```
+
+### Customizing which attributes are URLs
+
+[`module.parser.html.sources`](/configuration/module/#moduleparserhtmlsources) controls the whole list. Use the literal `"..."` to keep the built-in defaults and add your own on top:
+
+**webpack.config.js**
+
+```js
+export default {
+  experiments: { html: true },
+  module: {
+    parser: {
+      html: {
+        sources: [
+          "...", // keep the built-in defaults
+          { tag: "img", attribute: "data-src", type: "src" },
+          { tag: "img", attribute: "data-srcset", type: "srcset" },
+          { attribute: "data-href", type: "src" }, // any tag
+          { tag: "img", attribute: "src", type: false }, // drop a built-in default
+        ],
+      },
+    },
+  },
+};
+```
+
+Pass `sources: false` to switch URL extraction off entirely; inline `<script>` and `<style>` bodies are still processed. A `filter` callback skips individual elements:
+
+```js
+export default {
+  experiments: { html: true },
+  module: {
+    parser: {
+      html: {
+        sources: [
+          "...",
+          {
+            tag: "img",
+            attribute: "src",
+            type: "src",
+            // Leave absolute URLs to the CDN alone.
+            filter: (attributes, value) => !value.startsWith("https://"),
+          },
+        ],
+      },
+    },
+  },
+};
+```
+
+### Linking pages together
+
+The `html` source type makes an `href` to another page part of the build: the linked file is bundled as its own emitted page and the attribute is rewritten to its output filename.
+
+**webpack.config.js**
+
+```js
+export default {
+  entry: "./src/index.html",
+  experiments: { html: true },
+  module: {
+    parser: {
+      html: {
+        sources: ["...", { tag: "a", attribute: "href", type: "html" }],
+      },
+    },
+  },
+};
+```
+
+```html
+<!-- src/index.html -->
+<a href="./about.html">About</a>
+```
+
+## Configuring the generated page
+
+Every option below lives under [`output.html`](/configuration/output/#outputhtml) and applies to webpack-generated pages. They can be overridden per entry through the [entry descriptor](/configuration/entry-context/#entry-descriptor):
+
+**webpack.config.js**
+
+```js
+export default {
+  entry: {
+    app: "./src/app.js",
+    // This entry gets no HTML page.
+    worker: { import: "./src/worker.js", html: false },
+    // …and this one overrides a single option.
+    admin: { import: "./src/admin.js", html: { title: "Admin" } },
+  },
+  output: { html: { title: "My App" } },
+  experiments: { html: true },
+};
+```
+
+### Title, meta and base
+
+**webpack.config.js**
+
+```js
+export default {
+  experiments: { html: true },
+  output: {
+    html: {
+      title: "My App",
+      meta: {
+        viewport: "width=device-width, initial-scale=1",
+        description: "A webpack-built app",
+        "og:title": "My App",
+      },
+      base: { href: "/app/", target: "_self" },
+    },
+  },
+};
+```
+
+The `charset` key is special-cased into a charset declaration (`meta: { charset: "UTF-8" }` emits `<meta charset="UTF-8">`), and keys beginning with `og:` use the `property` attribute instead of `name`. Each of these is skipped when the page already declares it, so an authored page always wins.
+
+### Where the tags go
+
+[`output.html.inject`](/configuration/output/#outputhtmlinject) places the injected chunk tags: `'body'` (default; `'head'` with `output.module`), `'head'`, or `false` to suppress sibling-chunk injection. [`output.html.scriptLoading`](/configuration/output/#outputhtmlscriptloading) chooses how they load: `'auto'` (default — a module script for ES module output, `defer` otherwise), `'defer'`, or `'blocking'`.
+
+```js
+export default {
+  experiments: { html: true },
+  output: {
+    html: {
+      inject: "head",
+      scriptLoading: "defer",
+    },
+  },
+};
+```
+
+Stylesheet `<link>` tags always land in `<head>` when the page has one, ahead of the first blocking script.
+
+### Inlining critical chunks
+
+[`output.html.inline`](/configuration/output/#outputhtmlinline) writes a chunk's content straight into the page instead of linking it — the job `html-webpack-inline-source-plugin` used to do. The page's `[contenthash]` accounts for the inlined content.
+
+```js
+export default {
+  experiments: { html: true },
+  output: {
+    html: {
+      // `true` inlines everything; `'script'` / `'style'` narrow it by type.
+      inline: [/^runtime/, /critical/],
+    },
+  },
+};
+```
+
+An authored page can opt a single reference in or out with the `webpackInline` magic comment:
+
+```html
+<!-- webpackInline: true -->
+<script src="./critical.js"></script>
+```
+
+### Favicons and the web app manifest
+
+```js
+export default {
+  experiments: { html: true },
+  output: {
+    html: {
+      favicon: {
+        icon: [
+          { href: "./favicon.svg", type: "image/svg+xml" },
+          { href: "./favicon-32.png", sizes: "32x32" },
+          {
+            href: "./favicon-dark.png",
+            media: "(prefers-color-scheme: dark)",
+          },
+        ],
+        "apple-touch-icon": "./apple-touch-icon.png",
+      },
+      manifest: {
+        name: "My App",
+        short_name: "App",
+        start_url: "/",
+        display: "standalone",
+        icons: [{ src: "./icon-512.png", sizes: "512x512" }],
+      },
+    },
+  },
+};
+```
+
+Every icon — including the ones named inside the manifest — is emitted as a hashed asset through the normal pipeline, so `favicons-webpack-plugin` and friends are no longer needed. Both apply to webpack-generated pages only: an authored page is left exactly as written, so add the `<link>` tags to the page itself when you own its markup. Both options also accept a function receiving the page name, which is how you give each page of a multi-page build its own icon set.
+
+### Subresource Integrity and CSP
+
+```js
+export default {
+  experiments: { html: true },
+  output: {
+    crossOriginLoading: "anonymous",
+    html: {
+      integrity: true, // or ['sha256', 'sha384']
+      csp: {
+        policy: {
+          "img-src": ["'self'", "data:"],
+          "connect-src": "https://api.example.com",
+        },
+      },
+    },
+  },
+};
+```
+
+`integrity: true` adds `sha384` `integrity` attributes to injected `<script>` / `<link>` tags — pair it with [`output.crossOriginLoading`](/configuration/output/#outputcrossoriginloading), since SRI requires CORS-enabled fetches. `csp` injects a `<meta http-equiv="Content-Security-Policy">` with a strict baseline plus a hash of every inline `<script>` / `<style>`; set `nonce` instead when your server rewrites one per request. Both replace `webpack-subresource-integrity` and `csp-html-webpack-plugin`.
+
+### Resource hints
+
+[`output.resourceHints`](/configuration/output/#outputresourcehints) emits `<link rel="preload">` / `prefetch` / `modulepreload` / `preconnect` tags into the page — the job `preload-webpack-plugin` used to do:
+
+```js
+export default {
+  experiments: { html: true },
+  output: {
+    resourceHints: {
+      initial: true, // hint the initial dependency graph
+      preconnect: true, // preconnect to origins the build references
+      urlHints: [{ test: /\.woff2$/, preload: true, as: "font" }],
+    },
+  },
+};
+```
+
+An array gives you full control, including literal hrefs and references to a named chunk or entry:
+
+```js
+export default {
+  experiments: { html: true },
+  output: {
+    resourceHints: [
+      { rel: "preconnect", href: "https://cdn.example.com" },
+      {
+        rel: "preload",
+        href: "/fonts/inter.woff2",
+        as: "font",
+        type: "font/woff2",
+        crossorigin: true,
+      },
+      { rel: "prefetch", entry: "settings" },
+      { rel: "preload", chunk: "runtime", fetchPriority: "high" },
+    ],
+  },
+};
+```
+
+For fonts referenced from CSS, [`module.parser.css.fontPreload`](/configuration/module/#moduleparsercssfontpreload) seeds the hints automatically. For server-side rendering, `resourceHints.manifest` writes the resolved hint list to a JSON asset so the server can inject the tags itself.
+
+## Templating
+
+[`module.parser.html.template`](/configuration/module/#moduleparserhtmltemplate) transforms the raw HTML **before** the parser extracts dependencies, so URLs produced by a templating language are still discovered and bundled. It runs for authored pages and for generated ones alike.
+
+**webpack.config.js**
+
+```js
+export default {
+  experiments: { html: true },
+  module: {
+    parser: {
+      html: {
+        template: (source, { resource, addDependency }) => {
+          addDependency(resource);
+          return source
+            .replaceAll("{{title}}", "Hello world")
+            .replaceAll("{{image}}", "./image.png");
+        },
+      },
+    },
+  },
+};
+```
+
+The context object carries the current `module` and its `resource`, the build-dependency helpers (`addDependency`, `addContextDependency`, `addMissingDependency`, `addBuildDependency`) and `emitWarning` / `emitError`. Register the template files you read so watch mode picks up their changes.
+
+Any synchronous template engine plugs in the same way:
+
+```js
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import { compile } from "handlebars";
+
+const dataFile = fileURLToPath(new URL("./src/data.json", import.meta.url));
+
+export default {
+  experiments: { html: true },
+  module: {
+    parser: {
+      html: {
+        template: (source, { addDependency }) => {
+          // Rebuild the page when the data changes.
+          addDependency(dataFile);
+          const data = JSON.parse(fs.readFileSync(dataFile, "utf8"));
+          return compile(source)(data);
+        },
+      },
+    },
+  },
+};
+```
+
+### Parsing a fragment
+
+An HTML partial is not a document, and parsing it as one drops context-sensitive tags — a bare `<tr>` outside a table, for instance. [`module.parser.html.as`](/configuration/module/#moduleparserhtmlas) names the context element to parse the source as:
+
+```js
+export default {
+  experiments: { html: true },
+  module: {
+    rules: [
+      {
+        test: /\.rows\.html$/i,
+        type: "html",
+        parser: { as: "tbody" },
+      },
+      {
+        test: /\.partial\.html$/i,
+        type: "html",
+        parser: { as: "template" }, // a neutral fragment
+      },
+    ],
+  },
+};
+```
+
+## Minification
+
+HTML assets are minified by the built-in minimizer whenever [`optimization.minimize`](/configuration/optimization/#optimizationminimize) is on — which it is by default in `mode: 'production'`. There is nothing to install and nothing to wire up:
+
+**webpack.config.js**
+
+```js
+export default {
+  mode: "production",
+  experiments: { html: true },
+};
+```
+
+Every transform that keeps the document's DOM is on by default; the ones that change what a script or a selector can read back are opt-in. Configure them through the object form of `optimization.minimize`:
+
+```js
+export default {
+  mode: "production",
+  experiments: { html: true },
+  optimization: {
+    minimize: {
+      html: {
+        collapseWhitespace: "smart",
+        removeRedundantAttributes: "smart",
+        // Opt in — these change what the DOM reads back.
+        sortAttributes: true,
+        sortTokenLists: true,
+        mergeStyles: true,
+      },
+    },
+  },
+};
+```
+
+Inline `<style>` elements and `style=""` attributes are minified with the CSS minimizer using the options `optimization.minimize.css` names, so a stylesheet and the same declarations inline are treated identically. Disable HTML minification alone with `minimize: { html: false }`.
+
+## Hot Module Replacement
+
+HTML modules support [Hot Module Replacement](/concepts/hot-module-replacement/) with no extra configuration — it activates whenever HMR is on, for example via [`devServer.hot`](/configuration/dev-server/#devserverhot). For a page extracted to a real `.html` file, each update patches `document.body.innerHTML` and `document.title` in place; a change to `<head>` beyond the title falls back to a full reload.
+
+## Plugin hooks
+
+`webpack.html.HtmlModulesPlugin` exposes `injectTags`, `transformTags`, `transformHtml` and `htmlEmitted` compilation hooks — the extension point that `html-webpack-plugin`'s hooks provided. See [`HtmlModulesPlugin.getCompilationHooks`](/api/compilation-hooks/#htmlmodulesplugingetcompilationhookscompilation).
+
+```js
+class AddBuildStampPlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap("AddBuildStamp", (compilation) => {
+      const hooks =
+        compiler.webpack.html.HtmlModulesPlugin.getCompilationHooks(
+          compilation,
+        );
+
+      hooks.transformHtml.tap("AddBuildStamp", (html) =>
+        html.replace("</body>", `<!-- built ${Date.now()} --></body>`),
+      );
+    });
+  }
+}
+```
+
+## Migrating from `html-loader`
+
+`html-loader` turned an imported `.html` file into a string with its URLs resolved. Native HTML does the same thing without a loader, so the migration is mostly deletion.
+
+### At a glance
+
+| `html-loader` option | Native equivalent                                                                                  |
+| -------------------- | -------------------------------------------------------------------------------------------------- |
+| `sources`            | [`module.parser.html.sources`](/configuration/module/#moduleparserhtmlsources) — `true` by default |
+| `sources.list`       | the array form of `sources` (use `"..."` to keep the defaults)                                     |
+| `sources.urlFilter`  | a `filter` callback on a source entry, or a `webpackIgnore` comment                                |
+| `preprocessor`       | [`module.parser.html.template`](/configuration/module/#moduleparserhtmltemplate)                   |
+| `postprocessor`      | the `transformHtml` [compilation hook](#plugin-hooks)                                              |
+| `minimize`           | [`optimization.minimize`](#minification) — on by default in production                             |
+| `esModule`           | n/a — an HTML module exports the processed HTML as its default export                              |
+
+### Before
+
+**webpack.config.js**
+
+```js
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.html$/i,
+        loader: "html-loader",
+        options: {
+          sources: {
+            list: ["...", { tag: "img", attribute: "data-src", type: "src" }],
+          },
+          minimize: true,
+        },
+      },
+    ],
+  },
+};
+```
+
+### After
+
+**webpack.config.js**
+
+```js
+export default {
+  experiments: {
+    html: true,
+  },
+  module: {
+    parser: {
+      html: {
+        sources: ["...", { tag: "img", attribute: "data-src", type: "src" }],
+      },
+    },
+  },
+};
+```
+
+Your imports do not change:
+
+```js
+import page from "./page.html";
+```
+
+T> While `experiments.html` is `'auto'` (the default since 5.109.0), a `module.rules` entry that still names `html-loader` keeps that rule on the loader. Migrate one rule at a time and delete the rule last.
+
+## Migrating from `html-webpack-plugin`
+
+`html-webpack-plugin` did two jobs: scaffolding a document around your bundles, and rendering a template. Native HTML splits them — [`output.html`](#2-a-generated-page-for-a-javascript-entry) scaffolds, and an [HTML entry point](#1-html-as-an-entry-point) or [`module.parser.html.template`](#templating) renders.
+
+### At a glance
+
+| `html-webpack-plugin`                    | Native equivalent                                                                 |
+| ---------------------------------------- | --------------------------------------------------------------------------------- |
+| no `template`                            | [`output.html: true`](/configuration/output/#outputhtml)                          |
+| `template`                               | use the file as an [HTML entry point](#1-html-as-an-entry-point)                  |
+| `templateContent` / `templateParameters` | [`module.parser.html.template`](#templating)                                      |
+| `filename`                               | [`output.htmlFilename`](/configuration/output/#outputhtmlfilename)                |
+| `title`                                  | [`output.html.title`](/configuration/output/#outputhtmltitle)                     |
+| `meta`                                   | [`output.html.meta`](/configuration/output/#outputhtmlmeta)                       |
+| `base`                                   | [`output.html.base`](/configuration/output/#outputhtmlbase)                       |
+| `inject`                                 | [`output.html.inject`](/configuration/output/#outputhtmlinject)                   |
+| `scriptLoading`                          | [`output.html.scriptLoading`](/configuration/output/#outputhtmlscriptloading)     |
+| `favicon`                                | [`output.html.favicon`](/configuration/output/#outputhtmlfavicon)                 |
+| `publicPath`                             | [`output.publicPath`](/configuration/output/#outputpublicpath)                    |
+| `minify`                                 | [`optimization.minimize`](#minification)                                          |
+| `hash`                                   | `[contenthash]` in [`output.filename`](/configuration/output/#outputfilename)     |
+| `chunks` / `excludeChunks`               | one page per entrypoint; opt an entry out with the entry descriptor `html: false` |
+| several plugin instances (MPA)           | [several entries](#multi-page-application)                                        |
+| `chunksSortMode`                         | n/a — injection order follows the chunk graph                                     |
+| `cache`, `showErrors`, `xhtml`           | n/a                                                                               |
+| plugin hooks                             | [`HtmlModulesPlugin` hooks](#plugin-hooks)                                        |
+
+Companion plugins fold in too:
+
+| Plugin                              | Native equivalent                                                        |
+| ----------------------------------- | ------------------------------------------------------------------------ |
+| `html-webpack-inline-source-plugin` | [`output.html.inline`](#inlining-critical-chunks)                        |
+| `webpack-subresource-integrity`     | [`output.html.integrity`](#subresource-integrity-and-csp)                |
+| `csp-html-webpack-plugin`           | [`output.html.csp`](#subresource-integrity-and-csp)                      |
+| `preload-webpack-plugin`            | [`output.resourceHints`](#resource-hints)                                |
+| `favicons-webpack-plugin`           | [`output.html.favicon` / `manifest`](#favicons-and-the-web-app-manifest) |
+
+### Without a template
+
+**Before**
+
+```js
+import HtmlWebpackPlugin from "html-webpack-plugin";
+
+export default {
+  entry: { main: "./src/main.js" },
+  plugins: [
+    new HtmlWebpackPlugin({
+      title: "My App",
+      scriptLoading: "defer",
+      favicon: "./src/favicon.png",
+      meta: { viewport: "width=device-width, initial-scale=1" },
+    }),
+  ],
+};
+```
+
+**After**
+
+```js
+export default {
+  entry: { main: "./src/main.js" },
+  experiments: { html: true },
+  output: {
+    html: {
+      title: "My App",
+      scriptLoading: "defer",
+      favicon: "./src/favicon.png",
+      meta: { viewport: "width=device-width, initial-scale=1" },
+    },
+  },
+};
+```
+
+### With a template
+
+A template that only listed your bundles becomes the entry itself — write the `<script>` and `<link>` tags you actually want, pointing at your source files, and webpack rewrites them to the built assets:
+
+**Before**
+
+```js
+import HtmlWebpackPlugin from "html-webpack-plugin";
+
+export default {
+  entry: { main: "./src/main.js" },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: "./src/index.html",
+      filename: "index.html",
+    }),
+  ],
+};
+```
+
+```html
+<!-- src/index.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>My App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <!-- html-webpack-plugin injected the script here -->
+  </body>
+</html>
+```
+
+**After**
+
+```js
+export default {
+  entry: { index: "./src/index.html" },
+  experiments: { html: true, css: true },
+};
+```
+
+```html
+<!-- src/index.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>My App</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>
+```
+
+The page now says what it loads, so the `entry` list and the template no longer have to agree.
+
+T> Prefer to keep the JavaScript entry and have webpack inject into your existing template? Keep `output.html: true` and use [`module.parser.html.template`](#templating) to wrap the generated document — it receives the synthesized HTML and returns whatever should be parsed.
+
+### Multi-page application
+
+Instead of one plugin instance per page, use one entry per page:
+
+**Before**
+
+```js
+import HtmlWebpackPlugin from "html-webpack-plugin";
+
+export default {
+  entry: { home: "./src/home.js", about: "./src/about.js" },
+  plugins: [
+    new HtmlWebpackPlugin({ filename: "home.html", chunks: ["home"] }),
+    new HtmlWebpackPlugin({ filename: "about.html", chunks: ["about"] }),
+  ],
+};
+```
+
+**After**
+
+```js
+export default {
+  entry: {
+    home: "./src/home.html",
+    about: "./src/about.html",
+  },
+  output: {
+    htmlFilename: "[name].html",
+  },
+  experiments: { html: true, css: true },
+};
+```
+
+Each page pulls in exactly the chunks it references, so `chunks` / `excludeChunks` have nothing left to do. The same works with generated pages — `output.html: true` plus one JavaScript entry per page.
+
+## Popular examples
+
+### Single-page app with hashed assets
+
+**webpack.config.js**
+
+```js
+export default {
+  mode: "production",
+  entry: "./src/index.html",
+  output: {
+    filename: "js/[name].[contenthash].js",
+    cssFilename: "css/[name].[contenthash].css",
+    assetModuleFilename: "assets/[name].[contenthash][ext]",
+    htmlFilename: "[name].html",
+    clean: true,
+  },
+  experiments: { html: true, css: true },
+};
+```
+
+### Inline the runtime chunk
+
+**webpack.config.js**
+
+```js
+export default {
+  mode: "production",
+  entry: { main: "./src/main.js" },
+  optimization: { runtimeChunk: "single" },
+  output: {
+    html: {
+      inline: [/^runtime/],
+    },
+  },
+  experiments: { html: true, css: true },
+};
+```
+
+Inlining the runtime removes one blocking request; `inline: 'style'` does the same for every CSS chunk.
+
+### A page per locale
+
+**webpack.config.js**
+
+```js
+import { fileURLToPath } from "node:url";
+
+const locales = ["en", "de", "fr"];
+const greetings = { en: "Hello", de: "Hallo", fr: "Bonjour" };
+
+export default locales.map((locale) => ({
+  name: locale,
+  entry: { [locale]: "./src/index.html" },
+  output: {
+    path: fileURLToPath(new URL(`./dist/${locale}`, import.meta.url)),
+    htmlFilename: "index.html",
+  },
+  module: {
+    parser: {
+      html: {
+        template: (source) =>
+          source
+            .replaceAll("{{lang}}", locale)
+            .replaceAll("{{greeting}}", greetings[locale]),
+      },
+    },
+  },
+  experiments: { html: true, css: true },
+}));
+```
+
+### Strict CSP with hashed inline scripts
+
+**webpack.config.js**
+
+```js
+export default {
+  mode: "production",
+  entry: "./src/index.html",
+  output: {
+    crossOriginLoading: "anonymous",
+    html: {
+      integrity: true,
+      csp: true,
+    },
+  },
+  experiments: { html: true, css: true },
+};
+```
+
+`csp: true` writes a strict baseline (`script-src 'self'`, `style-src 'self'`, `object-src 'none'`, `base-uri 'self'`) and appends a `sha256` hash for each inline `<script>` / `<style>` so your own inline code keeps running.
+
+### An installable PWA
+
+**webpack.config.js**
+
+```js
+export default {
+  entry: { main: "./src/main.js" },
+  output: {
+    html: {
+      title: "My App",
+      meta: { viewport: "width=device-width, initial-scale=1" },
+      favicon: "./src/icon.svg",
+      manifest: {
+        name: "My App",
+        short_name: "App",
+        start_url: "/",
+        display: "standalone",
+        background_color: "#ffffff",
+        icons: [
+          { src: "./src/icon-192.png", sizes: "192x192" },
+          { src: "./src/icon-512.png", sizes: "512x512" },
+        ],
+      },
+    },
+  },
+  experiments: { html: true },
+};
+```
+
+See [Progressive Web Application](/guides/progressive-web-application/) for the service worker half.
+
+### HTML partials rendered at runtime
+
+**src/index.js**
+
+```js
+import card from "./card.partial.html";
+
+document.querySelector("#list").insertAdjacentHTML("beforeend", card);
+```
+
+**webpack.config.js**
+
+```js
+export default {
+  experiments: { html: true },
+  module: {
+    rules: [
+      {
+        test: /\.partial\.html$/i,
+        type: "html",
+        parser: { as: "template" },
+        generator: { extract: false },
+      },
+    ],
+  },
+};
+```
+
+### Lazy-loaded page fragments
+
+```js
+const template = await import("./modal.partial.html");
+
+document.body.insertAdjacentHTML("beforeend", template.default);
+```
+
+The fragment's own `<img>` and inline `<style>` are bundled and resolved just like a static import's, and only fetched when the dynamic import runs.
+
+### Development server
+
+**webpack.config.js**
+
+```js
+export default {
+  mode: "development",
+  entry: "./src/index.html",
+  devServer: {
+    hot: true,
+  },
+  experiments: { html: true, css: true },
+};
+```
+
+The emitted page is served from the build output, so there is no template to keep in sync with a static `index.html`, and edits to the page, its styles and its scripts are all hot-applied.
+
+## Limitations
+
+`experiments.html` is explicitly opt-in — test it before a broad rollout.
+
+- APIs and behavior may still evolve before the webpack v6 defaults.
+- Full parity with `html-webpack-plugin` is still in progress; `chunksSortMode`, `xhtml`, `showErrors` and `cache` have no equivalent, and template-engine loaders (`pug-loader`, `ejs-loader`, …) are replaced by the synchronous [`template`](#templating) hook rather than being reused as-is.
+- `html-loader`'s `sources.scriptingEnabled` (parsing `<noscript>` content as markup) has no native switch.
+- [Module concatenation](/configuration/optimization/#optimizationconcatenatemodules) is disabled for HTML modules while HMR is active, because each module needs its own `module.hot` scope.
+
+## Further reading
+
+- [`experiments.html`](/configuration/experiments/#experimentshtml) — the flag and everything it unlocks
+- [`output.html`](/configuration/output/#outputhtml) — every generated-page option
+- [`module.parser.html`](/configuration/module/#moduleparserhtml) — parser options
+- [`module.generator.html.extract`](/configuration/module/#modulegeneratorhtmlextract) — when a page is emitted
+- [Native CSS](/guides/native-css/) — the CSS half of the same effort

--- a/src/content/guides/native-html.mdx
+++ b/src/content/guides/native-html.mdx
@@ -774,6 +774,380 @@ export default {
 
 Each page pulls in exactly the chunks it references, so `chunks` / `excludeChunks` have nothing left to do. The same works with generated pages — `output.html: true` plus one JavaScript entry per page.
 
+## All options with examples
+
+HTML is configured in four places: the [parser](#parser-options) and [generator](#generator-options) under `module`, the [output options](#output-options) that describe the emitted page, and the [minimizer](#minifier-options) options under `optimization`. The tables below list every option, with the reference entry linked from each name.
+
+### Parser options
+
+Set them globally under `module.parser.html`, or per rule with `parser` on a rule whose `type` is `html`.
+
+| Option                                                        | Type                                     | Default      | Description                                                         |
+| ------------------------------------------------------------- | ---------------------------------------- | ------------ | ------------------------------------------------------------------- |
+| [`sources`](/configuration/module/#moduleparserhtmlsources)   | `boolean \| Array<'...' \| SourceEntry>` | `true`       | Which attribute values are treated as URLs and how each is bundled. |
+| [`as`](/configuration/module/#moduleparserhtmlas)             | `'document' \| string`                   | `'document'` | Parse a full page, or the named element's inner HTML (a fragment).  |
+| [`urlHints`](/configuration/module/#moduleparserhtmlurlhints) | `UrlHintRule[]`                          | `[]`         | Default resource-hint rules for the assets this parser references.  |
+| [`template`](/configuration/module/#moduleparserhtmltemplate) | `(source, context) => string`            | —            | Transform the HTML source before dependencies are extracted.        |
+
+**webpack.config.js**
+
+```js
+export default {
+  experiments: { html: true },
+  module: {
+    parser: {
+      html: {
+        sources: true,
+        as: "document",
+        urlHints: [{ test: /\.woff2$/, preload: true, as: "font" }],
+        template: (source) => source.replaceAll("{{title}}", "My App"),
+      },
+    },
+  },
+};
+```
+
+#### Source entries
+
+Each entry in the `sources` array is either the string `"..."` (inline the built-in defaults) or an object:
+
+| Field       | Type                                                          | Required | Description                                                    |
+| ----------- | ------------------------------------------------------------- | -------- | -------------------------------------------------------------- |
+| `attribute` | `string`                                                      | yes      | The attribute whose value is a URL.                            |
+| `type`      | see [source types](#source-types), or `false`                 | yes      | How the value is parsed and bundled; `false` drops a built-in. |
+| `tag`       | `string`                                                      | no       | Tag name to match. Omit to match any element.                  |
+| `filter`    | `(attributes: Map<string, string>, value: string) => boolean` | no       | Return `false` to skip this entry for a given element.         |
+
+An array without `"..."` opts out of the built-in list entirely. Inline `<script>` and `<style>` bodies are processed whatever `sources` says; only `sources: false` turns URL extraction off completely.
+
+#### Source types
+
+| `type`                       | What the value is                    | How it is bundled                                                  |
+| ---------------------------- | ------------------------------------ | ------------------------------------------------------------------ |
+| `src`                        | one URL                              | Plain asset (`<img src>`)                                          |
+| `srcset`                     | a `srcset` candidate list            | Each URL as a plain asset                                          |
+| `css-url`                    | a CSS value containing `url(...)`    | Each reference as a plain asset (an SVG presentation attribute)    |
+| `script`                     | a URL                                | Classic chunk entry, like `<script src>`                           |
+| `script-module`              | a URL                                | ES module chunk entry, like `<script type="module" src>`           |
+| `stylesheet`                 | a URL                                | CSS chunk entry, like `<link rel="stylesheet">`                    |
+| `html`                       | a URL                                | Another page, bundled and emitted; the attribute gets its filename |
+| `stylesheet-style`           | a full stylesheet                    | CSS pipeline; the processed CSS replaces the attribute's content   |
+| `stylesheet-style-attribute` | a declaration list (like `style=""`) | CSS pipeline, as a block's contents                                |
+| `srcdoc`                     | an entity-encoded HTML document      | HTML pipeline; the processed HTML replaces the attribute's content |
+| `false`                      | —                                    | Disables a built-in source for that `tag` / `attribute` pair       |
+
+**webpack.config.js**
+
+```js
+export default {
+  experiments: { html: true, css: true },
+  module: {
+    parser: {
+      html: {
+        sources: [
+          "...",
+          { tag: "img", attribute: "data-src", type: "src" },
+          { tag: "img", attribute: "data-srcset", type: "srcset" },
+          { tag: "a", attribute: "href", type: "html" },
+          { tag: "my-widget", attribute: "styles", type: "stylesheet-style" },
+          {
+            tag: "my-widget",
+            attribute: "css",
+            type: "stylesheet-style-attribute",
+          },
+          { tag: "template", attribute: "data-html", type: "srcdoc" },
+          { tag: "circle", attribute: "fill", type: "css-url" },
+          { attribute: "data-worker", type: "script-module" },
+          // Keep the defaults but stop treating `<img src>` as a URL.
+          { tag: "img", attribute: "src", type: false },
+        ],
+      },
+    },
+  },
+};
+```
+
+### Generator options
+
+| Option                                                         | Type                  | Default                                        | Description                                                                |
+| -------------------------------------------------------------- | --------------------- | ---------------------------------------------- | -------------------------------------------------------------------------- |
+| [`extract`](/configuration/module/#modulegeneratorhtmlextract) | `boolean \| 'inline'` | `true` for HTML entries, `false` when imported | Whether the processed HTML is emitted as a standalone `.html` output file. |
+
+`'inline'` processes the HTML and hands it back for write-back into the document that holds it — what an `<iframe srcdoc>` needs — without emitting a file of its own.
+
+**webpack.config.js**
+
+```js
+export default {
+  experiments: { html: true },
+  module: {
+    rules: [
+      // A partial imported from JS: string only, no file.
+      {
+        test: /\.partial\.html$/i,
+        type: "html",
+        generator: { extract: false },
+      },
+      // A page imported from JS that should still be emitted.
+      {
+        test: /\.page\.html$/i,
+        type: "html",
+        generator: { extract: true },
+      },
+    ],
+  },
+};
+```
+
+### Output options
+
+Everything under [`output.html`](/configuration/output/#outputhtml) describes the page webpack generates for a JavaScript entrypoint. Authored pages keep their own markup — of these, only `inject`, `inline`, `scriptLoading` and `integrity` affect what is injected into them.
+
+| Option                                                                       | Type                                         | Default                                  | Description                                                |
+| ---------------------------------------------------------------------------- | -------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------- |
+| [`title`](/configuration/output/#outputhtmltitle)                            | `string`                                     | —                                        | The page `<title>`. Skipped when the page has one.         |
+| [`meta`](/configuration/output/#outputhtmlmeta)                              | `object`                                     | —                                        | `<meta>` tags; `charset` and `og:` keys are special-cased. |
+| [`base`](/configuration/output/#outputhtmlbase)                              | `string \| { href, target }`                 | —                                        | A `<base>` element. Skipped when the page has one.         |
+| [`inject`](/configuration/output/#outputhtmlinject)                          | `'body' \| 'head' \| false`                  | `'body'` (`'head'` with `output.module`) | Where injected chunk tags go.                              |
+| [`scriptLoading`](/configuration/output/#outputhtmlscriptloading)            | `'auto' \| 'defer' \| 'blocking'`            | `'auto'`                                 | How injected `<script>` tags load.                         |
+| [`inline`](/configuration/output/#outputhtmlinline)                          | `boolean \| 'script' \| 'style' \| RegExp[]` | `false`                                  | Inline matching chunks into the page.                      |
+| [`favicon`](/configuration/output/#outputhtmlfavicon)                        | `boolean \| string \| object \| function`    | `false`                                  | Icon `<link>`s; every icon is emitted as a hashed asset.   |
+| [`manifest`](/configuration/output/#outputhtmlmanifest)                      | `false \| string \| object \| function`      | `false`                                  | A web app manifest to link, or to serialize and emit.      |
+| [`integrity`](/configuration/output/#outputhtmlintegrity)                    | `boolean \| string[] \| function`            | `false`                                  | Subresource Integrity attributes on injected tags.         |
+| [`csp`](/configuration/output/#outputhtmlcsp)                                | `boolean \| { policy, hashFunction, nonce }` | `false`                                  | A `<meta http-equiv="Content-Security-Policy">`.           |
+| [`output.htmlFilename`](/configuration/output/#outputhtmlfilename)           | `string \| function`                         | `output.filename` with `.html`           | Filename template for initial pages.                       |
+| [`output.htmlChunkFilename`](/configuration/output/#outputhtmlchunkfilename) | `string \| function`                         | `output.chunkFilename` with `.html`      | Filename template for on-demand pages.                     |
+
+**webpack.config.js**
+
+```js
+export default {
+  entry: { main: "./src/main.js" },
+  experiments: { html: true, css: true },
+  output: {
+    htmlFilename: "[name].html",
+    htmlChunkFilename: "pages/[name].[contenthash].html",
+    crossOriginLoading: "anonymous",
+    html: {
+      title: "My App",
+      meta: { viewport: "width=device-width, initial-scale=1" },
+      base: { href: "/app/", target: "_self" },
+      inject: "head",
+      scriptLoading: "defer",
+      inline: [/^runtime/],
+      favicon: { icon: "./src/favicon.svg" },
+      manifest: { name: "My App", short_name: "App" },
+      integrity: ["sha384"],
+      csp: { policy: { "img-src": ["'self'", "data:"] } },
+    },
+  },
+};
+```
+
+The `favicon`, `manifest` and `integrity` options also take a function, which is how a multi-page build varies them per page or per asset:
+
+```js
+export default {
+  experiments: { html: true },
+  output: {
+    html: {
+      favicon: (name) => `./src/icons/${name}.svg`,
+      manifest: (name) => (name === "app" ? "./src/app.webmanifest" : false),
+      // Skip SRI for the chunks a CDN rewrites.
+      integrity: ({ filename }) =>
+        filename.startsWith("vendor/") ? false : ["sha384"],
+    },
+  },
+};
+```
+
+Per-entry overrides use the [entry descriptor](/configuration/entry-context/#entry-descriptor) `html` option, which takes the same values and merges over `output.html` option by option:
+
+```js
+export default {
+  entry: {
+    app: "./src/app.js",
+    admin: { import: "./src/admin.js", html: { title: "Admin", csp: true } },
+    worker: { import: "./src/worker.js", html: false },
+  },
+  output: { html: { title: "My App" } },
+  experiments: { html: true },
+};
+```
+
+T> `inline` is resolved once per generated page, so it can only be set on `output.html`.
+
+### Resource-hint options
+
+[`output.resourceHints`](/configuration/output/#outputresourcehints) accepts the `initial` value directly as a shorthand, or the full object:
+
+| Option                  | Type                                                                             | Default                                 | Description                                                                   |
+| ----------------------- | -------------------------------------------------------------------------------- | --------------------------------------- | ----------------------------------------------------------------------------- |
+| `initial`               | `boolean \| 'preload' \| 'prefetch' \| 'none' \| HtmlResourceHint[] \| function` | `true` for ESM output, else `false`     | Hints for the entry's initial dependency chunks.                              |
+| `urlHints`              | `UrlHintRule[]`                                                                  | `[]`                                    | Project-wide rules for URL-referenced assets, applied to every parser.        |
+| `preconnect`            | `boolean`                                                                        | `false`                                 | Preconnect to a cross-origin `output.publicPath` origin.                      |
+| `dedupe`                | `boolean`                                                                        | `false`                                 | Skip a runtime-injected prefetch for a chunk the document already hints.      |
+| `modulePreloadPolyfill` | `boolean`                                                                        | from `output.environment.modulePreload` | Inject the inline `<link rel="modulepreload">` polyfill into extracted pages. |
+| `manifest`              | `string`                                                                         | —                                       | Emit the resolved hints per entrypoint as a JSON asset at this path.          |
+
+`'none'` is the hard off switch — no `<link>` anywhere, and empty stats and manifest. `false` only disables the chunk hints, leaving `urlHints` and magic comments working.
+
+Each descriptor in an `initial` array (and in `output.resourceHints` used as an array) is an `HtmlResourceHint`:
+
+| Field           | Type                                                                           | Description                                                          |
+| --------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| `rel`           | `'preload' \| 'prefetch' \| 'modulepreload' \| 'preconnect' \| 'dns-prefetch'` | Required — the hint's `rel`.                                         |
+| `href`          | `string`                                                                       | A literal URL, used verbatim.                                        |
+| `chunk`         | `string`                                                                       | A chunk name; its emitted URL is resolved for you.                   |
+| `entry`         | `string`                                                                       | An entrypoint name; expands to one hint per initial chunk.           |
+| `as`            | `string`                                                                       | The `as` attribute; defaults to `script` for chunk/entry references. |
+| `type`          | `string`                                                                       | The MIME type.                                                       |
+| `media`         | `string`                                                                       | The `media` attribute.                                               |
+| `crossorigin`   | `boolean \| 'anonymous' \| 'use-credentials'`                                  | CORS mode; `true` means `anonymous`.                                 |
+| `fetchPriority` | `'low' \| 'high' \| 'auto'`                                                    | The `fetchpriority` attribute.                                       |
+| `integrity`     | `boolean`                                                                      | Follows `output.html.integrity`; `false` opts this hint out.         |
+
+Exactly one of `href` / `chunk` / `entry` names the target; a descriptor that resolves to nothing is dropped silently.
+
+A `UrlHintRule` — used by `output.resourceHints.urlHints` and by every parser's `urlHints` — matches assets by request and sets what a magic comment would:
+
+| Field                          | Type                                 | Description                                                              |
+| ------------------------------ | ------------------------------------ | ------------------------------------------------------------------------ |
+| `test` / `include` / `exclude` | `RuleSetCondition`                   | Matched against the asset's request. Omit all three to match everything. |
+| `preload` / `prefetch`         | `boolean`                            | Which hint to emit for matching assets.                                  |
+| `as`, `type`, `media`          | `string`                             | Attributes for the emitted `<link>`.                                     |
+| `fetchPriority`                | `'low' \| 'high' \| 'auto' \| false` | The `fetchpriority` attribute.                                           |
+
+**webpack.config.js**
+
+```js
+export default {
+  experiments: { html: true, outputModule: true },
+  output: {
+    module: true,
+    resourceHints: {
+      initial: true,
+      preconnect: true,
+      dedupe: true,
+      modulePreloadPolyfill: false,
+      manifest: "resource-hints.json",
+      urlHints: [
+        { test: /\.woff2$/, preload: true, as: "font", type: "font/woff2" },
+        {
+          include: /\/hero\//,
+          preload: true,
+          as: "image",
+          media: "(min-width: 800px)",
+        },
+        {
+          test: /\.png$/,
+          exclude: /\/hero\//,
+          prefetch: true,
+          fetchPriority: "low",
+        },
+      ],
+    },
+  },
+};
+```
+
+An explicit magic comment always beats a rule, and a rule beats the defaults. The resolved list for each entrypoint is readable from [`stats`](/configuration/stats/) as `entrypoints[name].resourceHints`, which is what the `manifest` asset serializes for a server-side renderer.
+
+### Minifier options
+
+Every option of [`optimization.minimize.html`](/configuration/optimization/#optimizationminimizehtml), grouped by whether it is on by default. The ones that are off change what a script, a selector or a byte-for-byte comparison reads back, so they are opt-in.
+
+**On by default**
+
+| Option                          | Type                                                         | Default   | Description                                                                  |
+| ------------------------------- | ------------------------------------------------------------ | --------- | ---------------------------------------------------------------------------- |
+| `collapseBooleanAttributes`     | `boolean`                                                    | `true`    | `disabled="disabled"` becomes the bare name.                                 |
+| `collapseWhitespace`            | `boolean \| 'conservative' \| 'smart' \| 'all'`              | `true`    | Collapse whitespace runs; `pre` / `textarea` / `listing` are left alone.     |
+| `comments`                      | `boolean \| 'all' \| 'some' \| string \| RegExp \| function` | `'some'`  | Which comments survive — `'some'` keeps none, since HTML comments are inert. |
+| `minifyJson`                    | `boolean`                                                    | `true`    | Strip whitespace in a JSON `<script>`, copying literals byte for byte.       |
+| `minifyStyles`                  | `boolean`                                                    | `true`    | Run the CSS minimizer over inline `<style>` and `style=""`.                  |
+| `normalizeAttributeQuotes`      | `boolean`                                                    | `true`    | Use whichever delimiters cost least.                                         |
+| `normalizeEnumeratedAttributes` | `boolean`                                                    | `true`    | Fold an enumerated value to the keyword it names.                            |
+| `normalizeListAttributes`       | `boolean`                                                    | `true`    | Normalize list-shaped values (`class`, `rel`, `srcset`, viewport `content`). |
+| `normalizeNumericAttributes`    | `boolean`                                                    | `true`    | Write an integer attribute the one way its rules read it.                    |
+| `removeImpliedTags`             | `boolean \| 'smart' \| 'all'`                                | `'smart'` | How much of the `<html>` / `<head>` / `<body>` shell may be implied.         |
+| `removeOptionalTags`            | `boolean`                                                    | `true`    | Leave out other tags the parser can imply.                                   |
+
+**Off by default**
+
+| Option                      | Type                          | Default | Why it is opt-in                                                              |
+| --------------------------- | ----------------------------- | ------- | ----------------------------------------------------------------------------- |
+| `mergeStyles`               | `boolean`                     | `false` | Removes elements, so `document.styleSheets` and `style:nth-child()` differ.   |
+| `minifyConditionalComments` | `boolean`                     | `false` | The body is minified as if it started a document, not where the comment sits. |
+| `minifySrcdoc`              | `boolean`                     | `false` | A consumer comparing `iframe.srcdoc` byte for byte sees it change.            |
+| `removeEmptyAttributes`     | `boolean`                     | `false` | An attribute selector matches on presence, so `[class]` stops matching.       |
+| `removeEmptyElements`       | `boolean`                     | `false` | CSS the minifier cannot see may give an empty element a size or a `::before`. |
+| `removeRedundantAttributes` | `boolean \| 'smart' \| 'all'` | `false` | Dropping an attribute changes `getAttribute` and attribute selectors.         |
+| `sortAttributes`            | `boolean`                     | `false` | A script reading `element.attributes` back sees the new order.                |
+| `sortTokenLists`            | `boolean`                     | `false` | A script reading `className` or `rel` back sees the new order.                |
+
+**webpack.config.js**
+
+```js
+export default {
+  mode: "production",
+  experiments: { html: true, css: true },
+  optimization: {
+    minimize: {
+      html: {
+        collapseWhitespace: "smart",
+        comments: /^!/,
+        removeImpliedTags: "all",
+        removeRedundantAttributes: "smart",
+        removeEmptyAttributes: true,
+        removeEmptyElements: true,
+        mergeStyles: true,
+        minifySrcdoc: true,
+        sortAttributes: true,
+        sortTokenLists: true,
+      },
+    },
+  },
+};
+```
+
+T> A `comments` predicate runs in the minimizer's worker pool and is passed to it as source, so it must not close over anything outside itself.
+
+### Magic comments
+
+An HTML comment placed immediately before a tag configures that tag alone:
+
+| Comment                                 | Effect                                                             |
+| --------------------------------------- | ------------------------------------------------------------------ |
+| `<!-- webpackIgnore: true -->`          | Leave the tag's URLs untouched.                                    |
+| `<!-- webpackInline: true -->`          | Inline the referenced chunk into the page (`false` opts back out). |
+| `<!-- webpackPreload: true -->`         | Set the next referenced asset's hint to `preload`.                 |
+| `<!-- webpackPrefetch: true -->`        | Set it to `prefetch`.                                              |
+| `<!-- webpackFetchPriority: "high" -->` | Set the hint's `fetchpriority`.                                    |
+
+The hint comments set the same fields a [`urlHints`](#resource-hint-options) rule would and win over one. The resolved hints for each entrypoint are emitted as `<link>` tags in the extracted page's `<head>` and exposed through `stats.entrypoints[name].resourceHints`.
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <!-- webpackPreload: true -->
+    <link rel="stylesheet" href="./critical.css" />
+  </head>
+  <body>
+    <!-- webpackIgnore: true -->
+    <script src="https://cdn.example.com/analytics.js"></script>
+
+    <!-- webpackInline: true -->
+    <script src="./bootstrap.js"></script>
+
+    <!-- webpackPrefetch: true -->
+    <!-- webpackFetchPriority: "low" -->
+    <img src="./below-the-fold.avif" alt="" />
+  </body>
+</html>
+```
+
 ## Popular examples
 
 ### Single-page app with hashed assets

--- a/src/content/guides/production.mdx
+++ b/src/content/guides/production.mdx
@@ -228,7 +228,7 @@ T> Avoid `inline-***` and `eval-***` use in production as they can increase bund
 
 ## Minimize CSS
 
-It is crucial to minimize your CSS for production. Please see the [Minimizing for Production](/plugins/mini-css-extract-plugin/#minimizing-for-production) section.
+It is crucial to minimize your CSS for production, and webpack does it for you: [`optimization.minimize`](/configuration/optimization/#optimizationminimize) is on in `production` mode and covers CSS assets along with JavaScript, with no extra plugin to install. See [Minification](/guides/native-css/#minification) for what it does and how to tune each transform.
 
 ## CLI Alternatives
 

--- a/src/content/guides/tree-shaking.mdx
+++ b/src/content/guides/tree-shaking.mdx
@@ -168,7 +168,7 @@ If your code did have some side effects though, an array can be provided instead
 
 The array accepts simple glob patterns to the relevant files. It uses [glob-to-regexp](https://github.com/fitzgen/glob-to-regexp) under the hood (Supports: `*`, `**`, `{a,b}`, `[a-z]`). Patterns like `*.css`, which do not include a `/`, will be treated like `**/*.css`.
 
-T> Note that any imported file is subject to tree shaking. This means if you use something like `css-loader` in your project and import a CSS file, it needs to be added to the side effect list so it will not be unintentionally dropped in production mode:
+T> Note that any imported file is subject to tree shaking. A CSS file imported for its side effect alone needs to be added to the side effect list so it will not be unintentionally dropped in production mode:
 
 ```json
 {

--- a/src/content/loaders/index.mdx
+++ b/src/content/loaders/index.mdx
@@ -38,7 +38,9 @@ Loaders are activated by using `loadername!` prefixes in `import .. from "mod";`
 
 ## Templating
 
-- [`html-loader`](/loaders/html-loader) Exports HTML as string, require references to static resources
+W> Webpack bundles HTML on its own — see [`experiments.html`](/configuration/experiments/#experimentshtml) and the [Native HTML](/guides/native-html/) guide, which also covers migrating off `html-loader`.
+
+- [`html-loader`](/loaders/html-loader) **Deprecated** — superseded by webpack's [built-in HTML support](/guides/native-html/). Exports HTML as string, require references to static resources
 - [`pug-loader`](https://github.com/pugjs/pug-loader) Loads Pug and Jade templates and returns a function
 - [`markdown-loader`](https://github.com/peerigon/markdown-loader) Compiles Markdown to HTML
 - [`react-markdown-loader`](https://github.com/javiercf/react-markdown-loader) Compiles Markdown to a React Component using the markdown-parse parser
@@ -50,8 +52,10 @@ Loaders are activated by using `loadername!` prefixes in `import .. from "mod";`
 
 ## Styling
 
-- [`style-loader`](/loaders/style-loader) Add exports of a module as style to DOM
-- [`css-loader`](/loaders/css-loader) Loads CSS file with resolved imports and returns CSS code
+W> Webpack parses, extracts and minifies CSS on its own — see [`experiments.css`](/configuration/experiments/#experimentscss) and the [Native CSS](/guides/native-css/) guide, which also covers migrating off the loaders marked below. Preprocessor loaders (Sass, Less, PostCSS, Stylus) stay: pair them with a `css/auto` rule.
+
+- [`style-loader`](/loaders/style-loader) **Deprecated** — superseded by webpack's [built-in CSS support](/guides/native-css/). Add exports of a module as style to DOM
+- [`css-loader`](/loaders/css-loader) **Deprecated** — superseded by webpack's [built-in CSS support](/guides/native-css/). Loads CSS file with resolved imports and returns CSS code
 - [`css-utility-loader`](https://github.com/SahilKhanWDC/css-utility-loader-webpack-.git) - Automatically parses and translates legacy CSS properties into modern utility classes (Tailwind) at build-time.
 - [`less-loader`](/loaders/less-loader) Loads and compiles a LESS file
 - [`sass-loader`](/loaders/sass-loader) Loads and compiles a SASS/SCSS file

--- a/src/content/plugins/html-webpack-plugin.mdx
+++ b/src/content/plugins/html-webpack-plugin.mdx
@@ -10,6 +10,8 @@ contributors:
 
 The [`HtmlWebpackPlugin`](https://github.com/jantimon/html-webpack-plugin) simplifies creation of HTML files to serve your webpack bundles. This is especially useful for webpack bundles that include a hash in the filename which changes every compilation. You can either let the plugin generate an HTML file for you, supply your own template using [lodash templates](https://lodash.com/docs#template), or use your own [loader](/loaders).
 
+T> Webpack has built-in HTML support since 5.107.0 — [`experiments.html`](/configuration/experiments/#experimentshtml) and [`output.html`](/configuration/output/#outputhtml) cover most of what this plugin does, with no plugin to install. See the [Native HTML](/guides/native-html/) guide for the feature set and a migration path.
+
 ## Installation
 
 ```bash

--- a/src/content/plugins/index.mdx
+++ b/src/content/plugins/index.mdx
@@ -16,31 +16,33 @@ contributors:
 
 Webpack has a rich plugin interface. Most of the features within webpack itself use this plugin interface. This makes webpack **flexible**.
 
-| Name                                                                            | Description                                                                            |
-| ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| [`BannerPlugin`](/plugins/banner-plugin)                                        | Add a banner to the top of each generated chunk                                        |
-| [`ChunksWebpackPlugin`](/plugins/chunks-webpack-plugin/)                        | Create HTML files with entrypoints and chunks relations to serve your bundles          |
-| [`CompressionWebpackPlugin`](/plugins/compression-webpack-plugin)               | Prepare compressed versions of assets to serve them with Content-Encoding              |
-| [`ContextReplacementPlugin`](/plugins/context-replacement-plugin)               | Override the inferred context of a `require` expression                                |
-| [`CopyWebpackPlugin`](/plugins/copy-webpack-plugin)                             | Copies individual files or entire directories to the build directory                   |
-| [`DefinePlugin`](/plugins/define-plugin)                                        | Allow global constants configured at compile time                                      |
-| [`DllPlugin`](/plugins/dll-plugin)                                              | Split bundles in order to drastically improve build time                               |
-| [`EnvironmentPlugin`](/plugins/environment-plugin)                              | Shorthand for using the [`DefinePlugin`](/plugins/define-plugin) on `process.env` keys |
-| [`EslintWebpackPlugin`](/plugins/eslint-webpack-plugin)                         | A ESLint plugin for webpack                                                            |
-| [`HotModuleReplacementPlugin`](/plugins/hot-module-replacement-plugin)          | Enable Hot Module Replacement (HMR)                                                    |
-| [`HtmlWebpackPlugin`](/plugins/html-webpack-plugin)                             | Easily create HTML files to serve your bundles                                         |
-| [`IgnorePlugin`](/plugins/ignore-plugin)                                        | Exclude certain modules from bundles                                                   |
-| [`LimitChunkCountPlugin`](/plugins/limit-chunk-count-plugin)                    | Set min/max limits for chunking to better control chunking                             |
-| [`MergeDuplicateChunksPlugin`](/plugins/merge-duplicate-chunks-plugin)          | Merge chunks that contain the same modules                                             |
-| [`MinChunkSizePlugin`](/plugins/min-chunk-size-plugin)                          | Keep chunk size above the specified limit                                              |
-| [`MiniCssExtractPlugin`](/plugins/mini-css-extract-plugin)                      | creates a CSS file per JS file which requires CSS                                      |
-| [`NoEmitOnErrorsPlugin`](/configuration/optimization/#optimizationemitonerrors) | Skip the emitting phase when there are compilation errors                              |
-| [`NormalModuleReplacementPlugin`](/plugins/normal-module-replacement-plugin)    | Replace resource(s) that matches a regexp                                              |
-| [`ProgressPlugin`](/plugins/progress-plugin)                                    | Report compilation progress                                                            |
-| [`ProvidePlugin`](/plugins/provide-plugin)                                      | Use modules without having to use import/require                                       |
-| [`SourceMapDevToolPlugin`](/plugins/source-map-dev-tool-plugin)                 | Enables a more fine grained control of source maps                                     |
-| [`EvalSourceMapDevToolPlugin`](/plugins/eval-source-map-dev-tool-plugin)        | Enables a more fine grained control of eval source maps                                |
-| [`SvgChunkWebpackPlugin`](/plugins/svg-chunk-webpack-plugin/)                   | Generate SVG sprites optimized by SVGO based on your entry point dependencies          |
-| [`MinimizerPlugin`](/plugins/minimizer-webpack-plugin/)                         | Uses Terser (or other) to minify the JS/CSS/HTML/JSON/etc in your project              |
+W> Webpack now bundles CSS and HTML itself, so the plugins marked **Deprecated** below are no longer needed — see the [Native CSS](/guides/native-css/) and [Native HTML](/guides/native-html/) guides for the built-in equivalents and how to migrate.
+
+| Name                                                                            | Description                                                                                                                                                                |
+| ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`BannerPlugin`](/plugins/banner-plugin)                                        | Add a banner to the top of each generated chunk                                                                                                                            |
+| [`ChunksWebpackPlugin`](/plugins/chunks-webpack-plugin/)                        | Create HTML files with entrypoints and chunks relations to serve your bundles                                                                                              |
+| [`CompressionWebpackPlugin`](/plugins/compression-webpack-plugin)               | Prepare compressed versions of assets to serve them with Content-Encoding                                                                                                  |
+| [`ContextReplacementPlugin`](/plugins/context-replacement-plugin)               | Override the inferred context of a `require` expression                                                                                                                    |
+| [`CopyWebpackPlugin`](/plugins/copy-webpack-plugin)                             | Copies individual files or entire directories to the build directory                                                                                                       |
+| [`DefinePlugin`](/plugins/define-plugin)                                        | Allow global constants configured at compile time                                                                                                                          |
+| [`DllPlugin`](/plugins/dll-plugin)                                              | Split bundles in order to drastically improve build time                                                                                                                   |
+| [`EnvironmentPlugin`](/plugins/environment-plugin)                              | Shorthand for using the [`DefinePlugin`](/plugins/define-plugin) on `process.env` keys                                                                                     |
+| [`EslintWebpackPlugin`](/plugins/eslint-webpack-plugin)                         | A ESLint plugin for webpack                                                                                                                                                |
+| [`HotModuleReplacementPlugin`](/plugins/hot-module-replacement-plugin)          | Enable Hot Module Replacement (HMR)                                                                                                                                        |
+| [`HtmlWebpackPlugin`](/plugins/html-webpack-plugin)                             | **Deprecated** — superseded by [`output.html`](/configuration/output/#outputhtml); see [Native HTML](/guides/native-html/). Easily create HTML files to serve your bundles |
+| [`IgnorePlugin`](/plugins/ignore-plugin)                                        | Exclude certain modules from bundles                                                                                                                                       |
+| [`LimitChunkCountPlugin`](/plugins/limit-chunk-count-plugin)                    | Set min/max limits for chunking to better control chunking                                                                                                                 |
+| [`MergeDuplicateChunksPlugin`](/plugins/merge-duplicate-chunks-plugin)          | Merge chunks that contain the same modules                                                                                                                                 |
+| [`MinChunkSizePlugin`](/plugins/min-chunk-size-plugin)                          | Keep chunk size above the specified limit                                                                                                                                  |
+| [`MiniCssExtractPlugin`](/plugins/mini-css-extract-plugin)                      | **Deprecated** — superseded by webpack's [built-in CSS support](/guides/native-css/). Creates a CSS file per JS file which requires CSS                                    |
+| [`NoEmitOnErrorsPlugin`](/configuration/optimization/#optimizationemitonerrors) | Skip the emitting phase when there are compilation errors                                                                                                                  |
+| [`NormalModuleReplacementPlugin`](/plugins/normal-module-replacement-plugin)    | Replace resource(s) that matches a regexp                                                                                                                                  |
+| [`ProgressPlugin`](/plugins/progress-plugin)                                    | Report compilation progress                                                                                                                                                |
+| [`ProvidePlugin`](/plugins/provide-plugin)                                      | Use modules without having to use import/require                                                                                                                           |
+| [`SourceMapDevToolPlugin`](/plugins/source-map-dev-tool-plugin)                 | Enables a more fine grained control of source maps                                                                                                                         |
+| [`EvalSourceMapDevToolPlugin`](/plugins/eval-source-map-dev-tool-plugin)        | Enables a more fine grained control of eval source maps                                                                                                                    |
+| [`SvgChunkWebpackPlugin`](/plugins/svg-chunk-webpack-plugin/)                   | Generate SVG sprites optimized by SVGO based on your entry point dependencies                                                                                              |
+| [`MinimizerPlugin`](/plugins/minimizer-webpack-plugin/)                         | Uses Terser (or other) to minify the JS/CSS/HTML/JSON/etc in your project                                                                                                  |
 
 For more third-party plugins, see the list from [awesome-webpack](/awesome-webpack/#webpack-plugins).

--- a/src/content/plugins/split-chunks-plugin.mdx
+++ b/src/content/plugins/split-chunks-plugin.mdx
@@ -156,7 +156,7 @@ export default {
 };
 ```
 
-T> You can combine this configuration with the [HtmlWebpackPlugin](/plugins/html-webpack-plugin/) for Single Page Application or [ChunksWebpackPlugin](https://github.com/yoriiis/chunks-webpack-plugin?tab=readme-ov-file#chunkswebpackplugin) for Multiple Page Application. It will inject all the generated vendor chunks for you.
+T> Combine this with [`output.html`](/configuration/output/#outputhtml) — webpack generates the page and injects every generated vendor chunk for you, for a single page or one page per entry. See [Native HTML](/guides/native-html/).
 
 ### splitChunks.maxAsyncRequests
 


### PR DESCRIPTION
**Summary**

Now that native CSS and HTML cover almost the whole feature surface, the guides should too. This adds a **Native HTML** guide (there was none) with migration paths off `html-loader` and `html-webpack-plugin`, a full reference for every HTML parser/generator/output/minimizer option, and lots of examples; and it expands the existing **Native CSS** guide with the features added since it was written (`@custom-media` / `@custom-selector`, the built-in CSS minimizer and its browserslist vendor prefixing, font preloading and url hints, CSS referenced from HTML) plus more examples. It also documents two reference options both guides depend on: the object form of `optimization.minimize` (per-asset-type `css` / `html` / `javascript`) and the entry descriptor `html` option, neither of which was documented.

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

n/a — documentation only. Every configuration shown was verified by running it against webpack 5.110.0 (HTML entry points, `output.html` and per-entry overrides, the `sources` array with `"..."` / `type: false` / `filter`, the `template` hook, `<a href>` page linking, `inline`, favicon/manifest/integrity incl. their function forms, magic comments, multi-page output, `@custom-media` / `@custom-selector`, vendor prefixing, the CSS cache group, and every documented option in a single build to confirm it validates).

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

Documented here: the Native HTML guide (`/guides/native-html/`), the expanded Native CSS guide, `optimization.minimize`'s per-asset-type object form, and the entry descriptor `html` option. Nothing further is pending.

**Use of AI**

This PR was written with Claude Code. It read the option schemas and `lib/` sources in `webpack/webpack` for the option semantics, drafted the pages, and then verified every example by running real builds against webpack 5.110.0 rather than relying on the model's own recollection — two claims were wrong on first draft (a `splitChunks` cache group typed `css/mini-extract`, and `output.resourceHints.dedupe` defaulting to `true`) and were corrected from the source and a build. Prettier, markdownlint and ESLint were run locally; Vale could not be run in the sandbox. All output was reviewed before committing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NwjXQBKW6nPrk5SgMWH8Hh)_