### PR TITLE
fix: keep service worker installable when an asset cannot be precached

### DIFF
--- a/src/sw.js
+++ b/src/sw.js
@@ -27,9 +27,51 @@ const manifestURLs = [...manifest, ...otherManifest].map((entry) => {
   const url = new URL(entry.url, self.location);
   return url.href;
 });
+// Every URL below is served by a NetworkFirst route, so the cache is a warm-up
+// for offline use rather than something the site depends on. `cache.addAll()`
+// would make it a dependency: it rejects as a whole if any single request
+// fails, which aborts the install and leaves the site with no service worker at
+// all. Cache them individually instead, and keep the number of parallel
+// requests low so installing does not saturate the connection pool.
+const INSTALL_CONCURRENCY = 6;
+
+async function warmCache(cache, urls) {
+  const pending = [...urls];
+  const failed = [];
+
+  const worker = async () => {
+    let url;
+    while ((url = pending.shift()) !== undefined) {
+      try {
+        await cache.add(url);
+      } catch {
+        failed.push(url);
+      }
+    }
+  };
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(INSTALL_CONCURRENCY, pending.length) },
+      worker,
+    ),
+  );
+
+  return failed;
+}
+
 self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(cacheName).then((cache) => cache.addAll(manifestURLs)),
+    caches.open(cacheName).then(async (cache) => {
+      const failed = await warmCache(cache, manifestURLs);
+
+      if (failed.length > 0) {
+        console.warn(
+          `[sw] ${failed.length} of ${manifestURLs.length} assets could not be precached; they will be fetched from the network on demand.`,
+          failed,
+        );
+      }
+    }),
   );
 });
 


### PR DESCRIPTION
**Summary**

`src/sw.js` warmed its cache with a single `cache.addAll(manifestURLs)` over the whole precache list (184 URLs on a current build). `addAll` is all-or-nothing: it rejects as a whole if any one request fails, that rejection propagates out of `event.waitUntil`, and the install is aborted — so one unavailable asset leaves visitors with no service worker at all.

That matters here because every one of those URLs is served by a `NetworkFirst` route, so the cache is a warm-up for offline use, not something the site depends on. `addAll` turned an optimization into a hard dependency. This caches the URLs individually and tolerates individual failures, logging what it skipped; a skipped asset is simply fetched from the network on demand, as `NetworkFirst` would anyway. Parallelism is capped so installing does not open 184 requests at once.

Reproduced and verified against a real production build in real Chromium, serving `dist/`:

| Scenario | Before | After |
| --- | --- | --- |
| all assets present | activated, 184 cached | activated, 184 cached (0 missing, 0 stray) |
| one asset returning 404 | **no registration survives, cache empty** | activated, 183 cached — exactly the 404'd asset skipped |

Cost of the change, measured the same way — 5 trials per arm, fresh browser context each, medians, external fonts/analytics blocked so they cannot skew the page metrics. HTTP/2 was measured against a local `node:http2` server, since production serves over h2 and `http-server` is HTTP/1.1 only:

| | FCP | load | SW activated | cached |
| --- | --- | --- | --- | --- |
| HTTP/1.1, `addAll` | 128 ms | 255 ms | 1599 ms | 184 |
| HTTP/1.1, this PR | 112 ms | 249 ms | **1280 ms** | 184 |
| HTTP/2, `addAll` | 124 ms | 265 ms | 1710 ms | 184 |
| HTTP/2, this PR | 128 ms | 263 ms | **1394 ms** | 184 |

The request count is unchanged — `addAll` already issued one fetch per entry, so both arms make the same 184 requests and end with the same 184 cache entries. Page metrics are within noise in both directions: the install runs in the worker and does not block rendering. Install itself came out 18–20% faster on both protocols, apparently because 184 concurrent `cache.add()` calls contend on Cache API writes more than they gain from parallel fetching.

Worth reading that last number with care: these runs are over localhost, so they measure storage and CPU contention rather than round-trips. On a high-latency connection the unbounded version could still win on h2. The claim this PR rests on is "no page-load regression and no install regression measured", not "faster in production".

Offline behaviour was re-checked after the change: a precached asset still resolves from cache with the network off, and an offline navigation to `/concepts/` still renders through the app-shell fallback (200, correct title).

Refs #7738

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

No automated test — `src/sw.js` is a service worker entry with no exported units, and the repo has no service-worker test harness. It was verified manually in Chromium as described above.

**Does this PR introduce a breaking change?**

No. Cache name, routes, and the activate-time cleanup are unchanged; only the install-time population differs.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Claude Code was used to reproduce the failure, write the fix, and drive the Chromium verification runs described above. Two earlier hypotheses it formed (duplicate entries in the precache list, and a missing `/manifest.json`) were checked against the real build and disproved before the actual defect was identified. The benchmark above was likewise run to check a prediction it had made — that capping parallelism would cost install time on HTTP/2 — which the measurement contradicted; the numbers reported are the measured ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT)_

---
_Generated by [Claude Code](https://claude.ai/code)_