### PR TITLE
docs: document name, filename and remotes, and who loads a container

### DIFF
--- a/src/content/concepts/module-federation.mdx
+++ b/src/content/concepts/module-federation.mdx
@@ -187,6 +187,28 @@ It can be leveraged to connect remote containers to a host container dynamically
 
 T> A **container** is the remote container entry object exposed by a federated build, usually through that remote's `remoteEntry.js`. It provides the `get` and `init` methods shown here. In examples like `window[scope]` or `globalThis.someContainer`, the container is expected to exist only once the remote container script has already loaded.
 
+### Who loads the container
+
+For a remote listed in [`remotes`](/plugins/module-federation-plugin/#remotes), **webpack does**. The generated code injects the `<script>`, waits for the global named before the `@` to appear, and rejects with `ScriptExternalLoadError` if it never does — so `import Button from "app1/Button"` is all you write.
+
+You only take over that lifecycle when the location is not known at build time, which is the case the code above is for. Then loading the script is your job, and `container` is undefined until it finishes:
+
+```js
+function loadRemoteEntry(url, scope) {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = url;
+    script.onload = () => resolve(window[scope]);
+    script.onerror = reject;
+    document.head.appendChild(script);
+  });
+}
+```
+
+Load it once per remote and keep the result: calling `init()` twice on one container with different scopes throws, and re-adding the script re-runs the remote's entry.
+
+T> Static and dynamic remotes are not exclusive. Listing a remote in the config gives you plain imports and build-time errors for a location you already know; loading one by hand costs you the imports but lets a URL come from configuration, an environment, or a user choice. Use the config for the remotes that are fixed and the dynamic route for the ones that are not.
+
 The container tries to provide shared modules, but if the shared module has already been used (loaded), the newly provided one is ignored without a warning. The container might still use it as a fallback.
 
 This way you could dynamically load an A/B test which provides a different version of a shared module.

--- a/src/content/plugins/module-federation-plugin.mdx
+++ b/src/content/plugins/module-federation-plugin.mdx
@@ -37,6 +37,77 @@ export default {
 
 ## Options
 
+### name
+
+`string`
+
+The name of the container this build produces. For the default `script` remote type it is also the **global variable** the container is assigned to, which is how a consumer reaches it once `remoteEntry.js` has loaded.
+
+It must be unique among the builds on a page. It is a separate thing from [`output.uniqueName`](/configuration/output/#outputuniquename), which also has to be unique — see [Every build needs its own unique name](/concepts/module-federation/#every-build-needs-its-own-unique-name).
+
+### filename
+
+`string`
+
+The filename of the container entry, as a path relative to [`output.path`](/configuration/output/#outputpath). Conventionally `remoteEntry.js`.
+
+This names the file **this** build emits. It has nothing to do with the filenames of the remotes it consumes — those are whatever each remote chose, and appear in the URLs under [`remotes`](#remotes).
+
+### remotes
+
+`string[]` `object`
+
+The containers this build consumes. Each entry maps a **request scope** — the name you import through — to a **container location**:
+
+```js
+new ModuleFederationPlugin({
+  remotes: {
+    // request scope        container location
+    app1: "app1@http://localhost:3001/remoteEntry.js",
+  },
+});
+```
+
+which is then imported as:
+
+```js
+import Button from "app1/Button";
+```
+
+The two halves of the location string are split at the first `@`:
+
+| Part                                               | Meaning                                                                    |
+| -------------------------------------------------- | -------------------------------------------------------------------------- |
+| before `@` — `app1`                                | the remote's [`name`](#name), i.e. the global its container is assigned to |
+| after `@` — `http://localhost:3001/remoteEntry.js` | the URL its [`filename`](#filename) is served from                         |
+
+So a name appearing "twice" in a config is usually two different things that happen to match: the key is what **you** import through and can be renamed freely, while the part before `@` must match what the **remote** called itself. They are free to differ:
+
+```js
+new ModuleFederationPlugin({
+  remotes: {
+    // imported as "checkout/…", served by a container that calls itself "shop"
+    checkout: "shop@http://localhost:3001/remoteEntry.js",
+  },
+});
+```
+
+Passing an array instead of an object drops the keys and lets webpack infer each request scope from the location.
+
+T> A location without an `@`, or with one at either end, fails the build with `Invalid request "…"`.
+
+For a statically configured remote you do not load anything yourself: webpack emits code that injects the `<script>`, waits for the global to appear, and reports `ScriptExternalLoadError` if it does not. Loading the container by hand is only needed for [dynamic remotes](/concepts/module-federation/#dynamic-remote-containers), where the location is not known at build time.
+
+An entry can also be an object with `external` (the location) and `shareScope`, when one remote needs a different [share scope](/concepts/module-federation/#share-scopes) from the rest.
+
+### remoteType
+
+`string`
+
+How a remote is fetched, as an [`externalsType`](/configuration/externals/#externalstype).
+
+When unset it falls back to this plugin's own `library.type`, but only if that is a valid externals type, and otherwise to `'script'` — the `name@url` form described above. Since `library` itself defaults to `{ type: 'var', name }`, a config that sets neither gets `'script'`.
+
 ### runtime
 
 Create a new runtime chunk with the specified name.


### PR DESCRIPTION
**Summary**

#5067 lists specific things the Module Federation docs never explained. Checking them one by one, the container question had since been answered by a note on the concepts page, but three had not — and one of the gaps was larger than the issue suggests: **`name`, `filename`, `remotes` and `remoteType` were not documented as options at all.** The plugin page covered `runtime`, `exposes` and `shared` only, so the `app1@http://localhost:3001/remoteEntry.js` string appeared once in an example and was never decomposed anywhere.

That is what makes the config read as pointless repetition, which is the issue's second complaint ("`app1` occurs twice, `remoteEntry.js` occurs twice — why?"). The two halves of a location string are split at the first `@` (`extractUrlAndGlobal`): before it is the remote's `name` — the global its container is assigned to — and after it is the URL its `filename` is served from. The object key is a third, independent thing: the request scope you import through, which can be renamed freely. The new `remotes` section spells that out with a table and an example where the key and the remote's name deliberately differ.

The third complaint — "who's responsible for the container's lifecycle? If it's me, where and how should I create it?" — now has a **Who loads the container** section. For a remote listed in `remotes`, webpack does: the generated code injects the `<script>`, waits for the global, and rejects with `ScriptExternalLoadError` if it never appears (`getSourceForScriptExternal`). You only own that lifecycle for dynamic remotes, so the section shows the loader the examples previously left as `// or get the container somewhere else`, and notes that a container must be loaded once and reused since a second `init()` with a different scope throws.

The fourth — "what's the point of configuring remotes statically?" — is answered as a short note that the two are not exclusive, with what each buys.

Also documents `name` vs `output.uniqueName` (both must be unique, for different reasons) and `filename` being this build's own container file rather than anything to do with the remotes it consumes.

Closes #5067

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

n/a — documentation only; lint, prettier, markdownlint and the jest suite pass locally, and every anchor referenced from the new text was checked to exist.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — this PR is the documentation.

**Use of AI**

Claude Code was used to check each of the issue's complaints against the current pages, to read the option semantics out of `schemas/plugins/container/ModuleFederationPlugin.json`, `lib/container/ModuleFederationPlugin.js`, `lib/util/extractUrlAndGlobal.js` and `lib/ExternalModule.js`, and to draft the sections. One drafted sentence claimed `remoteType` falls back to `output.library.type`; reading the implementation showed it falls back to the plugin's own `library.type`, and only when that is a valid externals type — corrected before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT)_