### PR TITLE
docs: document intermediateFileSystem, the id plugins, rule merging and serialization

### DIFF
--- a/src/content/api/compilation-object.mdx
+++ b/src/content/api/compilation-object.mdx
@@ -408,5 +408,6 @@ Accessing the old members still works, but logs a deprecation warning naming a `
 | `module.usedExports`           | `moduleGraph.getUsedExports(module, runtime)`        |
 | `module.optimizationBailout`   | `moduleGraph.getOptimizationBailout(module)`         |
 | `module.profile`               | `moduleGraph.getProfile(module)`                     |
+| `dependency.originModule`      | `moduleGraph.getParentModule(dependency)`            |
 
 T> Outside a hook that hands you the compilation you can still reach a graph through `ChunkGraph.getChunkGraphForChunk(chunk, ...)` / `ModuleGraph.getModuleGraphForModule(module, ...)`, but taking it from the compilation is preferred.

--- a/src/content/api/node.mdx
+++ b/src/content/api/node.mdx
@@ -388,6 +388,18 @@ compiler.run((err, stats) => {
 });
 ```
 
+webpack distinguishes three file systems on the compiler:
+
+| Property                 | Used for                                                                                              |
+| ------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `inputFileSystem`        | Reading the files that are compiled — sources, `package.json`, everything the resolver touches.       |
+| `outputFileSystem`       | Writing the emitted assets.                                                                           |
+| `intermediateFileSystem` | Reading and writing files that are neither input nor output: the persistent cache, records, profiles. |
+
+`intermediateFileSystem` defaults to Node's `fs`. Set it when a build has to run without touching the disk at all, since replacing `outputFileSystem` alone still leaves the [cache](/configuration/cache/) and [records](/configuration/other-options/#recordspath) writing to it.
+
+W> `outputFileSystem` no longer needs an `mkdirp` method, and `join` is optional on it — webpack falls back to its own implementation when the file system does not provide one.
+
 Note that this is what
 [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware),
 used by [webpack-dev-server](https://github.com/webpack/webpack-dev-server)

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -2716,6 +2716,31 @@ W> `Rule.resolve` is Available since webpack 4.36.1
 Resolving can be configured on module level. See all available options on [resolve configuration page](/configuration/resolve/#resolve).
 All applied resolve options get deeply merged with higher level [resolve](/configuration/resolve/#resolve).
 
+The merge is per property: an object is merged into the one above it, while an array **replaces** the one above it. Use the `"..."` item to keep the outer value instead, at the position you put it — the same convention [`resolve.extensions`](/configuration/resolve/#resolveextensions) and the other array options use at the top level. `Rule.parser` is merged the same way, and so are the options passed to [`this.getResolve(options)`](/api/loaders/#thisgetresolve) in a loader.
+
+```js
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.txt$/,
+        resolve: {
+          // only .txt and .md are tried here, the outer extensions are dropped
+          extensions: [".txt", ".md"],
+        },
+      },
+      {
+        test: /\.mdx$/,
+        resolve: {
+          // .mdx is tried first, then whatever the outer config had
+          extensions: [".mdx", "..."],
+        },
+      },
+    ],
+  },
+};
+```
+
 For example, let's imagine we have an entry in `./src/index.js`, `./src/footer/default.js` and a `./src/footer/overridden.js` to demonstrate the module level resolve.
 
 **./src/index.js**

--- a/src/content/configuration/optimization.mdx
+++ b/src/content/configuration/optimization.mdx
@@ -716,6 +716,23 @@ export default {
 | `salt`           | `number`                       | `0`                | Mixed into the hash. Change it to move every id, for example to work around a collision.                                                                          |
 | `failOnConflict` | `boolean`                      | `false`            | Fails the build on a colliding id instead of rehashing it.                                                                                                        |
 
+### The id plugins
+
+Each value of `moduleIds` and `chunkIds` is implemented by a plugin under `webpack.ids`, which you can also use directly after setting the option to `false`. They are what the webpack 4 plugins of similar names became:
+
+| Plugin                                     | Equivalent to                | Options                                                                              |
+| ------------------------------------------ | ---------------------------- | ------------------------------------------------------------------------------------ |
+| `webpack.ids.NaturalModuleIdsPlugin`       | `moduleIds: 'natural'`       | —                                                                                    |
+| `webpack.ids.NamedModuleIdsPlugin`         | `moduleIds: 'named'`         | `context`                                                                            |
+| `webpack.ids.DeterministicModuleIdsPlugin` | `moduleIds: 'deterministic'` | see above                                                                            |
+| `webpack.ids.OccurrenceModuleIdsPlugin`    | `moduleIds: 'size'`          | `prioritiseInitial`                                                                  |
+| `webpack.ids.NamedChunkIdsPlugin`          | `chunkIds: 'named'`          | `context`, `delimiter`                                                               |
+| `webpack.ids.DeterministicChunkIdsPlugin`  | `chunkIds: 'deterministic'`  | see above                                                                            |
+| `webpack.ids.OccurrenceChunkIdsPlugin`     | `chunkIds: 'size'`           | `prioritiseInitial`                                                                  |
+| `webpack.ids.ChunkModuleIdRangePlugin`     | —                            | `name`, `order`, `start`, `end` — assigns ids in a range to the modules of one chunk |
+
+`context` makes the generated names relative to a directory other than the compiler's, and `prioritiseInitial` gives modules of initial chunks the shorter ids.
+
 W> `moduleIds: 'deterministic'` was added in webpack 5 and `moduleIds: 'hashed'` is deprecated in favor of it.
 
 W> `moduleIds: total-size` has been removed in webpack 5.

--- a/src/content/contribute/writing-a-plugin.mdx
+++ b/src/content/contribute/writing-a-plugin.mdx
@@ -507,6 +507,60 @@ vendor.js
 styles.css
 ```
 
+## Making your own classes cacheable
+
+A plugin that adds its own `Module` or `Dependency` class has to say how instances of it are written to and read from the [persistent cache](/configuration/cache/), or the cache will refuse to store anything that references them. `webpack.util.serialization` is the API for that:
+
+```js
+import webpack from "webpack";
+
+class MyDependency extends webpack.dependencies.ModuleDependency {
+  constructor(request, myOption) {
+    super(request);
+    this.myOption = myOption;
+  }
+
+  get type() {
+    return "my dependency";
+  }
+
+  serialize(context) {
+    const { write } = context;
+    // only this class's own fields — the base class writes its own
+    write(this.myOption);
+    super.serialize(context);
+  }
+
+  deserialize(context) {
+    const { read } = context;
+    this.myOption = read();
+    super.deserialize(context);
+  }
+}
+
+webpack.util.serialization.register(
+  MyDependency,
+  // the request webpack will `require` to get this class back when reading the
+  // cache, so it has to resolve to the file that registers it
+  "my-plugin/MyDependency",
+  null,
+  {
+    serialize(obj, context) {
+      obj.serialize(context);
+    },
+    deserialize(context) {
+      const obj = new MyDependency();
+      obj.deserialize(context);
+      return obj;
+    },
+  },
+);
+```
+
+The module also exposes `registerNotSerializable(Constructor)` for classes that must never be written, and `registerLoader(regExp, loader)` for resolving a request to the module that registers it.
+
+W> A class that is reachable from the module graph and is not registered makes the whole entry uncacheable, and webpack reports it as `No serializer registered for <Class>` with [`infrastructureLogging.debug`](/configuration/infrastructureLogging/) enabled.
+
 ## Testing your plugin
 
 Testing plugins is similar to testing any other build tool. The recommended approach is to run a webpack compilation with your plugin enabled and verify that the compilation produces the expected result.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Triaging the webpack 5 "Document webpack change" requests left a handful whose API is real, public and still undocumented. Closes #3110, Closes #2492, Closes #3025, Closes #3197, Closes #2428, Closes #2741.

Adds: the compiler's three file systems including `intermediateFileSystem`, which the cache and records write through even when `outputFileSystem` is replaced; a table of the `webpack.ids.*` plugins behind each `moduleIds` / `chunkIds` value with their options; how `Rule.resolve` and `Rule.parser` arrays merge and what `"..."` does there; `moduleGraph.getParentModule` in the deprecation table; and a section on making a plugin's own `Module` / `Dependency` classes cacheable with `webpack.util.serialization`.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

docs

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

No, content-only change; `lint:js`, `lint:prettier`, `lint:markdown` and `jest` pass locally.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes. AI was used to triage the remaining documentation issues against the current docs, to read the relevant source (`lib/Compiler.js`, `lib/ids/*`, `lib/index.js`, `lib/serialization/ObjectMiddleware.js`, `lib/dependencies/ModuleDependency.js`) for the option names, defaults and serialize/deserialize contract, and to draft the text. Each statement was checked against that source; the serialization example was corrected after checking that `ModuleDependency` already serializes its own fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT)_