### PR TITLE
docs: migrate the remaining pages to TypeScript notation

### DIFF
--- a/src/content/api/cli.mdx
+++ b/src/content/api/cli.mdx
@@ -196,7 +196,7 @@ npx webpack info --additional-package postcss
 
 **`-o`, `--output`**
 
-`string : 'json' | 'markdown'`
+`'json' | 'markdown'`
 
 To get the output in a specified format.
 

--- a/src/content/api/compilation-object.mdx
+++ b/src/content/api/compilation-object.mdx
@@ -19,7 +19,7 @@ The signatures below use two callback shapes that recur throughout the API:
 ```ts
 type ModuleCallback = (
   err?: WebpackError | null,
-  result?: Module | null
+  result?: Module | null,
 ) => void;
 
 type ErrorCallback = (err?: WebpackError | null) => void;

--- a/src/content/api/compilation-object.mdx
+++ b/src/content/api/compilation-object.mdx
@@ -14,15 +14,26 @@ The Compilation object has many methods and hooks available. On this page, we wi
 
 ## compilation object methods
 
+The signatures below use two callback shapes that recur throughout the API:
+
+```ts
+type ModuleCallback = (
+  err?: WebpackError | null,
+  result?: Module | null
+) => void;
+
+type ErrorCallback = (err?: WebpackError | null) => void;
+```
+
 ### getStats
 
-`function`
+`() => Stats`
 
 Returns Stats object for the current compilation.
 
 ### addModule
 
-`function (module, callback)`
+`(module: Module, callback: ModuleCallback) => void`
 
 Adds a module to the current compilation.
 
@@ -33,7 +44,7 @@ Parameters:
 
 ### getModule
 
-`function (module)`
+`(module: Module) => Module`
 
 Fetches a module from a compilation by its identifier.
 
@@ -43,7 +54,7 @@ Parameters:
 
 ### findModule
 
-`function (identifier)`
+`(identifier: string) => Module | undefined`
 
 Attempts to search for a module by its identifier. Returns the module, or `undefined` if none matches.
 
@@ -53,7 +64,7 @@ Parameters:
 
 ### buildModule
 
-`function (module, callback)`
+`(module: Module, callback: ModuleCallback) => void`
 
 Builds the given module.
 
@@ -64,7 +75,7 @@ Parameters:
 
 ### processModuleDependencies
 
-`function (module, callback)`
+`(module: Module, callback: ModuleCallback) => void`
 
 Process the given module dependencies.
 
@@ -75,7 +86,7 @@ Parameters:
 
 ### addEntry
 
-`function (context, entry, name, callback)`
+`(context: string, entry: Dependency, optionsOrName: string | EntryOptions, callback: ModuleCallback) => void`
 
 Adds an entry to the compilation.
 
@@ -88,7 +99,7 @@ Parameters:
 
 ### rebuildModule
 
-`function (module, thisCallback)`
+`(module: Module, callback: ModuleCallback) => void`
 
 Triggers a re-build of the module.
 
@@ -99,7 +110,7 @@ Parameters:
 
 ### finish
 
-`function (callback)`
+`(callback: ErrorCallback) => void`
 
 Finishes compilation and invokes the given callback.
 
@@ -109,7 +120,7 @@ Parameters:
 
 ### seal
 
-`function (callback)`
+`(callback: ErrorCallback) => void`
 
 Seals the compilation.
 
@@ -119,13 +130,13 @@ Parameters:
 
 ### unseal
 
-`function`
+`() => void`
 
 Unseals the compilation.
 
 ### reportDependencyErrorsAndWarnings
 
-`function (module, blocks)`
+`(module: Module, blocks: DependenciesBlock[]) => boolean`
 
 Adds errors and warnings of the given module to the compilation errors and warnings.
 
@@ -136,7 +147,7 @@ Parameters:
 
 ### addChunkInGroup
 
-`function (groupOptions, module, loc, request)`
+`(groupOptions: string | ChunkGroupOptions, module?: Module, loc?: DependencyLocation, request?: string) => ChunkGroup`
 
 Adds module to an existing chunk group or creates a new one. Returns a `chunkGroup`.
 
@@ -149,7 +160,7 @@ Parameters:
 
 ### addChunk
 
-`function (name)`
+`(name?: string | null) => Chunk`
 
 Creates and adds a new chunk to the `compilation.chunks`. Returns that `chunk`.
 
@@ -159,7 +170,7 @@ Parameters:
 
 ### assignDepth
 
-`function (module)`
+`(module: Module) => void`
 
 Assigns `depth` to the given module and its dependency blocks recursively.
 
@@ -169,7 +180,7 @@ Parameters:
 
 ### getDependencyReferencedExports
 
-`function (dependency, runtime)`
+`(dependency: Dependency, runtime: RuntimeSpec) => (string[] | ReferencedExport)[]`
 
 Returns the exports referenced by the given dependency.
 
@@ -180,7 +191,7 @@ Parameters:
 
 ### removeReasonsOfDependencyBlock
 
-`function (module, block)`
+`(module: Module, block: DependenciesBlockLike) => void`
 
 Removes relation of the module to the dependency block.
 
@@ -191,7 +202,7 @@ Parameters:
 
 ### patchChunksAfterReasonRemoval
 
-`function (module, chunk)`
+`(module: Module, chunk: Chunk) => void`
 
 Patches ties of module and chunk after removing dependency reasons. Called automatically by `removeReasonsOfDependencyBlock`.
 
@@ -202,7 +213,7 @@ Parameters:
 
 ### removeChunkFromDependencies
 
-`function (block, chunk)`
+`(block: DependenciesBlock, chunk: Chunk) => void`
 
 Removes given chunk from a dependencies block module and chunks after removing dependency reasons. Called automatically by `removeReasonsOfDependencyBlock`.
 
@@ -213,27 +224,27 @@ Parameters:
 
 ### sortItemsWithChunkIds
 
-`function`
+`() => void`
 
 ### summarizeDependencies
 
-`function`
+`() => void`
 
 ### createHash
 
-`function`
+`() => CodeGenerationJob[]`
 
 ### createModuleAssets
 
-`function`
+`() => void`
 
 ### createChunkAssets
 
-`function`
+`(callback: ErrorCallback) => void`
 
 ### getPath
 
-`function (filename, data)`
+`(filename: string | TemplatePathFn, data?: PathData) => string`
 
 Returns the interpolated path.
 
@@ -244,7 +255,7 @@ Parameters:
 
 ### getPathWithInfo
 
-`function (filename, data)`
+`(filename: string | TemplatePathFn, data?: PathData) => { path: string, info: AssetInfo }`
 
 Returns interpolated path and asset information.
 
@@ -255,7 +266,7 @@ Parameters:
 
 ### createChildCompiler
 
-`function (name, outputOptions, plugins)`
+`(name: string, outputOptions?: Partial<OutputNormalized>, plugins?: (WebpackPluginInstance | ((this: Compiler, compiler: Compiler) => void) | Falsy)[]) => Compiler`
 
 Allows running another instance of webpack inside of webpack. However, as a child with different settings and configurations applied. It copies all hooks and plugins from the parent (or top-level compiler) and creates a child `Compiler` instance. Returns the created `Compiler`.
 
@@ -267,21 +278,21 @@ Parameters:
 
 ### checkConstraints
 
-`function`
+`() => void`
 
 ### emitAsset
 
-`function (file, source, assetInfo = {})`
+`(file: string, source: Source, assetInfo?: AssetInfo) => void`
 
 Parameters:
 
 - `file` - file name of the asset
 - `source` - the source of the asset
-- `assetInfo` - additional asset information
+- `assetInfo` - additional asset information, `{}` when omitted
 
 ### updateAsset
 
-`function (file, newSourceOrFunction, assetInfoUpdateOrFunction)`
+`(file: string, newSourceOrFunction: Source | ((source: Source) => Source), assetInfoUpdateOrFunction?: AssetInfo | ((assetInfo?: AssetInfo) => AssetInfo | undefined)) => void`
 
 Parameters:
 
@@ -291,7 +302,7 @@ Parameters:
 
 ### deleteAsset
 
-`function (file)`
+`(file: string) => void`
 
 Parameters:
 
@@ -299,13 +310,13 @@ Parameters:
 
 ### getAssets
 
-`function`
+`() => Readonly<Asset>[]`
 
 Returns array of all assets under the current compilation.
 
 ### getAsset
 
-`function (name)`
+`(name: string) => Readonly<Asset> | undefined`
 
 Parameters:
 
@@ -313,7 +324,7 @@ Parameters:
 
 ### getCache
 
-`function (name)`
+`(name: string) => CacheFacade`
 
 Returns a `CacheFacade` for the given name, the API a plugin uses to store results between builds and reuse them from the [persistent cache](/configuration/cache/). Prefer it over `compiler.getCache(name)`, and over the deprecated `compilation.cache`, so that the cached entries belong to the compilation being built.
 

--- a/src/content/api/compiler-object.mdx
+++ b/src/content/api/compiler-object.mdx
@@ -115,7 +115,7 @@ For a child compiler, the compilation that created it and the top-level compiler
 
 ### run
 
-`function (callback)`
+`(callback: (err: Error | null, stats?: Stats) => void) => void`
 
 Run a single build. The callback receives `(err, stats)`.
 
@@ -123,43 +123,43 @@ W> `run` does not free the compiler's resources — call [`close`](#close) when 
 
 ### watch
 
-`function (watchOptions, handler)`
+`(watchOptions: WatchOptions, handler: (err: Error | null, stats?: Stats) => void) => Watching | undefined`
 
 Build, then rebuild whenever a watched file changes. Returns the [`Watching`](#watching) instance; `handler` is called with `(err, stats)` after every build.
 
 ### close
 
-`function (callback)`
+`(callback: (err: Error | null) => void) => void`
 
 Shut the compiler down: stop watching, let the cache write out, and release what the build held.
 
 ### getCache
 
-`function (name)`
+`(name: string) => CacheFacade`
 
 Returns a `CacheFacade` scoped to `name`, for storing results between builds. Prefer [`compilation.getCache(name)`](/api/compilation-object/#getcache) inside a compilation so entries belong to the build being made.
 
 ### getInfrastructureLogger
 
-`function (name)`
+`(name: string | (() => string)) => WebpackLogger`
 
 A [logger](/api/logging/) for output that is about the compiler rather than about a build — the infrastructure log. For anything tied to a build use `compilation.getLogger(name)` instead, so the message appears in that build's stats.
 
 ### isChild
 
-`function () => boolean`
+`() => boolean`
 
 Whether this is a child compiler.
 
 ### runAsChild
 
-`function (callback)`
+`(callback: (err: Error | null, entries?: Chunk[], compilation?: Compilation) => void) => void`
 
 Run a child compiler created with [`compilation.createChildCompiler`](/api/compilation-object/#createchildcompiler), passing its assets up to the parent compilation.
 
 ### purgeInputFileSystem
 
-`function ()`
+`() => void`
 
 Clear the input file system's cache. Rarely needed — webpack does it itself at the right points in watch mode.
 

--- a/src/content/api/loaders.mdx
+++ b/src/content/api/loaders.mdx
@@ -464,7 +464,7 @@ An optional salt to update the hash via Node.JS' [`hash.update`](https://nodejs.
 
 <Badge text="5.32.0+" />
 
-`this.importModule(request, options, [callback]): Promise`
+`(request: string, options?: ImportModuleOptions) => Promise<any>` `(request: string, options: ImportModuleOptions | undefined, callback: (err?: Error | null, exports?: any) => void) => void`
 
 An alternative lightweight solution for the child compiler to compile and execute a request at build time.
 

--- a/src/content/api/module-methods.mdx
+++ b/src/content/api/module-methods.mdx
@@ -79,7 +79,7 @@ export default {
 
 ### import()
 
-`function(string path):Promise`
+`(path: string) => Promise<any>`
 
 Dynamically load modules. Calls to `import()` are treated as split points, meaning the requested module and its children are split out into a separate chunk.
 

--- a/src/content/api/module-object.mdx
+++ b/src/content/api/module-object.mdx
@@ -93,43 +93,43 @@ T> `module.id`, `module.hash`, `module.issuer`, `module.usedExports` and friends
 
 ### identifier
 
-`function () => string`
+`() => string`
 
 A string that identifies the module uniquely in the compilation — the request with all loaders and their options. It is the key `compilation.findModule` looks up.
 
 ### readableIdentifier
 
-`function (requestShortener) => string`
+`(requestShortener: RequestShortener) => string`
 
 The same identity in the shortened form stats and warnings print. Take the shortener from `compilation.requestShortener`.
 
 ### originalSource
 
-`function () => Source | null`
+`() => Source | null`
 
 The module's source before code generation, or `null` for a module that has none.
 
 ### getSourceTypes
 
-`function () => Set<string>`
+`() => ReadonlySet<string>`
 
 Which kinds of code the module can generate, e.g. `'javascript'`, `'css'`, `'asset'`. Ask the module instead of deriving it from `type`.
 
 ### size
 
-`function (type) => number`
+`(type?: string) => number`
 
 The size of the module's source of that type, in bytes.
 
 ### nameForCondition
 
-`function () => string | null`
+`() => string | null`
 
 The path [rule conditions](/configuration/module/#condition) are matched against — the resource without its query and fragment. `null` when the module has no file behind it.
 
 ### addError / addWarning / getErrors / getWarnings
 
-`function`
+`(error: Error) => void` `(warning: Error) => void` `() => Error[] | undefined` `() => Error[] | undefined`
 
 Diagnostics attached to the module. One added here is reported against the module and survives into the cache, unlike a `compilation.errors` entry pushed after seal.
 

--- a/src/content/api/module-variables.mdx
+++ b/src/content/api/module-variables.mdx
@@ -466,7 +466,7 @@ The registry is keyed by style identifier and namespaced with [`output.uniqueNam
 
 ## \_\_webpack_get_script_filename\_\_ (webpack-specific)
 
