### PR TITLE
docs: explain loader restarts in watch mode and HMR in generated loader output

### DIFF
--- a/src/content/api/loaders.mdx
+++ b/src/content/api/loaders.mdx
@@ -405,14 +405,28 @@ All dependencies of the resolving operation are automatically added as dependenc
 
 ### this.hot
 
-Information about HMR for loaders.
+`boolean`
+
+Whether [Hot Module Replacement](/concepts/hot-module-replacement/) is enabled — `true` when [`HotModuleReplacementPlugin`](/plugins/hot-module-replacement-plugin/) is applied, which `--hot` and `devServer.hot` do for you.
+
+Check it before emitting the `import.meta.webpackHot.accept(...)` call that lets your generated module handle its own updates, so that production output does not carry it:
 
 ```js
 export default function (source) {
-  console.log(this.hot); // true if HMR is enabled via --hot flag or webpack configuration
-  return source;
+  const code = compile(source);
+
+  if (!this.hot) return code;
+
+  return `${code}
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}`;
 }
 ```
+
+See [Hot Module Replacement](/contribute/writing-a-loader/#hot-module-replacement) in the loader guide for what to accept and why.
+
+W> This is about the modules your loader generates. The loader's own source is not hot-reloadable — a change to it needs a restart of the build, see [changes to a loader need a restart](/contribute/writing-a-loader/#changes-to-a-loader-need-a-restart).
 
 ### this.hashDigest
 

--- a/src/content/contribute/writing-a-loader.mdx
+++ b/src/content/contribute/writing-a-loader.mdx
@@ -67,6 +67,19 @@ By the way, if you've already created a separate repository and package for your
 
 T> You can use [`webpack-defaults` package](https://github.com/webpack-contrib/webpack-defaults) to generate boilerplate code necessary to start writing your loader.
 
+### Changes to a loader need a restart
+
+W> Editing a loader's own source while a build is watching does **not** change the output. Restart the build process.
+
+This catches most people developing a loader against a demo project, and neither half of it fails loudly:
+
+- **The edit does not trigger a rebuild.** webpack records the loader's path in the module's `buildDependencies`, which invalidate the [persistent cache](/configuration/cache/#cachetype) on the next start — the watcher only watches file, context and missing dependencies, so nothing rebuilds when the loader file changes.
+- **Forcing a rebuild does not help either.** webpack loads a loader with `require()` (or `import()` for an ESM loader) once, and Node caches that module for the life of the process. A module rebuilt after the edit is handed the _old_ loader function and produces the old output, with no error and no warning.
+
+So calling `this.addDependency(__filename)` in your loader is not a workaround. It does what it says — the loader file is now watched, and editing it rebuilds the modules that use it — but that rebuild still runs the loader code the process loaded at startup, which is worse than not rebuilding at all: the build reports work it did not really redo.
+
+Develop the loader against its own tests instead, where each run is a fresh process (see [Testing](#testing)), and restart webpack when you want to see a change in the demo — `nodemon --watch loaders -- node_modules/.bin/webpack serve` or an equivalent wrapper makes that automatic.
+
 ## Simple Usage
 
 When a single loader is applied to the resource, the loader is called with only one parameter – a string containing the content of the resource file.
@@ -318,6 +331,31 @@ A CSS loader is a good example of the first approach: it transforms dependencies
 In the case of the `less-loader`, it cannot transform each `@import` to a `require` because all `.less` files must be compiled in one pass for variables and mixin tracking. Therefore, the `less-loader` extends the less compiler with custom path resolving logic. It then takes advantage of the second approach, `this.resolve`, to resolve the dependency through webpack.
 
 T> If the language only accepts relative urls (e.g. `url(file)` always refers to `./file`), you can use the `~` convention to specify references to installed modules (e.g. those in `node_modules`). In the case of `url`, that would look something like `url('~some-library/image.jpg')`.
+
+### Hot Module Replacement
+
+A loader takes part in [HMR](/concepts/hot-module-replacement/) through the code it generates: webpack replaces a changed module at runtime, and the generated module decides what to do with the new version by calling `module.hot.accept`. A loader that produces a side effect — installing a stylesheet, registering a template, seeding a store — has to emit that call itself, or an edit to one of its files will reload the whole page instead of being applied in place.
+
+[`this.hot`](/api/loaders/#thishot) tells you whether that is worth emitting: it is `true` only when [`HotModuleReplacementPlugin`](/plugins/hot-module-replacement-plugin/) is applied, so guard the extra code with it and keep production output clean.
+
+```js
+export default function (source) {
+  const installed = `install(${JSON.stringify(transform(source))});`;
+
+  if (!this.hot) return installed;
+
+  return `${installed}
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}`;
+}
+```
+
+Accepting in the generated module — rather than leaving it to whoever imports it — is what keeps an update from bubbling up to the entry point and forcing a full reload.
+
+Prefer `import.meta.webpackHot` over `module.hot` in generated code: webpack recognizes it whether the module ends up auto-detected or [strict ESM](/guides/ecma-script-modules/#flagging-modules-as-esm), while `module.hot` is unavailable in a strict ESM module — it compiles to a reference to an undefined `module`, which builds without an error and throws at runtime. A loader does not control which of the two its output becomes, since that follows from the file it processes.
+
+T> `this.hot` says nothing about the loader's own source, which is not hot-reloadable — see [changes to a loader need a restart](#changes-to-a-loader-need-a-restart).
 
 ### Common Code
 


### PR DESCRIPTION
**Summary**

#3829 reports aliasing a loader with `resolveLoader.alias`, editing the loader, and seeing the demo not update. Nothing documented explained it, and the behaviour fails silently in two different ways, so the loader guide now covers both:

- **Changes to a loader need a restart** (new section under Setup). The loader's path is recorded in the module's `buildDependencies`, which invalidate the persistent cache on the next start — `Watching` only watches file, context and missing dependencies, so editing a loader triggers no rebuild. And forcing one does not help: `loadLoader` uses `require()` / `import()`, so Node serves the loader from its module cache for the life of the process and a rebuilt module runs the *old* loader code. That also makes `this.addDependency(__filename)` a false workaround — it does cause a rebuild, which then silently produces the old output.
- **Hot Module Replacement** (new guideline section). The other half of the issue's title: what a loader has to emit so the module it generates handles its own updates, guarded by `this.hot`, and why `import.meta.webpackHot` is the spelling to generate — `module.hot` compiles to a reference to an undefined `module` in a strict ESM module, which builds cleanly and throws at runtime.

`this.hot` in the loader API reference was one line ("Information about HMR for loaders"); it now states the type, what sets it, and what to do with it, and points at both sections.

Behaviour was verified by experiment against webpack 5.110.3, not just read off the source: a watch build whose loader is edited mid-run still emits the original output (with and without `this.addDependency`), and a probe comparing both HMR spellings across `javascript/auto` and `javascript/esm` shows `import.meta.webpackHot` folding to a live binding in both while `module.hot` is left untransformed in strict ESM.

Closes #3829

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

n/a — documentation only; lint, prettier, markdownlint and the jest suite pass locally.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — this PR is the documentation.

**Use of AI**

Claude Code was used to trace the behaviour through `lib/loaders/loadLoader.js`, `lib/NormalModule.js` and `lib/Watching.js`, to run the watch-mode and HMR-spelling experiments described above, and to draft the prose. One claim in the first draft (that `module.hot` was the "CommonJS-only spelling" that also worked in ESM output) was wrong and was corrected from the probe results before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT)_