### PR TITLE
docs: say which hook a plugin creates assets in

### DIFF
--- a/src/content/api/compilation-hooks.mdx
+++ b/src/content/api/compilation-hooks.mdx
@@ -708,6 +708,25 @@ In addition to `name` and `stage`, you can pass an `additionalAssets` <Badge tex
    );
    ```
 
+### Choosing a stage
+
+`processAssets` is the hook for creating and changing assets, and the stage decides where in the pipeline your work lands. Pick it from what the plugin does:
+
+| What the plugin does                                   | Stage                                    |
+| ------------------------------------------------------ | ---------------------------------------- |
+| Emits a new file of its own                            | `PROCESS_ASSETS_STAGE_ADDITIONAL`        |
+| Adds to an existing asset, e.g. a banner               | `PROCESS_ASSETS_STAGE_ADDITIONS`         |
+| Minifies                                               | `PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE`     |
+| Writes a companion file, e.g. a source map             | `PROCESS_ASSETS_STAGE_DEV_TOOLING`       |
+| Prepares a compressed copy                             | `PROCESS_ASSETS_STAGE_OPTIMIZE_TRANSFER` |
+| Reads every asset without changing it, e.g. a manifest | `PROCESS_ASSETS_STAGE_SUMMARIZE`         |
+
+The stage is what makes plugins compose. A file emitted at `ADDITIONAL` is still ahead of the minifier, the source-map stage and the compressor, so it gets the same treatment as a chunk webpack generated itself — which is why adding assets from the compiler's [`emit`](/api/compiler-hooks/#emit) hook is wrong: it runs after all of these, so nothing downstream ever sees the file.
+
+Getting the stage wrong has the same shape of consequence. Emit at `SUMMARIZE` and the file is written unminified, because `OPTIMIZE_SIZE` has already run; read the assets at `ADDITIONAL` and the list is missing everything added after you.
+
+T> If you need to see assets added after your own stage, use [`additionalAssets`](#additional-assets) rather than moving to a later stage.
+
 ### List of asset processing stages
 
 Here's a list of supported stages (in the order of processing):

--- a/src/content/api/compiler-hooks.mdx
+++ b/src/content/api/compiler-hooks.mdx
@@ -262,6 +262,8 @@ Executed right before emitting assets to output dir. This hook is _not_ copied t
 
 - Callback Parameters: `compilation`
 
+W> **Do not add or change assets here.** `emit` runs after the compilation is sealed, so every [`processAssets`](/api/compilation-hooks/#processassets) stage has gone by: an asset added here is never minified or compressed, gets no source map, and no other plugin sees it. Webpack reports the write as deprecated (`DEP_WEBPACK_COMPILATION_ASSETS`). Use `processAssets` with the right [stage](/api/compilation-hooks/#choosing-a-stage) instead. Reading the assets here is fine.
+
 ### afterEmit
 
 `AsyncSeriesHook`

--- a/src/content/concepts/plugins.mdx
+++ b/src/content/concepts/plugins.mdx
@@ -101,3 +101,24 @@ compiler.run((err, stats) => {
 ```
 
 T> Did you know: The example seen above is extremely similar to the [webpack runtime itself!](https://github.com/webpack/webpack/blob/e7087ffeda7fa37dfe2ca70b5593c6e899629a2c/bin/webpack.js#L290-L292) There are lots of great usage examples hiding in the [webpack source code](https://github.com/webpack/webpack) that you can apply to your own configurations and scripts!
+
+## Writing your own
+
+The [Writing a Plugin](/contribute/writing-a-plugin/) guide takes the object above and builds it out into a real plugin — options, async hooks, file dependencies for watch mode, types and tests.
+
+Two things decide whether a plugin behaves well, and both are about _which_ hook it taps.
+
+### Where the hooks live
+
+Hooks belong to the object that owns them, and the two reference pages list them in the order they run:
+
+- [Compiler hooks](/api/compiler-hooks/) — once per build, around the whole run: `run`, `watchRun`, `compile`, `make`, `emit`, `done`.
+- [Compilation hooks](/api/compilation-hooks/) — inside a single build, over modules, chunks and assets.
+
+A compiler outlives the builds it runs: in watch mode every rebuild is a new [`Compilation`](/api/compilation-object/) on the same [`Compiler`](/api/compiler-object/). State that must survive a rebuild belongs on the compiler; state about one build belongs on the compilation.
+
+### Creating or changing assets
+
+Do it in [`processAssets`](/api/compilation-hooks/#processassets), with the [stage](/api/compilation-hooks/#choosing-a-stage) that matches the work — `PROCESS_ASSETS_STAGE_ADDITIONAL` to emit a new file, `PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE` to minify, and so on.
+
+W> A plugin that emits its files from the compiler's [`emit`](/api/compiler-hooks/#emit) hook instead is a common mistake, and webpack reports it as deprecated. `emit` runs after the compilation is sealed, so the file skips every stage that would have minified, compressed, source-mapped or hashed it, and no other plugin sees it. The stage system exists so that plugins compose without being ordered by hand in the configuration.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Closes #2864, whose stated main problem is that plugins add assets from the compiler's `emit` hook, and nothing in the docs said not to. The issue predates webpack 5 and proposed `additionalAssets`; the answer now is `processAssets` with a stage, which the reference documented mechanically without ever saying which stage to pick or what `emit` costs.

I measured the difference rather than asserting it — one build, production mode, the same source emitted from each hook:

| Added from | Emitted bytes | webpack says |
| --- | --- | --- |
| `compiler.hooks.emit` | 117, verbatim source | `DEP_WEBPACK_COMPILATION_ASSETS` deprecation |
| `processAssets` at `PROCESS_ASSETS_STAGE_ADDITIONAL` | 60, minified | nothing |

webpack's own deprecation text is the citation: *"No more changes should happen to Compilation.assets after sealing the Compilation. Do changes to assets earlier, e. g. in Compilation.hooks.processAssets. Make sure to select an appropriate stage."*

Three additions:

- **`emit`** (compiler hooks) gets a warning that writing assets there skips every stage and is reported as deprecated. Reading is still fine, which is what the existing `emit` examples elsewhere in the docs do.
- **`processAssets`** gets a **Choosing a stage** section — a table mapping what a plugin does to the stage it belongs in, plus why the stage system is what lets plugins compose without hand-ordering them in the configuration.
- **`/concepts/plugins`**, the page the issue names, gets a **Writing your own** section: a pointer to [Writing a Plugin](https://webpack.js.org/contribute/writing-a-plugin/), where the two hook families live and in what order they run (the request in the issue's comment), and the asset rule.

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

No — documentation only. Prettier, eslint, markdownlint and `npm run jest` (25 suites / 99 tests) pass.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — documented here.

**Use of AI**

Claude Code was used to read the issue, check what the docs already covered, build the two-plugin fixture that measured the difference, write the changes and run lint and tests. The claims about `emit` come from that build and from webpack's own deprecation message, not from the 2019 issue text, which recommends a hook that is itself deprecated now. I also checked the other `emit` usages in the docs and left them alone — all are read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT)_