-`function (chunkId)`
+`(chunkId: string | number) => string`
 
 It provides filename of the chunk by its id.
 

--- a/src/content/concepts/entry-points.mdx
+++ b/src/content/concepts/entry-points.mdx
@@ -31,10 +31,10 @@ T> When running webpack without a configuration file, the entry defaults to `'./
 
 ## Single Entry (Shorthand) Syntax
 
-Usage: `entry: string | [string]`
+Usage: `entry: string | string[]`
 
 - `string`: a single entry file
-- `[string]`: multiple entry files
+- `string[]`: multiple entry files
 
 **webpack.config.js**
 
@@ -86,12 +86,12 @@ Single Entry Syntax is a great choice when you are looking to quickly set up a w
 
 ## Object Syntax
 
-Usage: `entry: { <entryChunkName> string | [string] } | {}`
+Usage: `entry: Record<entryChunkName, string | string[]>`
 
-- `<entryChunkName>`: name of the entry chunk
+- `entryChunkName`: name of the entry chunk
 - `string`: single entry file
-- `[string]`: multiple entry files
-- `{}`: empty object
+- `string[]`: multiple entry files
+- `{}`: an empty object is also accepted
 
 **webpack.config.js**
 

--- a/src/content/configuration/cache.mdx
+++ b/src/content/configuration/cache.mdx
@@ -456,7 +456,7 @@ export default {
 
 ### cache.type
 
-`string: 'memory' | 'filesystem'`
+`'memory' | 'filesystem'`
 
 Sets the `cache` type to either in memory or on the file system. The `memory` option is straightforward, it tells webpack to store cache in memory and only accepts the [`cache.maxGenerations`](#cachemaxgenerations) and [`cache.cacheUnaffected`](#cachecacheunaffected) options:
 

--- a/src/content/configuration/cache.mdx
+++ b/src/content/configuration/cache.mdx
@@ -268,7 +268,7 @@ export default {
 
 ### cache.managedPaths
 
-`[string]`
+`(string | RegExp)[]`
 
 W> Moved to [snapshot.managedPaths](/configuration/other-options/#managedpaths)
 
@@ -432,7 +432,7 @@ export default {
 
 ### cache.store
 
-`string = 'pack': 'pack'`
+`'pack' = 'pack'`
 
 `cache.store` tells webpack when to store data on the file system.
 

--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -120,7 +120,7 @@ export default {
 
 ## devServer.allowedHosts
 
-`'auto' | 'all'` `[string]`
+`'auto' | 'all'` `string` `string[]`
 
 This option allows you to allowlist services that are allowed to access the dev server.
 
@@ -633,7 +633,7 @@ export default {
 
 ## devServer.headers
 
-`array` `function` `object`
+`object` `{ key: string, value: string }[]` `(req: Request, res: Response, context?: Context) => object | { key: string, value: string }[]`
 
 Adds headers to all responses:
 
@@ -928,7 +928,7 @@ W> Live reloading works only with web related [targets](/configuration/target/#s
 
 ## devserver.onListening
 
-`function (devServer)`
+`(devServer: WebpackDevServer) => void`
 
 Provides the ability to execute a custom function when webpack-dev-server starts listening for connections on a port.
 
@@ -952,7 +952,7 @@ export default {
 
 ## devServer.open
 
-`boolean` `string` `object` `[string, object]`
+`boolean` `string` `object` `(string | object)[]`
 
 Tells dev-server to open the browser after server had been started. Set it to `true` to open your default browser.
 
@@ -1105,7 +1105,7 @@ npx webpack serve --port auto
 
 ## devServer.proxy
 
-`[object, function]`
+`(object | Function)[]`
 
 Proxying some URLs can be useful when you have a separate API backend development server and you want to send API requests on the same domain.
 
@@ -1405,7 +1405,7 @@ export default {
 
 ## devServer.setupMiddlewares
 
-`function (middlewares, devServer)`
+`(middlewares: Middleware[], devServer: WebpackDevServer) => Middleware[]`
 
 <Badge text="v4.7.0+" />
 
@@ -1460,7 +1460,7 @@ export default {
 
 ## devServer.static
 
-`boolean` `string` `object` `[string, object]`
+`boolean` `string` `object` `(string | object)[]`
 
 This option allows configuring options for serving static files from the directory (by default 'public' directory). To disable set it to `false`:
 
@@ -1601,7 +1601,7 @@ export default {
 
 ### publicPath
 
-`string = '/'` `[string]`
+`string = '/'` `string[]`
 
 Tell the server at which URL to serve [`static.directory`](#directory) content. For example to serve a file `assets/manifest.json` at `/serve-public-path-url/manifest.json`, your configurations should be as following:
 
@@ -1758,7 +1758,7 @@ export default {
 
 ## devServer.watchFiles
 
-`string` `object` `[string, object]`
+`string` `object` `(string | object)[]`
 
 This option allows you to configure a list of globs/directories/files to watch for file changes. For example:
 

--- a/src/content/configuration/entry-context.mdx
+++ b/src/content/configuration/entry-context.mdx
@@ -43,7 +43,20 @@ By default, the current working directory of Node.js is used, but it's recommend
 
 ## entry
 
-`string` `[string]` `object = { <key> string | [string] | object = { import string | [string], dependOn string | [string], filename string, layer string, runtime string | false }}` `(function() => string | [string] | object = { <key> string | [string] } | object = { import string | [string], dependOn string | [string], filename string, layer string, runtime string | false })`
+`string` `string[]` `EntryObject` `EntryFn`
+
+```ts
+type Entry = string | string[] | EntryObject | EntryFn;
+
+// Each key names a chunk; see Entry descriptor below for EntryDescription.
+type EntryObject = Record<string, string | string[] | EntryDescription>;
+
+type EntryFn = () =>
+  | string
+  | string[]
+  | EntryObject
+  | Promise<string | string[] | EntryObject>;
+```
 
 The point or points where to start the application bundling process. If an array is passed then all items will be processed.
 

--- a/src/content/configuration/entry-context.mdx
+++ b/src/content/configuration/entry-context.mdx
@@ -52,10 +52,7 @@ type Entry = string | string[] | EntryObject | EntryFn;
 type EntryObject = Record<string, string | string[] | EntryDescription>;
 
 type EntryFn = () =>
-  | string
-  | string[]
-  | EntryObject
-  | Promise<string | string[] | EntryObject>;
+  string | string[] | EntryObject | Promise<string | string[] | EntryObject>;
 ```
 
 The point or points where to start the application bundling process. If an array is passed then all items will be processed.

--- a/src/content/configuration/externals.mdx
+++ b/src/content/configuration/externals.mdx
@@ -28,7 +28,7 @@ The `externals` configuration option provides a way of excluding dependencies fr
 
 ## externals
 
-`string` `object` `function` `RegExp` `[string, object, function, RegExp]`
+`string` `RegExp` `object` `ExternalsFn` `(string | RegExp | object | ExternalsFn)[]`
 
 **Prevent bundling** of certain `import`ed packages and instead retrieve these _external dependencies_ at runtime.
 
