### PR TITLE
docs: match the splash script tag to what webpack emits

### DIFF
--- a/src/components/Splash/first/left.mdx
+++ b/src/components/Splash/first/left.mdx
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
-    <script type="module" src="./index.js"></script>
+    <script src="./index.js"></script>
   </body>
 </html>
 ```


### PR DESCRIPTION
**Summary**

The front page showed `<script type="module" src="./index.js">` going into webpack and a classic `<script src>` coming out, captioned "webpack parses the page, bundles everything it references, and rewrites the URLs" — so it reads as though webpack silently dropped the module type.

It doesn't. Building the example verbatim on webpack 5.110.3:

| config | emitted tag |
| --- | --- |
| exactly as the splash shows it | `<script src=…js>` — chunk is a classic IIFE |
| `+ output.module: true` | `<script type=module src=…mjs>` — chunk is `[javascript module]` |
| classic `<script src>` input, same config | identical output, same content hash |

webpack matches the tag to the chunk it emits: it drops `type="module"` when the chunk is classic and keeps it when the chunk is a real ES module. That is the mirror of the upgrade already documented for `output.module`, and the only correct behaviour — loading an IIFE chunk as a module changes scope, strictness and timing. So the output shown was accurate; what misled was pairing it with a module tag on the input and describing the difference as a URL rewrite.

Showing a classic tag makes the before and after differ only in the URL, which is what the caption claims. The emitted page is unchanged.

The other direction — keep `type="module"` and add `output.module` so the output really is ESM — would put `experiments.outputModule` on the front page, since `output.module: true` is rejected without it. That seemed a bad trade for the splash.

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

No — one attribute in a documentation example. Verified by building the example three ways rather than by reading the source; prettier, markdownlint and eslint all pass.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — but two related spots I left alone and would value your read on: `guides/native-html.mdx` §1 uses the same `type="module"` input without showing an emitted page, so nothing contradicts there; and its table row saying `<script type="module" src>` "Becomes an ES module chunk entry" is not observable with `output.module` off (both tags produced byte-identical output for me), which I suspect describes the internal `script-module` entry type rather than the emitted format.

**Use of AI**

Claude Code was used to reproduce the example, determine from real builds whether webpack or the documentation was at fault, and make the change. The three builds above are actual output, not inference from the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cb4AP4BntRzji5vSqhzYWT)_