### PR TITLE
docs: add ESM and CommonJS interoperability resource

### DIFF
--- a/src/content/concepts/modules.mdx
+++ b/src/content/concepts/modules.mdx
@@ -10,6 +10,8 @@ contributors:
 related:
   - title: JavaScript Module Systems Showdown
     url: https://auth0.com/blog/javascript-module-systems-showdown/
+  - title: "ESM and CommonJS: semantics, interop, and packaging"
+    url: https://frontendatlas.com/javascript/trivia/js-esm-vs-cjs
 ---
 
 In [modular programming](https://en.wikipedia.org/wiki/Modular_programming), developers break programs up into discrete chunks of functionality called a _module_.


### PR DESCRIPTION
## Summary
Add one resource to the Modules page’s existing Further Reading list.

## Why
The current section includes a broad module-systems overview. This resource focuses specifically on ESM/CommonJS semantics, live bindings, package exports, interoperability pitfalls, and build behavior, directly complementing the page’s `import` and `require()` examples.

## Disclosure
I’m affiliated with FrontendAtlas, which publishes the linked free resource.

## Validation
Documentation-only frontmatter change. The rendered frontmatter link and live destination were checked; project CI can validate formatting.