### PR TITLE
docs: add a Compiler Object page

### DIFF
--- a/src/content/api/compiler-object.mdx
+++ b/src/content/api/compiler-object.mdx
@@ -1,0 +1,210 @@
+---
+title: Compiler Object
+description: The properties and methods of the webpack Compiler that plugins can rely on.
+group: Objects
+sort: 14
+contributors:
+  - hai-x
+---
+
+The `Compiler` is the object that drives a build. It is created once for a configuration, holds everything that outlives a single build — the resolved options, the file systems, the cache — and delegates the actual work to plugins through its [hooks](/api/compiler-hooks/).
+
+A plugin receives it as the argument to `apply`:
+
+```js
+class MyPlugin {
+  apply(compiler) {
+    compiler.hooks.done.tap("MyPlugin", (stats) => {
+      // ...
+    });
+  }
+}
+```
+
+One `Compiler` usually runs many builds — every rebuild in watch mode is a new [`Compilation`](/api/compilation-object/) on the same compiler. State that must survive a rebuild belongs here; state about one build belongs on the compilation.
+
+## Properties
+
+### hooks
+
+The [compiler hooks](/api/compiler-hooks/), the main way a plugin takes part in the build.
+
+### webpack
+
+The webpack exports — `Compilation`, `sources`, `NormalModule`, every plugin — taken from the running instance rather than from your own `require("webpack")`. Prefer it, so the plugin keeps working when the project resolves a different copy of webpack than the one next to your plugin.
+
+```js
+class MyPlugin {
+  apply(compiler) {
+    const { Compilation, sources } = compiler.webpack;
+    // ...
+  }
+}
+```
+
+### options
+
+The resolved configuration, after defaults and normalization have been applied. This is not the object the user wrote: reading `compiler.options.output.path` gives you the value webpack settled on, which is what the build actually uses.
+
+### context
+
+The absolute directory the build resolves from — [`context`](/configuration/entry-context/#context).
+
+### name
+
+The compiler's name, from [`name`](/configuration/other-options/#name). For a child compiler it is the name given when it was created.
+
+### outputPath
+
+The absolute output directory, i.e. the resolved [`output.path`](/configuration/output/#outputpath).
+
+### watchMode / running / idle
+
+`boolean`
+
+Whether this compiler was started with `watch()`, whether a build is in progress, and whether the compiler is idle (between builds, with the cache free to store). Read them rather than tracking build state yourself.
+
+### watching
+
+The `Watching` instance when running in watch mode, otherwise `undefined`. It carries the controls for the watch loop:
+
+| Method                 | What it does                                                    |
+| ---------------------- | --------------------------------------------------------------- |
+| `invalidate(callback)` | Trigger a rebuild now, without waiting for a file to change     |
+| `suspend()`            | Stop rebuilding on changes, while keeping the watchers in place |
+| `resume()`             | Resume after `suspend()`                                        |
+| `close(callback)`      | Stop watching                                                   |
+
+### modifiedFiles / removedFiles
+
+`Set<string> | undefined`
+
+In watch mode, the files that changed and that were removed since the previous build. They are `undefined` on the first build, and are the supported way to find out what a rebuild is reacting to.
+
+### fileTimestamps / contextTimestamps
+
+Timestamp caches used to decide what is out of date.
+
+W> These are an implementation detail of change detection, not a way to force a rebuild. To make one file rebuild when another changes, declare the dependency instead — see [making a module depend on another file](#making-a-module-depend-on-another-file).
+
+### inputFileSystem / outputFileSystem / intermediateFileSystem / watchFileSystem
+
+The file systems webpack reads sources from, writes assets to, and writes its own intermediate files (cache, records) to, plus the one that watches for changes. See [the file systems table](/api/node/#custom-file-systems) for which one to replace when.
+
+### cache
+
+The compiler-level cache. Use [`getCache(name)`](#getcache) rather than this object directly.
+
+### resolverFactory
+
+Creates and caches the resolvers webpack uses. Tap its hooks to influence resolution — see [Resolvers](/api/resolvers/).
+
+### platform
+
+The target environment resolved from [`target`](/configuration/target/), as read-only flags (`web`, `node`, `webworker`, …), each `true`, `false`, or `null` when the platform is left neutral. See [Compiler Instance](/api/node/#compiler-instance).
+
+### managedPaths / immutablePaths / unmanagedPaths
+
+The resolved [`snapshot`](/configuration/other-options/#snapshot) path sets that decide how aggressively webpack may trust files without re-checking them.
+
+### parentCompilation / root
+
+For a child compiler, the compilation that created it and the top-level compiler at the root of the tree. `isChild()` is the shorthand for the check.
+
+## Methods
+
+### run
+
+`function (callback)`
+
+Run a single build. The callback receives `(err, stats)`.
+
+W> `run` does not free the compiler's resources — call [`close`](#close) when the build is finished, or the filesystem cache may not be written out.
+
+### watch
+
+`function (watchOptions, handler)`
+
+Build, then rebuild whenever a watched file changes. Returns the [`Watching`](#watching) instance; `handler` is called with `(err, stats)` after every build.
+
+### close
+
+`function (callback)`
+
+Shut the compiler down: stop watching, let the cache write out, and release what the build held.
+
+### getCache
+
+`function (name)`
+
+Returns a `CacheFacade` scoped to `name`, for storing results between builds. Prefer [`compilation.getCache(name)`](/api/compilation-object/#getcache) inside a compilation so entries belong to the build being made.
+
+### getInfrastructureLogger
+
+`function (name)`
+
+A [logger](/api/logging/) for output that is about the compiler rather than about a build — the infrastructure log. For anything tied to a build use `compilation.getLogger(name)` instead, so the message appears in that build's stats.
+
+### isChild
+
+`function () => boolean`
+
+Whether this is a child compiler.
+
+### runAsChild
+
+`function (callback)`
+
+Run a child compiler created with [`compilation.createChildCompiler`](/api/compilation-object/#createchildcompiler), passing its assets up to the parent compilation.
+
+### purgeInputFileSystem
+
+`function ()`
+
+Clear the input file system's cache. Rarely needed — webpack does it itself at the right points in watch mode.
+
+## Common tasks
+
+### Making a module depend on another file
+
+The usual reason for reaching into the compiler is wanting a module rebuilt when some _other_ file changes — a config file, a schema, a template the module reads at build time.
+
+Declare it as a file dependency; do not touch [`fileTimestamps`](#filetimestamps--contexttimestamps). Webpack watches every path in `compilation.fileDependencies` and rebuilds the modules that declared them.
+
+From a loader, which is the simplest case:
+
+```js
+export default function (source) {
+  this.addDependency("/abs/path/to/config.json");
+  return transform(source);
+}
+```
+
+From a plugin, for a path the whole build depends on rather than one module:
+
+```js
+compiler.hooks.thisCompilation.tap("MyPlugin", (compilation) => {
+  compilation.fileDependencies.add("/abs/path/to/config.json");
+});
+```
+
+Use `contextDependencies` for a directory and `missingDependencies` for a path that does not exist yet but should trigger a rebuild when it appears.
+
+### Reacting to what changed in a rebuild
+
+```js
+compiler.hooks.watchRun.tap("MyPlugin", (compiler) => {
+  const changed = compiler.modifiedFiles;
+  const removed = compiler.removedFiles;
+
+  if (!changed) return; // first build
+
+  for (const file of changed) {
+    // ...
+  }
+});
+```
+
+### Rebuilding on demand
+
+`compiler.watching.invalidate()` starts a rebuild immediately — useful when something outside the file system changed and the watcher cannot see it.

--- a/src/content/contribute/writing-a-plugin.mdx
+++ b/src/content/contribute/writing-a-plugin.mdx
@@ -158,7 +158,7 @@ class HelloCompilationPlugin {
 export default HelloCompilationPlugin;
 ```
 
-For the list of hooks available on `compiler`, `compilation`, and other important objects, see the [plugins API](/api/plugins/) docs. The objects those hooks hand you are documented separately: what a compilation offers is on the [Compilation Object](/api/compilation-object/) page, and the modules it holds on the [Module Object](/api/module-object/) page.
+For the list of hooks available on `compiler`, `compilation`, and other important objects, see the [plugins API](/api/plugins/) docs. The objects those hooks hand you are documented separately: the compiler on the [Compiler Object](/api/compiler-object/) page, what a compilation offers on the [Compilation Object](/api/compilation-object/) page, and the modules it holds on the [Module Object](/api/module-object/) page.
 
 ## Async event hooks
 


### PR DESCRIPTION
**Summary**

#3148 points out that the hooks are documented well but the objects they hand you are not, that the compiler had only the short [Compiler Instance](/api/node/#compiler-instance) section, and that even that "is not referenced from the plugin docs". The Compilation and Module objects have since got pages of their own; this adds the third and links all three from "Writing a Plugin".

The page documents what a plugin author actually reaches for: `hooks`, `webpack` (and why to prefer it over your own `require("webpack")`), `options` as the *resolved* config rather than what the user wrote, `context`, `name`, `outputPath`, `watchMode`/`running`/`idle`, `watching` with the `Watching` controls, `modifiedFiles`/`removedFiles`, the four file systems, `cache`, `resolverFactory`, `platform`, the `snapshot` path sets, and the child-compiler relationship — then `run`, `watch`, `close`, `getCache`, `getInfrastructureLogger`, `isChild`, `runAsChild` and `purgeInputFileSystem`.

The issue also asks for the "if you're trying to do X, look at Y" angle, and gives a worked example of needing it: the reporter wanted one file rebuilt whenever another changed, and solved it by writing into `compiler.fileTimestamps`, suspecting that was wrong. It was — so the page ends with a **Common tasks** section that answers exactly that:

- declaring a file dependency (`this.addDependency` from a loader, `compilation.fileDependencies` from a plugin), with a warning on `fileTimestamps` that points there;
- reading `modifiedFiles` / `removedFiles` in `watchRun` to see what a rebuild is reacting to;
- `watching.invalidate()` to rebuild on demand.

Every property and method was taken from `lib/Compiler.js` and `lib/Watching.js` rather than from the existing prose.

Closes #3148

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

n/a — documentation only; lint, prettier, markdownlint and the jest suite pass locally, and every anchor referenced from the new page was checked to exist.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — this PR is the documentation.

**Use of AI**

Claude Code was used to enumerate the compiler's real surface from `lib/Compiler.js` and `lib/Watching.js`, to confirm where `modifiedFiles`/`removedFiles` are set and that `fileDependencies` is the supported rebuild trigger, and to draft the page. A code sample that was a bare method body outside a class was caught by lint and wrapped before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT)_