### PR TITLE
docs(config): document output.copy and the CopyPlugin behind it

### DIFF
--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -330,6 +330,181 @@ export default {
 };
 ```
 
+## output.copy
+
+<Badge text="5.111.0+" />
+
+`string` `[string, object]`
+
+Copy files and directories into [`output.path`](#outputpath) as part of the build. A copied file becomes an asset like any other, so [`output.clean`](#outputclean) keeps it, [stats](/configuration/stats/) reports it, and in [watch mode](/configuration/watch/) editing a source file copies it again without rebuilding the rest.
+
+```js
+export default {
+  // ...
+  output: {
+    copy: "static",
+  },
+};
+```
+
+A string is shorthand for the `from` of a single pattern. Pass an array to copy from more than one place, mixing strings and pattern objects:
+
+```js
+export default {
+  // ...
+  output: {
+    copy: [
+      // A directory keeps the structure below itself.
+      "static",
+      // Several sources into one destination, in order.
+      { from: ["licenses/*.txt", "vendor/licenses/*.txt"], to: "licenses" },
+      // A filename template renames, flattens and hashes.
+      { from: "img", to: "i", filename: "[name].[contenthash][ext]" },
+    ],
+  },
+};
+```
+
+Every copied asset carries `copied: true` and the `sourceFilename` it came from in its [asset info](/api/stats/#asset-objects), so a later plugin can tell the copied assets from the generated ones.
+
+W> A pattern that matches nothing warns, and copying a file onto an asset the compilation itself emits is an error — give the copy another name with `filename` or `to`. Within one `output.copy`, a later pattern may deliberately copy over what an earlier one wrote.
+
+### Copy patterns
+
+A pattern is a `from` plus the options below.
+
+| Option                | Type                                                                | Default                      | Description                                                                                                             |
+| --------------------- | ------------------------------------------------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `context`             | `string`                                                            | see below                    | Directory `from` is resolved from, and the directory the copied paths keep their structure below.                       |
+| `filename`            | `string` `function (pathData, assetInfo) => string`                 | `'[path][base]'`             | Name of the copied file inside `to`, as a [filename template](#template-strings).                                       |
+| `from`                | `string` `[string]`                                                 | required                     | Glob or path to copy from. A glob separates with `/`, matches dot files, and takes `*`, `**`, `?`, `[]` and `{}`.       |
+| `globOptions`         | `object`                                                            |                              | How the glob in `from` matches — see [glob options](#glob-options).                                                     |
+| `info`                | `object` `function (file) => object`                                |                              | [Asset info](/api/stats/#asset-objects) of the copied file, merged over the info the copy already carries.              |
+| `preservePermissions` | `boolean`                                                           | `false`                      | Whether the copy keeps the permissions of the file it came from. Has no effect on Windows.                              |
+| `preserveTimestamps`  | `boolean`                                                           | `false`                      | Whether the copy keeps the access and modification times of the file it came from, rather than the time it was written. |
+| `to`                  | `string` `function (file) => string`                                | [`output.path`](#outputpath) | Directory the files are copied to, relative to `output.path`.                                                           |
+| `transform`           | `function (content, absoluteFilename) => string \| Buffer` `object` |                              | Modifies the content on the way through — see [transforming content](#transforming-content).                            |
+
+`context` defaults to the compiler [`context`](/configuration/entry-context/#context), and to what `from` names when `from` is not a glob — so `from: 'static'` copies the tree below `static/` rather than into a `static/` directory. Setting it explicitly roots every `from` of the pattern at one directory, which is how several globs keep a shared structure:
+
+```js
+export default {
+  // ...
+  output: {
+    copy: [
+      // "vendor/a/x.js" lands at "lib/a/x.js", not at "lib/x.js".
+      { from: ["a/**/*.js", "b/**/*.js"], context: "vendor", to: "lib" },
+    ],
+  },
+};
+```
+
+`to` and `info` may each be a function of the file being copied, which receives `{ absoluteFilename, sourceFilename, filename }` — `filename` being the name the file has so far, relative to `to`:
+
+```js
+export default {
+  // ...
+  output: {
+    copy: [
+      {
+        from: "assets",
+        to: (file) => (file.filename.endsWith(".css") ? "css" : "media"),
+        info: (file) => ({ immutable: file.filename.endsWith(".png") }),
+      },
+    ],
+  },
+};
+```
+
+### Glob options
+
+`globOptions` says how the glob in `from` matches.
+
+| Option           | Type       | Default  | Description                                                                                                      |
+| ---------------- | ---------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
+| `caseSensitive`  | `boolean`  | `true`   | Whether the glob matches the case of a file name.                                                                |
+| `deep`           | `number`   | no limit | How many directory levels below the base of the glob are read, where `1` reads only the base itself.             |
+| `dot`            | `boolean`  | `true`   | Whether the glob reaches a file or directory whose name starts with a dot without naming it.                     |
+| `followSymlinks` | `boolean`  | `true`   | Whether a symbolic link is resolved and copied as what it points at. `false` copies the link itself, unresolved. |
+| `ignore`         | `[string]` |          | Globs of files which are not copied, resolved like `from`. A directory one of them matches is skipped whole.     |
+
+```js
+export default {
+  // ...
+  output: {
+    copy: [
+      {
+        from: "static/**/*.html",
+        to: "pages",
+        globOptions: { dot: false, deep: 2, ignore: ["**/draft-*.html"] },
+      },
+    ],
+  },
+};
+```
+
+### Transforming content
+
+`transform` rewrites a file on the way through. It receives the content as a `Buffer` and the absolute path it was read from, and may return a string, a `Buffer`, or a promise of either:
+
+```js
+export default {
+  // ...
+  output: {
+    copy: [
+      {
+        from: "config.json",
+        to: "runtime",
+        transform: (content) =>
+          content.toString().replace("__API__", "https://example.com"),
+      },
+    ],
+  },
+};
+```
+
+The result is cached on the content of the file. When the transform depends on anything else, say so with the object form so the cache misses when that changes:
+
+```js
+export default {
+  // ...
+  output: {
+    copy: [
+      {
+        from: "config.json",
+        transform: {
+          transformer: (content) =>
+            content.toString().replace("__API__", apiUrl),
+          cache: { keys: { apiUrl } },
+        },
+      },
+    ],
+  },
+};
+```
+
+`cache` also takes `false` to skip caching, or a function receiving `(defaultKeys, absoluteFilename)` and returning the keys to cache under.
+
+T> A symbolic link copied as a link (`globOptions.followSymlinks: false`) has its target as its whole content, so a `transform` never sees it.
+
+### Copying with the plugin
+
+`output.copy` covers the patterns; [`CopyPlugin`](/plugins/copy-plugin/) is the same copying with two more options on it — `concurrency` and the `processAssets` `stage` the files are copied at. Reach for it when you need either:
+
+```js
+import webpack from "webpack";
+
+export default {
+  // ...
+  plugins: [
+    new webpack.CopyPlugin({
+      patterns: ["static"],
+      concurrency: 50,
+    }),
+  ],
+};
+```
+
 ## output.crossOriginLoading
 
 `boolean = false` `string: 'anonymous' | 'use-credentials'`

--- a/src/content/plugins/copy-plugin.mdx
+++ b/src/content/plugins/copy-plugin.mdx
@@ -96,7 +96,7 @@ compilation.hooks.processAssets.tap(
     const assets = compilation
       .getAssets()
       .filter((asset) => asset.info.copied && /^licenses\//.test(asset.name))
-      .sort((a, b) => (a.name < b.name ? -1 : 1));
+      .toSorted((a, b) => (a.name < b.name ? -1 : 1));
     if (assets.length === 0) return;
 
     const merged = assets

--- a/src/content/plugins/copy-plugin.mdx
+++ b/src/content/plugins/copy-plugin.mdx
@@ -1,0 +1,116 @@
+---
+title: CopyPlugin
+group: webpack
+contributors:
+  - alexander-akait
+related:
+  - title: output.copy
+    url: /configuration/output/#outputcopy
+  - title: output-copy example
+    url: https://github.com/webpack/webpack/tree/main/examples/output-copy
+---
+
+Copies files and directories into [`output.path`](/configuration/output/#outputpath) as part of the build. This is the plugin behind [`output.copy`](/configuration/output/#outputcopy), and webpack applies it for you when that option is set — reach for the plugin directly when you need one of the two options `output.copy` does not carry, `concurrency` and `stage`.
+
+<Badge text="5.111.0+" />
+
+```js
+import webpack from "webpack";
+
+new webpack.CopyPlugin(options);
+```
+
+T> It supersedes [`copy-webpack-plugin`](/plugins/copy-webpack-plugin/), which is deprecated in its favour.
+
+## Options
+
+```ts
+{
+  patterns: (string | object)[], // what is copied, see output.copy
+  concurrency?: number, // how many files are read at the same time
+  stage?: number, // the processAssets stage the files are copied at
+}
+```
+
+- `patterns` (`(string | object)[]`): the files to copy. A pattern is a `from` plus `context`, `filename`, `globOptions`, `info`, `preservePermissions`, `preserveTimestamps`, `to` and `transform` — all documented under [`output.copy`](/configuration/output/#outputcopy), which takes the same patterns.
+- `concurrency` (`number = 100`): the maximum number of files read at the same time.
+- `stage` (`number = webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL`): the [`processAssets`](/api/compilation-hooks/#processassets) stage the files are copied at. At the default stage a copied file is minimized and compressed like every other asset; a later stage emits it after the taps that would have done so.
+
+## Usage
+
+```js
+import webpack from "webpack";
+
+export default {
+  // ...
+  plugins: [
+    new webpack.CopyPlugin({
+      patterns: [
+        "static",
+        { from: "img", to: "images" },
+        { from: "licenses/*.txt", to: "licenses" },
+      ],
+      concurrency: 50,
+    }),
+  ],
+};
+```
+
+### Keeping a file out of the minimizer
+
+A prebuilt file is already minimized, and running the minimizer over it again costs time for nothing. Mark it as minimized in its [asset info](/api/stats/#asset-objects) and the minimizer leaves it alone:
+
+```js
+import webpack from "webpack";
+
+export default {
+  // ...
+  plugins: [
+    new webpack.CopyPlugin({
+      patterns: [
+        {
+          from: "*.min.js",
+          context: "vendor",
+          to: "vendor",
+          info: { minimized: true },
+        },
+      ],
+    }),
+  ],
+};
+```
+
+W> A later `stage` is not how a file is kept out of the minimizer. Minimizers tap `processAssets` with `additionalAssets`, so they run again for assets added at any later stage; `info: { minimized: true }` is what tells them to skip one.
+
+### Merging copied assets
+
+One source file becomes one asset, so combining several into one is a second pass over what the copy emitted — which any plugin can do. Copied assets carry `copied: true` in their asset info, which is how you pick them out:
+
+```js
+compilation.hooks.processAssets.tap(
+  {
+    name: "MergeCopiedAssetsPlugin",
+    stage: webpack.Compilation.PROCESS_ASSETS_STAGE_DERIVED,
+  },
+  () => {
+    const assets = compilation
+      .getAssets()
+      .filter((asset) => asset.info.copied && /^licenses\//.test(asset.name))
+      .sort((a, b) => (a.name < b.name ? -1 : 1));
+    if (assets.length === 0) return;
+
+    const merged = assets
+      .map((asset) => `/* ${asset.name} */\n${asset.source.source()}`)
+      .join("\n");
+
+    compilation.emitAsset(
+      "THIRD_PARTY_LICENSES.txt",
+      new webpack.sources.RawSource(merged),
+      { copied: true },
+    );
+    for (const asset of assets) compilation.deleteAsset(asset.name);
+  },
+);
+```
+
+T> The [`output-copy` example](https://github.com/webpack/webpack/tree/main/examples/output-copy) carries this plugin in full, caching included, alongside a configuration exercising every pattern option.

--- a/src/content/plugins/index.mdx
+++ b/src/content/plugins/index.mdx
@@ -24,7 +24,8 @@ T> CSS and HTML are built in (experimental), so [`MiniCssExtractPlugin`](/plugin
 | [`ChunksWebpackPlugin`](/plugins/chunks-webpack-plugin/)                        | Create HTML files with entrypoints and chunks relations to serve your bundles          |
 | [`CompressionWebpackPlugin`](/plugins/compression-webpack-plugin)               | Prepare compressed versions of assets to serve them with Content-Encoding              |
 | [`ContextReplacementPlugin`](/plugins/context-replacement-plugin)               | Override the inferred context of a `require` expression                                |
-| [`CopyWebpackPlugin`](/plugins/copy-webpack-plugin)                             | Copies individual files or entire directories to the build directory                   |
+| [`CopyPlugin`](/plugins/copy-plugin)                                            | Copy files and directories into the output directory                                   |
+| [`CopyWebpackPlugin`](/plugins/copy-webpack-plugin)                             | Deprecated in favour of the built-in [`CopyPlugin`](/plugins/copy-plugin)              |
 | [`DefinePlugin`](/plugins/define-plugin)                                        | Allow global constants configured at compile time                                      |
 | [`DllPlugin`](/plugins/dll-plugin)                                              | Split bundles in order to drastically improve build time                               |
 | [`EnvironmentPlugin`](/plugins/environment-plugin)                              | Shorthand for using the [`DefinePlugin`](/plugins/define-plugin) on `process.env` keys |

--- a/src/content/plugins/index.mdx
+++ b/src/content/plugins/index.mdx
@@ -29,10 +29,10 @@ T> CSS and HTML are built in (experimental), so [`MiniCssExtractPlugin`](/plugin
 | [`DefinePlugin`](/plugins/define-plugin)                                        | Allow global constants configured at compile time                                      |
 | [`DllPlugin`](/plugins/dll-plugin)                                              | Split bundles in order to drastically improve build time                               |
 | [`EnvironmentPlugin`](/plugins/environment-plugin)                              | Shorthand for using the [`DefinePlugin`](/plugins/define-plugin) on `process.env` keys |
-| [`EslintWebpackPlugin`](/plugins/eslint-webpack-plugin)                         | A ESLint plugin for webpack                                                            |
 | [`HotModuleReplacementPlugin`](/plugins/hot-module-replacement-plugin)          | Enable Hot Module Replacement (HMR)                                                    |
 | [`IgnorePlugin`](/plugins/ignore-plugin)                                        | Exclude certain modules from bundles                                                   |
 | [`LimitChunkCountPlugin`](/plugins/limit-chunk-count-plugin)                    | Set min/max limits for chunking to better control chunking                             |
+| [`LintWebpackPlugin`](/plugins/lint-webpack-plugin)                             | Run ESLint and Stylelint over your sources as part of the build                        |
 | [`MergeDuplicateChunksPlugin`](/plugins/merge-duplicate-chunks-plugin)          | Merge chunks that contain the same modules                                             |
 | [`MinChunkSizePlugin`](/plugins/min-chunk-size-plugin)                          | Keep chunk size above the specified limit                                              |
 | [`NoEmitOnErrorsPlugin`](/configuration/optimization/#optimizationemitonerrors) | Skip the emitting phase when there are compilation errors                              |

--- a/src/content/plugins/index.mdx
+++ b/src/content/plugins/index.mdx
@@ -27,12 +27,12 @@ T> CSS and HTML are built in (experimental), so [`MiniCssExtractPlugin`](/plugin
 | [`CopyPlugin`](/plugins/copy-plugin)                                            | Copy files and directories into the output directory                                   |
 | [`CopyWebpackPlugin`](/plugins/copy-webpack-plugin)                             | Deprecated in favour of the built-in [`CopyPlugin`](/plugins/copy-plugin)              |
 | [`DefinePlugin`](/plugins/define-plugin)                                        | Allow global constants configured at compile time                                      |
+| [`DiagnosticsWebpackPlugin`](/plugins/diagnostics-webpack-plugin)               | Run linters and other diagnostic tools over your sources during the build              |
 | [`DllPlugin`](/plugins/dll-plugin)                                              | Split bundles in order to drastically improve build time                               |
 | [`EnvironmentPlugin`](/plugins/environment-plugin)                              | Shorthand for using the [`DefinePlugin`](/plugins/define-plugin) on `process.env` keys |
 | [`HotModuleReplacementPlugin`](/plugins/hot-module-replacement-plugin)          | Enable Hot Module Replacement (HMR)                                                    |
 | [`IgnorePlugin`](/plugins/ignore-plugin)                                        | Exclude certain modules from bundles                                                   |
 | [`LimitChunkCountPlugin`](/plugins/limit-chunk-count-plugin)                    | Set min/max limits for chunking to better control chunking                             |
-| [`LintWebpackPlugin`](/plugins/lint-webpack-plugin)                             | Run ESLint and Stylelint over your sources as part of the build                        |
 | [`MergeDuplicateChunksPlugin`](/plugins/merge-duplicate-chunks-plugin)          | Merge chunks that contain the same modules                                             |
 | [`MinChunkSizePlugin`](/plugins/min-chunk-size-plugin)                          | Keep chunk size above the specified limit                                              |
 | [`NoEmitOnErrorsPlugin`](/configuration/optimization/#optimizationemitonerrors) | Skip the emitting phase when there are compilation errors                              |

--- a/src/utilities/fetch-package-readmes.mjs
+++ b/src/utilities/fetch-package-readmes.mjs
@@ -42,15 +42,26 @@ const communityPackages = [
   },
 ];
 
+/** @type {{ loaders: string[], plugins: string[] }} */
+const repositories = Object.fromEntries(
+  await Promise.all(
+    types.map(async (type) => [
+      type,
+      JSON.parse(
+        await readFile(
+          path.resolve(__dirname, `../../repositories/${type}.json`),
+        ),
+      ),
+    ]),
+  ),
+);
+
 for (const type of types) {
   const outputDir = pathMap[type];
 
   await mkdirp(outputDir);
 
-  /** @type string[] */
-  const repos = JSON.parse(
-    await readFile(path.resolve(__dirname, `../../repositories/${type}.json`)),
-  );
+  const repos = repositories[type];
 
   for (const repo of repos) {
     const [owner, packageName] = repo.split("/");
@@ -118,7 +129,11 @@ for (const type of types) {
         format: "raw",
       },
     });
-    const body = processReadme(content, { source: url });
+    const body = processReadme(content, {
+      source: url,
+      loaders: repositories.loaders,
+      plugins: repositories.plugins,
+    });
     await writeFile(fileName, headmatter + body);
     console.log("Generated:", path.relative(cwd, fileName));
   }

--- a/src/utilities/process-readme.mjs
+++ b/src/utilities/process-readme.mjs
@@ -89,6 +89,21 @@ function getMatches(string, regex) {
   return matches;
 }
 
+// A README may link to a repository the site builds no page for, because the
+// repository was renamed or moved after that README was written. `repos` is the
+// list the pages are generated from, so a package missing from it keeps its
+// GitHub link, which redirects, rather than becoming a link to a page that does
+// not exist. Rewrite everything when no list is given.
+function hasPage(repos, packageName) {
+  if (!Array.isArray(repos)) {
+    return true;
+  }
+
+  return repos.some(
+    (repo) => repo.slice(repo.indexOf("/") + 1) === packageName,
+  );
+}
+
 export default function processREADME(body, options = {}) {
   let processingString = body
     // close <img> tags
@@ -147,10 +162,15 @@ export default function processREADME(body, options = {}) {
   );
   // dont make relative links for excluded loaders
   for (const match of loaderMatches) {
-    if (!excludedLoaders.includes(`${match[1]}/${match[2]}`)) {
+    const packageName = match[2].replace(/\/$/, "");
+
+    if (
+      !excludedLoaders.includes(`${match[1]}/${packageName}`) &&
+      hasPage(options.loaders, packageName)
+    ) {
       processingString = processingString.replace(
         match[0],
-        `/loaders/${match[2]}/)`,
+        `/loaders/${packageName}/)`,
       );
     }
   }
@@ -161,10 +181,15 @@ export default function processREADME(body, options = {}) {
   );
   // dont make relative links for excluded loaders
   for (const match of pluginMatches) {
-    if (!excludedPlugins.includes(`${match[1]}/${match[2]}`)) {
+    const packageName = match[2].replace(/\/$/, "");
+
+    if (
+      !excludedPlugins.includes(`${match[1]}/${packageName}`) &&
+      hasPage(options.plugins, packageName)
+    ) {
       processingString = processingString.replace(
         match[0],
-        `/plugins/${match[2]}/)`,
+        `/plugins/${packageName}/)`,
       );
     }
   }

--- a/src/utilities/process-readme.test.mjs
+++ b/src/utilities/process-readme.test.mjs
@@ -18,6 +18,46 @@ describe("processReadme", () => {
     );
   });
 
+  it("keeps the github link when the site builds no page for the package", () => {
+    const options = {
+      source: url,
+      loaders: ["webpack/css-loader"],
+      plugins: ["webpack/stylelint-webpack-plugin"],
+    };
+    const renamedPluginMDData =
+      "- [lint-webpack-plugin](https://github.com/webpack/lint-webpack-plugin)";
+    const renamedLoaderMDData =
+      "- [sass-loader](https://github.com/webpack/sass-loader)";
+
+    expect(processReadme(renamedPluginMDData, options)).toBe(
+      renamedPluginMDData,
+    );
+    expect(processReadme(renamedLoaderMDData, options)).toBe(
+      renamedLoaderMDData,
+    );
+  });
+
+  it("links a package the site has a page for under its current owner", () => {
+    const options = {
+      source: url,
+      loaders: ["webpack/css-loader"],
+      plugins: ["webpack/copy-webpack-plugin"],
+    };
+
+    expect(
+      processReadme(
+        "- [copy-webpack-plugin](https://github.com/webpack-contrib/copy-webpack-plugin)",
+        options,
+      ),
+    ).toBe("- [copy-webpack-plugin](/plugins/copy-webpack-plugin/)");
+    expect(
+      processReadme(
+        "- [css-loader](https://github.com/webpack/css-loader)",
+        options,
+      ),
+    ).toBe("- [css-loader](/loaders/css-loader/)");
+  });
+
   it("links without the site", () => {
     const options = { source: url };
     const loaderMDData =


### PR DESCRIPTION
webpack copies files itself since 5.111.0. Adds the output.copy reference with its pattern, glob and transform options, a CopyPlugin page for the concurrency and stage options output.copy does not carry, and lists the plugin in the index, marking copy-webpack-plugin as superseded.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->