### PR TITLE
docs: container plugin options, shared version ranges, ts-node overrides and conditional polyfills

### DIFF
--- a/src/content/comparison.mdx
+++ b/src/content/comparison.mdx
@@ -1,6 +1,6 @@
 ---
 title: Comparison
-description: A feature-by-feature comparison of webpack with Rollup, Parcel, Browserify and other bundlers.
+description: A feature-by-feature comparison of webpack with Rollup, Browserify, RequireJS, JSPM and Brunch.
 sort: 1
 contributors:
   - pksjce

--- a/src/content/concepts/module-federation.mdx
+++ b/src/content/concepts/module-federation.mdx
@@ -69,11 +69,26 @@ This applies to a host and a single remote as much as to several remotes, and it
 
 ### ContainerPlugin (low level)
 
-This plugin creates an additional container entry with the specified exposed modules.
+This plugin creates an additional container entry with the specified exposed modules. Use it when you only expose modules and consume none, or when you need to control the container entry itself:
+
+| Option       | Description                                                                                                 |
+| ------------ | ----------------------------------------------------------------------------------------------------------- |
+| `name`       | The name of the container, which is also the global a consumer reads it from.                               |
+| `exposes`    | The modules to expose, as described under [`exposes`](/plugins/module-federation-plugin/#exposes).          |
+| `filename`   | The filename of the container entry, relative to [`output.path`](/configuration/output/#outputpath).        |
+| `library`    | How the container is exposed, as a [`library`](/configuration/output/#outputlibrary) — `type` and `name`.   |
+| `runtime`    | The name of the runtime chunk. When set, the container is added to that runtime instead of getting its own. |
+| `shareScope` | The share scope this container puts its shared modules into, `'default'` by default.                        |
 
 ### ContainerReferencePlugin (low level)
 
 This plugin adds specific references to containers as externals (of the configured `remoteType`) and allows to import remote modules from these containers. At runtime it initializes the share scope via `__webpack_init_sharing__`, which passes that scope to the `init()` method of each referenced container, and then loads remote modules through the container's `get()` method.
+
+| Option       | Description                                                                                                                        |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `remotes`    | The containers to consume, as `name: "container@url"` — the same value `ModuleFederationPlugin` takes.                             |
+| `remoteType` | How a remote is loaded, as an [`externalsType`](/configuration/externals/#externalstype); `'script'` is the usual one for the web. |
+| `shareScope` | The share scope handed to every remote's `init()`, `'default'` by default.                                                         |
 
 ### ModuleFederationPlugin (high level)
 

--- a/src/content/configuration/configuration-languages.mdx
+++ b/src/content/configuration/configuration-languages.mdx
@@ -111,11 +111,12 @@ Starting with v22.18.0 Node.js supports built-in [type stripping](https://nodejs
 
 > To enable the transformation of non erasable TypeScript syntax, which requires JavaScript code generation, such as enum declarations, parameter properties use the flag [--experimental-transform-types](https://nodejs.org/api/cli.html#experimental-transform-types).
 
-If you are using an older version of Node.js that does not support the `typescript` format, or want to set `module` in `compilerOptions` in `tsconfig.json` to `commonjs` there are three solutions to this issue:
+If you are using an older version of Node.js that does not support the `typescript` format, or want to set `module` in `compilerOptions` in `tsconfig.json` to `commonjs` there are four solutions to this issue:
 
 - Modify `tsconfig.json`.
 - Modify `tsconfig.json` and add settings for `ts-node`.
-- Install `tsconfig-paths`.
+- Tell `ts-node` the module type of the config file.
+- Point `ts-node` at a separate TypeScript configuration.
 
 The **first option** is to open your `tsconfig.json` file and look for `compilerOptions`. Set `target` to `"ES5"` and `module` to `"CommonJS"` (or completely remove the `module` option).
 
@@ -136,13 +137,22 @@ You can keep `"module": "ESNext"` for `tsc`, and if you use webpack, or another 
 }
 ```
 
-The **third option** is to install the `tsconfig-paths` package:
+The **third option** is [`moduleTypes`](https://typestrong.org/ts-node/docs/module-type-overrides), which overrides the module type for the config file alone. It is usually the better of the two overrides: unlike `compilerOptions.module` it also tells Node.js to load that file as CommonJS, which avoids the error you get when Node is asked to `require()` an ES module.
 
-```bash
-npm install --save-dev tsconfig-paths
+```json
+{
+  "compilerOptions": {
+    "module": "ESNext"
+  },
+  "ts-node": {
+    "moduleTypes": {
+      "webpack.config.ts": "cjs"
+    }
+  }
+}
 ```
 
-And create a separate TypeScript configuration specifically for your webpack configs:
+The **fourth option** is to create a separate TypeScript configuration specifically for your webpack configs:
 
 **tsconfig-for-webpack-config.json**
 
@@ -156,9 +166,9 @@ And create a separate TypeScript configuration specifically for your webpack con
 }
 ```
 
-T> `ts-node` can resolve a `tsconfig.json` file using the environment variable provided by `tsconfig-paths`.
+T> `TS_NODE_PROJECT` is read by `ts-node` itself, so no additional package is needed to use it.
 
-Then set the environment variable `process.env.TS_NODE_PROJECT` provided by `tsconfig-paths` like so:
+Then set the environment variable `TS_NODE_PROJECT` like so:
 
 **package.json**
 

--- a/src/content/guides/ecma-script-modules.mdx
+++ b/src/content/guides/ecma-script-modules.mdx
@@ -191,7 +191,7 @@ console.log(foo); // 1 - named imports read properties of module.exports
 This interop applies when webpack treats the **imported** module as CommonJS.
 If that module itself uses ESM `export` syntax, webpack will auto-detect it as ESM
 and use its exports directly. This commonly affects projects that mix `.js` files
-files in a project that has `"type": "module"` set - webpack may treat some files as
+in a project that has `"type": "module"` set - webpack may treat some files as
 ESM while third-party packages in `node_modules` remain CommonJS.
 
 T> This is webpack's bundling behavior. When Node.js itself loads a CommonJS module from ESM,

--- a/src/content/guides/shimming.mdx
+++ b/src/content/guides/shimming.mdx
@@ -494,6 +494,78 @@ import "core-js/modules/web.dom.iterable";
 
 See [the babel-preset-env documentation](https://babeljs.io/docs/en/babel-preset-env) for more information.
 
+### Serving a smaller polyfill to modern browsers
+
+The same set of polyfills can be compiled twice and the right one picked at runtime, so that browsers which need little only download little. The entry decides which build to fetch, and both are loaded before the application:
+
+**src/index.js**
+
+{/* eslint-skip */}
+
+```js
+(async () => {
+  if (isLegacyBrowser()) {
+    await import("./polyfills?legacy");
+  } else {
+    await import(/* webpackMode: "eager" */ "./polyfills");
+  }
+  await import(/* webpackMode: "eager" */ "./app");
+})();
+```
+
+**src/polyfills.js**
+
+{/* eslint-skip */}
+
+```js
+import "core-js";
+import "regenerator-runtime/runtime";
+```
+
+The two builds differ only in what Babel is told to target, which [`Rule.resourceQuery`](/configuration/module/#ruleresourcequery) selects through the `?legacy` query:
+
+**webpack.config.js**
+
+```js
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        include: [path.resolve(__dirname, "src")],
+        oneOf: [
+          {
+            resourceQuery: /legacy/,
+            loader: "babel-loader",
+            options: {
+              presets: [
+                [
+                  "@babel/preset-env",
+                  { useBuiltIns: "entry", targets: "ie 11" },
+                ],
+              ],
+            },
+          },
+          {
+            loader: "babel-loader",
+            options: {
+              presets: [
+                [
+                  "@babel/preset-env",
+                  { useBuiltIns: "entry", targets: "last 2 versions" },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+```
+
+W> This is the trade-off the section above warns about: the polyfills now load asynchronously, so nothing outside the entry may run before they do — which is why the application itself is imported rather than being part of the entry. `isLegacyBrowser()` also has to be written in syntax the oldest target parses, since it runs before any polyfill.
+
 ## Node Built-Ins
 
 Node built-ins like `global`, `__dirname` and `__filename` can be handled directly from your configuration file with the [`node`](/configuration/node) option, without the use of any special loaders or plugins. `process` and Node core modules such as `buffer` are not polyfilled by webpack 5; provide them with [`ProvidePlugin`](/plugins/provide-plugin/) or [`resolve.fallback`](/configuration/resolve/#resolvefallback). See the [node configuration page](/configuration/node) for more information and examples.

--- a/src/content/plugins/module-federation-plugin.mdx
+++ b/src/content/plugins/module-federation-plugin.mdx
@@ -235,6 +235,10 @@ The package name that is used to determine required version from description fil
 
 This field specifies the required version of the package. It accepts semantic versioning, such as "^1.2.3". Additionally, it retrieves the version if it's provided as a URL, for instance: "git+ssh://git@github.com:foo/bar.git#v1.0.0".
 
+webpack implements the full [range grammar](https://github.com/npm/node-semver#ranges), so a required version can be an exact version (`1.2.3`), a partial one (`1.2`, which matches any patch), a comparator (`>=1.2.3 <2`), a caret or tilde range (`^1.2.3`, `~1.2.3`), a hyphen range (`1.2.3 - 2.3.4`) or several of those joined with `||`. Set it to `false` to accept whatever the scope offers.
+
+A share scope can hold several versions of the same module at once — each build provides the version it has, and a consumer gets the highest one that satisfies its own `requiredVersion`. That is what lets two builds that need different major versions of a library work on one page, at the cost of shipping both. `singleton: true` gives up that guarantee to keep one instance, and warns when the chosen version does not satisfy a consumer.
+
 ##### **`shareKey`**
 
 `string`


### PR DESCRIPTION
**Summary**

Fills the remaining documentation gaps reported for Module Federation, TypeScript configs and shimming:

- `ContainerPlugin` / `ContainerReferencePlugin` now have option tables on the Module Federation concept page, instead of being mentioned only by name.
- `requiredVersion` documents the full semver range grammar webpack implements, and explains that a share scope can hold several versions at once (and what `singleton: true` gives up).
- The TypeScript config page documents `ts-node.moduleTypes` as a per-file override, corrects the note about `TS_NODE_PROJECT` (it is read by `ts-node` itself, no extra package needed), and lists the four ways to make a `webpack.config.ts` load under CommonJS.
- The shimming guide gains a "Serving a smaller polyfill to modern browsers" section showing a conditional polyfill load.
- Drive-by: the comparison page no longer lists a tool it does not compare against, and a duplicated word in the ESM guide is removed.

Closes #3743, Closes #3757, Closes #3820, Closes #6154, Closes #6750

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

n/a — documentation only; lint, prettier, markdownlint and the jest suite pass locally.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — this PR is the documentation.

**Use of AI**

Claude Code was used to cross-check the documented behaviour against webpack's sources (`lib/container/`, `lib/sharing/`, `lib/util/semver.js`) and to draft the prose and tables. Every option, default and example was verified against the schemas and implementation, and the result was reviewed and edited before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT)_