### PR TITLE
fix: give the governance docs their own sidebar section

### DIFF
--- a/src/utilities/fetch-governance.mjs
+++ b/src/utilities/fetch-governance.mjs
@@ -11,8 +11,15 @@ const __dirname = path.dirname(__filename);
 const owner = "webpack";
 const repo = "governance";
 
-// Output directly under /contribute (no Governance subfolder)
+// Output directly under /contribute (no Governance subfolder). The pages are
+// grouped under their own "Governance" heading in that section's sidebar, which
+// is what `group` below controls.
 const outputDir = path.resolve(__dirname, "../content/contribute");
+
+// Words to keep upper-cased in titles, so AI_POLICY.md reads "AI Policy"
+// rather than "Ai Policy". Listed explicitly rather than detected by length,
+// which would also catch ordinary words like "CODE" and "OF".
+const ACRONYMS = new Set(["AI", "API", "CLI", "FAQ", "OSS", "TSC"]);
 
 // Generate readable title from filename
 function generateTitle(filename) {
@@ -21,8 +28,13 @@ function generateTitle(filename) {
     .replace(".md", "")
     .replaceAll("_", " ")
     .replaceAll("-", " ")
-    .toLowerCase()
-    .replaceAll(/\b\w/g, (char) => char.toUpperCase());
+    .split(" ")
+    .map((word) =>
+      ACRONYMS.has(word.toUpperCase())
+        ? word.toUpperCase()
+        : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
+    )
+    .join(" ");
 }
 
 // Fix internal markdown links (.md → /)
@@ -63,21 +75,24 @@ try {
     let content = await response.text();
     content = fixMarkdownLinks(content);
 
-    // Generate title and sorting order
+    // Generate title and sorting order. These sit above the range the
+    // hand-written /contribute pages use, so the governance docs stay one
+    // contiguous block below them instead of interleaving with the guides.
     const title = generateTitle(filename);
     const sortOrder =
       {
-        "README.md": 0,
-        "CHARTER.md": 1,
-        "MEMBER_EXPECTATIONS.md": 2,
-        "MODERATION_POLICY.md": 3,
-        "WORKING_GROUPS.md": 4,
-      }[filename] ?? 10;
+        "README.md": 100,
+        "CHARTER.md": 101,
+        "MEMBER_EXPECTATIONS.md": 102,
+        "MODERATION_POLICY.md": 103,
+        "WORKING_GROUPS.md": 104,
+        "AI_POLICY.md": 105,
+      }[filename] ?? 199;
 
     // Build YAML frontmatter
     const fm = {
       title,
-      group: "Contribute",
+      group: "Governance",
       sort: sortOrder,
       source: `https://github.com/${owner}/${repo}/blob/main/${filename}`,
       edit: `https://github.com/${owner}/${repo}/edit/main/${filename}`,


### PR DESCRIPTION
**Summary**

#7333 asked for the content of [webpack/governance](https://github.com/webpack/governance) to appear on the docs site as a governance section, with the repo's documents as its subsections. `fetch-governance.mjs` already pulls all six files in at build time, but the frontmatter it writes does not produce a section — the pages land *interleaved* with the hand-written contributing guides.

They were emitted with `group: "Contribute"` and `sort: 0–4` (plus `10`), while the `/contribute` pages use `sort: -1–7`, so the sidebar came out as:

```
 -1  Contribute
  0  Governance Overview
  1  Writer's Guide
  1  Charter
  2  Writing a Loader
  2  Member Expectations
  3  Writing a Plugin
  3  Moderation Policy
  4  Working Groups
  5  Plugin Patterns
  ...
 10  Ai Policy
```

`Sidebar.jsx` renders an `<h4>{group}</h4>` every time `page.group` changes, so that alternating sequence also emitted the heading — labelled "Contribute", duplicating the section's own name — several times down the list.

Three changes to the generator:

- **`group: "Governance"`** instead of `"Contribute"`, which is what puts the documents under a heading of their own.
- **`sort: 100–105`** (unknown files `199`), above the range the hand-written pages use, so the block stays contiguous below the guides rather than interleaving. `printable.mdx` is filtered out of the sidebar by `_strip`, so nothing follows the block.
- **Acronyms preserved in titles** — `AI_POLICY.md` rendered as "Ai Policy", because the title generator lowercased before title-casing. It also had no entry in the sort map, so it sorted last, away from the rest.

The result, computed from the generator's own logic against the six real files in the governance repo:

```
 -1  Contribute
  1  Writer's Guide
  2  Writing a Loader
  3  Writing a Plugin
  5  Plugin Patterns
  6  Release Process
  7  Debugging
      ## Governance        <- h4 heading
100  Governance Overview
101  Charter
102  Member Expectations
103  Moderation Policy
104  Working Groups
105  AI Policy
```

The acronym list is explicit rather than a "short and upper-case" heuristic — the first draft used the latter and would have turned a future `CODE_OF_CONDUCT.md` into "CODE OF Conduct". Checked against hypothetical additions: `CODE_OF_CONDUCT.md` → "Code Of Conduct", `TSC_MEMBERS.md` → "TSC Members", `api_guidelines.md` → "API Guidelines".

Closes #7333

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

No — the file is a build-time fetch script with no test harness in the repo. Its title, sort and grouping logic was exercised directly against the six real files from `webpack/governance` and against several hypothetical future filenames; lint, prettier and the jest suite pass.

**Does this PR introduce a breaking change?**

No. The same six pages are generated at the same URLs; only their frontmatter (`group`, `sort`) and one title change.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

Claude Code was used to trace the rendering path (`fetch-governance.mjs` → frontmatter → `Sidebar.jsx` grouping), to reproduce the interleaved ordering by running the generator's logic over a clone of the governance repo, and to write the fix. The ordering shown above is computed output, not an estimate. One draft of the acronym handling was rejected after testing it against filenames the repo does not yet have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT)_