@@ -104,7 +104,7 @@ export default {
 };
 ```
 
-### [string]
+### string[]
 
 ```js
 export default {
@@ -222,26 +222,28 @@ W> Only set it when the package really is free of side effects. Getting it wrong
 
 ### function
 
-- `function ({ context, request, contextInfo, getResolve }, callback)`
-- `function ({ context, request, contextInfo, getResolve }) => promise` <Badge text='5.15.0+' />
+An `ExternalsFn` comes in two forms:
+
+- `(ctx: ExternalsCtx, callback: ExternalsCallback) => void`
+- `(ctx: ExternalsCtx) => Promise<ExternalsResult>` <Badge text='5.15.0+' />
 
 It might be useful to define your own function to control the behavior of what you want to externalize from webpack. [webpack-node-externals](https://www.npmjs.com/package/webpack-node-externals), for example, excludes all modules from the `node_modules` directory and provides options to allowlist packages.
 
 Here're arguments the function can receive:
 
-- `ctx` (`object`): Object containing details of the file.
+- `ctx` (`ExternalsCtx`): Object containing details of the file.
   - `ctx.context` (`string`): The directory of the file which contains the import.
   - `ctx.request` (`string`): The import path being requested.
   - `ctx.originalRequest` (`string`) <Badge text='5.110.0+' />: Same as `ctx.request`, except for an element of a context module, where it is the request as written by the user.
   - `ctx.dependencyType` (`string`): The category of the referencing dependency, e.g. `'esm'`, `'commonjs'` or `'url'`.
   - `ctx.contextInfo` (`object`): Contains information about the issuer (e.g. the layer and compiler)
   - `ctx.getResolve` <Badge text='5.15.0+' />: Get a resolve function with the current resolver options.
-- `callback` (`function (err, result, type)`): Callback function used to indicate how the module should be externalized.
+- `callback` (`ExternalsCallback`, i.e. `(err?: Error | null, result?: ExternalsResult, type?: string) => void`): Callback function used to indicate how the module should be externalized.
 
 The callback function takes three arguments:
 
 - `err` (`Error`): Used to indicate if there has been an error while externalizing the import. If there is an error, this should be the only parameter used.
-- `result` (`string` `[string]` `object`): Describes the external module with the other external formats ([`string`](#string), [`[string]`](#string-1), or [`object`](#object))
+- `result` (`ExternalsResult`, i.e. `string | string[] | boolean | object`): Describes the external module with the other external formats ([`string`](#string), [`string[]`](#string-1), or [`object`](#object))
 - `type` (`string`): Optional parameter that indicates the module [external type](#externalstype) (if it has not already been indicated in the `result` parameter).
 
 As an example, to externalize all imports where the import path matches a regular expression you could do the following:
@@ -380,7 +382,7 @@ For more information on how to use this configuration, please refer to the artic
 
 ### byLayer
 
-`function` `object`
+`Record<string, ExternalItem>` `(layer: string | null) => ExternalItem`
 
 Specify externals by layer.
 

--- a/src/content/configuration/infrastructureLogging.mdx
+++ b/src/content/configuration/infrastructureLogging.mdx
@@ -82,7 +82,7 @@ export default {
 
 ## infrastructureLogging.debug
 
-`string` `boolean = false` `RegExp` `function(name) => boolean` `[string, RegExp, function(name) => boolean]`
+`string` `boolean = false` `RegExp` `(name: string) => boolean` `(string | RegExp | ((name: string) => boolean))[]`
 
 Enable debug information of specified loggers such as plugins or loaders. Similar to [`stats.loggingDebug`](/configuration/stats/#statsloggingdebug) option but for infrastructure. Defaults to `false`.
 
@@ -100,7 +100,7 @@ export default {
 
 ## infrastructureLogging.level
 
-`string = 'info' : 'none' | 'error' | 'warn' | 'info' | 'log' | 'verbose'`
+`'none' | 'error' | 'warn' | 'info' | 'log' | 'verbose' = 'info'`
 
 Enable infrastructure logging output. Similar to [`stats.logging`](/configuration/stats/#statslogging) option but for infrastructure. Defaults to `'info'`.
 

--- a/src/content/configuration/mode.mdx
+++ b/src/content/configuration/mode.mdx
@@ -16,7 +16,7 @@ related:
 
 Providing the `mode` configuration option tells webpack to use its built-in optimizations accordingly.
 
-`string = 'production': 'none' | 'development' | 'production'`
+`'none' | 'development' | 'production' = 'production'`
 
 ## Usage
 

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -1683,7 +1683,7 @@ export default {
 
 ## module.noParse
 
-`RegExp` `[RegExp]` `function(resource)` `string` `[string]`
+`RegExp` `string` `(request: string) => boolean` `(RegExp | string | ((request: string) => boolean))[]`
 
 Prevent webpack from parsing any files matching the given regular expression(s). Ignored files **should not** have calls to `import`, `require`, `define` or any other importing mechanism. This can boost build performance when ignoring large libraries.
 
@@ -1715,7 +1715,7 @@ export default {
 
 ## module.unsafeCache
 
-`boolean` `function (module)`
+`boolean` `(module: Module) => boolean`
 
 Cache the resolution of module requests. There are a couple of defaults for `module.unsafeCache`:
 
@@ -1929,7 +1929,7 @@ Include all modules matching any of these conditions. If you supply a `Rule.incl
 
 <Badge text="5.110.0+" />
 
-`string` `[string]`
+`string` `string[]`
 
 Match the module resource against one or more glob patterns. Unlike a regular expression, a glob matches the same way on every operating system: `/` and `\` are both read as a path separator, in the pattern as well as in the tested path, so a rule written on macOS keeps matching on Windows. See [`performance.osDependentRules`](/configuration/performance/#performanceosdependentrules) for a check that reports the regexp conditions that do not.
 
@@ -2189,7 +2189,7 @@ See [Asset Modules guide](/guides/asset-modules/) for additional information and
 
 ## Rule.parser.dataUrlCondition
 
-`object = { maxSize number = 8096 }` `function (source, { filename, module }) => boolean`
+`{ maxSize?: number = 8096 }` `(source: string | Buffer, context: { filename: string, module: Module }) => boolean`
 
 If a module source size is less than or equal to `maxSize` then module will be injected into the bundle as a Base64-encoded string, otherwise module file will be emitted into the output directory.
 
@@ -2240,7 +2240,7 @@ export default {
 
 ### Rule.generator.dataUrl
 
-`object = { encoding string = 'base64' | false, mimetype string = undefined }` `function (content, { filename, module }) => string`
+`{ encoding?: 'base64' | false = 'base64', mimetype?: string }` `(content: string | Buffer, context: { filename: string, module: Module }) => string`
 
 When `Rule.generator.dataUrl` is used as an object, you can configure two properties:
 
@@ -2504,7 +2504,7 @@ export default {
 
 ## Rule.parser.parse
 
-`function(input) => string | object`
+`(input: string) => Buffer | JsonValue`
 
 If `Rule.type` is set to `'json'` then `Rules.parser.parse` option may be a function that implements custom logic to parse module's source and convert it to a JavaScript `object`. It defaults to `JSON.parse`. It may be useful to import `toml`, `yaml` and other non-JSON files as JSON, without specific loaders:
 
@@ -2626,7 +2626,7 @@ export default {
 
 ## Rule.use
 
-`[UseEntry]` `function(info)`
+`UseEntry` `UseEntry[]` `(info: UseEntryInfo) => UseEntry | UseEntry[]`
 
 Starting with webpack 5.87.0 falsy values such as `undefined` `null` can be used to conditionally disable specific use entry.
 
@@ -2663,16 +2663,16 @@ export default {
 };
 ```
 
-**`function(info)`**
+**`(info: UseEntryInfo) => UseEntry | UseEntry[]`**
 
-`Rule.use` can also be a function which receives the object argument describing the module being loaded, and must return an array of `UseEntry` items.
+`Rule.use` can also be a function which receives an object describing the module being loaded, and must return an array of `UseEntry` items.
 
-The `info` object parameter has the following fields:
+The `info` parameter (`UseEntryInfo`) has the following fields:
 
-- `compiler`: The current webpack compiler (can be undefined)
-- `issuer`: The path to the module that is importing the module being loaded
-- `realResource`: Always the path to the module being loaded
-- `resource`: The path to the module being loaded, it is usually equal to `realResource` except when the resource name is overwritten via `!=!` in request string
+- `compiler` (`string | undefined`): The name of the current [child compiler](#rulecompiler), `undefined` outside one
+- `issuer` (`string`): The path to the module that is importing the module being loaded
+- `realResource` (`string | undefined`): Always the path to the module being loaded
+- `resource` (`string | undefined`): The path to the module being loaded, it is usually equal to `realResource` except when the resource name is overwritten via `!=!` in request string
 
 The same shortcut as an array can be used for the return value (i.e. `use: [ 'sass-loader' ]`).
 
@@ -2943,7 +2943,7 @@ export default {
 
 ## UseEntry
 
-`object` `function(info)`
+`object` `(info: UseEntryInfo) => UseEntry`
 
 **`object`**
 
@@ -2973,16 +2973,16 @@ export default {
 };
 ```
 
-**`function(info)`**
+**`(info: UseEntryInfo) => UseEntry`**
 
-A `UseEntry` can also be a function which receives the object argument describing the module being loaded, and must return a non-function `UseEntry` object. This can be used to vary the loader options on a per-module basis.
+A `UseEntry` can also be a function which receives an object describing the module being loaded, and must return a non-function `UseEntry` object. This can be used to vary the loader options on a per-module basis.
 
-The `info` object parameter has the following fields:
+The `info` parameter (`UseEntryInfo`) has the following fields:
 
-- `compiler`: The current webpack compiler (can be undefined)
-- `issuer`: The path to the module that is importing the module being loaded
-- `realResource`: Always the path to the module being loaded
-- `resource`: The path to the module being loaded, it is usually equal to `realResource` except when the resource name is overwritten via `!=!` in request string
+- `compiler` (`string | undefined`): The name of the current [child compiler](#rulecompiler), `undefined` outside one
+- `issuer` (`string`): The path to the module that is importing the module being loaded
+- `realResource` (`string | undefined`): Always the path to the module being loaded
+- `resource` (`string | undefined`): The path to the module being loaded, it is usually equal to `realResource` except when the resource name is overwritten via `!=!` in request string
 
 **webpack.config.js**
 

--- a/src/content/configuration/module.mdx
+++ b/src/content/configuration/module.mdx
@@ -2630,7 +2630,7 @@ export default {
 
 Starting with webpack 5.87.0 falsy values such as `undefined` `null` can be used to conditionally disable specific use entry.
 
-**`[UseEntry]`**
+**`UseEntry[]`**
 
 `Rule.use` can be an array of [UseEntry](#useentry) which are applied to modules. Each entry specifies a loader to be used.
 

--- a/src/content/configuration/optimization.mdx
+++ b/src/content/configuration/optimization.mdx
@@ -345,7 +345,7 @@ T> Supported guard forms include ternaries (`isDEV ? A : B`), `if` statements, a
 
 ## optimization.mangleExports
 
-`boolean` `string: 'deterministic' | 'size'`
+`boolean` `'deterministic' | 'size'`
 
 `optimization.mangleExports` allows to control export mangling.
 
@@ -493,7 +493,7 @@ What the built-in CSS minimizer may do beyond the transforms that always apply. 
 | `resolveCustomAtRules`    | `boolean`                                                    | `false`     | <Badge text="5.111.0+" /> Resolve `@custom-media` and `@custom-selector` at-rules in a stylesheet that reached the minimizer without being parsed.                                   |
 | `rewriteCustomProperties` | `boolean`                                                    | `false`     | Shorten custom property values, which are otherwise written back exactly as authored.                                                                                                |
 | `rewriteDirSelector`      | `boolean`                                                    | `false`     | <Badge text="5.111.0+" /> Write a `:dir()` the browserslist target cannot read as the `[dir]` attribute selector it approximates.                                                    |
-| `unusedSymbols`           | `[string]`                                                   | `undefined` | <Badge text="5.111.0+" /> Class, id, `@keyframes` and custom property names a whole-project analysis found unused, which the minimizer removes.                                      |
+| `unusedSymbols`           | `string[]`                                                   | `undefined` | <Badge text="5.111.0+" /> Class, id, `@keyframes` and custom property names a whole-project analysis found unused, which the minimizer removes.                                      |
 
 T> `vendorPrefixes` only has an effect for a `browserslist` [target](/configuration/target/) — any other target names no browsers to prefix for.
 
@@ -706,14 +706,14 @@ export default {
 
 `webpack.ids.DeterministicModuleIdsPlugin` is the plugin behind `moduleIds: 'deterministic'`. It hashes each module's request — made relative to `context`, so ids survive a checkout in another directory — into a number, and it accepts these options:
 
-| Option           | Type                           | Default            | Description                                                                                                                                                       |
-| ---------------- | ------------------------------ | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `context`        | `string`                       | `compiler.context` | The directory module names are made relative to before hashing.                                                                                                   |
-| `test`           | `function (module) => boolean` | all modules        | Restricts the plugin to the modules it returns `true` for, so another plugin can name the rest.                                                                   |
-| `maxLength`      | `number`                       | `3`                | The number of digits ids start with. webpack keeps multiplying that range by ten until it is roughly 20 times the number of modules, which keeps collisions rare. |
-| `fixedLength`    | `boolean`                      | `false`            | Keeps the id space at `maxLength` digits instead of growing it.                                                                                                   |
-| `salt`           | `number`                       | `0`                | Mixed into the hash. Change it to move every id, for example to work around a collision.                                                                          |
-| `failOnConflict` | `boolean`                      | `false`            | Fails the build on a colliding id instead of rehashing it.                                                                                                        |
+| Option           | Type                          | Default            | Description                                                                                                                                                       |
+| ---------------- | ----------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `context`        | `string`                      | `compiler.context` | The directory module names are made relative to before hashing.                                                                                                   |
+| `test`           | `(module: Module) => boolean` | all modules        | Restricts the plugin to the modules it returns `true` for, so another plugin can name the rest.                                                                   |
+| `maxLength`      | `number`                      | `3`                | The number of digits ids start with. webpack keeps multiplying that range by ten until it is roughly 20 times the number of modules, which keeps collisions rare. |
+| `fixedLength`    | `boolean`                     | `false`            | Keeps the id space at `maxLength` digits instead of growing it.                                                                                                   |
+| `salt`           | `number`                      | `0`                | Mixed into the hash. Change it to move every id, for example to work around a collision.                                                                          |
+| `failOnConflict` | `boolean`                     | `false`            | Fails the build on a colliding id instead of rehashing it.                                                                                                        |
 
 ### The id plugins
 
@@ -920,7 +920,7 @@ export default {
 
 ## optimization.sideEffects
 
-`boolean` `string: 'flag'`
+`boolean` `'flag'`
 
 Tells webpack to recognise the [`sideEffects`](https://github.com/webpack/webpack/blob/main/examples/side-effects/README.md) flag in `package.json` or rules to skip over modules which are flagged to contain no side effects when exports are not used.
 
@@ -978,7 +978,7 @@ By default webpack v4+ provides new common chunks strategies out of the box for 
 
 ## optimization.usedExports
 
-`boolean` `string: 'global'`
+`boolean` `'global'`
 
 Tells webpack to determine used exports for each module. This depends on [`optimization.providedExports`](#optimizationprovidedexports). Information collected by `optimization.usedExports` is used by other optimizations or code generation i.e. exports are not generated for unused exports, export names are mangled to single char identifiers when all usages are compatible.
 Dead code elimination in minimizers will benefit from this and can remove unused exports.

--- a/src/content/configuration/optimization.mdx
+++ b/src/content/configuration/optimization.mdx
@@ -51,8 +51,7 @@ export default {
 
 ## optimization.chunkIds
 
-`boolean: false`
-`string: 'natural' | 'named' | 'size' | 'total-size' | 'deterministic'`
+`'natural' | 'named' | 'size' | 'total-size' | 'deterministic' | false`
 
 - `false`: disable webpack's built-in chunk id algorithm
 - one of the following values:
@@ -582,7 +581,7 @@ Reach for it when minimizing is switched on elsewhere — by the [`mode`](/confi
 
 ## optimization.minimizer
 
-`[MinimizerPlugin]` and or `[function (compiler)]` or `undefined | null | 0 | false | ""`
+`(MinimizerPlugin | ((compiler: Compiler) => void) | '...' | false | 0 | '' | null | undefined)[]`
 
 Allows you to override the default minimizer by providing a different one or more customized [MinimizerPlugin](/plugins/minimizer-webpack-plugin/) instances. Starting with webpack 5.87.0 falsy values can be used to conditionally disable specific minimizers.
 
@@ -655,7 +654,7 @@ Basically, `'...'` is [a shortcut to access the default configuration value](htt
 
 ## optimization.moduleIds
 
-`boolean: false` `string: 'natural' | 'named' | 'deterministic' | 'size'`
+`'natural' | 'named' | 'deterministic' | 'size' | false`
 
 Tells webpack which algorithm to use when choosing module ids. Setting `optimization.moduleIds` to `false` tells webpack that none of built-in algorithms should be used, as custom one can be provided via plugin.
 
@@ -739,7 +738,7 @@ W> `moduleIds: total-size` has been removed in webpack 5.
 
 ## optimization.nodeEnv
 
-`boolean: false` `string`
+`string` `false`
 
 Tells webpack to set `process.env.NODE_ENV` to a given string value. `optimization.nodeEnv` uses [DefinePlugin](/plugins/define-plugin/) unless set to `false`.
 

--- a/src/content/configuration/other-options.mdx
+++ b/src/content/configuration/other-options.mdx
@@ -29,7 +29,7 @@ W> Help Wanted: This page is still a work in progress. If you are familiar with 
 
 ## amd
 
-`object` `boolean: false`
+`object` `false`
 
 Set the value of `require.amd` or `define.amd`. Setting `amd` to `false` will disable webpack's AMD support.
 
@@ -72,7 +72,7 @@ W> Avoid using `bail` option in [`watch`](/configuration/watch) mode, as it will
 
 ## dependencies
 
-`[string]`
+`string[]`
 
 A list of [`name`](#name) defining all sibling configurations it depends on. Dependent configurations need to be compiled first.
 
@@ -102,7 +102,7 @@ export default [
 
 ## ignoreWarnings
 
-`[RegExp, function (WebpackError, Compilation) => boolean, {module?: RegExp, file?: RegExp, message?: RegExp}]`
+`(RegExp | { module?: RegExp, file?: RegExp, message?: RegExp } | ((warning: WebpackError, compilation: Compilation) => boolean))[]`
 
 Tells webpack to ignore specific warnings. This can be done with a `RegExp`, a custom `function` to select warnings based on the raw warning instance which is getting `WebpackError` and `Compilation` as arguments and returns a `boolean`, an `object` with the following properties:
 
@@ -353,7 +353,7 @@ export default {
 
 ### buildDependencies
 
-`object = { hash boolean = true, timestamp boolean = true }`
+`{ hash?: boolean = true, timestamp?: boolean = true }`
 
 Snapshots for build dependencies when using the persistent cache.
 
@@ -420,7 +420,7 @@ A regular expression here is only tested against the path, so it doesn't need a 
 
 ### module
 
-`object = { timestamp boolean = true }`
+`{ hash?: boolean, timestamp?: boolean = true }`
 
 Snapshots for building modules. In [`production`](/configuration/mode/) mode the default is `{ timestamp: true, hash: true }`.
 
@@ -429,7 +429,7 @@ Snapshots for building modules. In [`production`](/configuration/mode/) mode the
 
 ### contextModule
 
-`object = { timestamp boolean = true }`
+`{ hash?: boolean, timestamp?: boolean = true }`
 
 Snapshots for building context modules.
 
@@ -438,7 +438,7 @@ Snapshots for building context modules.
 
 ### resolve
 
-`object = { timestamp boolean = true }`
+`{ hash?: boolean, timestamp?: boolean = true }`
 
 Snapshots for resolving of requests. In [`production`](/configuration/mode/) mode the default is `{ timestamp: true, hash: true }`.
 
@@ -447,7 +447,7 @@ Snapshots for resolving of requests. In [`production`](/configuration/mode/) mod
 
 ### resolveBuildDependencies
 
-`object = {hash boolean = true, timestamp boolean = true}`
+`{ hash?: boolean = true, timestamp?: boolean = true }`
 
 Snapshots for resolving of build dependencies when using the persistent cache.
 

--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -39,7 +39,7 @@ The top-level `output` key contains a set of options instructing webpack on how 
 
 ## output.assetModuleFilename
 
-`string = '[hash][ext][query][fragment]'` `function (pathData, assetInfo) => string`
+`string = '[hash][ext][query][fragment]'` `(pathData: PathData, assetInfo?: AssetInfo) => string`
 
 The same as [`output.filename`](#outputfilename) but for [Asset Modules](/guides/asset-modules/).
 
@@ -141,7 +141,7 @@ T> Although the `charset` attribute for `<script>` tag was [deprecated](https://
 
 ## output.chunkFilename
 
-`string = '[id].js'` `function (pathData, assetInfo) => string`
+`string = '[id].js'` `(pathData: PathData, assetInfo?: AssetInfo) => string`
 
 This option determines the name of non-initial chunk files. See [`output.filename`](#outputfilename) option for details on the possible values.
 
@@ -179,7 +179,7 @@ T> If the `output.filename` is defined as a string containing placeholder such a
 
 ## output.chunkFormat
 
-`false` `string: 'array-push' | 'commonjs' | 'module' | <any string>`
+`false` `'array-push' | 'commonjs' | 'module' | string`
 
 The format of chunks (formats included by default are `'array-push'` (web/WebWorker), `'commonjs'` (node.js), `'module'` (ESM), but others might be added by plugins).
 
@@ -345,7 +345,7 @@ export default {
 
 <Badge text="5.111.0+" />
 
-`string` `[string, object]`
+`string` `(string | object)[]`
 
 Copy files and directories into [`output.path`](#outputpath) as part of the build. A copied file becomes an asset like any other, so [`output.clean`](#outputclean) keeps it, [stats](/configuration/stats/) reports it, and in [watch mode](/configuration/watch/) editing a source file copies it again without rebuilding the rest.
 
@@ -384,17 +384,17 @@ W> A pattern that matches nothing warns, and copying a file onto an asset the co
 
 A pattern is a `from` plus the options below.
 
-| Option                | Type                                                                | Default                      | Description                                                                                                             |
-| --------------------- | ------------------------------------------------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `context`             | `string`                                                            | see below                    | Directory `from` is resolved from, and the directory the copied paths keep their structure below.                       |
-| `filename`            | `string` `function (pathData, assetInfo) => string`                 | `'[path][base]'`             | Name of the copied file inside `to`, as a [filename template](#template-strings).                                       |
-| `from`                | `string` `[string]`                                                 | required                     | Glob or path to copy from. A glob separates with `/`, matches dot files, and takes `*`, `**`, `?`, `[]` and `{}`.       |
-| `globOptions`         | `object`                                                            |                              | How the glob in `from` matches — see [glob options](#glob-options).                                                     |
-| `info`                | `object` `function (file) => object`                                |                              | [Asset info](/api/stats/#asset-objects) of the copied file, merged over the info the copy already carries.              |
-| `preservePermissions` | `boolean`                                                           | `false`                      | Whether the copy keeps the permissions of the file it came from. Has no effect on Windows.                              |
-| `preserveTimestamps`  | `boolean`                                                           | `false`                      | Whether the copy keeps the access and modification times of the file it came from, rather than the time it was written. |
-| `to`                  | `string` `function (file) => string`                                | [`output.path`](#outputpath) | Directory the files are copied to, relative to `output.path`.                                                           |
-| `transform`           | `function (content, absoluteFilename) => string \| Buffer` `object` |                              | Modifies the content on the way through — see [transforming content](#transforming-content).                            |
+| Option                | Type                                                                       | Default                      | Description                                                                                                             |
+| --------------------- | -------------------------------------------------------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `context`             | `string`                                                                   | see below                    | Directory `from` is resolved from, and the directory the copied paths keep their structure below.                       |
+| `filename`            | `string` `(pathData: PathData, assetInfo?: AssetInfo) => string`           | `'[path][base]'`             | Name of the copied file inside `to`, as a [filename template](#template-strings).                                       |
+| `from`                | `string` `string[]`                                                        | required                     | Glob or path to copy from. A glob separates with `/`, matches dot files, and takes `*`, `**`, `?`, `[]` and `{}`.       |
+| `globOptions`         | `object`                                                                   |                              | How the glob in `from` matches — see [glob options](#glob-options).                                                     |
+| `info`                | `object` `(file: CopiedFile) => object`                                    |                              | [Asset info](/api/stats/#asset-objects) of the copied file, merged over the info the copy already carries.              |
+| `preservePermissions` | `boolean`                                                                  | `false`                      | Whether the copy keeps the permissions of the file it came from. Has no effect on Windows.                              |
+| `preserveTimestamps`  | `boolean`                                                                  | `false`                      | Whether the copy keeps the access and modification times of the file it came from, rather than the time it was written. |
+| `to`                  | `string` `(file: CopiedFile) => string`                                    | [`output.path`](#outputpath) | Directory the files are copied to, relative to `output.path`.                                                           |
+| `transform`           | `(content: Buffer, absoluteFilename: string) => string \| Buffer` `object` |                              | Modifies the content on the way through — see [transforming content](#transforming-content).                            |
 
 `context` defaults to the compiler [`context`](/configuration/entry-context/#context), and to what `from` names when `from` is not a glob — so `from: 'static'` copies the tree below `static/` rather than into a `static/` directory. Setting it explicitly roots every `from` of the pattern at one directory, which is how several globs keep a shared structure:
 
@@ -410,7 +410,15 @@ export default {
 };
 ```
 
-`to` and `info` may each be a function of the file being copied, which receives `{ absoluteFilename, sourceFilename, filename }` — `filename` being the name the file has so far, relative to `to`:
+`to` and `info` may each be a function of the file being copied, which receives a `CopiedFile` — `filename` being the name the file has so far, relative to `to`:
+
+```ts
+type CopiedFile = {
+  absoluteFilename: string;
+  sourceFilename: string;
+  filename: string;
+};
+```
 
 ```js
 export default {
@@ -437,7 +445,7 @@ export default {
 | `deep`           | `number`   | no limit | How many directory levels below the base of the glob are read, where `1` reads only the base itself.             |
 | `dot`            | `boolean`  | `true`   | Whether the glob reaches a file or directory whose name starts with a dot without naming it.                     |
 | `followSymlinks` | `boolean`  | `true`   | Whether a symbolic link is resolved and copied as what it points at. `false` copies the link itself, unresolved. |
-| `ignore`         | `[string]` |          | Globs of files which are not copied, resolved like `from`. A directory one of them matches is skipped whole.     |
+| `ignore`         | `string[]` |          | Globs of files which are not copied, resolved like `from`. A directory one of them matches is skipped whole.     |
 
 ```js
 export default {
@@ -527,7 +535,7 @@ Tells webpack to enable [cross-origin](https://developer.mozilla.org/en/docs/Web
 
 ## output.cssChunkFilename
 
-`string` `function (pathData, assetInfo) => string`
+`string` `(pathData: PathData, assetInfo?: AssetInfo) => string`
 
 This option determines the name of non-initial CSS output files on disk. See [`output.filename`](#outputfilename) option for details on the possible values.
 
@@ -535,7 +543,7 @@ You **must not** specify an absolute path here. However, feel free to include fo
 
 ## output.cssFilename
 
-`string` `function (pathData, assetInfo) => string`
+`string` `(pathData: PathData, assetInfo?: AssetInfo) => string`
 
 This option determines the name of CSS output files on disk. See [`output.filename`](#outputfilename) option for details on the possible values.
 
@@ -543,7 +551,7 @@ You **must not** specify an absolute path here. However, feel free to include fo
 
 ## output.devtoolFallbackModuleFilenameTemplate
 
-`string` `function (info)`
+`string` `(context: ModuleFilenameTemplateContext) => string`
 
 A fallback is used when the template string or function above yields duplicates.
 
@@ -551,7 +559,7 @@ See [`output.devtoolModuleFilenameTemplate`](#outputdevtoolmodulefilenametemplat
 
 ## output.devtoolModuleFilenameTemplate
 
-`string = 'webpack://[namespace]/[resource-path]?[loaders]'` `function (info) => string`
+`string = 'webpack://[namespace]/[resource-path]?[loaders]'` `(context: ModuleFilenameTemplateContext) => string`
 
 This option is only used when [`devtool`](/configuration/devtool) uses an option that requires module names.
 
@@ -625,7 +633,7 @@ export default {
 
 ## output.enabledChunkLoadingTypes
 
-`[string: 'jsonp' | 'import-scripts' | 'require' | 'async-node' | <any string>]`
+`('jsonp' | 'import-scripts' | 'require' | 'async-node' | 'import' | string)[]`
 
 List of chunk loading types enabled for use by entry points. Will be automatically filled by webpack. Only needed when using a function as entry option and returning chunkLoading option from there.
 
@@ -643,7 +651,7 @@ export default {
 
 ## output.enabledLibraryTypes
 
-`[string]`
+`string[]`
 
 List of library types enabled for use by entry points.
 
@@ -658,7 +666,7 @@ export default {
 
 ## output.enabledWasmLoadingTypes
 
-`[string]`
+`string[]`
 
 List of wasm loading types enabled for use by entry points.
 
@@ -739,7 +747,7 @@ T> `let`, `spread`, `hasOwn`, `symbol`, and `nodeBuiltinModuleGetter` were added
 
 ## output.filename
 
-`string` `function (pathData, assetInfo) => string`
+`string` `(pathData: PathData, assetInfo?: AssetInfo) => string`
 
 This option determines the name of each output bundle. The bundle is written to the directory specified by the [`output.path`](#outputpath) option.
 
@@ -1348,7 +1356,7 @@ export default {
 
 <Badge text="5.107.0+" />
 
-`string = output.filename with '.js' replaced by '.html'` `function (pathData, assetInfo) => string`
+`string = output.filename with '.js' replaced by '.html'` `(pathData: PathData, assetInfo?: AssetInfo) => string`
 
 The filename template for HTML files emitted by [extracted HTML modules](/configuration/module/#modulegeneratorhtmlextract) (initial chunks). It works like [`output.filename`](#outputfilename) and supports the same [template strings](#template-strings). When unset, it is derived from `output.filename` by swapping the `.js` extension for `.html` (falling back to `[name].html` when `output.filename` is a function, or when the derived template contains no `[name]`, `[id]` or hash placeholder), mirroring how `cssFilename` derives from `filename`.
 
@@ -1368,7 +1376,7 @@ W> You must **not** specify an absolute path here. The path may contain folders 
 
 <Badge text="5.107.0+" />
 
-`string = output.chunkFilename with '.js' replaced by '.html'` `function (pathData, assetInfo) => string`
+`string = output.chunkFilename with '.js' replaced by '.html'` `(pathData: PathData, assetInfo?: AssetInfo) => string`
 
 The filename template for HTML files emitted by [extracted HTML modules](/configuration/module/#modulegeneratorhtmlextract) for non-initial (on-demand) chunks. It defaults from [`output.chunkFilename`](#outputchunkfilename) the same way `htmlFilename` defaults from `filename`.
 
@@ -2298,7 +2306,7 @@ define("MyLibrary", [], factory);
 
 W> We might drop support for this, so prefer to use [output.library.export](#outputlibraryexport) which works the same as `libraryExport`.
 
-`string` `[string]`
+`string` `string[]`
 
 Configure which module or modules will be exposed via the `libraryTarget`. It is `undefined` by default, same behaviour will be applied if you set `libraryTarget` to an empty string e.g. `''` it will export the whole (namespace) object. The examples below demonstrate the effect of this configuration when using `libraryTarget: 'var'`.
 
@@ -3239,7 +3247,7 @@ export default {
 
 ### output.trustedTypes.onPolicyCreationFailure
 
-`string = 'stop': 'continue' | 'stop'`
+`'continue' | 'stop' = 'stop'`
 
 <Badge text="5.82.0+" />
 
@@ -3350,7 +3358,7 @@ export default {
 
 ## output.workerChunkFilename
 
-`string` `function (pathData, assetInfo) => string`
+`string` `(pathData: PathData, assetInfo?: AssetInfo) => string`
 
 - Available: 5.108.0+
 
@@ -3374,7 +3382,7 @@ T> Entries that webpack creates automatically from `new Worker(new URL(...))` ar
 
 ## output.workerChunkLoading
 
-`string: 'require' | 'import-scripts' | 'async-node' | 'import'` `boolean: false`
+`'require' | 'import-scripts' | 'async-node' | 'import'` `false`
 
 The new option `workerChunkLoading` controls the chunk loading of workers.
 

--- a/src/content/configuration/output.mdx
+++ b/src/content/configuration/output.mdx
@@ -245,7 +245,7 @@ W> Prefer setting [`output.uniqueName`](#outputuniquename): it disambiguates [`o
 
 ## output.chunkLoading
 
-`false` `string: 'jsonp' | 'import-scripts' | 'require' | 'async-node' | 'import' | <any string>`
+`false` `'jsonp' | 'import-scripts' | 'require' | 'async-node' | 'import' | string`
 
 The method to load chunks (methods included by default are `'jsonp'` (web), `'import'` (ESM), `'import-scripts'` (WebWorker), `'require'` (sync node.js), `'async-node'` (async node.js), but others might be added by plugins).
 
@@ -526,7 +526,7 @@ export default {
 
 ## output.crossOriginLoading
 
-`boolean = false` `string: 'anonymous' | 'use-credentials'`
+`boolean = false` `'anonymous' | 'use-credentials'`
 
 Tells webpack to enable [cross-origin](https://developer.mozilla.org/en/docs/Web/HTML/Element/script#attr-crossorigin) loading of chunks. Only takes effect when the [`target`](/configuration/target/) is set to `'web'`, which uses JSONP for loading on-demand chunks, by adding script tags.
 
@@ -2754,7 +2754,7 @@ W> The path must not contain an exclamation mark (`!`) as it is reserved by webp
 
 ## output.pathinfo
 
-`boolean` `string: 'verbose'`
+`boolean` `'verbose'`
 
 Tells webpack to include comments in bundles with information about the contained modules. `'verbose'` shows more information like exports, runtime requirements and bailouts.
 
@@ -3101,7 +3101,7 @@ export default {
 
 ## output.scriptType
 
-`string: 'module' | 'text/javascript'` `boolean = false`
+`'module' | 'text/javascript'` `boolean = false`
 
 This option allows loading asynchronous chunks with a custom script type, such as `<script type="module" ...>`.
 

--- a/src/content/configuration/performance.mdx
+++ b/src/content/configuration/performance.mdx
@@ -121,7 +121,7 @@ export default {
 
 ### performance.assetFilter
 
-`function(assetFilename, source, assetInfo) => boolean`
+`(assetFilename: string, source: Source, assetInfo: AssetInfo) => boolean`
 
 This property allows webpack to control what files are used to calculate performance hints. The default function excludes assets whose `assetInfo.development` flag is set, such as source maps:
 
@@ -240,7 +240,7 @@ Report modules that call `eval` directly. A direct eval reads and writes any nam
 
 ### performance.hints
 
-`string: 'error' | 'warning' | 'stats'` `boolean: false`
+`'error' | 'warning' | 'stats'` `false`
 
 Turns hints on/off. In addition, tells webpack to throw either an error or a warning when hints are found.
 

--- a/src/content/configuration/plugins.mdx
+++ b/src/content/configuration/plugins.mdx
@@ -17,7 +17,7 @@ T> Note: This page only discusses using plugins, however if you are interested i
 
 ## plugins
 
-[`[Plugin]`](/plugins/)
+[`Plugin[]`](/plugins/)
 
 An array of webpack plugins. For example, [`DefinePlugin`](/plugins/define-plugin/) allows you to create global constants which can be configured at compile time. This can be useful for allowing different behavior between development builds and release builds. Starting with webpack 5.87.0 falsy values can be used to disable specific plugins conditionally.
 

--- a/src/content/configuration/resolve.mdx
+++ b/src/content/configuration/resolve.mdx
@@ -186,7 +186,7 @@ W> `resolve.alias` takes precedence over other module resolutions.
 
 W> [`null-loader`](https://github.com/webpack-contrib/null-loader) is deprecated in webpack 5. use `alias: { xyz$: false }` or absolute path `alias: {[path.resolve(__dirname, './path/to/module')]: false }`
 
-W> `[string]` values are supported since webpack 5.
+W> `string[]` values are supported since webpack 5.
 
 ```js
 import path from "node:path";
@@ -767,7 +767,7 @@ export default {
 
 ### resolve.plugins
 
-[`[Plugin | Function]`](/plugins/)
+[`(Plugin | Function)[]`](/plugins/)
 
 A list of additional resolve plugins which should be applied.
 

--- a/src/content/configuration/resolve.mdx
+++ b/src/content/configuration/resolve.mdx
@@ -226,9 +226,11 @@ T> To ignore modules based on a regex, you can use [IgnorePlugin](https://webpac
 
 ### resolve.aliasFields
 
-`[string]: ['browser']`
+`(string | string[])[] = ['browser']`
 
 Specify a field, such as `browser`, to be parsed according to [this specification](https://github.com/defunctzombie/package-browser-field-spec).
+
+An entry may also be an array of strings, which names a nested field path — `[['exports', 'browser']]` reads `package.json#exports.browser`.
 
 **webpack.config.js**
 
@@ -299,9 +301,9 @@ export default {
 
 ### resolve.cachePredicate
 
-`function(module) => boolean`
+`(request: ResolveRequest) => boolean`
 
-A function which decides whether a request should be cached or not. An object is passed to the function with `path` and `request` properties. It must return a boolean.
+A function which decides whether a request should be cached or not. It receives the [`ResolveRequest`](https://github.com/webpack/enhanced-resolve) being resolved — an object carrying `path` and `request` among other properties — and must return a boolean.
 
 **webpack.config.js**
 
@@ -309,7 +311,7 @@ A function which decides whether a request should be cached or not. An object is
 export default {
   // ...
   resolve: {
-    cachePredicate: (module) =>
+    cachePredicate: (request) =>
       // additional logic
       true,
   },
@@ -459,7 +461,7 @@ export default {
 
 ### resolve.descriptionFiles
 
-`[string] = ['package.json']`
+`string[] = ['package.json']`
 
 The JSON files to use for descriptions.
 
@@ -493,7 +495,7 @@ export default {
 
 ### resolve.exportsFields
 
-`[string] = ['exports']`
+`string[] = ['exports']`
 
 Fields in package.json that are used for resolving module requests. See [package-exports guideline](/guides/package-exports/) for more information.
 
@@ -530,7 +532,7 @@ export default {
 
 ### resolve.extensions
 
-`[string] = ['.js', '.json', '.wasm']`
+`string[] = ['.js', '.json', '.wasm']`
 
 Attempt to resolve these extensions in order. If multiple files share the same name but have different extensions, webpack will resolve the one with the extension listed first in the array and skip the rest.
 
@@ -646,7 +648,7 @@ export default {
 
 ### resolve.importsFields
 
-`[string]`
+`string[] = ['imports']`
 
 Fields from `package.json` which are used to provide the internal requests of a package (requests starting with `#` are considered internal).
 
@@ -663,7 +665,7 @@ export default {
 
 ### resolve.mainFields
 
-`[string]`
+`(string | string[])[]`
 
 When importing from an npm package, e.g. `import * as D3 from 'd3'`, this option will determine which fields in its `package.json` are checked. The default values will vary based upon the [`target`](/concepts/targets) specified in your webpack configuration.
 
@@ -706,7 +708,7 @@ When we `import * as Upstream from 'upstream'` this will actually resolve to the
 
 ### resolve.mainFiles
 
-`[string] = ['index']`
+`string[] = ['index']`
 
 The filename to be used while resolving directories.
 
@@ -723,7 +725,7 @@ export default {
 
 ### resolve.modules
 
-`[string] = ['node_modules']`
+`string[] = ['node_modules']`
 
 Tell webpack what directories should be searched when resolving modules.
 
@@ -851,7 +853,7 @@ const a = new URL("./module/path", import.meta.url);
 
 ### resolve.restrictions
 
-`[string, RegExp]`
+`(string | RegExp)[]`
 
 A list of resolve restrictions to restrict the paths that a request can be resolved on.
 
@@ -868,7 +870,7 @@ export default {
 
 ### resolve.roots
 
-`[string]`
+`string[]`
 
 A list of directories where requests of server-relative URLs (starting with '/') are resolved, defaults to [`context` configuration option](/configuration/entry-context/#context). These requests are resolved against `roots` first and as an absolute path afterwards; set [`resolve.preferAbsolute`](#resolvepreferabsolute) to `true` to flip that order.
 
@@ -1060,7 +1062,7 @@ T> This option is also available in `resolveLoader` with the same configuration 
 
 ## resolveLoader
 
-`object { modules [string] = ['node_modules'], extensions [string] = ['.js'], mainFields [string] = ['loader', 'main'], mainFiles [string] = ['index'], conditionNames [string] = ['loader', 'require', 'node'], exportsFields [string] = ['exports']}`
+`{ modules: string[] = ['node_modules'], extensions: string[] = ['.js'], mainFields: (string | string[])[] = ['loader', 'main'], mainFiles: string[] = ['index'], conditionNames: string[] = ['loader', 'require', 'node'], exportsFields: string[] = ['exports'] }`
 
 This set of options is identical to the `resolve` property set above, but is used only to resolve webpack's [loader](/concepts/loaders) packages.
 

--- a/src/content/configuration/stats.mdx
+++ b/src/content/configuration/stats.mdx
@@ -585,9 +585,9 @@ W> Deprecated and ineffective: `stats.exclude` is still accepted by the configur
 
 ### stats.excludeAssets
 
-`array = []: string | RegExp | function (assetName) => boolean` `string` `RegExp` `function (assetName) => boolean`
+`(string | RegExp | ((name: string, asset: StatsAsset) => boolean))[] = []` `string` `RegExp` `(name: string, asset: StatsAsset) => boolean`
 
-Tells `stats` to exclude the matching assets information. This can be done with a `string`, a `RegExp`, a `function` that is getting the assets name as an argument and returns a `boolean`. `stats.excludeAssets` can be an `array` of any of the above.
+Tells `stats` to exclude the matching assets information. This can be done with a `string`, a `RegExp`, or a function receiving the asset's name and its stats object. `stats.excludeAssets` can be an `array` of any of the above.
 
 ```js
 export default {
@@ -604,9 +604,17 @@ export default {
 
 ### stats.excludeModules
 
-`array = []: string | RegExp | function (moduleName, module, type) => boolean` `string` `RegExp` `function (moduleName, module, type) => boolean` `boolean: false`
+`(string | RegExp | ModuleFilterFn)[] = []` `string` `RegExp` `ModuleFilterFn` `false`
 
-Tells `stats` to exclude the matching modules information. This can be done with a `string`, a `RegExp`, a `function` that is getting the module's name (plus the stats module object and the type of the module list) as arguments and returns a `boolean`. `stats.excludeModules` can be an `array` of any of the above.
+Tells `stats` to exclude the matching modules information. This can be done with a `string`, a `RegExp`, or a `ModuleFilterFn`. `stats.excludeModules` can be an `array` of any of the above.
+
+```ts
+type ModuleFilterFn = (
+  name: string,
+  module: StatsModule,
+  type: "module" | "chunk" | "root-of-chunk" | "nested",
+) => boolean;
+```
 
 ```js
 export default {
@@ -876,7 +884,7 @@ export default {
 
 ### stats.logging
 
-`string = 'info': 'none' | 'error' | 'warn' | 'info' | 'log' | 'verbose'` `boolean`
+`'none' | 'error' | 'warn' | 'info' | 'log' | 'verbose' = 'info'` `boolean`
 
 Tells `stats` whether to add logging output.
 
@@ -898,7 +906,7 @@ export default {
 
 ### stats.loggingDebug
 
-`array = []: string | RegExp | function (name) => boolean` `string` `RegExp` `function (name) => boolean`
+`(string | RegExp | ((name: string) => boolean))[] = []` `string` `RegExp` `(name: string) => boolean` `boolean`
 
 Tells `stats` to include the debug information of the specified loggers such as Plugins or Loaders. Loggers matched by `stats.loggingDebug` are shown even when [`stats.logging`](#statslogging) is set to `false`.
 
@@ -1098,7 +1106,7 @@ export default {
 
 ### stats.preset
 
-`string` `boolean: false`
+`string` `false`
 
 Sets the [preset](/configuration/stats/#stats-presets) for the type of information that gets displayed. It is useful for [extending stats behaviours](/configuration/stats/#extending-stats-behaviours).
 
@@ -1299,9 +1307,13 @@ export default {
 
 ### stats.warningsFilter
 
-`array = []: string | RegExp | function (warning) => boolean` `string` `RegExp` `function (warning) => boolean`
+`(string | RegExp | WarningFilterFn)[] = []` `string` `RegExp` `WarningFilterFn`
 
-Tells `stats` to exclude the warnings that are matching given filters. This can be done with a `string`, a `RegExp`, a `function` that is getting a warning as an argument and returns a `boolean`. `stats.warningsFilter` can be an `array` of any of the above.
+Tells `stats` to exclude the warnings that are matching given filters. This can be done with a `string`, a `RegExp`, or a `WarningFilterFn`. `stats.warningsFilter` can be an `array` of any of the above.
+
+```ts
+type WarningFilterFn = (warning: StatsError, warningString: string) => boolean;
+```
 
 ```js
 export default {

--- a/src/content/configuration/target.mdx
+++ b/src/content/configuration/target.mdx
@@ -20,7 +20,7 @@ Webpack can compile for multiple environments or _targets_. To understand what a
 
 ## target
 
-`string` `[string]` `false`
+`string` `string[]` `false`
 
 Instructs webpack to generate runtime code for a specific environment. Note that webpack runtime code is not the same as the user code you write, you should transpile that code with transpilers like Babel if you want to target specific environments, e.g, you have arrow functions in source code and want to run the bundled code in ES5 environments. Webpack won't transpile them automatically with a `target` configured.
 

--- a/src/content/configuration/watch.mdx
+++ b/src/content/configuration/watch.mdx
@@ -69,7 +69,7 @@ export default {
 
 ### watchOptions.ignored
 
-`RegExp` `string` `[string]`
+`RegExp` `string` `string[]`
 
 For some systems, watching many files can result in a lot of CPU or memory usage. It is possible to exclude a huge folder like `node_modules` using a regular expression:
 

--- a/src/content/plugins/define-plugin.mdx
+++ b/src/content/plugins/define-plugin.mdx
@@ -102,13 +102,13 @@ new webpack.DefinePlugin({
 
 ## Runtime values via `runtimeValue`
 
-`function (getterFunction, [string] | true | object) => getterFunction()`
+`(fn: (context: { module: NormalModule, key: string, version: string | undefined }) => CodeValuePrimitive, options?: true | string[] | RuntimeValueOptions) => RuntimeValue`
 
 It is possible to define variables with values that rely on files and will be re-evaluated when such files change in the file system. This means webpack will rebuild when such watched files change.
 
 There're two arguments for `webpack.DefinePlugin.runtimeValue` function:
 
-- The first argument is a `function({ module, key, version })` that should return the value to be assigned to the definition.
+- The first argument is the generator function above: it receives `{ module, key, version }` and returns the value to be assigned to the definition.
 - The second argument could either be an array of file paths to watch for or a `true` to flag the module as uncacheable. Since 5.26.0, it can also take an object argument with the following properties:
   - `fileDependencies?: string[]` A list of files the function depends on.
   - `contextDependencies?: string[]` A list of directories the function depends on.

--- a/src/content/plugins/eval-source-map-dev-tool-plugin.mdx
+++ b/src/content/plugins/eval-source-map-dev-tool-plugin.mdx
@@ -29,11 +29,21 @@ This plugin wraps every module in an `eval()` call with its source map appended 
 
 The following options are supported:
 
-- `test` (`string` `RegExp` `function (module) => boolean` `[string, RegExp, function (module) => boolean]`): Generate source maps for modules whose path matches the given value. There is no default: all modules get source maps unless `test`, `include` or `exclude` restrict them. It matches the module's own path, not the name of the chunk it ends up in, so it cannot be used to exclude a whole entry point or bundle.
-- `include` (`string` `RegExp` `function (module) => boolean` `[string, RegExp, function (module) => boolean]`): Include source maps for module paths that match the given value.
-- `exclude` (`string` `RegExp` `function (module) => boolean` `[string, RegExp, function (module) => boolean]`): Exclude modules that match the given value from source map generation.
+```ts
+type Matcher =
+  | string
+  | RegExp
+  | ((name: string) => boolean)
+  | (string | RegExp | ((name: string) => boolean))[];
+```
+
+A `string` matches by prefix, a `RegExp` by test, and a function is called with the name and returns whether it matches.
+
+- `test` (`Matcher`): Generate source maps for modules whose path matches the given value. There is no default: all modules get source maps unless `test`, `include` or `exclude` restrict them. It matches the module's own path, not the name of the chunk it ends up in, so it cannot be used to exclude a whole entry point or bundle.
+- `include` (`Matcher`): Include source maps for module paths that match the given value.
+- `exclude` (`Matcher`): Exclude modules that match the given value from source map generation.
 - `append` (`string`): Appends the given value to the original asset. Usually the `#sourceMappingURL` comment. `[url]` is replaced with a URL to the source map file.
-- `ignoreList` (`string` `RegExp` `function (source) => boolean` `[string, RegExp, function (source) => boolean]`): Decide whether to ignore source files that match the specified value in source maps.
+- `ignoreList` (`Matcher`): Decide whether to ignore source files that match the specified value in source maps.
 - `module` (`boolean`): Indicates whether loaders should generate source maps (defaults to `true`).
 - `moduleFilenameTemplate` (`string`): See [`output.devtoolModuleFilenameTemplate`](/configuration/output/#outputdevtoolmodulefilenametemplate).
 - `columns` (`boolean`): Indicates whether column mappings should be used (defaults to `true`).

--- a/src/content/plugins/internal-plugins.mdx
+++ b/src/content/plugins/internal-plugins.mdx
@@ -47,7 +47,7 @@ Adds a cache to the compiler, where modules are cached in memory.
 
 `ProgressPlugin(handler)`
 
-Hook into the compiler to extract progress information. The `handler` must have the signature `function(percentage, message)`. Percentage is called with a value between 0 and 1, where 0 indicates the start and 1 the end.
+Hook into the compiler to extract progress information. The `handler` must have the signature `(percentage: number, message: string) => void`. Percentage is called with a value between 0 and 1, where 0 indicates the start and 1 the end.
 
 ### RecordIdsPlugin
 

--- a/src/content/plugins/manifest-plugin.mdx
+++ b/src/content/plugins/manifest-plugin.mdx
@@ -80,19 +80,19 @@ Allows filtering the files which make up the manifest.
 
 ### `generate`
 
-`function (manifest: ManifestObject) => ManifestObject`
+`(manifest: ManifestObject) => ManifestObject`
 
 Receives the manifest object, modifies it, and returns the modified manifest.
 
 ### `prefix`
 
-`string = "[publicpath]"`
+`string = '[publicpath]'`
 
 Specifies a path prefix for all keys in the manifest.
 
 ### serialize
 
-`function (manifest: ManifestObject) => string = (manifest) => JSON.stringify(manifest, null, 2)`
+`(manifest: ManifestObject) => string = (manifest) => JSON.stringify(manifest, null, 2)`
 
 Receives the manifest object and returns the manifest string.
 

--- a/src/content/plugins/progress-plugin.mdx
+++ b/src/content/plugins/progress-plugin.mdx
@@ -47,7 +47,7 @@ When providing an `object` to the `ProgressPlugin`, following properties are sup
 - `profile` (`boolean = false`): Tells `ProgressPlugin` to collect profile data for progress steps.
 - `dependencies` (`boolean = true`): Shows the count of dependencies in progress message.
 - `dependenciesCount` (`number = 10000`): A minimum dependencies count to start with. Takes effect when `dependencies` property is enabled.
-- `percentBy` (`string = null: 'entries' | 'dependencies' | 'modules' | null`): Tells `ProgressPlugin` how to calculate progress percentage.
+- `percentBy` (`'entries' | 'dependencies' | 'modules' | null = null`): Tells `ProgressPlugin` how to calculate progress percentage.
 - `progressBar` (`boolean | 'auto' | object = false`) <Badge text="5.107.0+" />: Renders a progress bar in the terminal instead of the plain percentage message. Only takes effect with the default handler, i.e. when no custom `handler` is provided. Pass `true` to enable it with defaults, `'auto'` <Badge text="5.109.0+" /> to enable it only in interactive terminals (TTY), or an object with the following properties:
   - `name` (`string = 'Build'`): Name shown before the progress bar.
   - `color` (`string = 'green'`): Color used for the filled portion of the bar. Falls back to `'green'` when the given color is not supported.

--- a/src/content/plugins/source-map-dev-tool-plugin.mdx
+++ b/src/content/plugins/source-map-dev-tool-plugin.mdx
@@ -25,11 +25,21 @@ new webpack.SourceMapDevToolPlugin(options);
 
 The following options are supported:
 
-- `test` (`string` `RegExp` `function (asset) => boolean` `[string, RegExp, function (asset) => boolean]`): Include source maps for modules based on their extension (defaults to `.js`, `.cjs`, `.mjs`, and `.css`).
-- `include` (`string` `RegExp` `function (asset) => boolean` `[string, RegExp, function (asset) => boolean]`): Include source maps for module paths that match the given value.
-- `exclude` (`string` `RegExp` `function (asset) => boolean` `[string, RegExp], function (asset) => boolean`): Exclude modules that match the given value from source map generation.
+```ts
+type Matcher =
+  | string
+  | RegExp
+  | ((name: string) => boolean)
+  | (string | RegExp | ((name: string) => boolean))[];
+```
+
+A `string` matches by prefix, a `RegExp` by test, and a function is called with the name and returns whether it matches.
+
+- `test` (`Matcher`): Include source maps for modules based on their extension (defaults to `.js`, `.cjs`, `.mjs`, and `.css`).
+- `include` (`Matcher`): Include source maps for module paths that match the given value.
+- `exclude` (`Matcher`): Exclude modules that match the given value from source map generation.
 - `filename` (`string`): Defines the output filename of the SourceMap (will be inlined if no value is provided).
-- `append` (`string` `function` `false`): Appends the given value to the original asset. Usually the `#sourceMappingURL` comment. `[url]` is replaced with a URL to the source map file. Since webpack v4.36.0, path parameters are supported: `[chunk]`, `[filename]` and `[contenthash]`. Setting `append` to `false` disables the appending.
+- `append` (`string` `(pathData: PathData, assetInfo?: AssetInfo) => string` `false`): Appends the given value to the original asset. Usually the `#sourceMappingURL` comment. `[url]` is replaced with a URL to the source map file. Since webpack v4.36.0, path parameters are supported: `[chunk]`, `[filename]` and `[contenthash]`. Setting `append` to `false` disables the appending.
 
   Starting from version 5.84.0, webpack allows the `append` option to be a function that accepts path data and an asset info object as arguments, and returns a string.
 
@@ -39,7 +49,7 @@ The following options are supported:
 
 - `moduleFilenameTemplate` (`string`): See [`output.devtoolModuleFilenameTemplate`](/configuration/output/#outputdevtoolmodulefilenametemplate).
 - `fallbackModuleFilenameTemplate` (`string`): See link above.
-- `ignoreList` (`string` `RegExp` `function (source) => boolean` `[string, RegExp, function (source) => boolean]`): Decide whether to ignore source files that match the specified value in source maps.
+- `ignoreList` (`Matcher`): Decide whether to ignore source files that match the specified value in source maps.
 - `module = true` (`boolean`): Indicates whether loaders should generate source maps.
 - `columns = true` (`boolean`): Indicates whether column mappings should be used.
 - `namespace` (`string`): Namespace prefix to allow multiple webpack roots in the devtools. See [`output.devtoolNamespace`](/configuration/output/#outputdevtoolnamespace).

--- a/src/content/plugins/split-chunks-plugin.mdx
+++ b/src/content/plugins/split-chunks-plugin.mdx
@@ -108,7 +108,7 @@ By default webpack will generate names using origin and name of the chunk (e.g. 
 
 ### splitChunks.chunks
 
-`string = 'async'` `function (chunk)` `RegExp`
+`'initial' | 'async' | 'all' = 'async'` `RegExp` `(chunk: Chunk) => boolean | undefined`
 
 This indicates which chunks will be selected for optimization. When a string is provided, valid values are `all`, `async`, and `initial`:
 
@@ -195,7 +195,7 @@ The default value of `splitChunks.maxInitialRequests` depends on the [`mode`](/c
 
 ### splitChunks.defaultSizeTypes
 
-`[string] = ['javascript', 'css', 'unknown']`
+`string[] = ['javascript', 'css', 'unknown']`
 
 Sets the size types which are used when a number is used for sizes. When the built-in CSS support ([`experiments.css`](/configuration/experiments/#experimentscss)) is disabled, the default is `['javascript', 'unknown']`.
 
@@ -213,7 +213,7 @@ Prevents exposing path info when creating names for parts splitted by maxSize.
 
 ### splitChunks.minSize
 
-`number` `{ [index: string]: number }`
+`number` `Record<string, number>`
 
 Minimum size, in bytes, for a chunk to be generated.
 
@@ -227,7 +227,7 @@ The default value of `splitChunks.minSize` depends on the [`mode`](/configuratio
 
 ### splitChunks.minSizeReduction
 
-`number` `{ [index: string]: number }`
+`number` `Record<string, number>`
 
 Minimum size reduction to the main chunk (bundle), in bytes, needed for a chunk to be generated. Meaning if splitting into a chunk does not reduce the size of the main chunk (bundle) by the given amount of bytes, it won't be split, even if it meets the `splitChunks.minSize` value.
 
@@ -302,7 +302,7 @@ The difference between `maxInitialSize` and `maxSize` is that `maxInitialSize` w
 
 ### splitChunks.name
 
-`boolean = false` `function (module, chunks, cacheGroupKey) => string` `string`
+`false = false` `string` `(module: Module, chunks: Chunk[], cacheGroupKey: string) => string | undefined`
 
 Also available for each cacheGroup: `splitChunks.cacheGroups.{cacheGroup}.name`.
 
@@ -468,7 +468,7 @@ Assign modules to a cache group by module layer.
 
 #### `splitChunks.cacheGroups.{cacheGroup}.test`
 
-`function (module, { chunkGraph, moduleGraph }) => boolean` `RegExp` `string`
+`RegExp` `string` `(module: Module, context: { chunkGraph: ChunkGraph, moduleGraph: ModuleGraph }) => boolean`
 
 Controls which modules are selected by this cache group. Omitting it selects all modules. It is matched against the module's resource path (`module.nameForCondition()`): a string matches by prefix, a `RegExp` by test.
 
@@ -531,7 +531,7 @@ export default {
 
 #### `splitChunks.cacheGroups.{cacheGroup}.filename`
 
-`string` `function (pathData, assetInfo) => string`
+`string` `(pathData: PathData, assetInfo?: AssetInfo) => string`
 
 Overrides the filename template for the chunks created by this cache group (initial and on-demand). It can also be set globally as `splitChunks.filename`.
 All placeholders available in [`output.filename`](/configuration/output/#outputfilename) are also available here.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Follow-up to #8382, which changed the writer's guide to prescribe TypeScript notation but deliberately left the annotations still using the old notation in place. This converts them — 31 pages — so the docs match the convention they now document. Refs #3333.

Each annotation was checked against `schemas/WebpackOptions.json`, the plugin schemas and the `tsType`/`@callback` declarations behind them rather than transliterated, which turned up a handful of types that were wrong independently of notation:

- `resolve.mainFields` / `resolve.aliasFields` are `(string | string[])[]` — an entry may be a nested field path — not `[string]`.
- `resolve.cachePredicate` receives the `ResolveRequest`, not a module (the example's parameter was named `module`).
- `module.noParse`'s function is called with the resolved request string, and `SourceMapDevToolPlugin`'s `test`/`include`/`exclude`/`ignoreList` matchers with a name string, not with a module or asset object.
- `stats.excludeModules` and `stats.warningsFilter` callbacks take arguments the docs did not list (`StatsModule` + list type; the warning string).
- `UseEntry`'s `info.compiler` is the child compiler's *name*, not the compiler.
- `output.enabledChunkLoadingTypes` was missing `'import'`; `stats.loggingDebug` was missing its `boolean` form; `resolve.importsFields` had no documented default.
- `SourceMapDevToolPlugin`'s `exclude` had a stray bracket (`` `[string, RegExp], function …` ``).

Long unions that repeat are named once and defined in a `ts` block next to the option (`Matcher`, `ModuleFilterFn`, `WarningFilterFn`, `CopiedFile`, `Entry`) instead of being inlined per bullet. The one heading that changed — `externals` `### [string]` → `### string[]` — keeps its `#string-1` anchor, verified against `github-slugger`.

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

No — documentation only. `npm run jest` (25 suites / 99 tests / 23 snapshots), prettier, eslint and markdownlint all pass.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — this is the documentation change.

**Use of AI**

Claude Code was used throughout: to inventory the remaining old-notation annotations, to resolve each option against webpack's schema and type declarations, to write the replacements, and to run the lint and test suites. Every type above was read out of `node_modules/webpack@5.110.3`'s schema or source before being written down, and the anchor-preservation claim was checked by running `github-slugger`. The changes were reviewed before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT)_