### PR TITLE
docs: document the API surface that had no documentation at all

### DIFF
--- a/src/content/api/compilation-hooks.mdx
+++ b/src/content/api/compilation-hooks.mdx
@@ -75,6 +75,32 @@ Executed when a module has been built successfully.
 
 - Callback Parameters: `module`
 
+## stillValidModule
+
+`SyncHook`
+
+Called when a module was found to be still valid and therefore not rebuilt, for example because the cache is still up to date.
+
+- Callback Parameters: `module`
+
+## succeedEntry
+
+`SyncHook`
+
+Called when an entry and its dependencies have been added successfully.
+
+- Callback Parameters: `entry` `options` `module`
+
+`entry` is the entry `Dependency`, `options` the [entry options](/configuration/entry-context/#entry-descriptor) it was added with.
+
+## failedEntry
+
+`SyncHook`
+
+Called when adding an entry failed.
+
+- Callback Parameters: `entry` `options` `error`
+
 ## finishModules
 
 `AsyncSeriesHook`
@@ -118,6 +144,20 @@ Fired at the beginning of dependency optimization.
 Fired after the dependency optimization.
 
 - Callback Parameters: `modules`
+
+## dependencyReferencedExports
+
+`SyncWaterfallHook`
+
+Called with the exports a dependency references, allowing them to be changed. The result decides what [`optimization.usedExports`](/configuration/optimization/#optimizationusedexports) keeps for that dependency.
+
+- Callback Parameters: `referencedExports` `dependency` `runtime`
+
+## beforeChunks
+
+`SyncHook`
+
+Called right before chunks are created from the entrypoints, i.e. before the chunk graph exists.
 
 ## afterChunks
 
@@ -304,6 +344,14 @@ Store chunk info to the records. This is only triggered if [`shouldRecord`](#sho
 
 - Callback Parameters: `chunks` `records`
 
+## renderManifest
+
+`SyncWaterfallHook`
+
+Called to collect the render manifest of a chunk — the list of files it renders to and how each one is generated. Plugins that emit an additional file type for a chunk add their entry here.
+
+- Callback Parameters: `result` `options`
+
 ## renderEmbeddedSource
 
 <Badge text="5.110.0+" />
@@ -340,6 +388,70 @@ Called while hashing a module that embeds a source of another language. Tap it t
 
 - Callback Parameters: `module`, `hash`
 
+## optimizeCodeGeneration
+
+`SyncHook`
+
+Called with all modules right before code generation, so their code generation can still be influenced.
+
+- Callback Parameters: `modules`
+
+## beforeCodeGeneration
+
+`SyncHook`
+
+Called before the code generation phase starts.
+
+## afterCodeGeneration
+
+`SyncHook`
+
+Called after the code generation phase has finished.
+
+## beforeRuntimeRequirements
+
+`SyncHook`
+
+Called before the runtime requirements of modules, chunks and chunk trees are collected.
+
+## additionalModuleRuntimeRequirements
+
+`SyncHook`
+
+Called for each module so that plugins can add runtime requirements ([`RuntimeGlobals`](https://github.com/webpack/webpack/blob/main/lib/RuntimeGlobals.js)) the module needs.
+
+- Callback Parameters: `module` `runtimeRequirements` `context`
+
+## additionalChunkRuntimeRequirements
+
+`SyncHook`
+
+Called for each chunk so that plugins can add runtime requirements the chunk needs.
+
+- Callback Parameters: `chunk` `runtimeRequirements` `context`
+
+## additionalTreeRuntimeRequirements
+
+`SyncHook`
+
+Called for each entry chunk so that plugins can add runtime requirements for the whole chunk tree, which is where most runtime modules are injected.
+
+- Callback Parameters: `chunk` `runtimeRequirements` `context`
+
+## runtimeModule
+
+`SyncHook`
+
+Called after a runtime module has been added to a chunk, and can be used to modify its generated code.
+
+- Callback Parameters: `module` `chunk`
+
+## afterRuntimeRequirements
+
+`SyncHook`
+
+Called after all runtime requirements have been collected.
+
 ## beforeModuleHash
 
 `SyncHook`
@@ -363,6 +475,22 @@ Called before the compilation is hashed.
 `SyncHook`
 
 Called after the compilation is hashed.
+
+## fullHash
+
+`SyncHook`
+
+Called with the compilation hash once every module and chunk has contributed to it, so further data can be hashed in.
+
+- Callback Parameters: `hash`
+
+## contentHash
+
+`SyncHook`
+
+Called for each chunk after its hash was computed, which is where content hashes per source type are added.
+
+- Callback Parameters: `chunk`
 
 ## recordHash
 
@@ -615,6 +743,14 @@ compilation.hooks.processAssets.tap({/** … */}, (assets) => {
 });
 ```
 
+## processAdditionalAssets
+
+`AsyncSeriesHook`
+
+Called with the assets that were added while [`processAssets`](#processassets) was running, so a plugin can process assets created by another plugin in the same stage.
+
+- Callback Parameters: `assets`
+
 ## afterProcessAssets
 
 `SyncHook`
@@ -672,6 +808,38 @@ Called to determine the path of an asset.
 `SyncBailHook`
 
 Called to determine if an asset needs to be processed further after being emitted.
+
+## processErrors
+
+`SyncWaterfallHook`
+
+Called with the compilation's errors before they are reported, and returns the list to report. Returning a shorter array drops errors.
+
+- Callback Parameters: `errors`
+
+## processWarnings
+
+`SyncWaterfallHook`
+
+Called with the compilation's warnings before they are reported. This is how [`ignoreWarnings`](/configuration/other-options/#ignorewarnings) filters them.
+
+- Callback Parameters: `warnings`
+
+## prepareModuleExecution
+
+`AsyncParallelHook`
+
+Called before a module is executed at build time, so its execution can be prepared.
+
+- Callback Parameters: `options` `context`
+
+## executeModule
+
+`SyncHook`
+
+Called when a module is executed during the build rather than at runtime — the mechanism behind `compilation.executeModule` and a loader's [`importModule`](/api/loaders/#thisimportmodule).
+
+- Callback Parameters: `options` `context`
 
 ## childCompiler
 

--- a/src/content/api/compilation-object.mdx
+++ b/src/content/api/compilation-object.mdx
@@ -310,3 +310,103 @@ Returns array of all assets under the current compilation.
 Parameters:
 
 - `name` - the name of the asset to return
+
+### getCache
+
+`function (name)`
+
+Returns a `CacheFacade` for the given name, the API a plugin uses to store results between builds and reuse them from the [persistent cache](/configuration/cache/). Prefer it over `compiler.getCache(name)`, and over the deprecated `compilation.cache`, so that the cached entries belong to the compilation being built.
+
+Parameters:
+
+- `name` - a name identifying the cache, conventionally your plugin's name
+
+```js
+compiler.hooks.compilation.tap("MyPlugin", (compilation) => {
+  const cache = compilation.getCache("MyPlugin");
+
+  compilation.hooks.processAssets.tapPromise("MyPlugin", async (assets) => {
+    for (const [name, source] of Object.entries(assets)) {
+      // the etag decides when an entry is stale: pass something derived
+      // from the inputs, here the source itself
+      const etag = cache.getLazyHashedEtag(source);
+      const cached = await cache.getPromise(name, etag);
+      if (cached !== undefined) {
+        compilation.updateAsset(name, cached);
+        continue;
+      }
+      const result = transform(source);
+      await cache.storePromise(name, etag, result);
+      compilation.updateAsset(name, result);
+    }
+  });
+});
+```
+
+A `CacheFacade` provides:
+
+| Method                                          | Description                                                                                                                                   |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `get(identifier, etag, callback)`               | Read an entry. The callback receives `undefined` when nothing valid is stored.                                                                |
+| `getPromise(identifier, etag)`                  | The promise form of `get`.                                                                                                                    |
+| `store(identifier, etag, data, callback)`       | Write an entry.                                                                                                                               |
+| `storePromise(identifier, etag, data)`          | The promise form of `store`.                                                                                                                  |
+| `provide(identifier, etag, computer, callback)` | Read an entry, or compute it with `computer` and store the result.                                                                            |
+| `getItemCache(identifier, etag)`                | An `ItemCacheFacade` bound to one identifier and etag, with `get` / `getPromise` / `store` / `storePromise` / `provide` taking no identifier. |
+| `getChildCache(name)`                           | A nested `CacheFacade` whose entries are namespaced under `name`.                                                                             |
+| `getLazyHashedEtag(obj)`                        | An etag for a hashable object such as a `Source`, computed only when it is actually needed.                                                   |
+| `mergeEtags(a, b)`                              | One etag standing for two, when an entry depends on more than one input.                                                                      |
+| `isEnabled()`                                   | Whether caching is enabled at all.                                                                                                            |
+
+W> An entry is only reused when its `etag` matches, so the etag has to cover everything the stored value was derived from — the source, your plugin's options, and anything else that would change the result.
+
+## Module and chunk graphs
+
+<Badge text="5.0.0+" />
+
+webpack 5 moved the relations between modules and chunks out of the `Module` and `Chunk` objects themselves and into two graphs held by the compilation:
+
+- `compilation.moduleGraph` — how modules relate to each other: which module issued which, what a dependency refers to, which exports are used.
+- `compilation.chunkGraph` — how modules relate to chunks: which chunk contains a module, a module's id and hash, which modules are entry modules of a chunk.
+
+The reason is that one module can now take part in several graphs (a module built once can appear in more than one runtime), so a value like "the id of this module" is only meaningful together with a graph.
+
+```js
+compilation.hooks.optimizeChunks.tap("MyPlugin", (chunks) => {
+  const { chunkGraph, moduleGraph } = compilation;
+
+  for (const chunk of chunks) {
+    for (const module of chunkGraph.getChunkModules(chunk)) {
+      const id = chunkGraph.getModuleId(module);
+      const issuer = moduleGraph.getIssuer(module);
+      // ...
+    }
+  }
+});
+```
+
+Accessing the old members still works, but logs a deprecation warning naming a `DEP_WEBPACK_*` code. These are the replacements:
+
+| Deprecated                     | Use instead                                          |
+| ------------------------------ | ---------------------------------------------------- |
+| `chunk.entryModule`            | `chunkGraph.getChunkEntryModulesIterable(chunk)`     |
+| `chunk.hasEntryModule()`       | `chunkGraph.getNumberOfEntryModules(chunk) > 0`      |
+| `chunk.getModules()`           | `chunkGraph.getChunkModules(chunk)`                  |
+| `chunk.getNumberOfModules()`   | `chunkGraph.getNumberOfChunkModules(chunk)`          |
+| `chunk.containsModule(module)` | `chunkGraph.isModuleInChunk(module, chunk)`          |
+| `chunk.removeModule(module)`   | `chunkGraph.disconnectChunkAndModule(chunk, module)` |
+| `module.id`                    | `chunkGraph.getModuleId(module)`                     |
+| `module.hash`                  | `chunkGraph.getModuleHash(module, runtime)`          |
+| `module.renderedHash`          | `chunkGraph.getRenderedModuleHash(module, runtime)`  |
+| `module.getChunks()`           | `chunkGraph.getModuleChunks(module)`                 |
+| `module.getNumberOfChunks()`   | `chunkGraph.getNumberOfModuleChunks(module)`         |
+| `module.isInChunk(chunk)`      | `chunkGraph.isModuleInChunk(module, chunk)`          |
+| `module.isEntryModule()`       | `chunkGraph.isEntryModule(module)`                   |
+| `module.index`                 | `moduleGraph.getPreOrderIndex(module)`               |
+| `module.depth`                 | `moduleGraph.getDepth(module)`                       |
+| `module.issuer`                | `moduleGraph.getIssuer(module)`                      |
+| `module.usedExports`           | `moduleGraph.getUsedExports(module, runtime)`        |
+| `module.optimizationBailout`   | `moduleGraph.getOptimizationBailout(module)`         |
+| `module.profile`               | `moduleGraph.getProfile(module)`                     |
+
+T> Outside a hook that hands you the compilation you can still reach a graph through `ChunkGraph.getChunkGraphForChunk(chunk, ...)` / `ModuleGraph.getModuleGraphForModule(module, ...)`, but taking it from the compilation is preferred.

--- a/src/content/api/compiler-hooks.mdx
+++ b/src/content/api/compiler-hooks.mdx
@@ -157,6 +157,12 @@ Runs a plugin after a [ContextModuleFactory](/api/contextmodulefactory-hooks) is
 
 - Callback Parameters: `contextModuleFactory`
 
+### readRecords
+
+`AsyncSeriesHook`
+
+Called to read the [records](/configuration/other-options/#recordspath) of the previous build, before the compilation starts. It only runs when a records path is configured.
+
 ### beforeCompile
 
 `AsyncSeriesHook`
@@ -215,6 +221,14 @@ Executed before finishing the compilation. This hook is _not_ copied to child co
 
 - Callback Parameters: `compilation`
 
+### finishMake
+
+`AsyncSeriesHook`
+
+Called after [`make`](#make), when every entry and its dependencies have been added to the compilation but before it is finished. Use it to add modules that depend on what the build already contains.
+
+- Callback Parameters: `compilation`
+
 ### afterCompile
 
 `AsyncSeriesHook`
@@ -256,6 +270,12 @@ Called after emitting assets to output directory. This hook is _not_ copied to c
 
 - Callback Parameters: `compilation`
 
+### emitRecords
+
+`AsyncSeriesHook`
+
+Called to write the [records](/configuration/other-options/#recordspath) of this build, after the assets were emitted. Like [`readRecords`](#readrecords) it only runs when a records path is configured.
+
 ### assetEmitted
 
 `AsyncSeriesHook`
@@ -280,6 +300,14 @@ compiler.hooks.assetEmitted.tap(
 `AsyncSeriesHook`
 
 Executed when the compilation has completed. This hook is _not_ copied to child compilers.
+
+- Callback Parameters: `stats`
+
+### afterDone
+
+`SyncHook`
+
+Called after [`done`](#done) has finished, once the callbacks of the run are settled. Being synchronous, it cannot delay the build, which makes it the place for reporting that must not hold the compiler up.
 
 - Callback Parameters: `stats`
 

--- a/src/content/api/loaders.mdx
+++ b/src/content/api/loaders.mdx
@@ -233,6 +233,16 @@ addMissingDependency(file: string)
 
 Add a non-existing file as a dependency of the loader result in order to make them watchable. Similar to `addDependency`, but handles the creation of files during compilation before watchers are attached correctly.
 
+### this.addBuildDependency
+
+```ts
+addBuildDependency(file: string)
+```
+
+Add a file as a build dependency, i.e. as something the loader's own behavior depends on rather than something the module's result depends on. A loader that reads a configuration file of its own registers it here, so that the [persistent cache](/configuration/cache/#cachetype) is invalidated when that file changes — see [`cache.buildDependencies`](/configuration/cache/#cachebuilddependencies).
+
+Use [`addDependency`](#thisadddependency) for files whose content becomes part of the result.
+
 ### this.async
 
 Tells the [loader-runner](https://github.com/webpack/loader-runner) that the loader intends to call back asynchronously. Returns `this.callback`.

--- a/src/content/api/module-variables.mdx
+++ b/src/content/api/module-variables.mdx
@@ -391,6 +391,56 @@ Access to the internal object of all modules.
 
 It provides access to the hash of the compilation.
 
+## \_\_webpack_layer\_\_ (webpack-specific)
+
+`string | null`
+
+The [layer](/configuration/module/#rulelayer) the current module was placed in, or `null` when it has no layer. webpack replaces it at build time with a literal, so it can be compared or branched on without any runtime cost, and `typeof __webpack_layer__` is evaluated statically as well:
+
+```js
+if (__webpack_layer__ === "server") {
+  // only kept in modules built in the "server" layer
+}
+```
+
+## \_\_webpack_nonce\_\_ (webpack-specific)
+
+`string`
+
+The [nonce](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#nonce-base64-value) webpack sets on every script tag it injects, for pages served under a Content Security Policy. Assign it once, before any chunk is loaded:
+
+```js
+__webpack_nonce__ = "2726c7f26c";
+```
+
+## \_\_webpack_chunkname\_\_ (webpack-specific)
+
+`string`
+
+The name of the chunk the current runtime belongs to.
+
+## \_\_webpack_init_sharing\_\_ (webpack-specific)
+
+`function`
+
+Initializes a [share scope](/concepts/module-federation/) and fills it with the shared modules this build provides. It returns a promise and takes the scope name:
+
+```js
+await __webpack_init_sharing__("default");
+```
+
+## \_\_webpack_share_scopes\_\_ (webpack-specific)
+
+`object`
+
+The share scopes this build knows about, keyed by scope name. It is what you hand to a remote container's `init()` after initializing the scope — see [Dynamic Remote Containers](/concepts/module-federation/#dynamic-remote-containers).
+
+## \_\_system_context\_\_ (webpack-specific)
+
+`object`
+
+The [System.register](https://github.com/systemjs/systemjs/blob/main/docs/system-register.md) context, available when building with `output.libraryTarget: 'system'`.
+
 ## \_\_webpack_css_server_styles\_\_ (webpack-specific)
 
 <Badge text="5.110.0+" />

--- a/src/content/api/parser.mdx
+++ b/src/content/api/parser.mdx
@@ -217,6 +217,38 @@ Where the `statement.type` could be:
 - `'LabeledStatement'`
 - `'WithStatement'`
 
+### preStatement
+
+`SyncBailHook`
+
+Called for every statement during the pre-walk, before any statement of the block is walked. This is where hoisted declarations are seen. Returning `true` tells the parser the statement was handled and stops the default pre-walk for it.
+
+- Callback Parameters: `statement`
+
+### blockPreStatement
+
+`SyncBailHook`
+
+Same as [`preStatement`](#prestatement), but for the block pre-walk, which only visits declarations scoped to the current block.
+
+- Callback Parameters: `statement`
+
+### unusedStatement
+
+`SyncBailHook`
+
+Called for each statement that follows a terminating statement in the same block and is therefore unreachable. Returning `true` skips walking it.
+
+- Callback Parameters: `statement`
+
+### terminate
+
+`SyncBailHook`
+
+Called for a `return` or `throw` statement outside the top-level scope. Returning `true` marks the scope as terminated, so the parser treats the statements after it as unreachable.
+
+- Callback Parameters: `statement`
+
 ### statementIf
 
 `SyncBailHook`
@@ -366,6 +398,22 @@ parser.hooks.varDeclaration.for("a").tap("MyPlugin", (identifier) => {
   // identifier is the `Identifier` node of a
 });
 ```
+
+### preDeclarator
+
+`SyncBailHook`
+
+Called for each declarator of a variable declaration during the pre-walk, before the declaration itself is walked.
+
+- Callback Parameters: `declarator` `declaration`
+
+### declarator
+
+`SyncBailHook`
+
+Called for each declarator of a variable declaration while walking it. Returning `true` stops the parser from walking that declarator itself.
+
+- Callback Parameters: `declarator` `statement`
 
 ### varDeclarationLet
 
@@ -524,6 +572,88 @@ parser.hooks.expression.for("this").tap("MyPlugin", (expression) => {});
 `SyncBailHook`
 
 Called when parsing a `ConditionalExpression` e.g. `condition ? a : b`
+
+- Callback Parameters: `expression`
+
+### expressionLogicalOperator
+
+`SyncBailHook`
+
+Called when parsing a `LogicalExpression` e.g. `a && b` or `a || b`. Returning a value stops the parser from walking the operands itself, which is how a plugin can skip a branch it evaluated as dead.
+
+- Callback Parameters: `expression`
+
+### binaryExpression
+
+`SyncBailHook`
+
+Called when parsing a `BinaryExpression` e.g. `a === b`. Returning a value stops the default walk of both operands.
+
+- Callback Parameters: `expression`
+
+### optionalChaining
+
+`SyncBailHook`
+
+Called when parsing a `ChainExpression`, i.e. an expression using optional chaining such as `a?.b` or `a?.()`.
+
+- Callback Parameters: `expression`
+
+### importCall
+
+`SyncBailHook`
+
+Called when parsing a dynamic [`import()`](/api/module-methods/#import-1). Returning `true` marks the call as handled, so webpack creates no dependency of its own for it.
+
+- Callback Parameters: `expression` `callExpression`
+
+`callExpression` is only given when the `import()` is immediately called, e.g. `import("./m").then(...)`.
+
+### topLevelAwait
+
+`SyncBailHook`
+
+Called when a top-level `await` is parsed, which is what turns the module into an async module.
+
+- Callback Parameters: `expression`
+
+### classExtendsExpression
+
+`SyncBailHook`
+
+Called with the expression a class extends, e.g. `Base` in `class A extends Base {}`.
+
+- Callback Parameters: `expression` `classDefinition`
+
+### classBodyElement
+
+`SyncBailHook`
+
+Called for each element of a class body — a method, a property definition or a static block. Returning `true` stops the parser from walking that element.
+
+- Callback Parameters: `element` `classDefinition`
+
+### classBodyValue
+
+`SyncBailHook`
+
+Called for the value of a class body element, i.e. a field initializer or a method's function expression. Returning `true` stops the parser from walking it.
+
+- Callback Parameters: `expression` `element` `classDefinition`
+
+### collectDestructuringAssignmentProperties
+
+`SyncBailHook`
+
+Called for a destructuring assignment so the properties it reads can be collected, which is what lets webpack treat a destructured import as a reference to only those exports.
+
+- Callback Parameters: `expression`
+
+### collectGuards
+
+`SyncBailHook`
+
+Called with the test of a conditional expression to collect the guards it implies, so the parser can narrow what the branches may evaluate to.
 
 - Callback Parameters: `expression`
 

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -239,6 +239,20 @@ console.log(styles.btn); // hashed class
 console.log(styles.BTN); // same hashed class, uppercase alias
 ```
 
+### module.generator.css.exportsOnly
+
+`boolean`
+
+Skip generating and loading a stylesheet and only embed the exports of a CSS module — the mapping from a local class name to its generated one — into the JavaScript output. This is what a server-side build wants, where the styles are shipped by the client build and the server only needs the names.
+
+- Default: `false` for targets that have a `document`, `true` for those that don't (`node`, for example), so a server build gets it without asking.
+
+### module.generator.css.esModule
+
+`boolean = true`
+
+Generate the exports of a CSS module with ES module syntax, so they can be tree-shaken and concatenated. Set it to `false` to emit CommonJS exports instead.
+
 ### module.generator.html.extract
 
 <Badge text="5.107.0+" />
@@ -897,6 +911,54 @@ export default {
 #### module.parser.javascript.commonjsMagicComments
 
 Enable [magic comments](/api/module-methods/#magic-comments) support for CommonJS.
+
+#### module.parser.javascript.createRequire
+
+Enable parsing of `import { createRequire } from "module"` and evaluation of the `require` function it returns, so that such calls become real dependencies.
+
+- Type: `boolean | string`
+- Default: `true` when the [`target`](/configuration/target/) is Node.js, `false` otherwise
+
+A string names the module to take `createRequire` from instead of `"module"`.
+
+#### module.parser.javascript.dynamicUrl
+
+Enable parsing of a `new URL()` whose first argument is not a static string, e.g. ``new URL(`./${name}.png`, import.meta.url)``. With `false`, only URLs webpack can resolve statically become assets and a dynamic one is left as written.
+
+- Type: `boolean`
+- Default: `true`
+
+#### module.parser.javascript.strictThisContextOnImports
+
+Handle the `this` context of imported functions the way the specification requires for namespace objects, i.e. call them with `this === undefined` rather than with the namespace object. Enabling it costs a little output size, which is why it is off by default.
+
+- Type: `boolean`
+- Default: `false`
+
+#### module.parser.javascript.worker
+
+Disable or configure which syntax is parsed as a Web Worker reference.
+
+- Type: `boolean | string[]`
+- Default: `["Worker", "SharedWorker", "navigator.serviceWorker.register()", "Worker from worker_threads"]`
+
+An entry is a constructor name (`"Abc"` handles `new Abc()`), an imported binding (`"Abc from xyz"` handles `new Abc()` where `Abc` is imported from `xyz`), or a call expression (`"abc.def()"`). `"..."` stands for the defaults, so you extend rather than replace them. Set it to `false` to stop webpack from bundling workers at all.
+
+**webpack.config.js**
+
+```js
+export default {
+  module: {
+    parser: {
+      javascript: {
+        worker: ["MyWorker from ./my-worker.js", "..."],
+      },
+    },
+  },
+};
+```
+
+T> [`module.parser.javascript.worklet`](#moduleparserjavascriptworklet) does the same for worklets, and the dynamic-dependency options (`exprContext*`, `unknownContext*`, `wrappedContext*`) are described under [Module Contexts](#module-contexts).
 
 - Type: `boolean`
 - Available: 5.17.0+
@@ -1960,6 +2022,10 @@ export default {
 
 Specify the layer in which the module should be placed in. A group of modules could be united in one layer which could then be used in [split chunks](/plugins/split-chunks-plugin/#splitchunkscachegroupscachegrouplayer), [stats](/configuration/stats/#statsgroupmodulesbylayer) or [entry options](/configuration/entry-context/#entry-descriptor).
 
+A module reached through a dynamic ``import(`./dir/${name}`)`` is resolved through a context module, which inherits the layer of the module that imported it. The modules it can resolve to therefore end up in the importer's layer unless a rule places them elsewhere, the same way a statically imported module would.
+
+The layer a module ended up in is readable from the module itself as [`__webpack_layer__`](/api/module-variables/#__webpack_layer__-webpack-specific).
+
 **webpack.config.js**
 
 ```js
@@ -2340,6 +2406,80 @@ export default {
 ## Rule.resource
 
 A [`Condition`](#condition) matched with the resource. See details in [`Rule` conditions](#rule-conditions).
+
+## Rule.realResource
+
+A [`Condition`](#condition) matched with the real resource — the path of the file that is actually read. It differs from [`Rule.resource`](#ruleresource) only when a [match resource](/api/loaders/#inline-matchresource) (`!=!`) made webpack apply the rules of a different path, in which case `resource` is the pretended one and `realResource` the file on disk.
+
+## Rule.resourceFragment
+
+A [`Condition`](#condition) matched with the fragment of the request, i.e. everything from the `#` onwards. For `import Foo from './foo.svg#icon'` the fragment is `#icon`:
+
+**webpack.config.js**
+
+```js
+export default {
+  // ...
+  module: {
+    rules: [
+      {
+        test: /\.svg$/,
+        resourceFragment: /^#icon$/,
+        type: "asset/inline",
+      },
+    ],
+  },
+};
+```
+
+## Rule.descriptionData
+
+A set of [`Condition`](#condition)s matched against the contents of the module's description file, which is usually the closest `package.json`. Each key names a property to test — nested properties are addressed by a dotted key:
+
+**webpack.config.js**
+
+```js
+export default {
+  // ...
+  module: {
+    rules: [
+      {
+        descriptionData: {
+          type: "module",
+        },
+        // ...
+      },
+    ],
+  },
+};
+```
+
+Like [`Rule.descriptionRelativePath`](#ruledescriptionrelativepath), the condition does not apply when a match resource replaced the resource.
+
+## Rule.dependency
+
+A [`Condition`](#condition) matched with the type of the dependency that requested the module, which is how a rule can treat the same file differently depending on how it was imported. Values webpack uses include `'esm'` for an `import`, `'commonjs'` for a `require()`, `'url'` for a `new URL()`, `'worker'` for a worker constructor, `'amd'`, `'css-import'` and `'unknown'`.
+
+**webpack.config.js**
+
+```js
+export default {
+  // ...
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        dependency: "url",
+        type: "asset/resource",
+      },
+    ],
+  },
+};
+```
+
+## Rule.phase
+
+A [`Condition`](#condition) matched with the [import phase](https://github.com/tc39/proposal-defer-import-eval) of the dependency: `'evaluation'` for an ordinary import, `'defer'` for `import defer`, and `'source'` for `import source`.
 
 ## Rule.resourceQuery
 

--- a/src/content/configuration/optimization.mdx
+++ b/src/content/configuration/optimization.mdx
@@ -554,6 +554,32 @@ W> These options configure the minimizer webpack installs by default. Replacing 
 
 Handed to the JavaScript minimizer as-is, defaulting to `{ compress: { passes: 2 } }`; `false` disables JavaScript minimizing while leaving CSS and HTML minimized.
 
+## optimization.minimizeOptions
+
+`object`
+
+<Badge text="5.110.0+" />
+
+The same per-asset-type object as above, set separately from [`optimization.minimize`](#optimizationminimize). Passing the object to `minimize` is a shorthand: webpack normalizes `minimize: { css: … }` to `minimize: true` plus `minimizeOptions: { css: … }`, so the two forms below are equivalent.
+
+**webpack.config.js**
+
+```js
+export default {
+  // ...
+  optimization: {
+    minimize: true,
+    minimizeOptions: {
+      css: {
+        comments: false,
+      },
+    },
+  },
+};
+```
+
+Reach for it when minimizing is switched on elsewhere — by the [`mode`](/configuration/mode/) default or by a config that is merged with yours — and you only want to adjust how it is done. It is also the property plugins see, since `optimization.minimize` is always a boolean after normalization.
+
 ## optimization.minimizer
 
 `[MinimizerPlugin]` and or `[function (compiler)]` or `undefined | null | 0 | false | ""`

--- a/src/content/configuration/stats.mdx
+++ b/src/content/configuration/stats.mdx
@@ -208,6 +208,23 @@ export default {
 };
 ```
 
+### stats.chunkGroupResourceHints
+
+`boolean = false`
+
+Include the resolved resource-hint descriptors of each entrypoint as `entrypoints[name].resourceHints`, combining [`output.resourceHints.chunks`](/configuration/output/#outputresourcehints) (the `modulepreload` / `preload` / `prefetch` hints for the initial graph) with `output.resourceHints.assets` (fonts, images and other URL-referenced assets).
+
+It lets a server-side renderer emit the `<link>` tags itself instead of walking the chunk graph. It is `false` in `stats.toString()` and `true` in `stats.toJson()`.
+
+```js
+export default {
+  // ...
+  stats: {
+    chunkGroupResourceHints: true,
+  },
+};
+```
+
 ### stats.chunkGroupMaxAssets
 
 `number`

--- a/src/content/plugins/module-federation-plugin.mdx
+++ b/src/content/plugins/module-federation-plugin.mdx
@@ -57,6 +57,38 @@ export default {
 };
 ```
 
+### exposes
+
+The modules this container makes available to other builds. The property name is the public name a consumer imports (`import Button from "remote/Button"`), the value the module to expose:
+
+**webpack.config.js**
+
+```js
+new ModuleFederationPlugin({
+  name: "remote",
+  exposes: {
+    "./Button": "./src/components/Button",
+  },
+});
+```
+
+An entry can also be an object:
+
+- `import` (`string`): the module to expose.
+- `name` (`string`): the name of the chunk webpack generates for it. Without it the chunk is named after the module's internal id, which changes as the build changes; setting it gives the file a stable name that can be referenced statically.
+
+```js
+new ModuleFederationPlugin({
+  name: "remote",
+  exposes: {
+    "./Button": {
+      import: "./src/components/Button",
+      name: "button-chunk",
+    },
+  },
+});
+```
+
 ### Sharing libraries
 
 With the `shared` key in the configuration you can define libraries that are shared between your federated modules. The package name is the same as the one found in the `dependencies` section of your package.json. However, by default webpack will only share the root level of a library.

--- a/src/content/plugins/split-chunks-plugin.mdx
+++ b/src/content/plugins/split-chunks-plugin.mdx
@@ -365,6 +365,28 @@ Figure out which exports are used by modules to mangle export names, omit unused
 
 Defaults to `true` when [`optimization.usedExports`](/configuration/optimization/#optimizationusedexports) is `true` (the case in `production` mode) and to `false` otherwise.
 
+### splitChunks.fallbackCacheGroup
+
+`object`
+
+Options for the modules that no cache group selected, which is the group webpack uses when it has to split a chunk further to honour [`maxSize`](#splitchunksmaxsize). It accepts `chunks`, `minSize`, `maxSize`, `maxAsyncSize`, `maxInitialSize` and `automaticNameDelimiter`, each defaulting to the value set at `splitChunks` level.
+
+**webpack.config.js**
+
+```js
+export default {
+  // ...
+  optimization: {
+    splitChunks: {
+      fallbackCacheGroup: {
+        maxSize: 100000,
+        automaticNameDelimiter: "~",
+      },
+    },
+  },
+};
+```
+
 ### splitChunks.cacheGroups
 
 Cache groups can inherit and/or override any options from `splitChunks.*`; but `test`, `priority` and `reuseExistingChunk` can only be configured on cache group level. To disable any of the default cache groups, set them to `false`.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

An audit of webpack's schemas, hook definitions, `APIPlugin` and loader context against every heading on the site turned up options, hooks and module variables that are reachable but documented nowhere. Closes #3843, Closes #4421, Closes #4496, Closes #6876.

Added: the 4 `Compiler`, 22 `Compilation` and 16 `JavascriptParser` hooks that had no entry (all three are now complete); `optimization.minimizeOptions`; the `Rule` conditions `dependency`, `descriptionData`, `phase`, `realResource` and `resourceFragment`; the parser options `worker`, `createRequire`, `dynamicUrl` and `strictThisContextOnImports`; the module variables `__webpack_layer__`, `__webpack_nonce__`, `__webpack_chunkname__`, `__webpack_init_sharing__`, `__webpack_share_scopes__` and `__system_context__`; `this.addBuildDependency`; `compilation.getCache` and the `CacheFacade`; the `moduleGraph` / `chunkGraph` APIs with a table mapping every deprecated `Chunk` / `Module` member to its replacement; `exposes`' `name` option; plus `stats.chunkGroupResourceHints`, `splitChunks.fallbackCacheGroup` and the CSS generator options.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

docs

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

No, content-only change; `lint:js`, `lint:prettier`, `lint:markdown` and `jest` pass locally.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes. AI was used to script the audit (schema properties, `this.hooks` blocks, `APIPlugin`, `NormalModule`'s loader context against the site's headings), to read each hook's call site and each option's schema entry and defaults for the descriptions, and to draft the text. Every entry was checked against the source before writing, and the audit was re-run afterwards to confirm no gaps remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT)_