### PR TITLE
docs: answer long-standing questions about inaccurate or missing reference docs

### DIFF
--- a/src/content/api/loaders.mdx
+++ b/src/content/api/loaders.mdx
@@ -616,7 +616,20 @@ In [the example](#example-for-the-loader-context): `'?rrr'`
 
 ### this.rootContext
 
-Since webpack 4, the formerly `this.options.context` is provided as `this.rootContext`.
+The absolute path of the project's base directory, i.e. the [`context`](/configuration/entry-context/#context) option of the configuration, which defaults to the directory webpack was started from. Unlike [`this.context`](#thiscontext), which is the directory of the module being loaded, it is the same for every module of a compilation.
+
+Use it whenever a loader needs a path that is stable across modules: to make a path relative for an output name or a source map, to look up a configuration file next to the project root, or to key a cache by project rather than by file.
+
+```js
+import path from "node:path";
+
+export default function loader(source) {
+  const relative = path.relative(this.rootContext, this.resourcePath);
+  // …
+}
+```
+
+T> Since webpack 4, this replaces the former `this.options.context`.
 
 ### this.sourceMap
 

--- a/src/content/api/module-methods.mdx
+++ b/src/content/api/module-methods.mdx
@@ -112,6 +112,26 @@ import(`./locale/${language}.json`).then((module) => {
 
 T> Using the [`webpackInclude` and `webpackExclude`](/api/module-methods/#magic-comments) options allows you to add regex patterns that reduce the number of files that webpack will bundle for this import.
 
+A fully dynamic `import(foo)` is not an error — webpack still creates a [context module](/guides/dependency-management/) for it, but an empty one. It reports `Critical dependency: the request of a dependency is an expression` at build time, bundles nothing for that call, and the returned promise rejects at runtime. Nothing is included because the parser can't tell which files could be requested, and including every file the expression might resolve to is almost never what you want.
+
+If it _is_ what you want, the [module context](/configuration/module/#module-contexts) options let you opt in — `exprContextRequest` is the directory to look in, `exprContextRegExp` selects the files inside it, `exprContextRecursive` decides whether subdirectories are included, and `exprContextCritical` controls the warning:
+
+```js
+export default {
+  module: {
+    parser: {
+      javascript: {
+        // bundle every module below the importing directory
+        exprContextRegExp: /^\.\/.*$/,
+        exprContextCritical: false,
+      },
+    },
+  },
+};
+```
+
+W> Every module matched this way ends up in the bundle, so this can grow the output dramatically. Prefer keeping a static prefix in the request, as in the example above. The equivalent options for an unanalyzable `require(expr)` are named `unknownContextRequest`, `unknownContextRegExp`, `unknownContextRecursive` and `unknownContextCritical`.
+
 #### Magic Comments
 
 By adding comments to the import, we can do things such as name our chunk or select different modes. For a full list of these magic comments see the code below followed by an explanation of what these comments do.
@@ -223,7 +243,7 @@ Since webpack 2.6.0, different modes for resolving dynamic imports can be specif
 
 - `'lazy'` (default): Generates a lazy-loadable chunk for each `import()`ed module.
 - `'lazy-once'`: Generates a single lazy-loadable chunk that can satisfy all calls to `import()`. The chunk will be fetched on the first call to `import()`, and subsequent calls to `import()` will use the same network response. Note that this only makes sense in the case of a partially dynamic statement, e.g. ``import(`./locales/${language}.json`)``, where multiple module paths that can potentially be requested.
-- `'eager'`: Generates no extra chunk. All modules are included in the current chunk and no additional network requests are made. A `Promise` is still returned but is already resolved. In contrast to a static import, the module isn't executed until the call to `import()` is made.
+- `'eager'`: Generates no extra chunk. All modules are included in the current chunk and no additional network requests are made. A `Promise` is still returned but is already resolved. In contrast to a static import, the module isn't executed until the call to `import()` is made. Since no chunk is created, `webpackChunkName` has no effect in this mode — use `'lazy'` or `'lazy-once'` when you want the module in a chunk of its own.
 - `'weak'`: Tries to load the module if the module function has already been loaded in some other way (e.g. another chunk imported it or a script containing the module was loaded). A `Promise` is still returned, but only successfully resolves if the chunks are already on the client. If the module is not available, the `Promise` is rejected. A network request will never be performed. This is useful for universal rendering when required chunks are always manually served in initial requests (embedded within the page), but not in cases where app navigation will trigger an import not initially served.
 
 ##### webpackPrefetch

--- a/src/content/concepts/module-federation.mdx
+++ b/src/content/concepts/module-federation.mdx
@@ -59,6 +59,12 @@ Shared modules are modules that are both overridable and provided as overrides t
 
 The `packageName` option allows setting a package name to look for a `requiredVersion`. It is automatically inferred for the module requests by default, set `requiredVersion` to `false` when automatic infer should be disabled.
 
+### Every build needs its own unique name
+
+Builds loaded by one document identify themselves by [`output.uniqueName`](/configuration/output/#outputuniquename), which webpack derives from the `name` field of your `package.json`. Two builds that share that name also share the global array their runtimes load chunks from ([`output.chunkLoadingGlobal`](/configuration/output/#outputchunkloadingglobal)) and become indistinguishable to the shared-module runtime, which uses the unique name to decide which build's copy of a shared module wins.
+
+This applies to a host and a single remote as much as to several remotes, and it is easy to run into when a remote is split out of an existing project and keeps its `package.json`. See [Setting `output.uniqueName`](#setting-outputuniquename) for how to fix it.
+
 ## Building blocks
 
 ### ContainerPlugin (low level)

--- a/src/content/configuration/mode.mdx
+++ b/src/content/configuration/mode.mdx
@@ -46,6 +46,36 @@ If not set, webpack sets `production` as the default value for `mode`.
 
 T> If `mode` is not provided via configuration or CLI, CLI will use any valid `NODE_ENV` value for `mode`.
 
+### Defaults per mode
+
+`mode` doesn't do anything by itself — it picks the defaults of other options, each of which you can still set explicitly. These are the options whose default depends on it:
+
+| Option                                                                                           | `development`        | `production`      | `none`      |
+| ------------------------------------------------------------------------------------------------ | -------------------- | ----------------- | ----------- |
+| [`cache`](/configuration/cache/)                                                                 | `{ type: 'memory' }` | `false`           | `false`     |
+| [`devtool`](/configuration/devtool/)                                                             | `'eval'`             | `false`           | `false`     |
+| [`output.pathinfo`](/configuration/output/#outputpathinfo)                                       | `true`               | `false`           | `false`     |
+| [`performance.hints`](/configuration/performance/#performancehints)                              | `false`              | `'warning'`       | `false`     |
+| [`optimization.chunkIds`](/configuration/optimization/#optimizationchunkids)                     | `'named'`            | `'deterministic'` | `'natural'` |
+| [`optimization.moduleIds`](/configuration/optimization/#optimizationmoduleids)                   | `'named'`            | `'deterministic'` | `'natural'` |
+| [`optimization.nodeEnv`](/configuration/optimization/#optimizationnodeenv)                       | `'development'`      | `'production'`    | `false`     |
+| [`optimization.emitOnErrors`](/configuration/optimization/#optimizationemitonerrors)             | `true`               | `false`           | `true`      |
+| [`optimization.sideEffects`](/configuration/optimization/#optimizationsideeffects)               | `'flag'`             | `true`            | `'flag'`    |
+| [`optimization.usedExports`](/configuration/optimization/#optimizationusedexports)               | `false`              | `true`            | `false`     |
+| [`optimization.innerGraph`](/configuration/optimization/#optimizationinnergraph)                 | `false`              | `true`            | `false`     |
+| [`optimization.mangleExports`](/configuration/optimization/#optimizationmangleexports)           | `false`              | `true`            | `false`     |
+| [`optimization.concatenateModules`](/configuration/optimization/#optimizationconcatenatemodules) | `false`              | `true`            | `false`     |
+| [`optimization.flagIncludedChunks`](/configuration/optimization/#optimizationflagincludedchunks) | `false`              | `true`            | `false`     |
+| [`optimization.realContentHash`](/configuration/optimization/#optimizationrealcontenthash)       | `false`              | `true`            | `false`     |
+| [`optimization.checkWasmTypes`](/configuration/optimization/#optimizationcheckwasmtypes)         | `false`              | `true`            | `false`     |
+| [`optimization.minimize`](/configuration/optimization/#optimizationminimize)                     | `false`              | `true`            | `false`     |
+
+[`optimization.splitChunks`](/configuration/optimization/#optimizationsplitchunks) is also tuned by mode: `minSize`, `enforceSizeThreshold`, `maxAsyncRequests` and `maxInitialRequests` are stricter in `production`. See [`SplitChunksPlugin`](/plugins/split-chunks-plugin/) for their values.
+
+Two rows come with a condition: `performance.hints` only applies to browser [targets](/configuration/target/), and `devtool` stays `false` in `development` when the build [outputs an ES module library](/configuration/output/#outputlibrarytype). With [`experiments.css`](/configuration/experiments/#experimentscss) enabled, `development` additionally defaults CSS assets to `source-map`.
+
+T> `mode: 'none'` only opts out of the defaults listed here. Options that don't depend on the mode — such as [`optimization.providedExports`](/configuration/optimization/#optimizationprovidedexports) or [`optimization.removeEmptyChunks`](/configuration/optimization/#optimizationremoveemptychunks) — keep their usual defaults, and `mode: 'none'` is not the same as disabling every optimization.
+
 ### Mode: development
 
 ```js

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -2390,7 +2390,7 @@ export default {
 
 `function(input) => string | object`
 
-If `Rule.type` is set to `'json'` then `Rules.parser.parse` option may be a function that implements custom logic to parse module's source and convert it to a JavaScript `object`. It may be useful to import `toml`, `yaml` and other non-JSON files as JSON, without specific loaders:
+If `Rule.type` is set to `'json'` then `Rules.parser.parse` option may be a function that implements custom logic to parse module's source and convert it to a JavaScript `object`. It defaults to `JSON.parse`. It may be useful to import `toml`, `yaml` and other non-JSON files as JSON, without specific loaders:
 
 **webpack.config.js**
 
@@ -2412,6 +2412,10 @@ export default {
   },
 };
 ```
+
+The `type: 'json'` above is not redundant, and webpack can't assume it. [`Rule.parser`](#ruleparser) is handed to the parser of the module type that the rule selects, and only [`Rule.type`](#ruletype) selects that type — by default only `.json` files and modules with the `application/json` mimetype are of type `'json'`, so a `.toml` file would otherwise be parsed as JavaScript and the `parse` function would never run.
+
+Every module type validates the parser options it is given against its own schema, so `parse` doesn't carry over to types that don't have it. With `type: 'asset'`, for example, the build fails with `parser has an unknown property 'parse'`.
 
 ## Rule.rules
 
@@ -2840,6 +2844,8 @@ Example for an `unknown` dynamic dependency: `require`.
 Example for an `expr` dynamic dependency: `require(expr)`.
 
 Example for an `wrapped` dynamic dependency: `require('./templates/' + expr)`.
+
+The same settings apply to the equivalent `import()` calls, so `exprContextRegExp` is what decides which modules a fully dynamic `import(expr)` pulls in. See [Dynamic expressions in import()](/api/module-methods/#dynamic-expressions-in-import) for what happens with the defaults.
 
 Here are the available options with their [defaults](https://github.com/webpack/webpack/blob/main/lib/config/defaults.js):
 

--- a/src/content/configuration/optimization.mdx
+++ b/src/content/configuration/optimization.mdx
@@ -111,6 +111,13 @@ export default {
 };
 ```
 
+`webpack.ids.DeterministicChunkIdsPlugin` is the plugin behind `chunkIds: 'deterministic'`. It hashes each chunk's name — its path relative to `context`, so ids don't change when the project moves — into a number, and it accepts these options:
+
+| Option      | Type     | Default            | Description                                                                                                                                                      |
+| ----------- | -------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `context`   | `string` | `compiler.context` | The directory chunk names are made relative to before hashing.                                                                                                   |
+| `maxLength` | `number` | `3`                | The number of digits ids start with. webpack keeps multiplying that range by ten until it is roughly 20 times the number of chunks, which keeps collisions rare. |
+
 ## optimization.concatenateModules
 
 `boolean` `object`
@@ -663,6 +670,17 @@ export default {
   ],
 };
 ```
+
+`webpack.ids.DeterministicModuleIdsPlugin` is the plugin behind `moduleIds: 'deterministic'`. It hashes each module's request — made relative to `context`, so ids survive a checkout in another directory — into a number, and it accepts these options:
+
+| Option           | Type                           | Default            | Description                                                                                                                                                       |
+| ---------------- | ------------------------------ | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `context`        | `string`                       | `compiler.context` | The directory module names are made relative to before hashing.                                                                                                   |
+| `test`           | `function (module) => boolean` | all modules        | Restricts the plugin to the modules it returns `true` for, so another plugin can name the rest.                                                                   |
+| `maxLength`      | `number`                       | `3`                | The number of digits ids start with. webpack keeps multiplying that range by ten until it is roughly 20 times the number of modules, which keeps collisions rare. |
+| `fixedLength`    | `boolean`                      | `false`            | Keeps the id space at `maxLength` digits instead of growing it.                                                                                                   |
+| `salt`           | `number`                       | `0`                | Mixed into the hash. Change it to move every id, for example to work around a collision.                                                                          |
+| `failOnConflict` | `boolean`                      | `false`            | Fails the build on a colliding id instead of rehashing it.                                                                                                        |
 
 W> `moduleIds: 'deterministic'` was added in webpack 5 and `moduleIds: 'hashed'` is deprecated in favor of it.
 

--- a/src/content/configuration/other-options.mdx
+++ b/src/content/configuration/other-options.mdx
@@ -372,7 +372,9 @@ Both `hash` and `timestamp` are optional.
 
 An array of paths that are managed by a package manager and contain a version or a hash in their paths so that all files are immutable.
 
-Make sure to wrap the path in a capture group if you use regular expressions.
+webpack records nothing at all for files below these paths — no timestamp, no content hash — and never checks them again. Reserve it for directories whose path itself changes whenever the content changes, such as the zip cache of [Yarn Plug'n'Play](https://yarnpkg.com/features/pnp), where the package version is part of the path. Editing a file below an immutable path will not invalidate anything that was built from it.
+
+A regular expression here is only tested against the path, so it doesn't need a capture group.
 
 ### managedPaths
 
@@ -380,7 +382,11 @@ Make sure to wrap the path in a capture group if you use regular expressions.
 
 An array of paths that are managed by a package manager and can be trusted to not be modified otherwise.
 
-Make sure you wrap the path in a capture group if you are using regular expressions so webpack can extract the path, for example, here's a RegExp webpack internally uses to match the `node_modules` directory:
+For files below these paths webpack does not snapshot the files themselves. It instead determines the package directory that contains the file and records `name@version` as read from that directory's `package.json`. Everything built from the package is invalidated when that string changes — which happens when the package manager installs a different version — and not when a file inside the package is edited in place. That is the difference from [`immutablePaths`](#immutablepaths): a managed path is still re-checked on every build, just once per package instead of once per file.
+
+"Otherwise" in the description above means exactly this: if you edit a file in `node_modules` by hand, or a tool patches one after install without changing the version, webpack keeps using the cached result. List such packages under [`unmanagedPaths`](#unmanagedpaths) (or narrow `managedPaths`, as shown below) so their files are snapshotted individually.
+
+Make sure the directory that contains the packages is wrapped in the first capture group of your regular expression, so webpack can extract it — for example, here's a RegExp webpack internally uses to match the `node_modules` directory:
 
 ```text
 /^(.+?[\\/]node_modules)[\\/]/
@@ -406,7 +412,9 @@ export default {
 
 An array of paths that are not managed by a package manager and the contents are subject to change.
 
-Make sure to wrap the path in a capture group if you use regular expressions.
+It is checked before [`immutablePaths`](#immutablepaths) and [`managedPaths`](#managedpaths), so it is the way to carve a directory out of them — a linked package inside `node_modules`, for example. Files below an unmanaged path are snapshotted individually, according to [`snapshot.module`](#module) and [`snapshot.resolve`](#resolve).
+
+A regular expression here is only tested against the path, so it doesn't need a capture group.
 
 ### module
 

--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -217,9 +217,11 @@ export default {
 
 ## output.chunkLoadingGlobal
 
-`string = 'webpackChunkwebpack'`
+`string = 'webpackChunk' + output.uniqueName`
 
-The global variable is used by webpack for loading chunks.
+The name of the global array webpack uses to load chunks whenever [`output.chunkFormat`](#outputchunkformat) is `'array-push'`, which is the default for the `web` and `webworker` [targets](/configuration/target/). The default name is `'webpackChunk'` followed by [`output.uniqueName`](#outputuniquename), with every character that is not valid in a JavaScript identifier replaced by `_`. The array lives on [`output.globalObject`](#outputglobalobject), so in a browser build of a package named `my-app` it is `self['webpackChunkmy_app']`.
+
+Every chunk file pushes its modules into that array, and the runtime contained in the initial chunk replaces the array's `push` method with its own callback. That way chunks that were loaded before the runtime and chunks that arrive after it are both installed, which is what makes asynchronous chunk loading work without a fixed loading order.
 
 **webpack.config.js**
 
@@ -232,6 +234,14 @@ export default {
   },
 };
 ```
+
+T> This option replaces webpack 4's `output.jsonpFunction`. Passing `jsonpFunction` to webpack 5 fails validation with a message pointing at `output.chunkLoadingGlobal`.
+
+Two builds loaded by one document that share the same `chunkLoadingGlobal` push their chunks into each other's array, which typically surfaces as a runtime error such as `Uncaught TypeError: __webpack_modules__[moduleId] is not a function`.
+
+webpack 5 prevents that by deriving the default from [`output.uniqueName`](#outputuniquename), which in turn defaults to the `name` in your `package.json`. So you only need to set this option — or, better, `output.uniqueName` — when several builds on a page would otherwise end up with the same unique name: a host application and a remote built from the same package name, or a library built twice with the same configuration.
+
+W> Prefer setting [`output.uniqueName`](#outputuniquename): it disambiguates [`output.hotUpdateGlobal`](#outputhotupdateglobal) and [`output.devtoolNamespace`](#outputdevtoolnamespace) along with the chunk loading global, whereas `chunkLoadingGlobal` only changes the latter.
 
 ## output.chunkLoading
 
@@ -561,18 +571,21 @@ export default {
 
 The following substitutions are available in template strings (via webpack's internal [`ModuleFilenameHelpers`](https://github.com/webpack/webpack/blob/main/lib/ModuleFilenameHelpers.js)):
 
-| Template                 | Description                                                                                         |
-| ------------------------ | --------------------------------------------------------------------------------------------------- |
-| [absolute-resource-path] | The absolute filename                                                                               |
-| [all-loaders]            | Automatic and explicit loaders and params up to the name of the first loader                        |
-| [hash]                   | The hash of the module identifier                                                                   |
-| [id]                     | The module identifier                                                                               |
-| [loaders]                | Explicit loaders and params up to the name of the first loader                                      |
-| [resource]               | The path used to resolve the file and any query params used on the first loader                     |
-| [resource-path]          | The path used to resolve the file without any query params                                          |
-| [namespace]              | The modules namespace. This is usually the library name when building as a library, empty otherwise |
+| Template                 | `info` property        | Description                                                                                         |
+| ------------------------ | ---------------------- | --------------------------------------------------------------------------------------------------- |
+| [absolute-resource-path] | `absoluteResourcePath` | The absolute filename                                                                               |
+| [all-loaders]            | `allLoaders`           | Automatic and explicit loaders and params up to the name of the first loader                        |
+| [hash]                   | `hash`                 | The hash of the module identifier                                                                   |
+| [id]                     | `moduleId`             | The module id                                                                                       |
+| [identifier]             | `identifier`           | The module identifier, which includes every loader and the query                                    |
+| [loaders]                | `loaders`              | Explicit loaders and params up to the name of the first loader                                      |
+| [query]                  | `query`                | The query of the resource, including the leading `?`, or an empty string                            |
+| [resource]               | `resource`             | The path used to resolve the file and any query params used on the first loader                     |
+| [resource-path]          | `resourcePath`         | The path used to resolve the file without any query params                                          |
+| [short-identifier]       | `shortIdentifier`      | The readable module identifier, as shown in [stats](/configuration/stats/)                          |
+| [namespace]              | `namespace`            | The modules namespace. This is usually the library name when building as a library, empty otherwise |
 
-When using a function, the same options are available camel-cased via the `info` parameter:
+When using a function, the same values are available through the `info` parameter, under the property names listed above. Note that they are not always the camel-cased template name: `[id]` is `info.moduleId`.
 
 ```js
 export default {

--- a/src/content/configuration/resolve.mdx
+++ b/src/content/configuration/resolve.mdx
@@ -43,6 +43,29 @@ export default {
 };
 ```
 
+### Defaults
+
+These are the defaults each option starts from. Where a default depends on the [`target`](/configuration/target/) or on how a module is requested, the option's own section below gives the exact rules.
+
+| Option                                         | Default                                                                         |
+| ---------------------------------------------- | ------------------------------------------------------------------------------- |
+| [`extensions`](#resolveextensions)             | `['.js', '.json', '.wasm']`                                                     |
+| [`mainFiles`](#resolvemainfiles)               | `['index']`                                                                     |
+| [`mainFields`](#resolvemainfields)             | `['browser', 'module', 'main']` for web targets, `['module', 'main']` otherwise |
+| [`aliasFields`](#resolvealiasfields)           | `['browser']` for web targets, `[]` otherwise                                   |
+| [`modules`](#resolvemodules)                   | `['node_modules']`                                                              |
+| [`descriptionFiles`](#resolvedescriptionfiles) | `['package.json']`                                                              |
+| [`exportsFields`](#resolveexportsfields)       | `['exports']`                                                                   |
+| [`importsFields`](#resolveimportsfields)       | `['imports']`                                                                   |
+| [`conditionNames`](#resolveconditionnames)     | derived from `mode` and `target`, e.g. `['webpack', 'production', 'browser']`   |
+| [`roots`](#resolveroots)                       | `[context]`                                                                     |
+| [`symlinks`](#resolvesymlinks)                 | `true`                                                                          |
+| [`preferRelative`](#resolvepreferrelative)     | `false`, except for `new URL()` and worker requests                             |
+| [`preferAbsolute`](#resolvepreferabsolute)     | `false`                                                                         |
+| [`enforceExtension`](#resolveenforceextension) | `false`                                                                         |
+
+T> `extensions`, `mainFields`, `aliasFields` and `conditionNames` are additionally refined per dependency type through [`resolve.byDependency`](#resolvebydependency) — a `require()` and an `import` of the same package can resolve to different files. The table there lists those values.
+
 ### resolve.alias
 
 `object`
@@ -221,6 +244,18 @@ export default {
 ### resolve.byDependency
 
 Configure resolve options by the type of module request.
+
+webpack ships defaults for the dependency types it knows, which is why an `import` and a `require()` of the same request can resolve differently. `'...'` stands for the value configured outside `byDependency`:
+
+| Dependency type                                     | Defaults                                                                                                                                                  |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `esm`, `wasm`, `loaderImport`                       | `conditionNames: ['import', 'module-sync', 'module', '...']`, `mainFields: ['browser', 'module', '...']` on web targets and `['module', '...']` elsewhere |
+| `commonjs`, `amd`, `loader`, `unknown`, `undefined` | the same, with `conditionNames: ['require', 'module-sync', 'module', '...']`                                                                              |
+| `worker`                                            | as `esm`, with `'worker'` prepended to `conditionNames` and `preferRelative: true`                                                                        |
+| `url`                                               | `preferRelative: true`                                                                                                                                    |
+| `css-import`                                        | `conditionNames: ['webpack', <mode>, 'style']`, `mainFields: ['style', '...']`, `mainFiles: []`, `extensions: ['.css']`, `preferRelative: true`           |
+
+`mainFiles: []` for CSS is deliberate: a CSS `@import` never resolves a directory to a main file, so the full path has to be written out.
 
 - Type: `[type: string]: ResolveOptions`
 - Example:

--- a/src/content/plugins/eval-source-map-dev-tool-plugin.mdx
+++ b/src/content/plugins/eval-source-map-dev-tool-plugin.mdx
@@ -23,13 +23,15 @@ This plugin enables more fine grained control of source map generation. It is al
 new webpack.EvalSourceMapDevToolPlugin(options);
 ```
 
+This plugin wraps every module in an `eval()` call with its source map appended as a data URL, so no `.map` files are emitted. It accepts the same options object as the [`SourceMapDevToolPlugin`](/plugins/source-map-dev-tool-plugin/), but the options that describe a separate source map file — `filename`, `fileContext` and `publicPath` — have nothing to name here and are ignored.
+
 ## Options
 
 The following options are supported:
 
-- `test` (`string` `RegExp` `function (asset) => boolean` `[string, RegExp, function (asset) => boolean]`): Include source maps for modules based on their extension (defaults to `.js` and `.css`).
-- `include` (`string` `RegExp` `function (asset) => boolean` `[string, RegExp, function (asset) => boolean]`): Include source maps for module paths that match the given value.
-- `exclude` (`string` `RegExp` `function (asset) => boolean` `[string, RegExp, function (asset) => boolean]`): Exclude modules that match the given value from source map generation.
+- `test` (`string` `RegExp` `function (module) => boolean` `[string, RegExp, function (module) => boolean]`): Generate source maps for modules whose path matches the given value. It matches the module's own path, not the name of the chunk it ends up in, so it cannot be used to exclude a whole entry point or bundle.
+- `include` (`string` `RegExp` `function (module) => boolean` `[string, RegExp, function (module) => boolean]`): Include source maps for module paths that match the given value.
+- `exclude` (`string` `RegExp` `function (module) => boolean` `[string, RegExp, function (module) => boolean]`): Exclude modules that match the given value from source map generation.
 - `append` (`string|function`): Appends the given value to the original asset. Usually the `#sourceMappingURL` comment. `[url]` is replaced with a URL to the source map file.
 
   Starting from version 5.84.0, webpack allows the `append` option to be a function that accepts path data and an asset info object as arguments, and returns a string.
@@ -70,10 +72,12 @@ export default {
 
 ### Exclude Vendor Maps
 
-The following code would exclude source maps for any modules in the `vendor.js` bundle:
+The following code would exclude source maps for any module coming from `node_modules`:
 
 ```js
 new webpack.EvalSourceMapDevToolPlugin({
-  exclude: ["vendor.js"],
+  exclude: /node_modules/,
 });
 ```
+
+W> `exclude` is matched against each module's path. Naming an output file such as `vendor.js` here matches nothing, because by the time modules are rendered the plugin only sees where they came from. Use [`SourceMapDevToolPlugin`](/plugins/source-map-dev-tool-plugin/) if you need per-asset control.

--- a/src/content/plugins/module-federation-plugin.mdx
+++ b/src/content/plugins/module-federation-plugin.mdx
@@ -206,13 +206,27 @@ This field specifies the required version of the package. It accepts semantic ve
 
 `string`
 
-The requested shared module is looked up under this key from the shared scope.
+The requested shared module is looked up under this key from the shared scope. It defaults to the key you used in `shared`, i.e. the request itself, so `shared: ['lodash']` is stored and looked up as `lodash`.
+
+Set it when the name a build imports and the name it should share under differ. Two builds only share a module when both the key and the scope match, so the key is what lets an application that imports `lodash-es` reuse what another build provided as `lodash`:
+
+```js
+new ModuleFederationPlugin({
+  shared: {
+    "lodash-es": {
+      shareKey: "lodash",
+    },
+  },
+});
+```
 
 ##### **`shareScope`**
 
 `string`
 
-The name of the shared scope.
+The name of the shared scope, defaulting to the plugin's own `shareScope` option and, when that is unset, to `'default'`. A scope is one namespace of shared modules: builds put the modules they provide into it and look the ones they need up from it, so builds using different scope names never share with each other even when their keys match.
+
+Change it to keep groups of builds apart — for example when a page hosts two independent sets of remotes that should each get their own copy of a library, or when a widget must not adopt the host's version of one. Both the providing and the consuming side have to name the same scope.
 
 ##### **`singleton`**
 

--- a/src/content/plugins/prefetch-plugin.mdx
+++ b/src/content/plugins/prefetch-plugin.mdx
@@ -19,3 +19,25 @@ new webpack.PrefetchPlugin([context], request);
 
 - `context`: An absolute path to a directory
 - `request`: A request string for a normal module
+
+## What it does
+
+webpack discovers modules by walking the dependency graph: a module deep in an import chain is only resolved once everything above it has been parsed. A long chain therefore builds partly in sequence, even though webpack processes modules in parallel wherever it can.
+
+This plugin starts one such chain at the very beginning of the compilation instead, when webpack would otherwise be waiting for the first modules to be parsed. By the time the real `import` is found, the module is already built and the result is reused.
+
+```js
+import path from "node:path";
+import webpack from "webpack";
+
+export default {
+  plugins: [
+    // start building the heaviest dependency right away
+    new webpack.PrefetchPlugin(path.resolve("./src"), "./deeply/nested/heavy"),
+  ],
+};
+```
+
+Prefetching a module that the build never imports only wastes the work: the module ends up in no chunk and nothing is emitted for it. That makes profiling the build first worthwhile — see [Build performance](/guides/build-performance/) — because the win depends entirely on picking a request that is both expensive and discovered late.
+
+W> This is about **build time**, not about what the browser does. It emits no [`<link rel="prefetch">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/prefetch) tag and changes nothing in the output. To tell the browser to fetch a chunk ahead of time, use the `webpackPrefetch` [magic comment](/api/module-methods/#magic-comments) described in [Prefetching/Preloading modules](/guides/code-splitting/#prefetchingpreloading-modules).

--- a/src/content/plugins/split-chunks-plugin.mdx
+++ b/src/content/plugins/split-chunks-plugin.mdx
@@ -110,7 +110,13 @@ By default webpack will generate names using origin and name of the chunk (e.g. 
 
 `string = 'async'` `function (chunk)` `RegExp`
 
-This indicates which chunks will be selected for optimization. When a string is provided, valid values are `all`, `async`, and `initial`. Providing `all` can be particularly powerful, because it means that chunks can be shared even between async and non-async chunks.
+This indicates which chunks will be selected for optimization. When a string is provided, valid values are `all`, `async`, and `initial`:
+
+- `'initial'` selects chunks that a browser loads up front, before any code of the application runs — the chunks that belong to an [entry point](/concepts/entry-points/), including its runtime and anything it statically imports.
+- `'async'` selects chunks that are loaded on demand, i.e. chunks created by [`import()`](/api/module-methods/#import-1) and other asynchronous dependencies.
+- `'all'` selects both.
+
+A chunk counts as initial when at least one of the chunk groups it belongs to is loaded with the page, so a chunk that is part of an entry point and is additionally pulled in by an `import()` somewhere else is treated as initial rather than async. Providing `all` can be particularly powerful, because it means that chunks can be shared even between async and non-async chunks.
 
 Note that it is applied to the fallback cache group as well (`splitChunks.fallbackCacheGroup.chunks`).
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Fills gaps and corrects statements in the configuration, API and plugin reference that open issues report, each checked against webpack's source: Closes #6336, Closes #4880, Closes #5986, Closes #6205, Closes #6408, Closes #2443, Closes #2080, Closes #4832, Closes #2211, Closes #2579, Closes #3426, Closes #3910, Closes #2047, Closes #4663, Closes #6070, Closes #6056.

The corrections worth calling out: `output.chunkLoadingGlobal` did not say what it is or that its default follows `output.uniqueName`; the `info` object of `devtoolModuleFilenameTemplate` is not simply the camel-cased template names (`[id]` is `info.moduleId`); `immutablePaths` and `unmanagedPaths` are only tested against the path, so the advice to wrap them in a capture group applied to `managedPaths` alone; `EvalSourceMapDevToolPlugin` matches modules rather than assets, so its "exclude the `vendor.js` bundle" example could not work.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

docs

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

No, content-only change; `lint:js`, `lint:prettier`, `lint:markdown` and `jest` pass locally.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes. AI was used to triage the open documentation issues, verify each claim against the webpack source (`lib/config/defaults.js`, `lib/FileSystemInfo.js`, `lib/ModuleFilenameHelpers.js`, `lib/ids/`, `lib/dependencies/ImportParserPlugin.js`, `lib/EvalSourceMapDevToolPlugin.js`, the schemas) and draft the text; every statement was checked against that source before writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT)_