### PR TITLE
docs: give every page its own meta description

### DIFF
--- a/cypress/e2e/check-server-side-rendering.cy.js
+++ b/cypress/e2e/check-server-side-rendering.cy.js
@@ -20,12 +20,12 @@ describe("server side rendered page", () => {
     cy.get('meta[charset="utf-8"]');
   });
 
-  it("should find the default meta description", () => {
+  it("should find the home page meta description", () => {
     cy.visit("/");
     cy.get('head meta[name="description"]').should(
       "have.attr",
       "content",
-      "webpack is a module bundler. Its main purpose is to bundle JavaScript files for usage in a browser, yet it is also capable of transforming, bundling, or packaging just about any resource or asset.",
+      "webpack bundles JavaScript, CSS, HTML, WebAssembly and assets into optimized output for browsers, Node.js, Deno, Bun and other environments.",
     );
   });
 

--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -194,7 +194,7 @@ function Site(props) {
 
   const description =
     getPageDescription(Content, location.pathname) ||
-    "webpack is a module bundler. Its main purpose is to bundle JavaScript files for usage in a browser, yet it is also capable of transforming, bundling, or packaging just about any resource or asset.";
+    "webpack is a module bundler for JavaScript, CSS, HTML, WebAssembly and assets. It builds a dependency graph from your project and emits optimized bundles for browsers, Node.js, Deno, Bun and other environments.";
 
   function isPrintPage(url) {
     return url.includes("/printable");

--- a/src/content/api/cli.mdx
+++ b/src/content/api/cli.mdx
@@ -1,5 +1,6 @@
 ---
 title: Command Line Interface
+description: Run webpack from the command line, with the flags and arguments the CLI accepts.
 sort: 1
 contributors:
   - anshumanv

--- a/src/content/api/compilation-hooks.mdx
+++ b/src/content/api/compilation-hooks.mdx
@@ -1,5 +1,6 @@
 ---
 title: Compilation Hooks
+description: The hooks the Compilation object exposes for plugins to tap during a build.
 group: Plugins
 sort: 10
 contributors:

--- a/src/content/api/compilation-object.mdx
+++ b/src/content/api/compilation-object.mdx
@@ -1,5 +1,6 @@
 ---
 title: Compilation Object
+description: The methods and properties available on the webpack Compilation object.
 group: Objects
 sort: 14
 contributors:

--- a/src/content/api/compiler-hooks.mdx
+++ b/src/content/api/compiler-hooks.mdx
@@ -1,5 +1,6 @@
 ---
 title: Compiler Hooks
+description: The hooks the Compiler exposes across the webpack build lifecycle.
 group: Plugins
 sort: 9
 contributors:

--- a/src/content/api/contextmodulefactory-hooks.mdx
+++ b/src/content/api/contextmodulefactory-hooks.mdx
@@ -1,5 +1,6 @@
 ---
 title: ContextModuleFactory Hooks
+description: The hooks ContextModuleFactory exposes when resolving require.context dependencies.
 group: Plugins
 sort: 11
 contributors:

--- a/src/content/api/hot-module-replacement.mdx
+++ b/src/content/api/hot-module-replacement.mdx
@@ -1,5 +1,6 @@
 ---
 title: Hot Module Replacement
+description: The runtime HMR API for accepting, disposing and handling module updates.
 sort: 4
 contributors:
   - sokra

--- a/src/content/api/index.mdx
+++ b/src/content/api/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Introduction
+description: The programmatic interfaces webpack exposes for customizing a compilation.
 sort: -1
 contributors:
   - tbroadley

--- a/src/content/api/loaders.mdx
+++ b/src/content/api/loaders.mdx
@@ -1,5 +1,6 @@
 ---
 title: Loader Interface
+description: Write a webpack loader, covering the loader context, async loaders and raw loaders.
 sort: 5
 contributors:
   - TheLarkInn

--- a/src/content/api/logging.mdx
+++ b/src/content/api/logging.mdx
@@ -1,5 +1,6 @@
 ---
 title: Logger Interface
+description: Emit build-time messages from loaders and plugins through webpack's logger.
 sort: 6
 contributors:
   - EugeneHlushko

--- a/src/content/api/module-methods.mdx
+++ b/src/content/api/module-methods.mdx
@@ -1,5 +1,6 @@
 ---
 title: Module Methods
+description: The module syntax webpack supports in your code, including dynamic import, require.context and magic comments.
 group: Modules
 sort: 7
 contributors:

--- a/src/content/api/module-variables.mdx
+++ b/src/content/api/module-variables.mdx
@@ -1,5 +1,6 @@
 ---
 title: Module Variables
+description: The variables webpack makes available inside compiled modules, such as import.meta and __webpack_public_path__.
 group: Modules
 sort: 8
 contributors:

--- a/src/content/api/node.mdx
+++ b/src/content/api/node.mdx
@@ -1,5 +1,6 @@
 ---
 title: Node Interface
+description: Run webpack programmatically from Node.js and work with the resulting stats.
 sort: 2
 contributors:
   - sallar

--- a/src/content/api/normalmodulefactory-hooks.mdx
+++ b/src/content/api/normalmodulefactory-hooks.mdx
@@ -1,5 +1,6 @@
 ---
 title: NormalModuleFactory Hooks
+description: The hooks NormalModuleFactory exposes while resolving and creating modules.
 group: Plugins
 sort: 13
 contributors:

--- a/src/content/api/parser.mdx
+++ b/src/content/api/parser.mdx
@@ -1,5 +1,6 @@
 ---
 title: JavascriptParser Hooks
+description: The JavascriptParser hooks that plugins tap to inspect and transform parsed code.
 group: Plugins
 sort: 12
 contributors:

--- a/src/content/api/plugins.mdx
+++ b/src/content/api/plugins.mdx
@@ -1,5 +1,6 @@
 ---
 title: Plugin API
+description: Write a webpack plugin using tapable hooks on the compiler and the compilation.
 group: Plugins
 sort: 14
 contributors:

--- a/src/content/api/resolvers.mdx
+++ b/src/content/api/resolvers.mdx
@@ -1,5 +1,6 @@
 ---
 title: Resolvers
+description: The resolver instances webpack builds with enhanced-resolve, and the hooks they expose.
 group: Plugins
 sort: 15
 contributors:

--- a/src/content/api/stats.mdx
+++ b/src/content/api/stats.mdx
@@ -1,5 +1,6 @@
 ---
 title: Stats Data
+description: The structure of webpack's JSON stats output, for analyzing modules, chunks and assets.
 sort: 3
 contributors:
   - skipjack

--- a/src/content/api/webpack-dev-server.mdx
+++ b/src/content/api/webpack-dev-server.mdx
@@ -1,5 +1,6 @@
 ---
 title: webpack-dev-server API
+description: The Node.js API for starting and controlling webpack-dev-server programmatically.
 sort: 3
 contributors:
   - snitin315

--- a/src/content/awesome-webpack.mdx
+++ b/src/content/awesome-webpack.mdx
@@ -1,5 +1,6 @@
 ---
 title: Awesome webpack
+description: A curated list of webpack resources, libraries, tools and applications from the community.
 sort: 2
 contributors:
   - snitin315

--- a/src/content/branding.mdx
+++ b/src/content/branding.mdx
@@ -1,5 +1,6 @@
 ---
 title: Branding Guidelines
+description: The webpack logo, colors and typography, and the rules for using them.
 sort: 2
 contributors:
   - jhnns

--- a/src/content/comparison.mdx
+++ b/src/content/comparison.mdx
@@ -1,5 +1,6 @@
 ---
 title: Comparison
+description: A feature-by-feature comparison of webpack with Rollup, Parcel, Browserify and other bundlers.
 sort: 1
 contributors:
   - pksjce

--- a/src/content/concepts/configuration.mdx
+++ b/src/content/concepts/configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configuration
+description: A webpack config is a JavaScript file exporting a configuration object, so it can be composed, computed and shared.
 sort: 5
 contributors:
   - TheLarkInn

--- a/src/content/concepts/dependency-graph.mdx
+++ b/src/content/concepts/dependency-graph.mdx
@@ -1,5 +1,6 @@
 ---
 title: Dependency Graph
+description: How webpack walks imports from your entry points to build a graph of every module and asset a project needs.
 sort: 9
 contributors:
   - TheLarkInn

--- a/src/content/concepts/entry-points.mdx
+++ b/src/content/concepts/entry-points.mdx
@@ -1,5 +1,6 @@
 ---
 title: Entry Points
+description: The ways to define the entry option, from a single file to multiple named entries with shared dependencies.
 sort: 1
 contributors:
   - TheLarkInn

--- a/src/content/concepts/hot-module-replacement.mdx
+++ b/src/content/concepts/hot-module-replacement.mdx
@@ -1,5 +1,6 @@
 ---
 title: Hot Module Replacement
+description: How webpack exchanges, adds and removes modules in a running application without a full page reload.
 sort: 12
 contributors:
   - kryptokinght

--- a/src/content/concepts/index.mdx
+++ b/src/content/concepts/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Concepts
+description: The core ideas behind webpack — entry, output, loaders, plugins, mode and the dependency graph.
 sort: -1
 contributors:
   - TheLarkInn

--- a/src/content/concepts/loaders.mdx
+++ b/src/content/concepts/loaders.mdx
@@ -1,5 +1,6 @@
 ---
 title: Loaders
+description: Transformations applied to a module's source as it is imported, and how to chain and configure them.
 sort: 3
 contributors:
   - manekinekko

--- a/src/content/concepts/manifest.mdx
+++ b/src/content/concepts/manifest.mdx
@@ -1,5 +1,6 @@
 ---
 title: The Manifest
+description: How webpack tracks modules and chunks at runtime so that emitted bundles can resolve and load each other.
 sort: 11
 contributors:
   - skipjack

--- a/src/content/concepts/module-federation.mdx
+++ b/src/content/concepts/module-federation.mdx
@@ -1,5 +1,6 @@
 ---
 title: Module Federation
+description: Let separately built applications share modules at runtime and behave as a single application.
 sort: 8
 contributors:
   - sokra

--- a/src/content/concepts/module-resolution.mdx
+++ b/src/content/concepts/module-resolution.mdx
@@ -1,5 +1,6 @@
 ---
 title: Module Resolution
+description: How webpack turns an import request into a file on disk, following Node.js resolution rules and your resolve config.
 sort: 7
 contributors:
   - pksjce

--- a/src/content/concepts/modules.mdx
+++ b/src/content/concepts/modules.mdx
@@ -1,5 +1,6 @@
 ---
 title: Modules
+description: What counts as a module in webpack — ECMAScript, CommonJS, AMD, CSS, HTML, assets and WebAssembly.
 sort: 6
 contributors:
   - TheLarkInn
@@ -43,6 +44,8 @@ Webpack supports the following module types natively:
 - AMD modules
 - [Assets](/guides/asset-modules)
 - WebAssembly modules
+- [CSS](/guides/native-css)
+- [HTML](/guides/native-html)
 
 In addition to that webpack supports modules written in a variety of languages and preprocessors via _loaders_. _Loaders_ describe to webpack **how** to process non-native _modules_ and include these _dependencies_ into your _bundles_.
 The webpack community has built _loaders_ for a wide variety of popular languages and language processors, including:

--- a/src/content/concepts/output.mdx
+++ b/src/content/concepts/output.mdx
@@ -1,5 +1,6 @@
 ---
 title: Output
+description: Where webpack writes the bundles it builds, and how to name them for long-term caching.
 sort: 2
 contributors:
   - TheLarkInn

--- a/src/content/concepts/plugins.mdx
+++ b/src/content/concepts/plugins.mdx
@@ -1,5 +1,6 @@
 ---
 title: Plugins
+description: What plugins do that loaders cannot, and how to add them to a webpack build.
 sort: 4
 contributors:
   - TheLarkInn

--- a/src/content/concepts/targets.mdx
+++ b/src/content/concepts/targets.mdx
@@ -1,5 +1,6 @@
 ---
 title: Targets
+description: Why webpack compiles differently for browsers, Node.js, Deno, Bun and other deployment environments.
 sort: 10
 contributors:
   - TheLarkInn

--- a/src/content/concepts/under-the-hood.mdx
+++ b/src/content/concepts/under-the-hood.mdx
@@ -1,5 +1,6 @@
 ---
 title: Under The Hood
+description: The internals of a webpack build — how files become modules, then chunks, then emitted assets.
 sort: 14
 contributors:
   - smelukov

--- a/src/content/concepts/why-webpack.mdx
+++ b/src/content/concepts/why-webpack.mdx
@@ -1,5 +1,6 @@
 ---
 title: Why webpack
+description: Why bundlers exist, and the problems webpack solves compared with script tags and earlier tooling.
 sort: 13
 contributors:
   - debs-obrien

--- a/src/content/configuration/cache.mdx
+++ b/src/content/configuration/cache.mdx
@@ -1,5 +1,6 @@
 ---
 title: Cache
+description: Speed up rebuilds with webpack's memory and filesystem caches, including cache type, versioning and invalidation.
 sort: 12
 contributors:
   - snitin315

--- a/src/content/configuration/configuration-languages.mdx
+++ b/src/content/configuration/configuration-languages.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configuration Languages
+description: Author a webpack config in TypeScript, Babel, CoffeeScript, JSON or ESM instead of plain CommonJS JavaScript.
 sort: 2
 contributors:
   - piouson

--- a/src/content/configuration/configuration-types.mdx
+++ b/src/content/configuration/configuration-types.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configuration Types
+description: Export a function, a promise, or multiple configurations from a webpack config file.
 sort: 3
 contributors:
   - sokra

--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -1,5 +1,6 @@
 ---
 title: DevServer
+description: Configure webpack-dev-server for local development, including hot reloading, proxying, history API fallback and HTTPS.
 sort: 11
 contributors:
   - sokra

--- a/src/content/configuration/devtool.mdx
+++ b/src/content/configuration/devtool.mdx
@@ -1,5 +1,6 @@
 ---
 title: Devtool
+description: Choose how webpack generates source maps, trading build speed against source map quality in development and production.
 sort: 12
 contributors:
   - sokra

--- a/src/content/configuration/dotenv.mdx
+++ b/src/content/configuration/dotenv.mdx
@@ -1,5 +1,6 @@
 ---
 title: Dotenv
+description: Load environment variables from .env files with webpack's built-in dotenv support.
 sort: 16
 contributors:
   - xiaoxiaojx

--- a/src/content/configuration/entry-context.mdx
+++ b/src/content/configuration/entry-context.mdx
@@ -1,5 +1,6 @@
 ---
 title: Entry and Context
+description: Set where webpack starts building the dependency graph, and the base directory used to resolve entry files.
 sort: 4
 contributors:
   - sokra

--- a/src/content/configuration/experiments.mdx
+++ b/src/content/configuration/experiments.mdx
@@ -1,5 +1,6 @@
 ---
 title: Experiments
+description: Enable webpack's opt-in features, including native CSS, HTML and TypeScript support, WebAssembly, lazy compilation and ES module output.
 sort: 19
 contributors:
   - EugeneHlushko

--- a/src/content/configuration/extending-configurations.mdx
+++ b/src/content/configuration/extending-configurations.mdx
@@ -1,5 +1,6 @@
 ---
 title: Extends
+description: Reuse and extend an existing webpack configuration with the extends option.
 sort: 12
 contributors:
   - burhanuday

--- a/src/content/configuration/externals.mdx
+++ b/src/content/configuration/externals.mdx
@@ -1,5 +1,6 @@
 ---
 title: Externals
+description: Exclude dependencies from your bundles and load them from the consumer environment instead.
 sort: 15
 contributors:
   - sokra

--- a/src/content/configuration/index.mdx
+++ b/src/content/configuration/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configuration
+description: Every top-level option in a webpack configuration file, with defaults and examples.
 sort: 1
 contributors:
   - sokra

--- a/src/content/configuration/infrastructureLogging.mdx
+++ b/src/content/configuration/infrastructureLogging.mdx
@@ -1,5 +1,6 @@
 ---
 title: InfrastructureLogging
+description: Control webpack's infrastructure level logging, including log level, output stream and debug filtering.
 sort: 20
 contributors:
   - snitin315

--- a/src/content/configuration/mode.mdx
+++ b/src/content/configuration/mode.mdx
@@ -1,5 +1,6 @@
 ---
 title: Mode
+description: Set development, production or none to choose which built-in optimizations webpack applies.
 sort: 5
 contributors:
   - EugeneHlushko

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -1,5 +1,6 @@
 ---
 title: Module
+description: Configure how webpack treats each module type with rules, parser and generator options, covering JavaScript, CSS, HTML, assets and WebAssembly.
 sort: 7
 contributors:
   - sokra

--- a/src/content/configuration/node.mdx
+++ b/src/content/configuration/node.mdx
@@ -1,5 +1,6 @@
 ---
 title: Node
+description: Control whether webpack polyfills or mocks Node.js globals such as __dirname and __filename.
 sort: 17
 contributors:
   - sokra

--- a/src/content/configuration/optimization.mdx
+++ b/src/content/configuration/optimization.mdx
@@ -1,5 +1,6 @@
 ---
 title: Optimization
+description: Configure code splitting, minification, tree shaking, module concatenation and runtime chunks.
 sort: 9
 contributors:
   - EugeneHlushko

--- a/src/content/configuration/other-options.mdx
+++ b/src/content/configuration/other-options.mdx
@@ -1,5 +1,6 @@
 ---
 title: Other Options
+description: The remaining webpack options, including amd, bail, dependencies, loader, parallelism, profile, recordsPath and snapshot.
 sort: 22
 contributors:
   - sokra

--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -1,5 +1,6 @@
 ---
 title: Output
+description: Control how and where webpack emits bundles and assets, including filenames, content hashes, public path, library output and generated HTML.
 sort: 6
 contributors:
   - sokra

--- a/src/content/configuration/performance.mdx
+++ b/src/content/configuration/performance.mdx
@@ -1,5 +1,6 @@
 ---
 title: Performance
+description: Configure the size hints webpack shows when assets or entry points exceed a budget.
 sort: 21
 contributors:
   - thelarkinn

--- a/src/content/configuration/plugins.mdx
+++ b/src/content/configuration/plugins.mdx
@@ -1,5 +1,6 @@
 ---
 title: Plugins
+description: Add and configure webpack plugins to customize the build, including the plugins bundled with webpack itself.
 sort: 10
 contributors:
   - sokra

--- a/src/content/configuration/resolve.mdx
+++ b/src/content/configuration/resolve.mdx
@@ -1,5 +1,6 @@
 ---
 title: Resolve
+description: Change how webpack resolves module requests with aliases, extensions, module directories and package export conditions.
 sort: 8
 contributors:
   - sokra

--- a/src/content/configuration/stats.mdx
+++ b/src/content/configuration/stats.mdx
@@ -1,5 +1,6 @@
 ---
 title: Stats
+description: Control how much build information webpack reports, from presets to per-field configuration.
 sort: 18
 contributors:
   - SpaceK33z

--- a/src/content/configuration/target.mdx
+++ b/src/content/configuration/target.mdx
@@ -1,5 +1,6 @@
 ---
 title: Target
+description: Compile for browsers, Node.js, Deno, Bun, web workers, Electron and NW.js, or for a browserslist query.
 sort: 13
 contributors:
   - juangl

--- a/src/content/configuration/watch.mdx
+++ b/src/content/configuration/watch.mdx
@@ -1,5 +1,6 @@
 ---
 title: Watch and WatchOptions
+description: Recompile automatically when files change, and tune polling, ignored paths and aggregation delay.
 sort: 14
 contributors:
   - sokra

--- a/src/content/contribute/debugging.mdx
+++ b/src/content/contribute/debugging.mdx
@@ -1,5 +1,6 @@
 ---
 title: Debugging
+description: Debugging tools and techniques for working on webpack core, loaders and plugins.
 sort: 7
 contributors:
   - skipjack

--- a/src/content/contribute/index.mdx
+++ b/src/content/contribute/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Contribute
+description: How to contribute to webpack, from reporting issues to writing documentation and code.
 sort: -1
 contributors:
   - rouzbeh84

--- a/src/content/contribute/plugin-patterns.mdx
+++ b/src/content/contribute/plugin-patterns.mdx
@@ -1,5 +1,6 @@
 ---
 title: Plugin Patterns
+description: Common patterns for writing webpack plugins that hook into the build system.
 sort: 5
 contributors:
   - nveenjain

--- a/src/content/contribute/release-process.mdx
+++ b/src/content/contribute/release-process.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release Process
+description: The steps the webpack team follows to cut and publish a release.
 sort: 6
 contributors:
   - d3viant0ne

--- a/src/content/contribute/writers-guide.mdx
+++ b/src/content/contribute/writers-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: Writer's Guide
+description: Formatting and style conventions for editing content on the webpack documentation site.
 sort: 1
 contributors:
   - pranshuchittora

--- a/src/content/contribute/writing-a-loader.mdx
+++ b/src/content/contribute/writing-a-loader.mdx
@@ -1,5 +1,6 @@
 ---
 title: Writing a Loader
+description: Write a webpack loader, from a minimal transform to async and pitching loaders.
 sort: 2
 contributors:
   - asulaiman

--- a/src/content/contribute/writing-a-plugin.mdx
+++ b/src/content/contribute/writing-a-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: Writing a Plugin
+description: Write a webpack plugin using the compiler's staged build callbacks.
 sort: 3
 contributors:
   - slavafomin

--- a/src/content/glossary.mdx
+++ b/src/content/glossary.mdx
@@ -1,5 +1,6 @@
 ---
 title: Glossary
+description: Definitions of the terms used throughout webpack's documentation and ecosystem.
 sort: 3
 contributors:
   - kryptokinght

--- a/src/content/guides/asset-management.mdx
+++ b/src/content/guides/asset-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: Asset Management
+description: Load CSS, images, fonts and data into a webpack build and let the dependency graph manage them alongside your JavaScript.
 sort: 2
 contributors:
   - skipjack

--- a/src/content/guides/asset-modules.mdx
+++ b/src/content/guides/asset-modules.mdx
@@ -1,5 +1,6 @@
 ---
 title: Asset Modules
+description: Emit, inline or read asset files such as images and fonts without file-loader, url-loader or raw-loader.
 sort: 25
 contributors:
   - smelukov

--- a/src/content/guides/author-libraries.mdx
+++ b/src/content/guides/author-libraries.mdx
@@ -1,5 +1,6 @@
 ---
 title: Authoring Libraries
+description: Bundle and publish a JavaScript library with webpack, covering output.library, externals and package entry points.
 sort: 7
 contributors:
   - pksjce

--- a/src/content/guides/build-performance.mdx
+++ b/src/content/guides/build-performance.mdx
@@ -1,5 +1,6 @@
 ---
 title: Build Performance
+description: Practical ways to make webpack builds and rebuilds faster in development and in CI.
 sort: 9
 contributors:
   - sokra

--- a/src/content/guides/caching.mdx
+++ b/src/content/guides/caching.mdx
@@ -1,5 +1,6 @@
 ---
 title: Caching
+description: Use content hashes, runtime chunks and stable module IDs so browsers cache webpack bundles reliably across deploys.
 sort: 6
 contributors:
   - okonet

--- a/src/content/guides/code-splitting.mdx
+++ b/src/content/guides/code-splitting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Code Splitting
+description: Split code into multiple bundles using entry points, SplitChunksPlugin and dynamic import.
 sort: 5
 contributors:
   - pksjce

--- a/src/content/guides/csp.mdx
+++ b/src/content/guides/csp.mdx
@@ -1,5 +1,6 @@
 ---
 title: Content Security Policies
+description: Emit a nonce and CSP-compatible output so webpack bundles run under a Content Security Policy.
 sort: 10
 contributors:
   - EugeneHlushko

--- a/src/content/guides/dependency-management.mdx
+++ b/src/content/guides/dependency-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: Dependency Management
+description: How webpack resolves dynamic requires by building a context of the modules an expression could match.
 sort: 12
 contributors:
   - ndelangen

--- a/src/content/guides/development-vagrant.mdx
+++ b/src/content/guides/development-vagrant.mdx
@@ -1,5 +1,6 @@
 ---
 title: Development - Vagrant
+description: Run a webpack development server inside a Vagrant virtual machine.
 sort: 11
 contributors:
   - SpaceK33z

--- a/src/content/guides/development.mdx
+++ b/src/content/guides/development.mdx
@@ -1,5 +1,6 @@
 ---
 title: Development
+description: Set up source maps, watch mode and webpack-dev-server for a fast local development loop.
 sort: 4
 contributors:
   - SpaceK33z

--- a/src/content/guides/ecma-script-modules.mdx
+++ b/src/content/guides/ecma-script-modules.mdx
@@ -1,5 +1,6 @@
 ---
 title: ECMAScript Modules
+description: How webpack treats ECMAScript modules, including interop with CommonJS and the .mjs extension.
 sort: 19
 contributors:
   - sokra

--- a/src/content/guides/entry-advanced.mdx
+++ b/src/content/guides/entry-advanced.mdx
@@ -1,5 +1,6 @@
 ---
 title: Advanced entry
+description: Provide several files in one entry to emit separate bundles from a single entry name.
 sort: 25
 contributors:
   - EugeneHlushko

--- a/src/content/guides/environment-variables.mdx
+++ b/src/content/guides/environment-variables.mdx
@@ -1,5 +1,6 @@
 ---
 title: Environment Variables
+description: Pass environment variables into a webpack config through the env argument and the CLI.
 sort: 8
 contributors:
   - simon04

--- a/src/content/guides/hot-module-replacement.mdx
+++ b/src/content/guides/hot-module-replacement.mdx
@@ -1,5 +1,6 @@
 ---
 title: Hot Module Replacement
+description: Enable Hot Module Replacement so modules update in a running application without a full reload.
 sort: 15
 contributors:
   - jmreidy

--- a/src/content/guides/index.mdx
+++ b/src/content/guides/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Guides
+description: Step-by-step guides for building, optimizing and shipping projects with webpack.
 sort: -1
 contributors:
   - skipjack

--- a/src/content/guides/installation.mdx
+++ b/src/content/guides/installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: Installation
+description: Install webpack locally, globally, or from a bleeding-edge build.
 sort: 13
 contributors:
   - pksjce

--- a/src/content/guides/integrations.mdx
+++ b/src/content/guides/integrations.mdx
@@ -1,5 +1,6 @@
 ---
 title: Integrations
+description: How webpack relates to task runners such as npm scripts, Grunt and Gulp.
 sort: 24
 contributors:
   - pksjce

--- a/src/content/guides/lazy-loading.mdx
+++ b/src/content/guides/lazy-loading.mdx
@@ -1,5 +1,6 @@
 ---
 title: Lazy Loading
+description: Load code on demand with dynamic import so the initial bundle stays small.
 sort: 18
 contributors:
   - iammerrick

--- a/src/content/guides/output-management.mdx
+++ b/src/content/guides/output-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: Output Management
+description: Keep emitted files in sync with your bundles by making the page itself an entry point with webpack's native HTML support.
 sort: 3
 contributors:
   - skipjack

--- a/src/content/guides/package-exports.mdx
+++ b/src/content/guides/package-exports.mdx
@@ -1,5 +1,6 @@
 ---
 title: Package exports
+description: Use the exports field in package.json to declare a package's public entry points and resolution conditions.
 sort: 25
 contributors:
   - sokra

--- a/src/content/guides/production.mdx
+++ b/src/content/guides/production.mdx
@@ -1,5 +1,6 @@
 ---
 title: Production
+description: Separate development and production configuration, and enable minification, hashing and source maps for release builds.
 sort: 17
 contributors:
   - henriquea

--- a/src/content/guides/progressive-web-application.mdx
+++ b/src/content/guides/progressive-web-application.mdx
@@ -1,5 +1,6 @@
 ---
 title: Progressive Web Application
+description: Add offline support to a webpack build with a service worker and a web app manifest.
 sort: 22
 contributors:
   - johnnyreilly

--- a/src/content/guides/public-path.mdx
+++ b/src/content/guides/public-path.mdx
@@ -1,5 +1,6 @@
 ---
 title: Public Path
+description: Set output.publicPath so assets resolve correctly from a CDN, a subpath, or dynamically at runtime.
 sort: 23
 contributors:
   - rafaelrinaldi

--- a/src/content/guides/shimming.mdx
+++ b/src/content/guides/shimming.mdx
@@ -1,5 +1,6 @@
 ---
 title: Shimming
+description: Provide globals, polyfills and shims for third-party code that expects them.
 sort: 20
 contributors:
   - pksjce

--- a/src/content/guides/tree-shaking.mdx
+++ b/src/content/guides/tree-shaking.mdx
@@ -1,5 +1,6 @@
 ---
 title: Tree Shaking
+description: Remove unused exports from bundles using ES modules, the sideEffects flag and production mode.
 sort: 16
 contributors:
   - simon04

--- a/src/content/guides/typescript.mdx
+++ b/src/content/guides/typescript.mdx
@@ -1,5 +1,6 @@
 ---
 title: TypeScript
+description: Compile TypeScript in a webpack build with ts-loader or Babel, and configure source maps and type checking.
 sort: 21
 contributors:
   - morsdyce

--- a/src/content/guides/web-workers.mdx
+++ b/src/content/guides/web-workers.mdx
@@ -1,5 +1,6 @@
 ---
 title: Web Workers
+description: Create Web Workers with new Worker and import.meta.url, with no worker-loader required.
 sort: 21
 contributors:
   - chenxsan

--- a/src/content/index.mdx
+++ b/src/content/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: webpack
+description: webpack bundles JavaScript, CSS, HTML, WebAssembly and assets into optimized output for browsers, Node.js, Deno, Bun and other environments.
 sort: -1
 ---
 

--- a/src/content/license.mdx
+++ b/src/content/license.mdx
@@ -1,5 +1,6 @@
 ---
 title: License
+description: Webpack is released under the MIT license.
 sort: 5
 contributors:
   - EugeneHlushko

--- a/src/content/loaders/index.mdx
+++ b/src/content/loaders/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Loaders
+description: The loaders webpack still needs, and what it now handles natively without one.
 sort: -1
 contributors:
   - simon04

--- a/src/content/migrate/3.mdx
+++ b/src/content/migrate/3.mdx
@@ -1,5 +1,6 @@
 ---
 title: To v2 or v3 from v1
+description: Migrate a webpack 1 configuration to webpack 2 or 3.
 sort: 3
 contributors:
   - sokra

--- a/src/content/migrate/4.mdx
+++ b/src/content/migrate/4.mdx
@@ -1,5 +1,6 @@
 ---
 title: To v4 from v3
+description: Migrate a webpack 3 configuration to webpack 4.
 sort: 2
 contributors:
   - sokra

--- a/src/content/migrate/5.mdx
+++ b/src/content/migrate/5.mdx
@@ -1,5 +1,6 @@
 ---
 title: To v5 from v4
+description: Migrate a webpack 4 configuration to webpack 5, including removed Node.js polyfills and deprecated options.
 sort: 1
 contributors:
   - sokra

--- a/src/content/migrate/index.mdx
+++ b/src/content/migrate/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Migrate
+description: Guides for upgrading between major webpack versions.
 sort: -1
 contributors:
   - EugeneHlushko

--- a/src/content/plugins/NoEmitOnErrorsPlugin.mdx
+++ b/src/content/plugins/NoEmitOnErrorsPlugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: NoEmitOnErrorsPlugin
+description: Skip emitting assets when a compilation produces errors. Enabled by default in webpack 5.
 group: webpack
 contributors:
   - jeffin

--- a/src/content/plugins/automatic-prefetch-plugin.mdx
+++ b/src/content/plugins/automatic-prefetch-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: AutomaticPrefetchPlugin
+description: Resolve and build all modules from the previous compilation upfront to speed up watch mode rebuilds.
 group: webpack
 contributors:
   - sokra

--- a/src/content/plugins/banner-plugin.mdx
+++ b/src/content/plugins/banner-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: BannerPlugin
+description: Add a banner, such as a license header, to the top of each generated chunk.
 group: webpack
 contributors:
   - simon04

--- a/src/content/plugins/context-exclusion-plugin.mdx
+++ b/src/content/plugins/context-exclusion-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: ContextExclusionPlugin
+description: Exclude matching contexts from a build so webpack does not generate modules for them.
 group: webpack
 contributors:
   - jeffin

--- a/src/content/plugins/context-replacement-plugin.mdx
+++ b/src/content/plugins/context-replacement-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: ContextReplacementPlugin
+description: Override the context webpack infers for a dynamic require, narrowing which modules it can resolve.
 group: webpack
 contributors:
   - simon04

--- a/src/content/plugins/copy-plugin.mdx
+++ b/src/content/plugins/copy-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: CopyPlugin
+description: Copy files and directories into output.path as part of the build.
 group: webpack
 contributors:
   - alexander-akait

--- a/src/content/plugins/define-plugin.mdx
+++ b/src/content/plugins/define-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: DefinePlugin
+description: Replace variables in your code with values or expressions at compile time.
 group: webpack
 contributors:
   - simon04

--- a/src/content/plugins/dll-plugin.mdx
+++ b/src/content/plugins/dll-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: DllPlugin
+description: Split vendor code into a separate bundle with DllPlugin and DllReferencePlugin to speed up builds.
 group: webpack
 contributors:
   - aretecode

--- a/src/content/plugins/environment-plugin.mdx
+++ b/src/content/plugins/environment-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: EnvironmentPlugin
+description: Shorthand for applying DefinePlugin to process.env variables.
 group: webpack
 contributors:
   - simon04

--- a/src/content/plugins/eval-source-map-dev-tool-plugin.mdx
+++ b/src/content/plugins/eval-source-map-dev-tool-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: EvalSourceMapDevToolPlugin
+description: Fine-grained control over eval-based source map generation.
 group: webpack
 contributors:
   - johnnyreilly

--- a/src/content/plugins/hashed-module-ids-plugin.mdx
+++ b/src/content/plugins/hashed-module-ids-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: HashedModuleIdsPlugin
+description: Derive module IDs from module paths so hashes stay stable between builds.
 group: webpack
 contributors:
   - shaodahong

--- a/src/content/plugins/hot-module-replacement-plugin.mdx
+++ b/src/content/plugins/hot-module-replacement-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: HotModuleReplacementPlugin
+description: Enable Hot Module Replacement so modules update in a running application.
 group: webpack
 contributors:
   - skipjack

--- a/src/content/plugins/ignore-plugin.mdx
+++ b/src/content/plugins/ignore-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: IgnorePlugin
+description: Prevent webpack from generating modules for imports matching a pattern or filter.
 group: webpack
 contributors:
   - simon04

--- a/src/content/plugins/index.mdx
+++ b/src/content/plugins/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Plugins
+description: The plugins bundled with webpack, and what each one configures in a build.
 sort: -1
 contributors:
   - simon04

--- a/src/content/plugins/internal-plugins.mdx
+++ b/src/content/plugins/internal-plugins.mdx
@@ -1,5 +1,6 @@
 ---
 title: Internal webpack plugins
+description: The plugins webpack applies internally to implement its own features.
 group: webpack
 contributors:
   - iAziz786

--- a/src/content/plugins/limit-chunk-count-plugin.mdx
+++ b/src/content/plugins/limit-chunk-count-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: LimitChunkCountPlugin
+description: Cap the number of chunks a build produces by merging the smallest ones.
 group: webpack
 contributors:
   - rouzbeh84

--- a/src/content/plugins/manifest-plugin.mdx
+++ b/src/content/plugins/manifest-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: ManifestPlugin
+description: Generate an asset manifest mapping source filenames to emitted output files.
 group: webpack
 contributors:
   - hai-x

--- a/src/content/plugins/merge-duplicate-chunks-plugin.mdx
+++ b/src/content/plugins/merge-duplicate-chunks-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: MergeDuplicateChunksPlugin
+description: Merge chunks that contain identical modules. Enabled by default.
 group: webpack
 contributors:
   - shivxmsharma

--- a/src/content/plugins/min-chunk-size-plugin.mdx
+++ b/src/content/plugins/min-chunk-size-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: MinChunkSizePlugin
+description: Merge chunks smaller than a threshold to keep chunk size above a minimum.
 group: webpack
 contributors:
   - byzyk

--- a/src/content/plugins/module-concatenation-plugin.mdx
+++ b/src/content/plugins/module-concatenation-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: ModuleConcatenationPlugin
+description: Hoist modules into a single scope to produce smaller, faster bundles. Also known as scope hoisting.
 group: webpack
 contributors:
   - skipjack

--- a/src/content/plugins/module-federation-plugin.mdx
+++ b/src/content/plugins/module-federation-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: ModuleFederationPlugin
+description: Share modules between independently built applications at runtime.
 group: webpack
 contributors:
   - XiaofengXie16

--- a/src/content/plugins/normal-module-replacement-plugin.mdx
+++ b/src/content/plugins/normal-module-replacement-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: NormalModuleReplacementPlugin
+description: Replace resources matching a pattern with a different module.
 group: webpack
 contributors:
   - gonzoyumo

--- a/src/content/plugins/prefetch-plugin.mdx
+++ b/src/content/plugins/prefetch-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: PrefetchPlugin
+description: Resolve and build a module ahead of its first import to shorten the critical build path.
 group: webpack
 contributors:
   - skipjack

--- a/src/content/plugins/profiling-plugin.mdx
+++ b/src/content/plugins/profiling-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: ProfilingPlugin
+description: Record plugin execution timings to a Chrome profile file for performance analysis.
 group: webpack
 contributors:
   - EugeneHlushko

--- a/src/content/plugins/progress-plugin.mdx
+++ b/src/content/plugins/progress-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: ProgressPlugin
+description: Customize how webpack reports compilation progress.
 group: webpack
 contributors:
   - elliottsj

--- a/src/content/plugins/provide-plugin.mdx
+++ b/src/content/plugins/provide-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: ProvidePlugin
+description: Load modules automatically instead of importing or requiring them everywhere.
 group: webpack
 contributors:
   - sokra

--- a/src/content/plugins/source-map-dev-tool-plugin.mdx
+++ b/src/content/plugins/source-map-dev-tool-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: SourceMapDevToolPlugin
+description: Fine-grained control over source map generation, including filenames and which assets get maps.
 group: webpack
 contributors:
   - johnnyreilly

--- a/src/content/plugins/split-chunks-plugin.mdx
+++ b/src/content/plugins/split-chunks-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: SplitChunksPlugin
+description: Extract shared and vendor code into separate chunks to avoid duplication across bundles.
 group: webpack
 contributors:
   - sokra

--- a/src/content/plugins/virtual-url-plugin.mdx
+++ b/src/content/plugins/virtual-url-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: VirtualUrlPlugin
+description: Create virtual modules of any type, generating module content at build time without a file on disk.
 group: webpack
 contributors:
   - xiaoxiaojx

--- a/src/content/plugins/watch-ignore-plugin.mdx
+++ b/src/content/plugins/watch-ignore-plugin.mdx
@@ -1,5 +1,6 @@
 ---
 title: WatchIgnorePlugin
+description: Ignore matching paths while in watch mode so they do not trigger rebuilds.
 group: webpack
 contributors:
   - skipjack


### PR DESCRIPTION
## What

All 136 non-blog pages shared a single fallback meta description, so every page emitted an identical `<meta name="description">` and `og:description`. Only four pages set their own (`getting-started`, `native-css`, `native-html`, `modern-web-platform`).

Duplicate descriptions sitewide give search engines and retrieval pipelines no per-page signal — Google generally discards them and synthesizes a snippet instead. `configuration/experiments`, the canonical page for `experiments.css` and `experiments.html`, was describing itself as being about "bundling JavaScript files for usage in a browser".

This adds a description to each of the 132 pages that lacked one, so all 136 now have a unique one.

## Positioning

The fallback in `Site.jsx` is also rewritten. Both it and the new descriptions reflect what webpack actually bundles and what it targets:

> webpack is a module bundler for JavaScript, CSS, HTML, WebAssembly and assets. It builds a dependency graph from your project and emits optimized bundles for browsers, Node.js, Deno, Bun and other environments.

Each claim was checked against the docs before being written into 130+ pages:

- **Deno, Bun, universal** — documented targets, `configuration/target.mdx`, all 5.108.0+
- **WebAssembly** — native via `asyncWebAssembly`, `'auto'` since 5.109.0
- **CSS, HTML** — native module types via `experiments.css` / `experiments.html`

Descriptions name the concrete options and superseded packages a reader actually searches for, following the pattern the native CSS and HTML guides already use.

## Also

`concepts/modules.mdx` listed the native module types as ECMAScript, CommonJS, AMD, assets and WebAssembly — CSS and HTML were missing. Added, with links to the two guides, so the page body matches its new description.

## Verification

- 136/136 non-blog pages have a description; **zero duplicates**
- All frontmatter parses as valid YAML
- `prettier --check` clean across all 133 changed files
- Metadata path confirmed: `content-tree-enhancers.mjs` spreads all frontmatter onto the tree node via `Object.assign`, `getPageDescription` reads `page.description`, and `Site.jsx` renders it into both meta tags. The existing test in `content-utils.test.mjs` already asserts this end to end for `getting-started`.

`vale`, `eslint` and `markdownlint` were **not** run locally — `npm install` failed in the authoring environment. CI covers them; the changes are additive frontmatter plus one string and two list items.

## Notes for reviewers

- `guides/typescript` is described as teaching `ts-loader`, because that is what it still does. It was not updated for `experiments.typescript` the way the CSS and HTML guides were in #8355 — likely worth a follow-up, out of scope here.
- No redirect, sitemap or structured-data changes are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDxiMfJ9FnjuLdeRkwdWPa

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDxiMfJ9FnjuLdeRkwdWPa)_