### PR TITLE
docs: add Module Object page, deploy chunk load errors and HMR record persistence

### DIFF
--- a/src/content/api/loaders.mdx
+++ b/src/content/api/loaders.mdx
@@ -530,7 +530,7 @@ In [the example](#example-for-the-loader-context): in loader1: `0`, in loader2: 
 loadModule(request: string, callback: function(err, source, sourceMap, module))
 ```
 
-Resolves the given request to a module, applies all configured loaders and calls back with the generated source, the sourceMap and the module instance (usually an instance of [`NormalModule`](https://github.com/webpack/webpack/blob/main/lib/NormalModule.js)). Use this function if you need to know the source code of another module to generate the result.
+Resolves the given request to a module, applies all configured loaders and calls back with the generated source, the sourceMap and the module instance (usually an instance of [`NormalModule`](/api/module-object/#properties-of-a-normalmodule)). Use this function if you need to know the source code of another module to generate the result.
 
 `this.loadModule` in a loader context uses CommonJS resolve rules by default. Use `this.getResolve` with an appropriate `dependencyType`, e.g. `'esm'`, `'commonjs'` or a custom one before using a different semantic.
 

--- a/src/content/api/module-object.mdx
+++ b/src/content/api/module-object.mdx
@@ -1,0 +1,167 @@
+---
+title: Module Object
+description: The properties and methods of a webpack Module that plugins and loaders can rely on.
+group: Objects
+sort: 14
+contributors:
+  - hai-x
+---
+
+Every file webpack builds becomes a `Module` in the [compilation](/api/compilation-object/). Plugins meet them everywhere — iterating `compilation.modules`, on the `succeedModule` hook, behind `moduleGraph.getIssuer(module)` — and a loader can reach its own through the loader context.
+
+`Module` is a base class. What a build actually holds is one of its subclasses, and which one depends on where the module came from:
+
+| Class                | Comes from                                                                                                                 |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `NormalModule`       | a resolved file processed by loaders — the usual case                                                                      |
+| `RawModule`          | source webpack generated itself, with no file behind it                                                                    |
+| `ExternalModule`     | a request matched by [`externals`](/configuration/externals/)                                                              |
+| `ContextModule`      | a [context](/guides/dependency-management/), i.e. a `require` of an expression                                             |
+| `ConcatenatedModule` | several modules merged by [`optimization.concatenateModules`](/configuration/optimization/#optimizationconcatenatemodules) |
+| `DllModule`          | a module delivered by [`DllReferencePlugin`](/plugins/dll-plugin/)                                                         |
+
+W> Test with `instanceof` (`module instanceof compiler.webpack.NormalModule`) rather than by name or by `module.type` — [`type`](#type) says which kind of source the module holds, not which class it is.
+
+## Properties on every module
+
+### type
+
+`string`
+
+The module type, e.g. `'javascript/auto'`, `'javascript/esm'`, `'json'`, `'css/auto'`, `'asset/resource'`, `'webassembly/async'`. A plugin can add its own, so match a prefix rather than a fixed list when you mean "any JavaScript".
+
+### layer
+
+`string | null`
+
+The [layer](/configuration/module/#rulelayer) the module was built in, or `null`.
+
+### context
+
+`string | null`
+
+The absolute path of the directory the module's requests are resolved against.
+
+### buildMeta
+
+`object`
+
+What the parser worked out about the module, filled during the build. The fields a plugin normally reads:
+
+| Field                 | Meaning                                                                                                     |
+| --------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `exportsType`         | how the module's exports are consumed: `'namespace'`, `'default'`, `'flagged'`, `'dynamic'`, or `undefined` |
+| `defaultObject`       | how a `default` import of a CommonJS module is built: `false`, `'redirect'`, `'redirect-warn'`              |
+| `strictHarmonyModule` | the module is ESM and must be treated strictly                                                              |
+| `async`               | the module is asynchronous (top-level `await`)                                                              |
+| `sideEffectFree`      | the module was determined to have no side effects                                                           |
+
+### buildInfo
+
+`object`
+
+What the build itself produced — dependencies to watch, assets emitted from the module, and whether the result may be cached:
+
+| Field                                                            | Meaning                                                                               |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `cacheable`                                                      | `false` when a loader called `this.cacheable(false)`                                  |
+| `fileDependencies`, `contextDependencies`, `missingDependencies` | paths watched for changes, as collected from the loader context                       |
+| `buildDependencies`                                              | paths whose change invalidates the persistent cache, from `this.addBuildDependency()` |
+| `assets`, `assetsInfo`                                           | assets the module emitted through `this.emitFile()`                                   |
+| `strict`, `exportsArgument`, `moduleArgument`                    | set by the parser; they shape the code the generator emits                            |
+| `hash`                                                           | the hash of the build result                                                          |
+
+`buildInfo` is serialized with the module, so it is also where a loader leaves data for a plugin to pick up: it is still there on a build restored from the [persistent cache](/configuration/cache/#cachetype), where the loader itself never runs again. Store plain, serializable values only, under a property named after your plugin.
+
+W> Both are `undefined` until the module is built. Read them from `succeedModule`, `finishModules` or later, never from `buildModule`.
+
+### dependencies
+
+`Dependency[]`
+
+What the module requires. `presentationalDependencies` holds the ones that only affect code generation, and `blocks` (`AsyncDependenciesBlock[]`) the ones behind an `import()`. To find the module a dependency points at, ask the graph: `moduleGraph.getModule(dependency)`.
+
+### factoryMeta
+
+`object`
+
+Set by the module factory before the build, e.g. `sideEffectFree` derived from the package's `sideEffects` field.
+
+T> `module.id`, `module.hash`, `module.issuer`, `module.usedExports` and friends are deprecated — a module can take part in more than one graph, so those values live on `chunkGraph` and `moduleGraph` now. The [replacement table](/api/compilation-object/#module-and-chunk-graphs) lists them all.
+
+## Methods on every module
+
+### identifier
+
+`function () => string`
+
+A string that identifies the module uniquely in the compilation — the request with all loaders and their options. It is the key `compilation.findModule` looks up.
+
+### readableIdentifier
+
+`function (requestShortener) => string`
+
+The same identity in the shortened form stats and warnings print. Take the shortener from `compilation.requestShortener`.
+
+### originalSource
+
+`function () => Source | null`
+
+The module's source before code generation, or `null` for a module that has none.
+
+### getSourceTypes
+
+`function () => Set<string>`
+
+Which kinds of code the module can generate, e.g. `'javascript'`, `'css'`, `'asset'`. Ask the module instead of deriving it from `type`.
+
+### size
+
+`function (type) => number`
+
+The size of the module's source of that type, in bytes.
+
+### nameForCondition
+
+`function () => string | null`
+
+The path [rule conditions](/configuration/module/#condition) are matched against — the resource without its query and fragment. `null` when the module has no file behind it.
+
+### addError / addWarning / getErrors / getWarnings
+
+`function`
+
+Diagnostics attached to the module. One added here is reported against the module and survives into the cache, unlike a `compilation.errors` entry pushed after seal.
+
+## Properties of a NormalModule
+
+A `NormalModule` is a resolved file plus the loaders applied to it, so it carries the parts of the request separately:
+
+| Property              | Example for `'babel-loader!./src/app.js?x=1'`                                            |
+| --------------------- | ---------------------------------------------------------------------------------------- |
+| `request`             | the full request with all resolved loaders, `'/abs/babel-loader.js!/abs/src/app.js?x=1'` |
+| `userRequest`         | the request without automatically added loaders                                          |
+| `rawRequest`          | the request as written in the source, `'./app.js?x=1'`                                   |
+| `resource`            | the resolved file with query and fragment, `'/abs/src/app.js?x=1'`                       |
+| `matchResource`       | the [`!=!` match resource](/api/loaders/#inline-matchresource), if any                   |
+| `resourceResolveData` | what the resolver returned — `descriptionFileData` holds the package.json                |
+| `loaders`             | `[{ loader, options, ident, type }]` in the order they run                               |
+| `binary`              | `true` for asset and WebAssembly modules, whose source is a `Buffer`                     |
+
+A loader reaches its own module as `this._module`. That property is not part of the documented [loader context](/api/loaders/), but loader/plugin pairs rely on it.
+
+```js
+class MyPlugin {
+  apply(compiler) {
+    const { NormalModule } = compiler.webpack;
+
+    compiler.hooks.compilation.tap("MyPlugin", (compilation) => {
+      compilation.hooks.succeedModule.tap("MyPlugin", (module) => {
+        if (!(module instanceof NormalModule)) return;
+
+        console.log(module.resource, module.getSourceTypes());
+      });
+    });
+  }
+}
+```

--- a/src/content/concepts/hot-module-replacement.mdx
+++ b/src/content/concepts/hot-module-replacement.mdx
@@ -41,7 +41,9 @@ In addition to normal assets, the compiler needs to emit an "update" to allow up
 
 The manifest lists the ids of the updated chunks, the removed chunks and the removed modules. Each update chunk contains the new code for its updated modules; the update for the runtime chunk also carries the new compilation hash.
 
-The compiler ensures that module IDs and chunk IDs are consistent between these builds. It typically stores these IDs in memory (e.g. with [webpack-dev-server](/configuration/dev-server/)), but it's also possible to store them in a JSON file.
+The compiler ensures that module IDs and chunk IDs are consistent between these builds. A watching compiler keeps them in memory, which is all a dev server needs. To keep them consistent across separate compiler runs — a build on one machine that has to produce updates applicable to a build from another — write them to a JSON file with [`recordsPath`](/configuration/other-options/#recordspath).
+
+T> The update files are emitted like any other asset, so under [webpack-dev-server](/configuration/dev-server/) they live in memory and are served from there. Set [`devServer.devMiddleware.writeToDisk`](/configuration/dev-server/#devserverdevmiddleware) when something outside the server has to read them from `output.path`.
 
 ### In a Module
 

--- a/src/content/contribute/writing-a-plugin.mdx
+++ b/src/content/contribute/writing-a-plugin.mdx
@@ -158,7 +158,7 @@ class HelloCompilationPlugin {
 export default HelloCompilationPlugin;
 ```
 
-For the list of hooks available on `compiler`, `compilation`, and other important objects, see the [plugins API](/api/plugins/) docs.
+For the list of hooks available on `compiler`, `compilation`, and other important objects, see the [plugins API](/api/plugins/) docs. The objects those hooks hand you are documented separately: what a compilation offers is on the [Compilation Object](/api/compilation-object/) page, and the modules it holds on the [Module Object](/api/module-object/) page.
 
 ## Async event hooks
 

--- a/src/content/guides/caching.mdx
+++ b/src/content/guides/caching.mdx
@@ -357,6 +357,31 @@ Entrypoint main = runtime.725a1a51ede5ae0cfde0.js vendors.55e79e5927a639d21a1b.j
 
 We can see that both builds yielded `55e79e5927a639d21a1b` in the `vendor` bundle's filename.
 
+## Deploying a new build
+
+Content hashes make every deploy emit a new set of filenames, and that interacts with [code splitting](/guides/code-splitting/) in a way worth planning for: a visitor who loaded the page before the deploy is running the _old_ entry chunk, which asks for the old filename of an async chunk. If that file is gone from the server, the `import()` rejects and the application sees a `ChunkLoadError` — usually as a route or a lazily loaded widget that fails for exactly as long as the tab stays open.
+
+The fix is on the deployment side, not in the configuration. Two measures cover it:
+
+**Keep the previous build's assets around.** Serving old files costs little and makes the error disappear for anyone who loaded the page before the deploy. Copy the new build over the old one instead of replacing the directory; if you clean the output directory on build, [`output.clean`](/configuration/output/#outputclean) accepts a `keep` predicate, and a CDN can expire the old objects after a day or so rather than on the next deploy.
+
+**Handle the rejection anyway.** No retention window covers a tab left open over a weekend, so treat a failed chunk load as "this page is out of date" and reload it:
+
+```js
+async function loadWidget() {
+  try {
+    return await import("./widget.js");
+  } catch {
+    // the deploy removed the chunk this build asks for
+    globalThis.location.reload();
+  }
+}
+```
+
+T> Reloading unconditionally will loop if the chunk is missing for another reason — a broken deploy, an offline user. Reload at most once (record it in `sessionStorage`), and surface a "new version available, reload" prompt instead when you already have one.
+
+Two related options: [`output.chunkLoadTimeout`](/configuration/output/#outputchunkloadtimeout) sets how long webpack waits before rejecting, and [`output.crossOriginLoading`](/configuration/output/#outputcrossoriginloading) is needed to get a useful error rather than an opaque one when chunks are served from a different origin.
+
 ## Conclusion
 
 Caching can be complicated, but the benefit to application or site users makes it worth the effort. See the _Further Reading_ section below to learn more.


### PR DESCRIPTION
**Summary**

Three long-standing documentation gaps:

- **New [Module Object] API page.** `NormalModule` was referenced from the loader docs only as a link into webpack's source, leaving plugin authors to guess which parts are safe to use. The page documents the subclasses and how to tell them apart, the properties every module carries (`type`, `layer`, `context`, `buildMeta`, `buildInfo`, `dependencies`, `factoryMeta`), the methods (`identifier`, `readableIdentifier`, `originalSource`, `getSourceTypes`, `size`, `nameForCondition`, the diagnostics helpers) and the request-related properties specific to a `NormalModule`. Every field was read off `lib/Module.js`, `lib/NormalModule.js` and `KnownBuildMeta` in `types.d.ts`. Linked from "Writing a Plugin" and from the `this.loadModule` entry that previously pointed at GitHub.
- **Caching guide: deploying a new build.** `[contenthash]` plus code splitting means a tab opened before a deploy requests chunk filenames that no longer exist, which surfaces as `ChunkLoadError`. The guide now says why it happens and what to do — keep the previous build's assets (including `output.clean`'s `keep`), and treat a failed `import()` as "this page is out of date" — plus the related `output.chunkLoadTimeout` and `output.crossOriginLoading`.
- **HMR concept page.** "It typically stores these IDs in memory … but it's also possible to store them in a JSON file" named neither mechanism. It now points at `recordsPath` for persisting IDs across separate compiler runs, and at `devServer.devMiddleware.writeToDisk` for getting the update files onto disk.

Closes #3672, Closes #3938, Closes #2853

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

n/a — documentation only; lint, prettier, markdownlint and the jest suite pass locally.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — this PR is the documentation.

**Use of AI**

Claude Code was used to enumerate the module properties and `buildInfo` / `buildMeta` fields from webpack's sources and to draft the pages. Each documented member was checked against the implementation rather than from memory, and the result was reviewed and edited before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT)_